### PR TITLE
ci: fix PR commit lint range and format after document-change

### DIFF
--- a/.changeset/ci-document-change-format.md
+++ b/.changeset/ci-document-change-format.md
@@ -1,0 +1,8 @@
+---
+"@ifi/oh-pi": patch
+---
+
+Improve project automation ergonomics:
+
+- fix pull-request conventional-commit validation to lint real PR commits instead of synthetic merge commit messages
+- update `knope document-change` workflow to run `pnpm format` after creating a changeset file

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -25,7 +25,10 @@ jobs:
           PATTERN='^(feat|fix|docs|style|refactor|perf|test|build|ci|chore|revert)(\(.+\))?!?: .+'
 
           if [ "${{ github.event_name }}" = "pull_request" ]; then
-            COMMITS=$(git log --format='%s' origin/${{ github.base_ref }}..${{ github.sha }})
+            BASE_SHA='${{ github.event.pull_request.base.sha }}'
+            HEAD_SHA='${{ github.event.pull_request.head.sha }}'
+            # Validate only real PR commits (exclude synthetic merge commits from refs/pull/*/merge).
+            COMMITS=$(git log --format='%s' --no-merges "${BASE_SHA}..${HEAD_SHA}")
           else
             # On push, check only the head commit
             COMMITS=$(git log --format='%s' -1)

--- a/knope.toml
+++ b/knope.toml
@@ -59,6 +59,10 @@ help_text = "Create a new changeset file for the next release"
 [[workflows.steps]]
 type = "CreateChangeFile"
 
+[[workflows.steps]]
+type = "Command"
+command = "pnpm format"
+
 [[workflows]]
 name = "get-version"
 help_text = "Print the current version"


### PR DESCRIPTION
## Summary

- fix PR commit-lint to validate real PR commits (`base.sha..head.sha`) and ignore synthetic merge refs
- keep push behavior unchanged (still validates the latest pushed commit)
- update `knope document-change` to run `pnpm format` right after creating the changeset file
- add a changeset for this automation update

## Why

The previous PR commit-lint range could include GitHub's synthetic merge commit message (e.g. `Merge ... into ...`),
which is not a conventional commit and caused false failures.

Also, `document-change` now leaves the repo formatted automatically after generating a changeset.

## Validation

- `pnpm lint`
