### PR TITLE
feat: add /btw and /qq side-conversation extension and skill

### DIFF
--- a/.changeset/btw-qq-side-conversation.md
+++ b/.changeset/btw-qq-side-conversation.md
@@ -1,0 +1,18 @@
+---
+"@ifi/oh-pi-extensions": minor
+"@ifi/oh-pi-skills": minor
+"@ifi/oh-pi": minor
+---
+
+Add `/btw` and `/qq` side-conversation extension and skill:
+
+- `/btw` opens a parallel side conversation without interrupting the main agent run
+- `/qq` is an alias for `/btw` ("quick question")
+- streams answers into a widget above the editor
+- maintains a continuous thread across exchanges, persisted in session state
+- keeps BTW entries out of the main agent's LLM context
+- supports `--save` to persist an exchange as a visible session note
+- sub-commands: `:new`, `:clear`, `:inject`, `:summarize` for thread management
+- includes a `btw` skill for discoverability and guidance
+
+Based on https://github.com/dbachelder/pi-btw by Dan Bachelder (MIT).

--- a/packages/extensions/extensions/btw.ts
+++ b/packages/extensions/extensions/btw.ts
@@ -1,0 +1,744 @@
+/**
+ * oh-pi BTW / QQ Extension — parallel side conversations
+ *
+ * Adds /btw and /qq commands that open a side conversation without interrupting
+ * the main agent run. Answers stream into a widget above the editor.
+ *
+ * Features:
+ * - Runs immediately, even while the main agent is busy
+ * - Maintains a continuous BTW thread across exchanges
+ * - Keeps BTW entries out of the main agent's LLM context
+ * - Can inject the full thread or a summary back into the main agent
+ * - Optionally saves individual exchanges as visible session notes with --save
+ *
+ * Based on https://github.com/dbachelder/pi-btw by Dan Bachelder (MIT).
+ */
+
+import {
+	type ThinkingLevel as AiThinkingLevel,
+	type AssistantMessage,
+	completeSimple,
+	type Message,
+	streamSimple,
+} from "@mariozechner/pi-ai";
+import {
+	buildSessionContext,
+	type ExtensionAPI,
+	type ExtensionCommandContext,
+	type ExtensionContext,
+} from "@mariozechner/pi-coding-agent";
+import { Text } from "@mariozechner/pi-tui";
+
+const BTW_MESSAGE_TYPE = "btw-note";
+const BTW_ENTRY_TYPE = "btw-thread-entry";
+const BTW_RESET_TYPE = "btw-thread-reset";
+
+const BTW_SYSTEM_PROMPT = [
+	"You are having an aside conversation with the user, separate from their main working session.",
+	"The main session messages are provided for context only — that work is being handled by another agent.",
+	"Focus on answering the user's side questions, helping them think through ideas, or planning next steps.",
+	"Do not act as if you need to continue unfinished work from the main session unless the user explicitly asks you to prepare something for injection back to it.",
+].join(" ");
+
+type SessionThinkingLevel = "off" | AiThinkingLevel;
+
+interface BtwDetails {
+	question: string;
+	thinking: string;
+	answer: string;
+	provider: string;
+	model: string;
+	thinkingLevel: SessionThinkingLevel;
+	timestamp: number;
+	usage?: AssistantMessage["usage"];
+}
+
+interface ParsedBtwArgs {
+	question: string;
+	save: boolean;
+}
+
+type SaveState = "not-saved" | "saved" | "queued";
+
+interface BtwSlot {
+	question: string;
+	modelLabel: string;
+	thinking: string;
+	answer: string;
+	done: boolean;
+	controller: AbortController;
+}
+
+interface WidgetThemeHelpers {
+	dim: (text: string) => string;
+	success: (text: string) => string;
+	italic: (text: string) => string;
+	warning: (text: string) => string;
+}
+
+function isVisibleBtwMessage(message: { role: string; customType?: string }): boolean {
+	return message.role === "custom" && message.customType === BTW_MESSAGE_TYPE;
+}
+
+function isCustomEntry(
+	entry: unknown,
+	customType: string,
+): entry is { type: "custom"; customType: string; data?: unknown } {
+	return (
+		!!entry &&
+		typeof entry === "object" &&
+		(entry as { type?: string }).type === "custom" &&
+		(entry as { customType?: string }).customType === customType
+	);
+}
+
+function toReasoning(level: SessionThinkingLevel): AiThinkingLevel | undefined {
+	return level === "off" ? undefined : level;
+}
+
+function extractText(parts: AssistantMessage["content"], type: "text" | "thinking"): string {
+	const chunks: string[] = [];
+	for (const part of parts) {
+		if (type === "text" && part.type === "text") {
+			chunks.push(part.text);
+		} else if (type === "thinking" && part.type === "thinking") {
+			chunks.push(part.thinking);
+		}
+	}
+	return chunks.join("\n").trim();
+}
+
+function extractAnswer(message: AssistantMessage): string {
+	return extractText(message.content, "text") || "(No text response)";
+}
+
+function extractThinking(message: AssistantMessage): string {
+	return extractText(message.content, "thinking");
+}
+
+function parseBtwArgs(args: string): ParsedBtwArgs {
+	const save = /(?:^|\s)(?:--save|-s)(?=\s|$)/.test(args);
+	const question = args.replace(/(?:^|\s)(?:--save|-s)(?=\s|$)/g, " ").trim();
+	return { question, save };
+}
+
+function buildMainMessages(ctx: ExtensionCommandContext): Message[] {
+	const sessionContext = buildSessionContext(ctx.sessionManager.getEntries(), ctx.sessionManager.getLeafId());
+	return sessionContext.messages.filter((message) => !isVisibleBtwMessage(message));
+}
+
+/** Build the thread history portion of the BTW context messages. */
+function buildThreadMessages(ctx: ExtensionCommandContext, thread: BtwDetails[]): Message[] {
+	const messages: Message[] = [
+		{
+			role: "user",
+			content: [{ type: "text", text: "[The following is a separate side conversation. Continue this thread.]" }],
+			timestamp: Date.now(),
+		},
+		{
+			role: "assistant",
+			content: [{ type: "text", text: "Understood, continuing our side conversation." }],
+			provider: ctx.model?.provider ?? "unknown",
+			model: ctx.model?.id ?? "unknown",
+			api: ctx.model?.api ?? "openai-responses",
+			usage: {
+				input: 0,
+				output: 0,
+				cacheRead: 0,
+				cacheWrite: 0,
+				totalTokens: 0,
+				cost: { input: 0, output: 0, cacheRead: 0, cacheWrite: 0, total: 0 },
+			},
+			stopReason: "stop",
+			timestamp: Date.now(),
+		},
+	];
+
+	for (const entry of thread) {
+		messages.push(
+			{
+				role: "user",
+				content: [{ type: "text", text: entry.question }],
+				timestamp: entry.timestamp,
+			},
+			{
+				role: "assistant",
+				content: [{ type: "text", text: entry.answer }],
+				provider: entry.provider,
+				model: entry.model,
+				api: ctx.model?.api ?? "openai-responses",
+				usage: entry.usage ?? {
+					input: 0,
+					output: 0,
+					cacheRead: 0,
+					cacheWrite: 0,
+					totalTokens: 0,
+					cost: { input: 0, output: 0, cacheRead: 0, cacheWrite: 0, total: 0 },
+				},
+				stopReason: "stop",
+				timestamp: entry.timestamp,
+			},
+		);
+	}
+
+	return messages;
+}
+
+function buildBtwContext(ctx: ExtensionCommandContext, question: string, thread: BtwDetails[]) {
+	const messages: Message[] = [...buildMainMessages(ctx)];
+
+	if (thread.length > 0) {
+		messages.push(...buildThreadMessages(ctx, thread));
+	}
+
+	messages.push({
+		role: "user",
+		content: [{ type: "text", text: question }],
+		timestamp: Date.now(),
+	});
+
+	return {
+		systemPrompt: [ctx.getSystemPrompt(), BTW_SYSTEM_PROMPT].filter(Boolean).join("\n\n"),
+		messages,
+	};
+}
+
+function buildBtwMessageContent(question: string, answer: string): string {
+	return `Q: ${question}\n\nA: ${answer}`;
+}
+
+function formatThread(thread: BtwDetails[]): string {
+	return thread.map((entry) => `User: ${entry.question.trim()}\nAssistant: ${entry.answer.trim()}`).join("\n\n---\n\n");
+}
+
+function saveVisibleBtwNote(
+	pi: ExtensionAPI,
+	details: BtwDetails,
+	saveRequested: boolean,
+	wasBusy: boolean,
+): SaveState {
+	if (!saveRequested) {
+		return "not-saved";
+	}
+
+	const message = {
+		customType: BTW_MESSAGE_TYPE,
+		content: buildBtwMessageContent(details.question, details.answer),
+		display: true,
+		details,
+	};
+
+	if (wasBusy) {
+		pi.sendMessage(message, { deliverAs: "followUp" });
+		return "queued";
+	}
+
+	pi.sendMessage(message);
+	return "saved";
+}
+
+function notify(ctx: ExtensionContext | ExtensionCommandContext, message: string, level: "info" | "warning" | "error") {
+	if (ctx.hasUI) {
+		ctx.ui.notify(message, level);
+	}
+}
+
+/** Render a single slot's lines into the widget parts array. */
+function renderSlotLines(slot: BtwSlot, parts: string[], helpers: WidgetThemeHelpers) {
+	const { dim, success, italic, warning } = helpers;
+
+	parts.push(`${dim("│ ")}${success("› ")}${slot.question}`);
+
+	if (slot.thinking) {
+		const cursor = slot.answer || slot.done ? "" : warning(" ▍");
+		parts.push(`${dim("│ ")}${italic(slot.thinking)}${cursor}`);
+	}
+
+	if (slot.answer) {
+		const answerLines = slot.answer.split("\n");
+		parts.push(`${dim("│ ")}${answerLines[0]}`);
+		if (answerLines.length > 1) {
+			parts.push(answerLines.slice(1).join("\n"));
+		}
+		if (!slot.done) {
+			parts[parts.length - 1] += warning(" ▍");
+		}
+	} else if (!slot.done) {
+		parts.push(`${dim("│ ")}${warning("⏳ thinking...")}`);
+	}
+
+	parts.push(`${dim("│ ")}${dim(`model: ${slot.modelLabel}`)}`);
+}
+
+/** Remove a slot and re-render after abort. */
+function removeSlotAndRender(
+	slot: BtwSlot,
+	allSlots: BtwSlot[],
+	ctx: ExtensionContext | ExtensionCommandContext,
+	render: (ctx: ExtensionContext | ExtensionCommandContext) => void,
+) {
+	const idx = allSlots.indexOf(slot);
+	if (idx >= 0) {
+		allSlots.splice(idx, 1);
+		render(ctx);
+	}
+}
+
+/** Process the stream response after streaming completes. */
+function processStreamResponse(response: AssistantMessage, slot: BtwSlot): { answer: string; thinking: string } {
+	if (!response) {
+		throw new Error("BTW request finished without a response.");
+	}
+	if (response.stopReason === "error") {
+		throw new Error(response.errorMessage || "BTW request failed.");
+	}
+
+	return {
+		answer: extractAnswer(response),
+		thinking: extractThinking(response) || slot.thinking,
+	};
+}
+
+export default function (pi: ExtensionAPI) {
+	let pendingThread: BtwDetails[] = [];
+	let slots: BtwSlot[] = [];
+	let widgetStatus: string | null = null;
+
+	function abortActiveSlots() {
+		for (const slot of slots) {
+			if (!slot.done) {
+				slot.controller.abort();
+			}
+		}
+	}
+
+	function renderWidget(ctx: ExtensionContext | ExtensionCommandContext) {
+		if (!ctx.hasUI) {
+			return;
+		}
+
+		if (slots.length === 0) {
+			ctx.ui.setWidget("btw", undefined);
+			return;
+		}
+
+		ctx.ui.setWidget(
+			"btw",
+			(_tui, theme) => {
+				const helpers: WidgetThemeHelpers = {
+					dim: (text: string) => theme.fg("dim", text),
+					success: (text: string) => theme.fg("success", text),
+					italic: (text: string) => theme.fg("dim", theme.italic(text)),
+					warning: (text: string) => theme.fg("warning", text),
+				};
+
+				const parts: string[] = [];
+				const title = " 💭 btw ";
+				const hint = " /btw:clear dismiss · /btw:inject send ";
+				const lineWidth = Math.max(22, 68 - title.length - hint.length);
+
+				parts.push(helpers.dim(`╭${title}${"─".repeat(lineWidth)}${hint}╮`));
+
+				for (let i = 0; i < slots.length; i++) {
+					if (i > 0) {
+						parts.push(helpers.dim("│ ───"));
+					}
+					renderSlotLines(slots[i], parts, helpers);
+				}
+
+				if (widgetStatus) {
+					parts.push(`${helpers.dim("│ ")}${helpers.warning(widgetStatus)}`);
+				}
+
+				parts.push(helpers.dim(`╰${"─".repeat(68)}╯`));
+
+				return new Text(parts.join("\n"), 0, 0);
+			},
+			{ placement: "aboveEditor" },
+		);
+	}
+
+	function resetThread(ctx: ExtensionContext | ExtensionCommandContext, persist = true) {
+		abortActiveSlots();
+		pendingThread = [];
+		slots = [];
+		widgetStatus = null;
+
+		if (persist) {
+			pi.appendEntry(BTW_RESET_TYPE, { timestamp: Date.now() });
+		}
+
+		renderWidget(ctx);
+	}
+
+	function restoreThread(ctx: ExtensionContext) {
+		abortActiveSlots();
+		pendingThread = [];
+		slots = [];
+		widgetStatus = null;
+
+		const branch = ctx.sessionManager.getBranch();
+		let lastResetIndex = -1;
+
+		for (let i = 0; i < branch.length; i++) {
+			if (isCustomEntry(branch[i], BTW_RESET_TYPE)) {
+				lastResetIndex = i;
+			}
+		}
+
+		for (let i = lastResetIndex + 1; i < branch.length; i++) {
+			const entry = branch[i];
+			if (isCustomEntry(entry, BTW_ENTRY_TYPE) && entry.data) {
+				const details = entry.data as BtwDetails;
+				pendingThread.push(details);
+				slots.push({
+					question: details.question,
+					modelLabel: `${details.provider}/${details.model}`,
+					thinking: details.thinking,
+					answer: details.answer,
+					done: true,
+					controller: new AbortController(),
+				});
+			}
+		}
+
+		renderWidget(ctx);
+	}
+
+	/** Stream the BTW request and update the slot with incoming tokens. */
+	async function streamBtwRequest(
+		ctx: ExtensionCommandContext,
+		slot: BtwSlot,
+		threadSnapshot: BtwDetails[],
+		question: string,
+	): Promise<AssistantMessage | "aborted"> {
+		const model = ctx.model!;
+		const apiKey = (await ctx.modelRegistry.getApiKey(model))!;
+		const thinkingLevel = pi.getThinkingLevel() as SessionThinkingLevel;
+
+		const stream = streamSimple(model, buildBtwContext(ctx, question, threadSnapshot), {
+			apiKey,
+			reasoning: toReasoning(thinkingLevel),
+			signal: slot.controller.signal,
+		});
+
+		let response: AssistantMessage | null = null;
+
+		for await (const event of stream) {
+			if (event.type === "thinking_delta") {
+				slot.thinking += event.delta;
+				renderWidget(ctx);
+			} else if (event.type === "text_delta") {
+				slot.answer += event.delta;
+				renderWidget(ctx);
+			} else if (event.type === "done") {
+				response = event.message;
+			} else if (event.type === "error") {
+				response = event.error;
+			}
+		}
+
+		if (!response) {
+			throw new Error("BTW request finished without a response.");
+		}
+
+		if (response.stopReason === "aborted") {
+			return "aborted";
+		}
+
+		return response;
+	}
+
+	async function runBtw(ctx: ExtensionCommandContext, question: string, saveRequested: boolean) {
+		const model = ctx.model;
+		if (!model) {
+			notify(ctx, "No active model selected.", "error");
+			return;
+		}
+
+		const apiKey = await ctx.modelRegistry.getApiKey(model);
+		if (!apiKey) {
+			notify(ctx, `No credentials available for ${model.provider}/${model.id}.`, "error");
+			return;
+		}
+
+		const wasBusy = !ctx.isIdle();
+
+		const slot: BtwSlot = {
+			question,
+			modelLabel: `${model.provider}/${model.id}`,
+			thinking: "",
+			answer: "",
+			done: false,
+			controller: new AbortController(),
+		};
+
+		const threadSnapshot = pendingThread.slice();
+		slots.push(slot);
+		renderWidget(ctx);
+
+		try {
+			const response = await streamBtwRequest(ctx, slot, threadSnapshot, question);
+
+			if (response === "aborted") {
+				removeSlotAndRender(slot, slots, ctx, renderWidget);
+				return;
+			}
+
+			const { answer, thinking } = processStreamResponse(response, slot);
+
+			slot.thinking = thinking;
+			slot.answer = answer;
+			slot.done = true;
+			renderWidget(ctx);
+
+			const details: BtwDetails = {
+				question,
+				thinking,
+				answer,
+				provider: model.provider,
+				model: model.id,
+				thinkingLevel: pi.getThinkingLevel() as SessionThinkingLevel,
+				timestamp: Date.now(),
+				usage: response.usage,
+			};
+
+			pendingThread.push(details);
+			pi.appendEntry(BTW_ENTRY_TYPE, details);
+
+			const saveState = saveVisibleBtwNote(pi, details, saveRequested, wasBusy);
+			if (saveState === "saved") {
+				notify(ctx, "Saved BTW note to the session.", "info");
+			} else if (saveState === "queued") {
+				notify(ctx, "BTW note queued to save after the current turn finishes.", "info");
+			}
+		} catch (error) {
+			if (slot.controller.signal.aborted) {
+				removeSlotAndRender(slot, slots, ctx, renderWidget);
+				return;
+			}
+
+			slot.answer = `❌ ${error instanceof Error ? error.message : String(error)}`;
+			slot.done = true;
+			renderWidget(ctx);
+			notify(ctx, error instanceof Error ? error.message : String(error), "error");
+		}
+	}
+
+	async function summarizeThread(ctx: ExtensionCommandContext, thread: BtwDetails[]): Promise<string> {
+		const model = ctx.model;
+		if (!model) {
+			throw new Error("No active model selected.");
+		}
+
+		const apiKey = await ctx.modelRegistry.getApiKey(model);
+		if (!apiKey) {
+			throw new Error(`No credentials available for ${model.provider}/${model.id}.`);
+		}
+
+		const response = await completeSimple(
+			model,
+			{
+				systemPrompt:
+					"Summarize the side conversation concisely. Preserve key decisions, plans, insights, risks, and action items. Output only the summary.",
+				messages: [
+					{
+						role: "user",
+						content: [{ type: "text", text: formatThread(thread) }],
+						timestamp: Date.now(),
+					},
+				],
+			},
+			{ apiKey, reasoning: "low" },
+		);
+
+		if (response.stopReason === "error") {
+			throw new Error(response.errorMessage || "Failed to summarize BTW thread.");
+		}
+		if (response.stopReason === "aborted") {
+			throw new Error("BTW summarize aborted.");
+		}
+
+		return extractAnswer(response);
+	}
+
+	function sendThreadToMain(ctx: ExtensionCommandContext, content: string) {
+		if (ctx.isIdle()) {
+			pi.sendUserMessage(content);
+		} else {
+			pi.sendUserMessage(content, { deliverAs: "followUp" });
+		}
+	}
+
+	// ── Message renderer ──────────────────────────────────────────────────────
+
+	pi.registerMessageRenderer(BTW_MESSAGE_TYPE, (message, { expanded }, theme) => {
+		const details = message.details as BtwDetails | undefined;
+		const content = typeof message.content === "string" ? message.content : "[non-text btw message]";
+		const lines = [theme.fg("accent", theme.bold("[BTW]")), content];
+
+		if (expanded && details) {
+			lines.push(theme.fg("dim", `model: ${details.provider}/${details.model} · thinking: ${details.thinkingLevel}`));
+			if (details.usage) {
+				lines.push(
+					theme.fg(
+						"dim",
+						`tokens: in ${details.usage.input} · out ${details.usage.output} · total ${details.usage.totalTokens}`,
+					),
+				);
+			}
+		}
+
+		return new Text(lines.join("\n"), 1, 1);
+	});
+
+	// ── Context filter — keep BTW notes out of the main agent ─────────────────
+
+	pi.on("context", async (event) => {
+		return {
+			messages: event.messages.filter((message) => !isVisibleBtwMessage(message)),
+		};
+	});
+
+	// ── Session lifecycle — restore / cleanup ─────────────────────────────────
+
+	pi.on("session_start", async (_event, ctx) => {
+		restoreThread(ctx);
+	});
+
+	pi.on("session_switch", async (_event, ctx) => {
+		restoreThread(ctx);
+	});
+
+	pi.on("session_tree", async (_event, ctx) => {
+		restoreThread(ctx);
+	});
+
+	pi.on("session_shutdown", async () => {
+		abortActiveSlots();
+	});
+
+	// ── Command handlers ──────────────────────────────────────────────────────
+
+	const btwHandler = async (args: string, ctx: ExtensionCommandContext) => {
+		const { question, save } = parseBtwArgs(args);
+		if (!question) {
+			notify(ctx, "Usage: /btw [--save] <question>", "warning");
+			return;
+		}
+		await runBtw(ctx, question, save);
+	};
+
+	const btwNewHandler = async (args: string, ctx: ExtensionCommandContext) => {
+		resetThread(ctx);
+		const { question, save } = parseBtwArgs(args);
+		if (question) {
+			await runBtw(ctx, question, save);
+		} else {
+			notify(ctx, "Started a fresh BTW thread.", "info");
+		}
+	};
+
+	const btwClearHandler = async (_args: string, ctx: ExtensionCommandContext) => {
+		resetThread(ctx);
+		notify(ctx, "Cleared BTW thread.", "info");
+	};
+
+	const btwInjectHandler = async (args: string, ctx: ExtensionCommandContext) => {
+		if (pendingThread.length === 0) {
+			notify(ctx, "No BTW thread to inject.", "warning");
+			return;
+		}
+
+		const instructions = args.trim();
+		const content = instructions
+			? `Here is a side conversation I had. ${instructions}\n\n${formatThread(pendingThread)}`
+			: `Here is a side conversation I had for additional context:\n\n${formatThread(pendingThread)}`;
+
+		sendThreadToMain(ctx, content);
+		const count = pendingThread.length;
+		resetThread(ctx);
+		notify(ctx, `Injected BTW thread (${count} exchange${count === 1 ? "" : "s"}).`, "info");
+	};
+
+	const btwSummarizeHandler = async (args: string, ctx: ExtensionCommandContext) => {
+		if (pendingThread.length === 0) {
+			notify(ctx, "No BTW thread to summarize.", "warning");
+			return;
+		}
+
+		widgetStatus = "⏳ summarizing...";
+		renderWidget(ctx);
+
+		try {
+			const summary = await summarizeThread(ctx, pendingThread);
+			const instructions = args.trim();
+			const content = instructions
+				? `Here is a summary of a side conversation I had. ${instructions}\n\n${summary}`
+				: `Here is a summary of a side conversation I had:\n\n${summary}`;
+
+			sendThreadToMain(ctx, content);
+			const count = pendingThread.length;
+			resetThread(ctx);
+			notify(ctx, `Injected BTW summary (${count} exchange${count === 1 ? "" : "s"}).`, "info");
+		} catch (error) {
+			widgetStatus = null;
+			renderWidget(ctx);
+			notify(ctx, error instanceof Error ? error.message : String(error), "error");
+		}
+	};
+
+	// ── Register /btw commands ────────────────────────────────────────────────
+
+	pi.registerCommand("btw", {
+		description: "Side conversation in a widget above the editor. Add --save to persist a visible note.",
+		handler: btwHandler,
+	});
+
+	pi.registerCommand("btw:new", {
+		description: "Start a fresh BTW thread. Optionally ask the first question immediately.",
+		handler: btwNewHandler,
+	});
+
+	pi.registerCommand("btw:clear", {
+		description: "Dismiss the BTW widget and clear the current thread.",
+		handler: btwClearHandler,
+	});
+
+	pi.registerCommand("btw:inject", {
+		description: "Inject the full BTW thread into the main agent as a user message.",
+		handler: btwInjectHandler,
+	});
+
+	pi.registerCommand("btw:summarize", {
+		description: "Summarize the BTW thread, then inject the summary into the main agent.",
+		handler: btwSummarizeHandler,
+	});
+
+	// ── Register /qq aliases ──────────────────────────────────────────────────
+
+	pi.registerCommand("qq", {
+		description: "Quick question — alias for /btw. Side conversation without interrupting the main agent.",
+		handler: btwHandler,
+	});
+
+	pi.registerCommand("qq:new", {
+		description: "Start a fresh QQ thread. Alias for /btw:new.",
+		handler: btwNewHandler,
+	});
+
+	pi.registerCommand("qq:clear", {
+		description: "Dismiss the QQ widget and clear the thread. Alias for /btw:clear.",
+		handler: btwClearHandler,
+	});
+
+	pi.registerCommand("qq:inject", {
+		description: "Inject the full QQ thread into the main agent. Alias for /btw:inject.",
+		handler: btwInjectHandler,
+	});
+
+	pi.registerCommand("qq:summarize", {
+		description: "Summarize the QQ thread and inject into the main agent. Alias for /btw:summarize.",
+		handler: btwSummarizeHandler,
+	});
+}

--- a/packages/skills/skills/btw/SKILL.md
+++ b/packages/skills/skills/btw/SKILL.md
@@ -1,0 +1,149 @@
+---
+name: btw
+description: Helps you use the /btw (or /qq) side-conversation workflow effectively. Use when you want to think in parallel, ask side questions without interrupting ongoing work, or inject a side thread back into the main agent.
+---
+
+# BTW / QQ — Side Conversations
+
+Use this skill when the user wants to work in parallel with the main agent instead of derailing the current turn.
+
+Both `/btw` and `/qq` are identical — use whichever feels natural. `/qq` stands for "quick question".
+
+## When to use BTW
+
+Prefer the BTW workflow when the user wants to:
+
+- ask a side question while the main agent keeps working
+- brainstorm or compare options without interrupting the current run
+- prepare a plan or summary before handing it back to the main agent
+- keep exploratory discussion out of the main transcript/context
+
+## Commands
+
+Use these commands in your guidance to the user:
+
+```text
+/btw <question>
+/btw --save <question>
+/btw:new [question]
+/btw:clear
+/btw:inject [instructions]
+/btw:summarize [instructions]
+```
+
+Every `/btw` command has a `/qq` equivalent:
+
+```text
+/qq <question>
+/qq --save <question>
+/qq:new [question]
+/qq:clear
+/qq:inject [instructions]
+/qq:summarize [instructions]
+```
+
+## How to guide the user
+
+### For a quick side question
+
+Recommend:
+
+```text
+/btw <question>
+```
+
+or
+
+```text
+/qq <question>
+```
+
+Use this when the user wants an immediate aside and does not need a visible saved note.
+
+### For a saved one-off note
+
+Recommend:
+
+```text
+/btw --save <question>
+```
+
+Use this when the user wants the exchange to appear as a visible BTW note in the session transcript.
+
+### For a fresh side thread
+
+Recommend:
+
+```text
+/btw:new
+```
+
+or
+
+```text
+/btw:new <question>
+```
+
+Use this when the previous BTW discussion is no longer relevant.
+
+### To hand the full thread back to the main agent
+
+Recommend:
+
+```text
+/btw:inject <instructions>
+```
+
+Use this when the exact discussion matters and the user wants the main agent to act on it.
+
+### To hand back a condensed version
+
+Recommend:
+
+```text
+/btw:summarize <instructions>
+```
+
+Use this when the thread is long and only the distilled outcome should go back into the main agent.
+
+## Recommendation rules
+
+- Prefer `/btw` over normal chat when the user explicitly wants a side conversation.
+- Prefer `/btw:summarize` over `/btw:inject` for long exploratory threads.
+- Prefer `/btw:inject` when precise wording, detailed tradeoffs, or a full plan matters.
+- Suggest `/btw:new` before starting a totally unrelated side topic.
+- Suggest `/btw:clear` when the widget/thread should be dismissed.
+
+## Response style
+
+When helping the user use BTW:
+
+- give the exact slash command to run
+- explain briefly why that command fits
+- keep the guidance short and operational
+
+## Examples
+
+### Example: brainstorm while coding continues
+
+```text
+/btw what are the risks of switching this to optimistic updates?
+```
+
+### Example: quick question shorthand
+
+```text
+/qq what does this error mean?
+```
+
+### Example: create a clean new thread
+
+```text
+/btw:new sketch a safer migration plan
+```
+
+### Example: send the result back
+
+```text
+/btw:summarize implement the recommended migration plan
+```


### PR DESCRIPTION
## Summary

Adds a `/btw` (and `/qq` alias) extension that opens a parallel side conversation without interrupting the main agent run. Based on [dbachelder/pi-btw](https://github.com/dbachelder/pi-btw) (MIT).

## What it does

- **`/btw <question>`** — runs immediately, even while the main agent is busy
- **`/qq <question>`** — identical alias ("quick question")
- Streams answers into a widget above the editor
- Maintains a continuous thread across exchanges, persisted in session state
- Keeps BTW entries out of the main agent's LLM context
- Supports `--save` to persist an exchange as a visible session note

### Sub-commands

| Command | Description |
|---------|-------------|
| `/btw` or `/qq` | Ask a side question |
| `:new [question]` | Start a fresh thread |
| `:clear` | Dismiss widget and clear thread |
| `:inject [instructions]` | Send full thread back to main agent |
| `:summarize [instructions]` | Summarize thread and inject summary |

## Files added

- `packages/extensions/extensions/btw.ts` — the extension
- `packages/skills/skills/btw/SKILL.md` — discoverability skill
- `.changeset/btw-qq-side-conversation.md` — minor changeset

## Verification

- ✅ Lint passes
- ✅ Typecheck passes
- ✅ All 366 tests pass