### PR TITLE
feat: add scheduler extension with /loop, /remind, /schedule, and /unschedule commands

### DIFF
--- a/.changeset/scheduler-extension.md
+++ b/.changeset/scheduler-extension.md
@@ -1,0 +1,18 @@
+---
+"@ifi/oh-pi-extensions": minor
+"@ifi/oh-pi": minor
+---
+
+Add scheduler extension with `/loop`, `/remind`, `/schedule`, and `/unschedule` commands:
+
+- `/loop` creates recurring scheduled prompts with interval or cron expressions
+- `/remind` creates one-time reminders with delay durations
+- `/schedule` manages tasks via TUI manager or subcommands (list, enable, disable, delete, clear)
+- `/unschedule` is an alias for `/schedule delete <id>`
+- Exposes `schedule_prompt` LLM-callable tool for agent-driven scheduling
+- Tasks run only when pi is idle; recurring tasks auto-expire after 3 days
+- State is persisted to `.pi/scheduler.json` across sessions
+- Supports both interval (5m, 2h) and cron expressions (5-field and 6-field)
+- Max 50 active tasks with jitter to prevent thundering herd
+
+Based on pi-scheduler by @manojlds (MIT).

--- a/packages/extensions/extensions/scheduler.test.ts
+++ b/packages/extensions/extensions/scheduler.test.ts
@@ -1,0 +1,1873 @@
+/**
+ * Tests for the scheduler extension.
+ *
+ * Exercises: parsing (/loop, /remind), cron normalization, duration parsing,
+ * schedule_prompt tool validation, SchedulerRuntime lifecycle, task management,
+ * event wiring, command handlers, tool actions, persistence, and edge cases.
+ */
+
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+
+// ─── Mocks ──────────────────────────────────────────────────────────────────
+
+vi.mock("node:fs", async (importOriginal) => {
+	const actual = await importOriginal<typeof import("node:fs")>();
+	return {
+		...actual,
+		existsSync: vi.fn().mockReturnValue(false),
+		mkdirSync: vi.fn(),
+		readFileSync: vi.fn().mockReturnValue("{}"),
+		writeFileSync: vi.fn(),
+		renameSync: vi.fn(),
+	};
+});
+
+vi.mock("@mariozechner/pi-coding-agent", () => ({}));
+vi.mock("@mariozechner/pi-ai", () => ({}));
+
+vi.mock("@sinclair/typebox", () => ({
+	Type: {
+		Object: (schema: any) => schema,
+		String: (opts?: any) => ({ type: "string", ...opts }),
+		Number: (opts?: any) => ({ type: "number", ...opts }),
+		Optional: (t: any) => ({ optional: true, ...t }),
+		Union: (types: any[], opts?: any) => ({ oneOf: types, ...opts }),
+		Literal: (value: any) => ({ const: value }),
+	},
+}));
+
+// ─── Test helpers ────────────────────────────────────────────────────────────
+
+function createMockPi() {
+	const handlers = new Map<string, ((...args: any[]) => any)[]>();
+	const tools = new Map<string, any>();
+	const commands = new Map<string, any>();
+	const messages: any[] = [];
+	const userMessages: string[] = [];
+
+	return {
+		on(event: string, handler: (...args: any[]) => any) {
+			if (!handlers.has(event)) {
+				handlers.set(event, []);
+			}
+			handlers.get(event)!.push(handler);
+		},
+		registerTool(tool: any) {
+			tools.set(tool.name, tool);
+		},
+		registerCommand(name: string, opts: any) {
+			commands.set(name, opts);
+		},
+		sendMessage(msg: any) {
+			messages.push(msg);
+		},
+		sendUserMessage(prompt: string) {
+			userMessages.push(prompt);
+		},
+
+		_handlers: handlers,
+		_tools: tools,
+		_commands: commands,
+		_messages: messages,
+		_userMessages: userMessages,
+		_emit(event: string, ...args: any[]) {
+			const fns = handlers.get(event) ?? [];
+			for (const fn of fns) {
+				fn(...args);
+			}
+		},
+	};
+}
+
+function createMockCtx(overrides: Record<string, any> = {}) {
+	const notifications: { msg: string; type: string }[] = [];
+	const statusMap = new Map<string, any>();
+
+	return {
+		cwd: overrides.cwd ?? "/mock-project",
+		hasUI: overrides.hasUI ?? true,
+		isIdle: overrides.isIdle ?? (() => true),
+		hasPendingMessages: overrides.hasPendingMessages ?? (() => false),
+		ui: {
+			notify(msg: string, type: string) {
+				notifications.push({ msg, type });
+			},
+			setStatus(key: string, value: any) {
+				if (value === undefined) {
+					statusMap.delete(key);
+				} else {
+					statusMap.set(key, value);
+				}
+			},
+			select: overrides.select ?? vi.fn().mockResolvedValue(null),
+			confirm: overrides.confirm ?? vi.fn().mockResolvedValue(true),
+			input: overrides.input ?? vi.fn().mockResolvedValue(null),
+		},
+		_notifications: notifications,
+		_statusMap: statusMap,
+	};
+}
+
+// ─── Imports ─────────────────────────────────────────────────────────────────
+
+import { existsSync, mkdirSync, readFileSync, renameSync, writeFileSync } from "node:fs";
+import schedulerExtension, {
+	computeNextCronRunAt,
+	DEFAULT_LOOP_INTERVAL,
+	FIFTEEN_MINUTES,
+	formatDurationShort,
+	MAX_TASKS,
+	normalizeCronExpression,
+	normalizeDuration,
+	ONE_MINUTE,
+	parseDuration,
+	parseLoopScheduleArgs,
+	parseRemindScheduleArgs,
+	SchedulerRuntime,
+	THREE_DAYS,
+	validateSchedulePromptAddInput,
+} from "./scheduler.js";
+
+// ─── Duration parsing ────────────────────────────────────────────────────────
+
+describe("parseDuration", () => {
+	it("parses seconds with short unit", () => {
+		expect(parseDuration("30s")).toBe(30_000);
+	});
+
+	it("parses minutes with short unit", () => {
+		expect(parseDuration("5m")).toBe(5 * ONE_MINUTE);
+	});
+
+	it("parses hours with short unit", () => {
+		expect(parseDuration("2h")).toBe(2 * 60 * ONE_MINUTE);
+	});
+
+	it("parses days with short unit", () => {
+		expect(parseDuration("1d")).toBe(24 * 60 * ONE_MINUTE);
+	});
+
+	it("parses word form: seconds", () => {
+		expect(parseDuration("10 seconds")).toBe(10_000);
+	});
+
+	it("parses word form: sec", () => {
+		expect(parseDuration("10 sec")).toBe(10_000);
+	});
+
+	it("parses word form: minutes", () => {
+		expect(parseDuration("5 minutes")).toBe(5 * ONE_MINUTE);
+	});
+
+	it("parses word form: mins", () => {
+		expect(parseDuration("5 mins")).toBe(5 * ONE_MINUTE);
+	});
+
+	it("parses word form: hours", () => {
+		expect(parseDuration("3 hours")).toBe(3 * 60 * ONE_MINUTE);
+	});
+
+	it("parses word form: hrs", () => {
+		expect(parseDuration("3 hrs")).toBe(3 * 60 * ONE_MINUTE);
+	});
+
+	it("parses word form: days", () => {
+		expect(parseDuration("2 days")).toBe(2 * 24 * 60 * ONE_MINUTE);
+	});
+
+	it("parses word form: day (singular)", () => {
+		expect(parseDuration("1 day")).toBe(24 * 60 * ONE_MINUTE);
+	});
+
+	it("returns undefined for empty string", () => {
+		expect(parseDuration("")).toBeUndefined();
+	});
+
+	it("returns undefined for whitespace", () => {
+		expect(parseDuration("   ")).toBeUndefined();
+	});
+
+	it("returns undefined for non-duration text", () => {
+		expect(parseDuration("banana")).toBeUndefined();
+	});
+
+	it("returns undefined for missing number", () => {
+		expect(parseDuration("minutes")).toBeUndefined();
+	});
+
+	it("returns undefined for negative values", () => {
+		expect(parseDuration("-5m")).toBeUndefined();
+	});
+
+	it("handles extra whitespace between number and unit", () => {
+		expect(parseDuration("5   minutes")).toBe(5 * ONE_MINUTE);
+	});
+
+	it("is case insensitive", () => {
+		expect(parseDuration("5M")).toBe(5 * ONE_MINUTE);
+		expect(parseDuration("2H")).toBe(2 * 60 * ONE_MINUTE);
+	});
+});
+
+// ─── Duration normalization ──────────────────────────────────────────────────
+
+describe("normalizeDuration", () => {
+	it("passes through exact minute values", () => {
+		const result = normalizeDuration(5 * ONE_MINUTE);
+		expect(result.durationMs).toBe(5 * ONE_MINUTE);
+		expect(result.note).toBeUndefined();
+	});
+
+	it("rounds up sub-minute durations to 1m", () => {
+		const result = normalizeDuration(30_000);
+		expect(result.durationMs).toBe(ONE_MINUTE);
+		expect(result.note).toContain("Rounded");
+	});
+
+	it("rounds up to nearest minute", () => {
+		const result = normalizeDuration(ONE_MINUTE + 1000);
+		expect(result.durationMs).toBe(2 * ONE_MINUTE);
+		expect(result.note).toContain("minute granularity");
+	});
+
+	it("handles zero duration", () => {
+		const result = normalizeDuration(0);
+		expect(result.durationMs).toBe(ONE_MINUTE);
+		expect(result.note).toContain("Rounded up to 1m");
+	});
+
+	it("handles negative duration", () => {
+		const result = normalizeDuration(-5000);
+		expect(result.durationMs).toBe(ONE_MINUTE);
+		expect(result.note).toContain("minimum interval");
+	});
+});
+
+// ─── formatDurationShort ─────────────────────────────────────────────────────
+
+describe("formatDurationShort", () => {
+	it("formats minutes", () => {
+		expect(formatDurationShort(5 * ONE_MINUTE)).toBe("5m");
+	});
+
+	it("formats hours", () => {
+		expect(formatDurationShort(2 * 60 * ONE_MINUTE)).toBe("2h");
+	});
+
+	it("formats days", () => {
+		expect(formatDurationShort(24 * 60 * ONE_MINUTE)).toBe("1d");
+	});
+
+	it("falls back to minutes for odd values", () => {
+		expect(formatDurationShort(90 * ONE_MINUTE)).toBe("90m");
+	});
+});
+
+// ─── Cron normalization ──────────────────────────────────────────────────────
+
+describe("normalizeCronExpression", () => {
+	it("normalizes 5-field cron to 6-field by prepending seconds=0", () => {
+		const result = normalizeCronExpression("*/5 * * * *");
+		expect(result).toBeDefined();
+		expect(result!.expression).toBe("0 */5 * * * *");
+		expect(result!.note).toContain("5-field cron");
+	});
+
+	it("accepts 6-field cron as-is", () => {
+		const result = normalizeCronExpression("0 */10 * * * *");
+		expect(result).toBeDefined();
+		expect(result!.expression).toBe("0 */10 * * * *");
+		expect(result!.note).toBeUndefined();
+	});
+
+	it("rejects empty input", () => {
+		expect(normalizeCronExpression("")).toBeUndefined();
+	});
+
+	it("rejects whitespace-only input", () => {
+		expect(normalizeCronExpression("   ")).toBeUndefined();
+	});
+
+	it("rejects invalid cron (too few fields)", () => {
+		expect(normalizeCronExpression("*/5 *")).toBeUndefined();
+	});
+
+	it("rejects invalid cron (too many fields)", () => {
+		expect(normalizeCronExpression("0 0 0 * * * *")).toBeUndefined();
+	});
+
+	it("rejects non-cron text", () => {
+		expect(normalizeCronExpression("not-a-cron")).toBeUndefined();
+	});
+
+	it("rejects invalid cron values", () => {
+		expect(normalizeCronExpression("99 99 99 99 99")).toBeUndefined();
+	});
+});
+
+// ─── computeNextCronRunAt ────────────────────────────────────────────────────
+
+describe("computeNextCronRunAt", () => {
+	it("returns a future timestamp", () => {
+		const now = Date.now();
+		const next = computeNextCronRunAt("0 */5 * * * *", now);
+		expect(next).toBeDefined();
+		expect(next!).toBeGreaterThan(now);
+	});
+
+	it("returns undefined for invalid expression", () => {
+		expect(computeNextCronRunAt("invalid cron")).toBeUndefined();
+	});
+
+	it("computes from a specific timestamp", () => {
+		const from = new Date("2026-01-01T00:00:00Z").getTime();
+		const next = computeNextCronRunAt("0 */5 * * * *", from);
+		expect(next).toBeDefined();
+		expect(next!).toBeGreaterThan(from);
+	});
+});
+
+// ─── parseLoopScheduleArgs ───────────────────────────────────────────────────
+
+describe("parseLoopScheduleArgs", () => {
+	it("returns undefined for empty input", () => {
+		expect(parseLoopScheduleArgs("")).toBeUndefined();
+	});
+
+	it("returns undefined for whitespace-only input", () => {
+		expect(parseLoopScheduleArgs("   ")).toBeUndefined();
+	});
+
+	it("parses leading duration: /loop 5m check build", () => {
+		const result = parseLoopScheduleArgs("5m check build");
+		expect(result).toBeDefined();
+		expect(result!.prompt).toBe("check build");
+		expect(result!.recurring.mode).toBe("interval");
+		if (result!.recurring.mode === "interval") {
+			expect(result!.recurring.durationMs).toBe(5 * ONE_MINUTE);
+		}
+	});
+
+	it("parses trailing every: /loop check build every 2h", () => {
+		const result = parseLoopScheduleArgs("check build every 2h");
+		expect(result).toBeDefined();
+		expect(result!.prompt).toBe("check build");
+		expect(result!.recurring.mode).toBe("interval");
+		if (result!.recurring.mode === "interval") {
+			expect(result!.recurring.durationMs).toBe(2 * 60 * ONE_MINUTE);
+		}
+	});
+
+	it("defaults to 10m interval when no duration given", () => {
+		const result = parseLoopScheduleArgs("check build status");
+		expect(result).toBeDefined();
+		expect(result!.prompt).toBe("check build status");
+		expect(result!.recurring.mode).toBe("interval");
+		if (result!.recurring.mode === "interval") {
+			expect(result!.recurring.durationMs).toBe(DEFAULT_LOOP_INTERVAL);
+		}
+	});
+
+	it("parses explicit cron with 5-field expression", () => {
+		const result = parseLoopScheduleArgs("cron */5 * * * * check ci status");
+		expect(result).toBeDefined();
+		expect(result!.prompt).toBe("check ci status");
+		expect(result!.recurring.mode).toBe("cron");
+		if (result!.recurring.mode === "cron") {
+			expect(result!.recurring.cronExpression).toBe("0 */5 * * * *");
+		}
+	});
+
+	it("parses explicit cron with quoted 6-field expression", () => {
+		const result = parseLoopScheduleArgs("cron '0 */10 * * * *' check deployment");
+		expect(result).toBeDefined();
+		expect(result!.prompt).toBe("check deployment");
+		expect(result!.recurring.mode).toBe("cron");
+		if (result!.recurring.mode === "cron") {
+			expect(result!.recurring.cronExpression).toBe("0 */10 * * * *");
+		}
+	});
+
+	it("parses explicit cron with double-quoted expression", () => {
+		const result = parseLoopScheduleArgs('cron "0 */15 * * * *" run tests');
+		expect(result).toBeDefined();
+		expect(result!.prompt).toBe("run tests");
+		expect(result!.recurring.mode).toBe("cron");
+	});
+
+	it("returns undefined for invalid explicit cron syntax", () => {
+		expect(parseLoopScheduleArgs("cron nope check deployment")).toBeUndefined();
+	});
+
+	it("handles word-form duration: /loop check CI every 30 minutes", () => {
+		const result = parseLoopScheduleArgs("check CI every 30 minutes");
+		expect(result).toBeDefined();
+		expect(result!.prompt).toBe("check CI");
+		if (result!.recurring.mode === "interval") {
+			expect(result!.recurring.durationMs).toBe(30 * ONE_MINUTE);
+		}
+	});
+
+	it("rounds sub-minute durations up", () => {
+		const result = parseLoopScheduleArgs("30s check build");
+		expect(result).toBeDefined();
+		if (result!.recurring.mode === "interval") {
+			expect(result!.recurring.durationMs).toBe(ONE_MINUTE);
+			expect(result!.recurring.note).toContain("Rounded");
+		}
+	});
+});
+
+// ─── parseRemindScheduleArgs ─────────────────────────────────────────────────
+
+describe("parseRemindScheduleArgs", () => {
+	it("returns undefined for empty input", () => {
+		expect(parseRemindScheduleArgs("")).toBeUndefined();
+	});
+
+	it("parses with 'in' prefix: in 45m check tests", () => {
+		const result = parseRemindScheduleArgs("in 45m check tests");
+		expect(result).toBeDefined();
+		expect(result!.prompt).toBe("check tests");
+		expect(result!.durationMs).toBe(45 * ONE_MINUTE);
+	});
+
+	it("parses without 'in' prefix: 2h follow up", () => {
+		const result = parseRemindScheduleArgs("2h follow up");
+		expect(result).toBeDefined();
+		expect(result!.prompt).toBe("follow up");
+		expect(result!.durationMs).toBe(2 * 60 * ONE_MINUTE);
+	});
+
+	it("returns undefined when no duration found", () => {
+		expect(parseRemindScheduleArgs("do something later")).toBeUndefined();
+	});
+
+	it("returns undefined for duration-only input (no prompt)", () => {
+		expect(parseRemindScheduleArgs("5m")).toBeUndefined();
+	});
+});
+
+// ─── validateSchedulePromptAddInput ──────────────────────────────────────────
+
+describe("validateSchedulePromptAddInput", () => {
+	it("rejects cron for once tasks", () => {
+		const result = validateSchedulePromptAddInput({ kind: "once", cron: "*/5 * * * *" });
+		expect(result.ok).toBe(false);
+		if (!result.ok) {
+			expect(result.error).toBe("invalid_cron_for_once");
+		}
+	});
+
+	it("requires duration for once tasks", () => {
+		const result = validateSchedulePromptAddInput({ kind: "once" });
+		expect(result.ok).toBe(false);
+		if (!result.ok) {
+			expect(result.error).toBe("missing_duration");
+		}
+	});
+
+	it("rejects both duration and cron for recurring", () => {
+		const result = validateSchedulePromptAddInput({ kind: "recurring", duration: "5m", cron: "*/5 * * * *" });
+		expect(result.ok).toBe(false);
+		if (!result.ok) {
+			expect(result.error).toBe("conflicting_schedule_inputs");
+		}
+	});
+
+	it("rejects invalid duration", () => {
+		const result = validateSchedulePromptAddInput({ kind: "recurring", duration: "banana" });
+		expect(result.ok).toBe(false);
+		if (!result.ok) {
+			expect(result.error).toBe("invalid_duration");
+		}
+	});
+
+	it("rejects invalid cron", () => {
+		const result = validateSchedulePromptAddInput({ kind: "recurring", cron: "not-a-cron" });
+		expect(result.ok).toBe(false);
+		if (!result.ok) {
+			expect(result.error).toBe("invalid_cron");
+		}
+	});
+
+	it("validates and normalizes recurring cron", () => {
+		const result = validateSchedulePromptAddInput({ kind: "recurring", cron: "*/5 * * * *" });
+		expect(result.ok).toBe(true);
+		if (result.ok) {
+			expect(result.plan.kind).toBe("recurring");
+			if (result.plan.kind === "recurring") {
+				expect(result.plan.mode).toBe("cron");
+				if (result.plan.mode === "cron") {
+					expect(result.plan.cronExpression).toBe("0 */5 * * * *");
+				}
+			}
+		}
+	});
+
+	it("validates recurring duration", () => {
+		const result = validateSchedulePromptAddInput({ kind: "recurring", duration: "5m" });
+		expect(result.ok).toBe(true);
+		if (result.ok && result.plan.kind === "recurring" && result.plan.mode === "interval") {
+			expect(result.plan.durationMs).toBe(5 * ONE_MINUTE);
+		}
+	});
+
+	it("defaults recurring to 10m interval when no schedule provided", () => {
+		const result = validateSchedulePromptAddInput({});
+		expect(result.ok).toBe(true);
+		if (result.ok) {
+			expect(result.plan.kind).toBe("recurring");
+			if (result.plan.kind === "recurring" && result.plan.mode === "interval") {
+				expect(result.plan.durationMs).toBe(DEFAULT_LOOP_INTERVAL);
+			}
+		}
+	});
+
+	it("validates once with valid duration", () => {
+		const result = validateSchedulePromptAddInput({ kind: "once", duration: "30m" });
+		expect(result.ok).toBe(true);
+		if (result.ok) {
+			expect(result.plan.kind).toBe("once");
+			if (result.plan.kind === "once") {
+				expect(result.plan.durationMs).toBe(30 * ONE_MINUTE);
+			}
+		}
+	});
+
+	it("normalizes once duration sub-minute values", () => {
+		const result = validateSchedulePromptAddInput({ kind: "once", duration: "30s" });
+		expect(result.ok).toBe(true);
+		if (result.ok && result.plan.kind === "once") {
+			expect(result.plan.durationMs).toBe(ONE_MINUTE);
+			expect(result.plan.note).toContain("Rounded");
+		}
+	});
+});
+
+// ─── SchedulerRuntime ────────────────────────────────────────────────────────
+
+describe("SchedulerRuntime", () => {
+	let pi: ReturnType<typeof createMockPi>;
+	let runtime: SchedulerRuntime;
+
+	beforeEach(() => {
+		vi.useFakeTimers();
+		vi.clearAllMocks();
+		(existsSync as ReturnType<typeof vi.fn>).mockReturnValue(false);
+		(readFileSync as ReturnType<typeof vi.fn>).mockReturnValue("{}");
+		(mkdirSync as ReturnType<typeof vi.fn>).mockImplementation(() => undefined);
+		(writeFileSync as ReturnType<typeof vi.fn>).mockImplementation(() => undefined);
+		(renameSync as ReturnType<typeof vi.fn>).mockImplementation(() => undefined);
+		pi = createMockPi();
+		runtime = new SchedulerRuntime(pi as any);
+	});
+
+	afterEach(() => {
+		runtime.stopScheduler();
+		vi.useRealTimers();
+	});
+
+	describe("task management", () => {
+		it("starts with zero tasks", () => {
+			expect(runtime.taskCount).toBe(0);
+		});
+
+		it("adds recurring interval task", () => {
+			const task = runtime.addRecurringIntervalTask("check build", 5 * ONE_MINUTE);
+			expect(task.kind).toBe("recurring");
+			expect(task.intervalMs).toBe(5 * ONE_MINUTE);
+			expect(task.enabled).toBe(true);
+			expect(task.runCount).toBe(0);
+			expect(runtime.taskCount).toBe(1);
+		});
+
+		it("adds recurring cron task", () => {
+			const task = runtime.addRecurringCronTask("check ci", "0 */5 * * * *");
+			expect(task).toBeDefined();
+			expect(task!.kind).toBe("recurring");
+			expect(task!.cronExpression).toBe("0 */5 * * * *");
+			expect(runtime.taskCount).toBe(1);
+		});
+
+		it("returns undefined for invalid cron task", () => {
+			const task = runtime.addRecurringCronTask("check ci", "invalid");
+			expect(task).toBeUndefined();
+			expect(runtime.taskCount).toBe(0);
+		});
+
+		it("adds one-shot task", () => {
+			const task = runtime.addOneShotTask("check deploy", 30 * ONE_MINUTE);
+			expect(task.kind).toBe("once");
+			expect(task.runCount).toBe(0);
+			expect(runtime.taskCount).toBe(1);
+		});
+
+		it("generates unique IDs", () => {
+			const task1 = runtime.addRecurringIntervalTask("a", 5 * ONE_MINUTE);
+			const task2 = runtime.addRecurringIntervalTask("b", 5 * ONE_MINUTE);
+			expect(task1.id).not.toBe(task2.id);
+		});
+
+		it("enables and disables tasks", () => {
+			const task = runtime.addRecurringIntervalTask("check", 5 * ONE_MINUTE);
+			expect(runtime.setTaskEnabled(task.id, false)).toBe(true);
+			expect(runtime.getTask(task.id)!.enabled).toBe(false);
+
+			expect(runtime.setTaskEnabled(task.id, true)).toBe(true);
+			expect(runtime.getTask(task.id)!.enabled).toBe(true);
+		});
+
+		it("returns false when enabling nonexistent task", () => {
+			expect(runtime.setTaskEnabled("nonexistent", true)).toBe(false);
+		});
+
+		it("deletes tasks", () => {
+			const task = runtime.addRecurringIntervalTask("check", 5 * ONE_MINUTE);
+			expect(runtime.deleteTask(task.id)).toBe(true);
+			expect(runtime.taskCount).toBe(0);
+		});
+
+		it("returns false when deleting nonexistent task", () => {
+			expect(runtime.deleteTask("nonexistent")).toBe(false);
+		});
+
+		it("clears all tasks", () => {
+			runtime.addRecurringIntervalTask("a", 5 * ONE_MINUTE);
+			runtime.addRecurringIntervalTask("b", 5 * ONE_MINUTE);
+			runtime.addOneShotTask("c", 30 * ONE_MINUTE);
+			expect(runtime.clearTasks()).toBe(3);
+			expect(runtime.taskCount).toBe(0);
+		});
+
+		it("returns tasks sorted by nextRunAt", () => {
+			const now = Date.now();
+			const task1 = runtime.addRecurringIntervalTask("later", 10 * ONE_MINUTE);
+			const task2 = runtime.addRecurringIntervalTask("sooner", 2 * ONE_MINUTE);
+			const sorted = runtime.getSortedTasks();
+			expect(sorted[0].id).toBe(task2.id);
+			expect(sorted[1].id).toBe(task1.id);
+		});
+
+		it("disabling a task clears its pending flag", () => {
+			const task = runtime.addRecurringIntervalTask("check", 5 * ONE_MINUTE);
+			const stored = runtime.getTask(task.id)!;
+			stored.pending = true;
+			runtime.setTaskEnabled(task.id, false);
+			expect(runtime.getTask(task.id)!.pending).toBe(false);
+		});
+	});
+
+	describe("recurring task expiry", () => {
+		it("sets expiresAt to 3 days after creation for interval tasks", () => {
+			const now = Date.now();
+			const task = runtime.addRecurringIntervalTask("check", 5 * ONE_MINUTE);
+			expect(task.expiresAt).toBe(now + THREE_DAYS);
+		});
+
+		it("sets expiresAt to 3 days after creation for cron tasks", () => {
+			const now = Date.now();
+			const task = runtime.addRecurringCronTask("check", "0 */5 * * * *");
+			expect(task).toBeDefined();
+			expect(task!.expiresAt).toBe(now + THREE_DAYS);
+		});
+
+		it("does not set expiresAt for one-shot tasks", () => {
+			const task = runtime.addOneShotTask("remind", 30 * ONE_MINUTE);
+			expect(task.expiresAt).toBeUndefined();
+		});
+	});
+
+	describe("jitter", () => {
+		it("applies jitter bounded by 10% of interval (capped at 15m)", () => {
+			const task = runtime.addRecurringIntervalTask("check", 60 * ONE_MINUTE);
+			const maxJitter = Math.min(Math.floor(60 * ONE_MINUTE * 0.1), FIFTEEN_MINUTES);
+			expect(task.jitterMs).toBeGreaterThanOrEqual(0);
+			expect(task.jitterMs).toBeLessThanOrEqual(maxJitter);
+		});
+
+		it("applies zero jitter for very small intervals", () => {
+			const jitter = runtime.computeJitterMs("test", 0);
+			expect(jitter).toBe(0);
+		});
+
+		it("produces deterministic jitter for same task ID", () => {
+			const j1 = runtime.computeJitterMs("abc", 10 * ONE_MINUTE);
+			const j2 = runtime.computeJitterMs("abc", 10 * ONE_MINUTE);
+			expect(j1).toBe(j2);
+		});
+
+		it("produces different jitter for different task IDs", () => {
+			const j1 = runtime.computeJitterMs("abc", 60 * ONE_MINUTE);
+			const j2 = runtime.computeJitterMs("xyz", 60 * ONE_MINUTE);
+			// They *could* collide but extremely unlikely with different strings
+			// This is a probabilistic check
+			expect(typeof j1).toBe("number");
+			expect(typeof j2).toBe("number");
+		});
+
+		it("cron tasks have zero jitter", () => {
+			const task = runtime.addRecurringCronTask("check", "0 */5 * * * *");
+			expect(task!.jitterMs).toBe(0);
+		});
+
+		it("one-shot tasks have zero jitter", () => {
+			const task = runtime.addOneShotTask("remind", 30 * ONE_MINUTE);
+			expect(task.jitterMs).toBe(0);
+		});
+	});
+
+	describe("formatRelativeTime", () => {
+		it('returns "due now" for past timestamps', () => {
+			expect(runtime.formatRelativeTime(Date.now() - 1000)).toBe("due now");
+		});
+
+		it("returns minutes for <60m", () => {
+			const result = runtime.formatRelativeTime(Date.now() + 5 * ONE_MINUTE);
+			expect(result).toBe("in 5m");
+		});
+
+		it("returns at least 1m for very short future", () => {
+			const result = runtime.formatRelativeTime(Date.now() + 1000);
+			expect(result).toMatch(/in \d+m/);
+		});
+
+		it("returns hours for >=60m <48h", () => {
+			const result = runtime.formatRelativeTime(Date.now() + 3 * 60 * ONE_MINUTE);
+			expect(result).toBe("in 3h");
+		});
+
+		it("returns days for >=48h", () => {
+			const result = runtime.formatRelativeTime(Date.now() + 3 * 24 * 60 * ONE_MINUTE);
+			expect(result).toBe("in 3d");
+		});
+	});
+
+	describe("formatTaskList", () => {
+		it("returns no-tasks message when empty", () => {
+			expect(runtime.formatTaskList()).toBe("No scheduled tasks.");
+		});
+
+		it("includes task details in list", () => {
+			runtime.addRecurringIntervalTask("check build", 5 * ONE_MINUTE);
+			const list = runtime.formatTaskList();
+			expect(list).toContain("Scheduled tasks:");
+			expect(list).toContain("check build");
+			expect(list).toContain("every 5m");
+			expect(list).toContain("runs=0");
+		});
+
+		it("truncates long prompts", () => {
+			const longPrompt = "a".repeat(100);
+			runtime.addRecurringIntervalTask(longPrompt, 5 * ONE_MINUTE);
+			const list = runtime.formatTaskList();
+			expect(list).toContain("...");
+		});
+	});
+
+	describe("taskMode", () => {
+		it('returns "once" for one-shot tasks', () => {
+			const task = runtime.addOneShotTask("remind", 5 * ONE_MINUTE);
+			expect(runtime.taskMode(task)).toBe("once");
+		});
+
+		it('returns "every Xm" for interval tasks', () => {
+			const task = runtime.addRecurringIntervalTask("check", 5 * ONE_MINUTE);
+			expect(runtime.taskMode(task)).toBe("every 5m");
+		});
+
+		it('returns "cron <expr>" for cron tasks', () => {
+			const task = runtime.addRecurringCronTask("check", "0 */5 * * * *");
+			expect(runtime.taskMode(task!)).toBe("cron 0 */5 * * * *");
+		});
+	});
+
+	describe("scheduler tick", () => {
+		it("marks tasks as pending when due", async () => {
+			const ctx = createMockCtx();
+			runtime.setRuntimeContext(ctx as any);
+
+			const task = runtime.addRecurringIntervalTask("check", 1 * ONE_MINUTE);
+			expect(runtime.getTask(task.id)!.pending).toBe(false);
+
+			// Advance past the task's nextRunAt
+			vi.advanceTimersByTime(task.nextRunAt - Date.now() + 1000);
+			await runtime.tickScheduler();
+
+			// Task should have been dispatched (pending cleared, runCount incremented)
+			const updated = runtime.getTask(task.id);
+			if (updated) {
+				expect(updated.runCount).toBe(1);
+				expect(updated.pending).toBe(false);
+			}
+		});
+
+		it("does not dispatch when not idle", async () => {
+			const ctx = createMockCtx({ isIdle: () => false });
+			runtime.setRuntimeContext(ctx as any);
+
+			const task = runtime.addRecurringIntervalTask("check", 1 * ONE_MINUTE);
+			vi.advanceTimersByTime(task.nextRunAt - Date.now() + 1000);
+			await runtime.tickScheduler();
+
+			expect(runtime.getTask(task.id)!.pending).toBe(true);
+			expect(pi._userMessages).toHaveLength(0);
+		});
+
+		it("does not dispatch when pending messages exist", async () => {
+			const ctx = createMockCtx({ hasPendingMessages: () => true });
+			runtime.setRuntimeContext(ctx as any);
+
+			const task = runtime.addRecurringIntervalTask("check", 1 * ONE_MINUTE);
+			vi.advanceTimersByTime(task.nextRunAt - Date.now() + 1000);
+			await runtime.tickScheduler();
+
+			expect(runtime.getTask(task.id)!.pending).toBe(true);
+			expect(pi._userMessages).toHaveLength(0);
+		});
+
+		it("removes expired recurring tasks on tick", async () => {
+			const ctx = createMockCtx();
+			runtime.setRuntimeContext(ctx as any);
+
+			const task = runtime.addRecurringIntervalTask("check", 5 * ONE_MINUTE);
+			expect(runtime.taskCount).toBe(1);
+
+			// Advance past 3 days
+			vi.advanceTimersByTime(THREE_DAYS + 1000);
+			await runtime.tickScheduler();
+
+			expect(runtime.taskCount).toBe(0);
+		});
+
+		it("skips disabled tasks", async () => {
+			const ctx = createMockCtx();
+			runtime.setRuntimeContext(ctx as any);
+
+			const task = runtime.addRecurringIntervalTask("check", 1 * ONE_MINUTE);
+			runtime.setTaskEnabled(task.id, false);
+
+			vi.advanceTimersByTime(task.nextRunAt - Date.now() + 1000);
+			await runtime.tickScheduler();
+
+			expect(runtime.getTask(task.id)!.pending).toBe(false);
+			expect(pi._userMessages).toHaveLength(0);
+		});
+
+		it("does nothing without runtime context", async () => {
+			const task = runtime.addRecurringIntervalTask("check", 1 * ONE_MINUTE);
+			vi.advanceTimersByTime(2 * ONE_MINUTE);
+			await runtime.tickScheduler();
+			expect(pi._userMessages).toHaveLength(0);
+		});
+	});
+
+	describe("dispatchTask", () => {
+		it("sends user message for enabled task", () => {
+			const ctx = createMockCtx();
+			runtime.setRuntimeContext(ctx as any);
+
+			const task = runtime.addRecurringIntervalTask("check ci", 5 * ONE_MINUTE);
+			task.pending = true;
+			runtime.dispatchTask(task);
+
+			expect(pi._userMessages).toEqual(["check ci"]);
+			expect(task.runCount).toBe(1);
+			expect(task.lastStatus).toBe("success");
+			expect(task.pending).toBe(false);
+		});
+
+		it("removes one-shot task after dispatch", () => {
+			const ctx = createMockCtx();
+			runtime.setRuntimeContext(ctx as any);
+
+			const task = runtime.addOneShotTask("remind me", 5 * ONE_MINUTE);
+			task.pending = true;
+			runtime.dispatchTask(task);
+
+			expect(pi._userMessages).toEqual(["remind me"]);
+			expect(runtime.taskCount).toBe(0);
+		});
+
+		it("advances cron task to next run after dispatch", () => {
+			const ctx = createMockCtx();
+			runtime.setRuntimeContext(ctx as any);
+
+			const task = runtime.addRecurringCronTask("check", "0 */5 * * * *")!;
+			const originalNextRun = task.nextRunAt;
+			task.pending = true;
+
+			// Advance time past the task's nextRunAt so dispatch computes a future cron tick
+			vi.setSystemTime(originalNextRun + 1000);
+			runtime.dispatchTask(task);
+
+			expect(task.nextRunAt).toBeGreaterThan(originalNextRun);
+			expect(runtime.taskCount).toBe(1);
+		});
+
+		it("advances interval task to next run after dispatch", () => {
+			const ctx = createMockCtx();
+			runtime.setRuntimeContext(ctx as any);
+
+			const task = runtime.addRecurringIntervalTask("check", 5 * ONE_MINUTE);
+			const firstNextRun = task.nextRunAt;
+			task.pending = true;
+
+			// Move time to the task's nextRunAt
+			vi.setSystemTime(firstNextRun);
+			runtime.dispatchTask(task);
+
+			expect(task.nextRunAt).toBeGreaterThan(firstNextRun);
+		});
+
+		it("does not dispatch disabled task", () => {
+			const ctx = createMockCtx();
+			runtime.setRuntimeContext(ctx as any);
+
+			const task = runtime.addRecurringIntervalTask("check", 5 * ONE_MINUTE);
+			runtime.setTaskEnabled(task.id, false);
+			task.pending = true;
+			runtime.dispatchTask(task);
+
+			expect(pi._userMessages).toHaveLength(0);
+		});
+
+		it("marks task as error if sendUserMessage throws", () => {
+			const ctx = createMockCtx();
+			runtime.setRuntimeContext(ctx as any);
+
+			pi.sendUserMessage = () => {
+				throw new Error("send failed");
+			};
+
+			const task = runtime.addRecurringIntervalTask("check", 5 * ONE_MINUTE);
+			task.pending = true;
+			runtime.dispatchTask(task);
+
+			expect(task.lastStatus).toBe("error");
+			expect(task.pending).toBe(true);
+		});
+	});
+
+	describe("scheduler lifecycle", () => {
+		it("startScheduler is idempotent", () => {
+			runtime.startScheduler();
+			runtime.startScheduler(); // Should not create second timer
+			runtime.stopScheduler();
+		});
+
+		it("stopScheduler is safe when not started", () => {
+			runtime.stopScheduler(); // Should not throw
+		});
+	});
+
+	describe("status bar updates", () => {
+		it("clears status when no tasks", () => {
+			const ctx = createMockCtx();
+			runtime.setRuntimeContext(ctx as any);
+			runtime.updateStatus();
+			expect(ctx._statusMap.has("pi-scheduler")).toBe(false);
+		});
+
+		it("shows active count and next run", () => {
+			const ctx = createMockCtx();
+			runtime.setRuntimeContext(ctx as any);
+			runtime.addRecurringIntervalTask("check", 5 * ONE_MINUTE);
+			runtime.updateStatus();
+			expect(ctx._statusMap.get("pi-scheduler")).toContain("⏰ 1 active");
+		});
+
+		it("shows paused message when all tasks disabled", () => {
+			const ctx = createMockCtx();
+			runtime.setRuntimeContext(ctx as any);
+			const task = runtime.addRecurringIntervalTask("check", 5 * ONE_MINUTE);
+			runtime.setTaskEnabled(task.id, false);
+			runtime.updateStatus();
+			expect(ctx._statusMap.get("pi-scheduler")).toContain("⏸");
+		});
+
+		it("does not update without UI", () => {
+			const ctx = createMockCtx({ hasUI: false });
+			runtime.setRuntimeContext(ctx as any);
+			runtime.addRecurringIntervalTask("check", 5 * ONE_MINUTE);
+			runtime.updateStatus();
+			expect(ctx._statusMap.size).toBe(0);
+		});
+	});
+
+	describe("persistence", () => {
+		it("persists tasks to disk on add", () => {
+			const ctx = createMockCtx();
+			runtime.setRuntimeContext(ctx as any);
+			runtime.addRecurringIntervalTask("check", 5 * ONE_MINUTE);
+
+			expect(writeFileSync).toHaveBeenCalled();
+			const writes = (writeFileSync as ReturnType<typeof vi.fn>).mock.calls;
+			const schedulerWrite = writes.find(
+				(c: unknown[]) => typeof c[0] === "string" && (c[0] as string).includes("scheduler.json"),
+			);
+			expect(schedulerWrite).toBeDefined();
+		});
+
+		it("uses atomic write (tmp + rename)", () => {
+			const ctx = createMockCtx();
+			runtime.setRuntimeContext(ctx as any);
+			runtime.addRecurringIntervalTask("check", 5 * ONE_MINUTE);
+
+			const writes = (writeFileSync as ReturnType<typeof vi.fn>).mock.calls;
+			const tmpWrite = writes.find((c: unknown[]) => typeof c[0] === "string" && (c[0] as string).includes(".tmp"));
+			expect(tmpWrite).toBeDefined();
+			expect(renameSync).toHaveBeenCalled();
+		});
+
+		it("loads tasks from disk on context set", () => {
+			const now = Date.now();
+			(existsSync as ReturnType<typeof vi.fn>).mockReturnValue(true);
+			(readFileSync as ReturnType<typeof vi.fn>).mockReturnValue(
+				JSON.stringify({
+					version: 1,
+					tasks: [
+						{
+							id: "test1234",
+							prompt: "check build",
+							kind: "recurring",
+							enabled: true,
+							createdAt: now,
+							nextRunAt: now + 5 * ONE_MINUTE,
+							intervalMs: 5 * ONE_MINUTE,
+							expiresAt: now + THREE_DAYS,
+							jitterMs: 0,
+							runCount: 3,
+							pending: false,
+						},
+					],
+				}),
+			);
+
+			const ctx = createMockCtx();
+			runtime.setRuntimeContext(ctx as any);
+
+			expect(runtime.taskCount).toBe(1);
+			const task = runtime.getTask("test1234");
+			expect(task).toBeDefined();
+			expect(task!.prompt).toBe("check build");
+			expect(task!.runCount).toBe(3);
+		});
+
+		it("skips expired tasks when loading from disk", () => {
+			const now = Date.now();
+			(existsSync as ReturnType<typeof vi.fn>).mockReturnValue(true);
+			(readFileSync as ReturnType<typeof vi.fn>).mockReturnValue(
+				JSON.stringify({
+					version: 1,
+					tasks: [
+						{
+							id: "expired1",
+							prompt: "old task",
+							kind: "recurring",
+							enabled: true,
+							createdAt: now - 4 * 24 * 60 * ONE_MINUTE,
+							nextRunAt: now - ONE_MINUTE,
+							intervalMs: 5 * ONE_MINUTE,
+							expiresAt: now - ONE_MINUTE, // Already expired
+							jitterMs: 0,
+							runCount: 0,
+							pending: false,
+						},
+					],
+				}),
+			);
+
+			const ctx = createMockCtx();
+			runtime.setRuntimeContext(ctx as any);
+			expect(runtime.taskCount).toBe(0);
+		});
+
+		it("handles corrupted JSON gracefully", () => {
+			(existsSync as ReturnType<typeof vi.fn>).mockReturnValue(true);
+			(readFileSync as ReturnType<typeof vi.fn>).mockReturnValue("not-json{{{");
+
+			const ctx = createMockCtx();
+			runtime.setRuntimeContext(ctx as any);
+			expect(runtime.taskCount).toBe(0);
+		});
+
+		it("handles missing file gracefully", () => {
+			(existsSync as ReturnType<typeof vi.fn>).mockReturnValue(false);
+
+			const ctx = createMockCtx();
+			runtime.setRuntimeContext(ctx as any);
+			expect(runtime.taskCount).toBe(0);
+		});
+
+		it("skips tasks with missing id or prompt", () => {
+			(existsSync as ReturnType<typeof vi.fn>).mockReturnValue(true);
+			(readFileSync as ReturnType<typeof vi.fn>).mockReturnValue(
+				JSON.stringify({
+					version: 1,
+					tasks: [
+						{ id: null, prompt: "no id", kind: "recurring" },
+						{ id: "valid", prompt: null, kind: "recurring" },
+						{
+							id: "ok123",
+							prompt: "valid",
+							kind: "recurring",
+							createdAt: Date.now(),
+							nextRunAt: Date.now() + ONE_MINUTE,
+							jitterMs: 0,
+							runCount: 0,
+							pending: false,
+						},
+					],
+				}),
+			);
+
+			const ctx = createMockCtx();
+			runtime.setRuntimeContext(ctx as any);
+			expect(runtime.taskCount).toBe(1);
+		});
+
+		it("defaults enabled to true and runCount to 0 when loading", () => {
+			const now = Date.now();
+			(existsSync as ReturnType<typeof vi.fn>).mockReturnValue(true);
+			(readFileSync as ReturnType<typeof vi.fn>).mockReturnValue(
+				JSON.stringify({
+					version: 1,
+					tasks: [
+						{
+							id: "loaded1",
+							prompt: "test",
+							kind: "once",
+							createdAt: now,
+							nextRunAt: now + 5 * ONE_MINUTE,
+							jitterMs: 0,
+							// enabled and runCount missing
+						},
+					],
+				}),
+			);
+
+			const ctx = createMockCtx();
+			runtime.setRuntimeContext(ctx as any);
+			const task = runtime.getTask("loaded1");
+			expect(task!.enabled).toBe(true);
+			expect(task!.runCount).toBe(0);
+			expect(task!.pending).toBe(false);
+		});
+
+		it("does not persist without storage path", () => {
+			// Don't set runtime context (no storage path)
+			runtime.addRecurringIntervalTask("check", 5 * ONE_MINUTE);
+			// writeFileSync may not be called for scheduler writes
+			const schedulerWrites = (writeFileSync as ReturnType<typeof vi.fn>).mock.calls.filter(
+				(c: unknown[]) => typeof c[0] === "string" && (c[0] as string).includes("scheduler.json"),
+			);
+			expect(schedulerWrites).toHaveLength(0);
+		});
+	});
+
+	describe("hashString", () => {
+		it("returns a number", () => {
+			expect(typeof runtime.hashString("test")).toBe("number");
+		});
+
+		it("returns same hash for same input", () => {
+			expect(runtime.hashString("hello")).toBe(runtime.hashString("hello"));
+		});
+
+		it("returns different hashes for different inputs", () => {
+			expect(runtime.hashString("abc")).not.toBe(runtime.hashString("xyz"));
+		});
+
+		it("returns unsigned 32-bit integer", () => {
+			const hash = runtime.hashString("test");
+			expect(hash).toBeGreaterThanOrEqual(0);
+			expect(hash).toBeLessThanOrEqual(0xffffffff);
+		});
+	});
+});
+
+// ─── Extension registration ─────────────────────────────────────────────────
+
+describe("schedulerExtension registration", () => {
+	let pi: ReturnType<typeof createMockPi>;
+
+	beforeEach(() => {
+		vi.useFakeTimers();
+		vi.clearAllMocks();
+		(existsSync as ReturnType<typeof vi.fn>).mockReturnValue(false);
+		(readFileSync as ReturnType<typeof vi.fn>).mockReturnValue("{}");
+		(mkdirSync as ReturnType<typeof vi.fn>).mockImplementation(() => undefined);
+		(writeFileSync as ReturnType<typeof vi.fn>).mockImplementation(() => undefined);
+		(renameSync as ReturnType<typeof vi.fn>).mockImplementation(() => undefined);
+		pi = createMockPi();
+	});
+
+	afterEach(() => {
+		vi.useRealTimers();
+	});
+
+	it("registers all four commands", () => {
+		schedulerExtension(pi as any);
+		expect(pi._commands.has("loop")).toBe(true);
+		expect(pi._commands.has("remind")).toBe(true);
+		expect(pi._commands.has("schedule")).toBe(true);
+		expect(pi._commands.has("unschedule")).toBe(true);
+	});
+
+	it("registers schedule_prompt tool", () => {
+		schedulerExtension(pi as any);
+		expect(pi._tools.has("schedule_prompt")).toBe(true);
+	});
+
+	it("registers event handlers", () => {
+		schedulerExtension(pi as any);
+		expect(pi._handlers.has("session_start")).toBe(true);
+		expect(pi._handlers.has("session_switch")).toBe(true);
+		expect(pi._handlers.has("session_fork")).toBe(true);
+		expect(pi._handlers.has("session_tree")).toBe(true);
+		expect(pi._handlers.has("session_shutdown")).toBe(true);
+	});
+});
+
+// ─── Command handlers ───────────────────────────────────────────────────────
+
+describe("command handlers", () => {
+	let pi: ReturnType<typeof createMockPi>;
+	let ctx: ReturnType<typeof createMockCtx>;
+
+	beforeEach(() => {
+		vi.useFakeTimers();
+		vi.clearAllMocks();
+		(existsSync as ReturnType<typeof vi.fn>).mockReturnValue(false);
+		(readFileSync as ReturnType<typeof vi.fn>).mockReturnValue("{}");
+		(mkdirSync as ReturnType<typeof vi.fn>).mockImplementation(() => undefined);
+		(writeFileSync as ReturnType<typeof vi.fn>).mockImplementation(() => undefined);
+		(renameSync as ReturnType<typeof vi.fn>).mockImplementation(() => undefined);
+		pi = createMockPi();
+		ctx = createMockCtx();
+		schedulerExtension(pi as any);
+		pi._emit("session_start", { type: "session_start" }, ctx);
+	});
+
+	afterEach(() => {
+		vi.useRealTimers();
+	});
+
+	describe("/loop", () => {
+		it("creates interval task with duration", async () => {
+			await pi._commands.get("loop").handler("5m check build", ctx);
+			expect(ctx._notifications.some((n: any) => n.msg.includes("Scheduled every 5m"))).toBe(true);
+		});
+
+		it("creates cron task", async () => {
+			await pi._commands.get("loop").handler("cron */5 * * * * check ci", ctx);
+			expect(ctx._notifications.some((n: any) => n.msg.includes("Scheduled cron"))).toBe(true);
+		});
+
+		it("creates task with default 10m interval", async () => {
+			await pi._commands.get("loop").handler("check build status", ctx);
+			expect(ctx._notifications.some((n: any) => n.msg.includes("Scheduled every 10m"))).toBe(true);
+		});
+
+		it("shows warning on empty args", async () => {
+			await pi._commands.get("loop").handler("", ctx);
+			expect(ctx._notifications.some((n: any) => n.type === "warning")).toBe(true);
+		});
+
+		it("shows error when task limit reached", async () => {
+			// Fill up to MAX_TASKS
+			for (let i = 0; i < MAX_TASKS; i++) {
+				await pi._commands.get("loop").handler(`check ${i} every 5m`, ctx);
+			}
+			ctx._notifications.length = 0;
+
+			await pi._commands.get("loop").handler("5m one more", ctx);
+			expect(ctx._notifications.some((n: any) => n.type === "error" && n.msg.includes("Task limit"))).toBe(true);
+		});
+
+		it("shows note when duration is rounded", async () => {
+			await pi._commands.get("loop").handler("30s check build", ctx);
+			expect(ctx._notifications.some((n: any) => n.msg.includes("Rounded"))).toBe(true);
+		});
+	});
+
+	describe("/remind", () => {
+		it("creates one-shot reminder with 'in' prefix", async () => {
+			await pi._commands.get("remind").handler("in 45m check tests", ctx);
+			expect(ctx._notifications.some((n: any) => n.msg.includes("Reminder set"))).toBe(true);
+		});
+
+		it("creates one-shot reminder without 'in' prefix", async () => {
+			await pi._commands.get("remind").handler("2h follow up", ctx);
+			expect(ctx._notifications.some((n: any) => n.msg.includes("Reminder set"))).toBe(true);
+		});
+
+		it("shows warning on invalid args", async () => {
+			await pi._commands.get("remind").handler("", ctx);
+			expect(ctx._notifications.some((n: any) => n.type === "warning")).toBe(true);
+		});
+
+		it("shows warning on missing duration", async () => {
+			await pi._commands.get("remind").handler("do something later", ctx);
+			expect(ctx._notifications.some((n: any) => n.type === "warning")).toBe(true);
+		});
+
+		it("shows error when task limit reached", async () => {
+			for (let i = 0; i < MAX_TASKS; i++) {
+				await pi._commands.get("loop").handler(`check ${i} every 5m`, ctx);
+			}
+			ctx._notifications.length = 0;
+
+			await pi._commands.get("remind").handler("in 5m test", ctx);
+			expect(ctx._notifications.some((n: any) => n.type === "error")).toBe(true);
+		});
+	});
+
+	describe("/schedule", () => {
+		it("shows list with /schedule list", async () => {
+			await pi._commands.get("loop").handler("5m check build", ctx);
+			await pi._commands.get("schedule").handler("list", ctx);
+			expect(pi._messages.some((m: any) => m.customType === "pi-scheduler")).toBe(true);
+		});
+
+		it("enables and disables tasks", async () => {
+			await pi._commands.get("loop").handler("5m check build", ctx);
+			const taskId = ctx._notifications[0].msg.match(/id: (\w+)/)?.[1];
+			ctx._notifications.length = 0;
+
+			await pi._commands.get("schedule").handler(`disable ${taskId}`, ctx);
+			expect(ctx._notifications.some((n: any) => n.msg.includes("Disabled"))).toBe(true);
+
+			ctx._notifications.length = 0;
+			await pi._commands.get("schedule").handler(`enable ${taskId}`, ctx);
+			expect(ctx._notifications.some((n: any) => n.msg.includes("Enabled"))).toBe(true);
+		});
+
+		it("deletes tasks with /schedule delete", async () => {
+			await pi._commands.get("loop").handler("5m check build", ctx);
+			const taskId = ctx._notifications[0].msg.match(/id: (\w+)/)?.[1];
+			ctx._notifications.length = 0;
+
+			await pi._commands.get("schedule").handler(`delete ${taskId}`, ctx);
+			expect(ctx._notifications.some((n: any) => n.msg.includes("Deleted"))).toBe(true);
+		});
+
+		it("handles rm alias for delete", async () => {
+			await pi._commands.get("loop").handler("5m check build", ctx);
+			const taskId = ctx._notifications[0].msg.match(/id: (\w+)/)?.[1];
+			ctx._notifications.length = 0;
+
+			await pi._commands.get("schedule").handler(`rm ${taskId}`, ctx);
+			expect(ctx._notifications.some((n: any) => n.msg.includes("Deleted"))).toBe(true);
+		});
+
+		it("handles remove alias for delete", async () => {
+			await pi._commands.get("loop").handler("5m check build", ctx);
+			const taskId = ctx._notifications[0].msg.match(/id: (\w+)/)?.[1];
+			ctx._notifications.length = 0;
+
+			await pi._commands.get("schedule").handler(`remove ${taskId}`, ctx);
+			expect(ctx._notifications.some((n: any) => n.msg.includes("Deleted"))).toBe(true);
+		});
+
+		it("clears all tasks", async () => {
+			await pi._commands.get("loop").handler("5m check a", ctx);
+			await pi._commands.get("loop").handler("10m check b", ctx);
+			ctx._notifications.length = 0;
+
+			await pi._commands.get("schedule").handler("clear", ctx);
+			expect(ctx._notifications.some((n: any) => n.msg.includes("Cleared 2 tasks"))).toBe(true);
+		});
+
+		it("handles singular task in clear message", async () => {
+			await pi._commands.get("loop").handler("5m check a", ctx);
+			ctx._notifications.length = 0;
+
+			await pi._commands.get("schedule").handler("clear", ctx);
+			expect(ctx._notifications.some((n: any) => n.msg.includes("Cleared 1 task"))).toBe(true);
+		});
+
+		it("shows warning for unknown subcommand", async () => {
+			await pi._commands.get("schedule").handler("unknown", ctx);
+			expect(ctx._notifications.some((n: any) => n.type === "warning" && n.msg.includes("Usage"))).toBe(true);
+		});
+
+		it("shows warning for enable without id", async () => {
+			await pi._commands.get("schedule").handler("enable", ctx);
+			expect(ctx._notifications.some((n: any) => n.type === "warning" && n.msg.includes("Usage"))).toBe(true);
+		});
+
+		it("shows warning for disable without id", async () => {
+			await pi._commands.get("schedule").handler("disable", ctx);
+			expect(ctx._notifications.some((n: any) => n.type === "warning")).toBe(true);
+		});
+
+		it("shows warning for delete without id", async () => {
+			await pi._commands.get("schedule").handler("delete", ctx);
+			expect(ctx._notifications.some((n: any) => n.type === "warning")).toBe(true);
+		});
+
+		it("shows warning for not-found task on enable", async () => {
+			await pi._commands.get("schedule").handler("enable nonexistent", ctx);
+			expect(ctx._notifications.some((n: any) => n.msg.includes("Task not found"))).toBe(true);
+		});
+
+		it("shows warning for not-found task on delete", async () => {
+			await pi._commands.get("schedule").handler("delete nonexistent", ctx);
+			expect(ctx._notifications.some((n: any) => n.msg.includes("Task not found"))).toBe(true);
+		});
+	});
+
+	describe("/unschedule", () => {
+		it("deletes a task by id", async () => {
+			await pi._commands.get("loop").handler("5m check build", ctx);
+			const taskId = ctx._notifications[0].msg.match(/id: (\w+)/)?.[1];
+			ctx._notifications.length = 0;
+
+			await pi._commands.get("unschedule").handler(taskId!, ctx);
+			expect(ctx._notifications.some((n: any) => n.msg.includes("Deleted"))).toBe(true);
+		});
+
+		it("shows warning for empty id", async () => {
+			await pi._commands.get("unschedule").handler("", ctx);
+			expect(ctx._notifications.some((n: any) => n.type === "warning" && n.msg.includes("Usage"))).toBe(true);
+		});
+
+		it("shows warning for not-found task", async () => {
+			await pi._commands.get("unschedule").handler("nonexistent", ctx);
+			expect(ctx._notifications.some((n: any) => n.msg.includes("Task not found"))).toBe(true);
+		});
+	});
+});
+
+// ─── Tool: schedule_prompt ──────────────────────────────────────────────────
+
+describe("schedule_prompt tool", () => {
+	let pi: ReturnType<typeof createMockPi>;
+	let ctx: ReturnType<typeof createMockCtx>;
+	let tool: any;
+
+	beforeEach(() => {
+		vi.useFakeTimers();
+		vi.clearAllMocks();
+		(existsSync as ReturnType<typeof vi.fn>).mockReturnValue(false);
+		(readFileSync as ReturnType<typeof vi.fn>).mockReturnValue("{}");
+		(mkdirSync as ReturnType<typeof vi.fn>).mockImplementation(() => undefined);
+		(writeFileSync as ReturnType<typeof vi.fn>).mockImplementation(() => undefined);
+		(renameSync as ReturnType<typeof vi.fn>).mockImplementation(() => undefined);
+		pi = createMockPi();
+		ctx = createMockCtx();
+		schedulerExtension(pi as any);
+		pi._emit("session_start", { type: "session_start" }, ctx);
+		tool = pi._tools.get("schedule_prompt");
+	});
+
+	afterEach(() => {
+		vi.useRealTimers();
+	});
+
+	describe("action: add", () => {
+		it("adds a recurring interval task", async () => {
+			const result = await tool.execute("id", {
+				action: "add",
+				prompt: "check build",
+				kind: "recurring",
+				duration: "5m",
+			});
+			expect(result.content[0].text).toContain("Recurring task scheduled");
+			expect(result.content[0].text).toContain("every 5m");
+			expect(result.details.task).toBeDefined();
+		});
+
+		it("adds a recurring cron task", async () => {
+			const result = await tool.execute("id", {
+				action: "add",
+				prompt: "check ci",
+				kind: "recurring",
+				cron: "*/5 * * * *",
+			});
+			expect(result.content[0].text).toContain("Recurring cron task scheduled");
+			expect(result.details.task).toBeDefined();
+		});
+
+		it("adds a one-time reminder", async () => {
+			const result = await tool.execute("id", {
+				action: "add",
+				prompt: "follow up",
+				kind: "once",
+				duration: "30m",
+			});
+			expect(result.content[0].text).toContain("Reminder scheduled");
+			expect(result.details.task).toBeDefined();
+		});
+
+		it("defaults to recurring with 10m interval", async () => {
+			const result = await tool.execute("id", {
+				action: "add",
+				prompt: "check status",
+			});
+			expect(result.content[0].text).toContain("Recurring task scheduled");
+			expect(result.content[0].text).toContain("every 10m");
+		});
+
+		it("returns error for missing prompt", async () => {
+			const result = await tool.execute("id", { action: "add" });
+			expect(result.content[0].text).toContain("Error: prompt is required");
+			expect(result.details.error).toBe("missing_prompt");
+		});
+
+		it("returns error for missing duration on once task", async () => {
+			const result = await tool.execute("id", {
+				action: "add",
+				prompt: "test",
+				kind: "once",
+			});
+			expect(result.content[0].text).toContain("duration is required");
+			expect(result.details.error).toBe("missing_duration");
+		});
+
+		it("returns error for invalid duration", async () => {
+			const result = await tool.execute("id", {
+				action: "add",
+				prompt: "test",
+				kind: "recurring",
+				duration: "banana",
+			});
+			expect(result.content[0].text).toContain("invalid duration");
+			expect(result.details.error).toBe("invalid_duration");
+		});
+
+		it("returns error for cron on once task", async () => {
+			const result = await tool.execute("id", {
+				action: "add",
+				prompt: "test",
+				kind: "once",
+				cron: "*/5 * * * *",
+			});
+			expect(result.content[0].text).toContain("cron is only valid");
+			expect(result.details.error).toBe("invalid_cron_for_once");
+		});
+
+		it("returns error for both duration and cron", async () => {
+			const result = await tool.execute("id", {
+				action: "add",
+				prompt: "test",
+				kind: "recurring",
+				duration: "5m",
+				cron: "*/5 * * * *",
+			});
+			expect(result.content[0].text).toContain("either duration or cron");
+			expect(result.details.error).toBe("conflicting_schedule_inputs");
+		});
+
+		it("returns error for invalid cron", async () => {
+			const result = await tool.execute("id", {
+				action: "add",
+				prompt: "test",
+				kind: "recurring",
+				cron: "not-a-cron",
+			});
+			expect(result.content[0].text).toContain("invalid cron");
+			expect(result.details.error).toBe("invalid_cron");
+		});
+
+		it("returns error when task limit reached", async () => {
+			for (let i = 0; i < MAX_TASKS; i++) {
+				await tool.execute("id", { action: "add", prompt: `task ${i}`, duration: "5m" });
+			}
+			const result = await tool.execute("id", { action: "add", prompt: "one more", duration: "5m" });
+			expect(result.content[0].text).toContain("Task limit reached");
+			expect(result.details.error).toBe("task_limit");
+		});
+
+		it("includes normalization note in response", async () => {
+			const result = await tool.execute("id", {
+				action: "add",
+				prompt: "test",
+				kind: "recurring",
+				cron: "*/5 * * * *",
+			});
+			expect(result.content[0].text).toContain("5-field cron");
+		});
+	});
+
+	describe("action: list", () => {
+		it("returns empty list message", async () => {
+			const result = await tool.execute("id", { action: "list" });
+			expect(result.content[0].text).toBe("No scheduled tasks.");
+			expect(result.details.tasks).toEqual([]);
+		});
+
+		it("lists tasks with details", async () => {
+			await tool.execute("id", { action: "add", prompt: "check build", duration: "5m" });
+			const result = await tool.execute("id", { action: "list" });
+			expect(result.content[0].text).toContain("check build");
+			expect(result.content[0].text).toContain("on");
+			expect(result.details.tasks.length).toBe(1);
+		});
+	});
+
+	describe("action: delete", () => {
+		it("deletes existing task", async () => {
+			const addResult = await tool.execute("id", { action: "add", prompt: "check", duration: "5m" });
+			const taskId = addResult.details.task.id;
+
+			const result = await tool.execute("id", { action: "delete", id: taskId });
+			expect(result.content[0].text).toContain("Deleted");
+			expect(result.details.removed).toBe(true);
+		});
+
+		it("returns error for missing id", async () => {
+			const result = await tool.execute("id", { action: "delete" });
+			expect(result.content[0].text).toContain("id is required");
+		});
+
+		it("returns not-found for invalid id", async () => {
+			const result = await tool.execute("id", { action: "delete", id: "nope" });
+			expect(result.content[0].text).toContain("Task not found");
+			expect(result.details.removed).toBe(false);
+		});
+	});
+
+	describe("action: enable/disable", () => {
+		it("enables a disabled task", async () => {
+			const addResult = await tool.execute("id", { action: "add", prompt: "check", duration: "5m" });
+			const taskId = addResult.details.task.id;
+
+			await tool.execute("id", { action: "disable", id: taskId });
+			const result = await tool.execute("id", { action: "enable", id: taskId });
+			expect(result.content[0].text).toContain("Enabled");
+			expect(result.details.enabled).toBe(true);
+		});
+
+		it("disables an enabled task", async () => {
+			const addResult = await tool.execute("id", { action: "add", prompt: "check", duration: "5m" });
+			const taskId = addResult.details.task.id;
+
+			const result = await tool.execute("id", { action: "disable", id: taskId });
+			expect(result.content[0].text).toContain("Disabled");
+			expect(result.details.enabled).toBe(false);
+		});
+
+		it("returns error for missing id on enable", async () => {
+			const result = await tool.execute("id", { action: "enable" });
+			expect(result.content[0].text).toContain("id is required");
+		});
+
+		it("returns error for missing id on disable", async () => {
+			const result = await tool.execute("id", { action: "disable" });
+			expect(result.content[0].text).toContain("id is required");
+		});
+
+		it("returns not-found for invalid id", async () => {
+			const result = await tool.execute("id", { action: "enable", id: "nope" });
+			expect(result.content[0].text).toContain("Task not found");
+			expect(result.details.updated).toBe(false);
+		});
+	});
+
+	describe("action: clear", () => {
+		it("clears all tasks", async () => {
+			await tool.execute("id", { action: "add", prompt: "a", duration: "5m" });
+			await tool.execute("id", { action: "add", prompt: "b", duration: "10m" });
+
+			const result = await tool.execute("id", { action: "clear" });
+			expect(result.content[0].text).toContain("Cleared 2");
+			expect(result.details.cleared).toBe(2);
+		});
+
+		it("handles clear with zero tasks", async () => {
+			const result = await tool.execute("id", { action: "clear" });
+			expect(result.content[0].text).toContain("Cleared 0");
+		});
+	});
+
+	describe("action: unsupported", () => {
+		it("returns error for unknown action", async () => {
+			const result = await tool.execute("id", { action: "banana" });
+			expect(result.content[0].text).toContain("unsupported action");
+			expect(result.details.error).toBe("unsupported_action");
+		});
+	});
+});
+
+// ─── Event wiring ────────────────────────────────────────────────────────────
+
+describe("event wiring", () => {
+	let pi: ReturnType<typeof createMockPi>;
+
+	beforeEach(() => {
+		vi.useFakeTimers();
+		vi.clearAllMocks();
+		(existsSync as ReturnType<typeof vi.fn>).mockReturnValue(false);
+		(readFileSync as ReturnType<typeof vi.fn>).mockReturnValue("{}");
+		(mkdirSync as ReturnType<typeof vi.fn>).mockImplementation(() => undefined);
+		(writeFileSync as ReturnType<typeof vi.fn>).mockImplementation(() => undefined);
+		(renameSync as ReturnType<typeof vi.fn>).mockImplementation(() => undefined);
+		pi = createMockPi();
+		schedulerExtension(pi as any);
+	});
+
+	afterEach(() => {
+		vi.useRealTimers();
+	});
+
+	it("starts scheduler on session_start", () => {
+		const ctx = createMockCtx();
+		pi._emit("session_start", { type: "session_start" }, ctx);
+		// Scheduler is started (no easy way to verify timer, but it should not throw)
+	});
+
+	it("updates status on session_switch", () => {
+		const ctx = createMockCtx();
+		pi._emit("session_start", { type: "session_start" }, ctx);
+		const ctx2 = createMockCtx({ cwd: "/other-project" });
+		pi._emit("session_switch", { type: "session_switch" }, ctx2);
+		// Should not throw
+	});
+
+	it("updates status on session_fork", () => {
+		const ctx = createMockCtx();
+		pi._emit("session_start", { type: "session_start" }, ctx);
+		pi._emit("session_fork", { type: "session_fork" }, ctx);
+	});
+
+	it("updates status on session_tree", () => {
+		const ctx = createMockCtx();
+		pi._emit("session_start", { type: "session_start" }, ctx);
+		pi._emit("session_tree", { type: "session_tree" }, ctx);
+	});
+
+	it("stops scheduler and clears status on session_shutdown", () => {
+		const ctx = createMockCtx();
+		pi._emit("session_start", { type: "session_start" }, ctx);
+
+		// Add a task to have status
+		pi._commands.get("loop")?.handler("5m check build", ctx);
+
+		pi._emit("session_shutdown", { type: "session_shutdown" }, ctx);
+		expect(ctx._statusMap.has("pi-scheduler")).toBe(false);
+	});
+});
+
+// ─── Constants ───────────────────────────────────────────────────────────────
+
+describe("constants", () => {
+	it("MAX_TASKS is 50", () => {
+		expect(MAX_TASKS).toBe(50);
+	});
+
+	it("ONE_MINUTE is 60000", () => {
+		expect(ONE_MINUTE).toBe(60_000);
+	});
+
+	it("FIFTEEN_MINUTES is 15 * ONE_MINUTE", () => {
+		expect(FIFTEEN_MINUTES).toBe(15 * 60_000);
+	});
+
+	it("THREE_DAYS is 3 days in ms", () => {
+		expect(THREE_DAYS).toBe(3 * 24 * 60 * 60_000);
+	});
+
+	it("DEFAULT_LOOP_INTERVAL is 10 * ONE_MINUTE", () => {
+		expect(DEFAULT_LOOP_INTERVAL).toBe(10 * 60_000);
+	});
+});
+
+// ─── Edge cases ──────────────────────────────────────────────────────────────
+
+describe("edge cases", () => {
+	let pi: ReturnType<typeof createMockPi>;
+	let ctx: ReturnType<typeof createMockCtx>;
+
+	beforeEach(() => {
+		vi.useFakeTimers();
+		vi.clearAllMocks();
+		(existsSync as ReturnType<typeof vi.fn>).mockReturnValue(false);
+		(readFileSync as ReturnType<typeof vi.fn>).mockReturnValue("{}");
+		(mkdirSync as ReturnType<typeof vi.fn>).mockImplementation(() => undefined);
+		(writeFileSync as ReturnType<typeof vi.fn>).mockImplementation(() => undefined);
+		(renameSync as ReturnType<typeof vi.fn>).mockImplementation(() => undefined);
+		pi = createMockPi();
+		ctx = createMockCtx();
+		schedulerExtension(pi as any);
+		pi._emit("session_start", { type: "session_start" }, ctx);
+	});
+
+	afterEach(() => {
+		vi.useRealTimers();
+	});
+
+	it("handles /loop with word-form trailing duration", async () => {
+		await pi._commands.get("loop").handler("check deploy every 30 minutes", ctx);
+		expect(ctx._notifications.some((n: any) => n.msg.includes("Scheduled every 30m"))).toBe(true);
+	});
+
+	it("handles /loop with very long prompt", async () => {
+		const longPrompt = "a".repeat(200);
+		await pi._commands.get("loop").handler(`5m ${longPrompt}`, ctx);
+		expect(ctx._notifications.some((n: any) => n.msg.includes("Scheduled every 5m"))).toBe(true);
+	});
+
+	it("handles /schedule list with no tasks", async () => {
+		await pi._commands.get("schedule").handler("list", ctx);
+		expect(pi._messages.some((m: any) => m.content.includes("No scheduled tasks"))).toBe(true);
+	});
+
+	it("handles /schedule tui alias", async () => {
+		// With no tasks, TUI manager should show "No scheduled tasks" notification
+		await pi._commands.get("schedule").handler("tui", ctx);
+		expect(ctx._notifications.some((n: any) => n.msg.includes("No scheduled tasks"))).toBe(true);
+	});
+
+	it("handles /schedule with no args (TUI manager)", async () => {
+		await pi._commands.get("schedule").handler("", ctx);
+		expect(ctx._notifications.some((n: any) => n.msg.includes("No scheduled tasks"))).toBe(true);
+	});
+
+	it("creates and then deletes a task via different commands", async () => {
+		await pi._commands.get("loop").handler("5m check build", ctx);
+		const taskId = ctx._notifications[0].msg.match(/id: (\w+)/)?.[1];
+		ctx._notifications.length = 0;
+
+		await pi._commands.get("unschedule").handler(taskId!, ctx);
+		expect(ctx._notifications.some((n: any) => n.msg.includes("Deleted"))).toBe(true);
+
+		// Verify task is gone
+		await pi._commands.get("schedule").handler("list", ctx);
+		expect(pi._messages.some((m: any) => m.content.includes("No scheduled tasks"))).toBe(true);
+	});
+
+	it("tool add then tool list shows the task", async () => {
+		const tool = pi._tools.get("schedule_prompt");
+		await tool.execute("id", { action: "add", prompt: "check", duration: "5m" });
+		const listResult = await tool.execute("id", { action: "list" });
+		expect(listResult.content[0].text).toContain("check");
+		expect(listResult.details.tasks).toHaveLength(1);
+	});
+
+	it("tool add + delete + list shows empty", async () => {
+		const tool = pi._tools.get("schedule_prompt");
+		const addResult = await tool.execute("id", { action: "add", prompt: "check", duration: "5m" });
+		const taskId = addResult.details.task.id;
+
+		await tool.execute("id", { action: "delete", id: taskId });
+		const listResult = await tool.execute("id", { action: "list" });
+		expect(listResult.content[0].text).toBe("No scheduled tasks.");
+	});
+
+	it("handles whitespace in /schedule args", async () => {
+		await pi._commands.get("schedule").handler("  list  ", ctx);
+		expect(pi._messages.some((m: any) => m.customType === "pi-scheduler")).toBe(true);
+	});
+
+	it("handles whitespace-padded id in /unschedule", async () => {
+		await pi._commands.get("loop").handler("5m check build", ctx);
+		const taskId = ctx._notifications[0].msg.match(/id: (\w+)/)?.[1];
+		ctx._notifications.length = 0;
+
+		await pi._commands.get("unschedule").handler(`  ${taskId}  `, ctx);
+		expect(ctx._notifications.some((n: any) => n.msg.includes("Deleted"))).toBe(true);
+	});
+});

--- a/packages/extensions/extensions/scheduler.ts
+++ b/packages/extensions/extensions/scheduler.ts
@@ -1,0 +1,1448 @@
+/**
+ * oh-pi Scheduler Extension
+ *
+ * Adds recurring checks (`/loop`), one-time reminders (`/remind`), and a
+ * task manager (`/schedule`) to pi. Also exposes an LLM-callable tool
+ * (`schedule_prompt`) so the agent can create/list/delete schedules in
+ * natural language.
+ *
+ * Based on pi-scheduler by @manojlds (MIT).
+ *
+ * Tasks run only while pi is active and idle. Recurring tasks auto-expire
+ * after 3 days. State is persisted to `.pi/scheduler.json`.
+ */
+
+import * as fs from "node:fs";
+import * as path from "node:path";
+import type { ExtensionAPI, ExtensionContext } from "@mariozechner/pi-coding-agent";
+import { Type } from "@sinclair/typebox";
+import { Cron } from "croner";
+
+// ── Constants ───────────────────────────────────────────────────────────────
+
+export const MAX_TASKS = 50;
+export const ONE_MINUTE = 60_000;
+export const FIFTEEN_MINUTES = 15 * ONE_MINUTE;
+export const THREE_DAYS = 3 * 24 * 60 * ONE_MINUTE;
+export const DEFAULT_LOOP_INTERVAL = 10 * ONE_MINUTE;
+
+// ── Types ───────────────────────────────────────────────────────────────────
+
+export type TaskKind = "recurring" | "once";
+export type TaskStatus = "pending" | "success" | "error";
+
+export interface ScheduleTask {
+	id: string;
+	prompt: string;
+	kind: TaskKind;
+	enabled: boolean;
+	createdAt: number;
+	nextRunAt: number;
+	intervalMs?: number;
+	cronExpression?: string;
+	expiresAt?: number;
+	jitterMs: number;
+	lastRunAt?: number;
+	lastStatus?: TaskStatus;
+	runCount: number;
+	pending: boolean;
+}
+
+export type RecurringSpec =
+	| { mode: "interval"; durationMs: number; note?: string }
+	| { mode: "cron"; cronExpression: string; note?: string };
+
+export interface ParseResult {
+	prompt: string;
+	recurring: RecurringSpec;
+}
+
+export interface ReminderParseResult {
+	prompt: string;
+	durationMs: number;
+	note?: string;
+}
+
+export type SchedulePromptAddPlan =
+	| { kind: "once"; durationMs: number; note?: string }
+	| { kind: "recurring"; mode: "interval"; durationMs: number; note?: string }
+	| { kind: "recurring"; mode: "cron"; cronExpression: string; note?: string };
+
+interface SchedulerStore {
+	version: 1;
+	tasks: ScheduleTask[];
+}
+
+// ── Scheduling helpers ──────────────────────────────────────────────────────
+
+export function normalizeCronExpression(rawInput: string): { expression: string; note?: string } | undefined {
+	const input = rawInput.trim();
+	if (!input) {
+		return undefined;
+	}
+
+	const fields = input.split(/\s+/).filter(Boolean);
+	if (fields.length !== 5 && fields.length !== 6) {
+		return undefined;
+	}
+
+	const expression = fields.length === 5 ? `0 ${fields.join(" ")}` : fields.join(" ");
+	try {
+		// biome-ignore lint/suspicious/noEmptyBlockStatements: Cron requires a callback
+		const cron = new Cron(expression, () => {});
+		cron.stop();
+		return {
+			expression,
+			note: fields.length === 5 ? "Interpreted as 5-field cron and normalized by prepending seconds=0." : undefined,
+		};
+	} catch {
+		return undefined;
+	}
+}
+
+export function computeNextCronRunAt(expression: string, fromTs = Date.now()): number | undefined {
+	try {
+		// biome-ignore lint/suspicious/noEmptyBlockStatements: Cron requires a callback
+		const cron = new Cron(expression, () => {});
+		const next = cron.nextRun(new Date(fromTs));
+		cron.stop();
+		return next?.getTime();
+	} catch {
+		return undefined;
+	}
+}
+
+export function formatDurationShort(ms: number): string {
+	if (ms % (24 * 60 * ONE_MINUTE) === 0) {
+		return `${ms / (24 * 60 * ONE_MINUTE)}d`;
+	}
+	if (ms % (60 * ONE_MINUTE) === 0) {
+		return `${ms / (60 * ONE_MINUTE)}h`;
+	}
+	return `${ms / ONE_MINUTE}m`;
+}
+
+export function normalizeDuration(durationMs: number): { durationMs: number; note?: string } {
+	if (durationMs <= 0) {
+		return { durationMs: ONE_MINUTE, note: "Rounded up to 1m (minimum interval)." };
+	}
+
+	const rounded = Math.ceil(durationMs / ONE_MINUTE) * ONE_MINUTE;
+	if (rounded !== durationMs) {
+		return {
+			durationMs: rounded,
+			note: `Rounded to ${formatDurationShort(rounded)} (minute granularity).`,
+		};
+	}
+	return { durationMs };
+}
+
+export function parseDuration(text: string): number | undefined {
+	const raw = text.trim().toLowerCase();
+	if (!raw) {
+		return undefined;
+	}
+
+	let match = raw.match(/^(\d+)\s*([smhd])$/i);
+	if (match) {
+		const n = Number.parseInt(match[1], 10);
+		const unit = match[2].toLowerCase();
+		if (unit === "s") {
+			return n * 1000;
+		}
+		if (unit === "m") {
+			return n * ONE_MINUTE;
+		}
+		if (unit === "h") {
+			return n * 60 * ONE_MINUTE;
+		}
+		if (unit === "d") {
+			return n * 24 * 60 * ONE_MINUTE;
+		}
+	}
+
+	match = raw.match(/^(\d+)\s*(seconds?|secs?|minutes?|mins?|hours?|hrs?|days?)$/i);
+	if (!match) {
+		return undefined;
+	}
+	const n = Number.parseInt(match[1], 10);
+	const unit = match[2].toLowerCase();
+	if (unit.startsWith("sec")) {
+		return n * 1000;
+	}
+	if (unit.startsWith("min")) {
+		return n * ONE_MINUTE;
+	}
+	if (unit.startsWith("hour") || unit.startsWith("hr")) {
+		return n * 60 * ONE_MINUTE;
+	}
+	if (unit.startsWith("day")) {
+		return n * 24 * 60 * ONE_MINUTE;
+	}
+	return undefined;
+}
+
+function extractLeadingDuration(input: string): { durationMs: number; prompt: string } | undefined {
+	const tokens = input.trim().split(/\s+/);
+	if (tokens.length < 2) {
+		return undefined;
+	}
+
+	const maxPrefix = Math.min(3, tokens.length - 1);
+	for (let i = 1; i <= maxPrefix; i++) {
+		const durationCandidate = tokens.slice(0, i).join(" ");
+		const durationMs = parseDuration(durationCandidate);
+		if (!durationMs) {
+			continue;
+		}
+		const prompt = tokens.slice(i).join(" ").trim();
+		if (!prompt) {
+			continue;
+		}
+		return { durationMs, prompt };
+	}
+
+	return undefined;
+}
+
+function extractLeadingCron(input: string): { cronExpression: string; prompt: string; note?: string } | undefined {
+	const trimmed = input.trim();
+	if (!trimmed.toLowerCase().startsWith("cron ")) {
+		return undefined;
+	}
+
+	const rest = trimmed.slice(5).trim();
+	if (!rest) {
+		return undefined;
+	}
+
+	const quotedMatch = rest.match(/^(["'])(.+?)\1\s+(.+)$/);
+	if (quotedMatch) {
+		const normalized = normalizeCronExpression(quotedMatch[2]);
+		const prompt = quotedMatch[3].trim();
+		if (!(normalized && prompt)) {
+			return undefined;
+		}
+		return { cronExpression: normalized.expression, prompt, note: normalized.note };
+	}
+
+	const tokens = rest.split(/\s+/);
+	for (const fieldCount of [6, 5]) {
+		if (tokens.length <= fieldCount) {
+			continue;
+		}
+		const expressionCandidate = tokens.slice(0, fieldCount).join(" ");
+		const normalized = normalizeCronExpression(expressionCandidate);
+		if (!normalized) {
+			continue;
+		}
+		const prompt = tokens.slice(fieldCount).join(" ").trim();
+		if (!prompt) {
+			continue;
+		}
+		return { cronExpression: normalized.expression, prompt, note: normalized.note };
+	}
+
+	return undefined;
+}
+
+export function parseLoopScheduleArgs(args: string): ParseResult | undefined {
+	const input = args.trim();
+	if (!input) {
+		return undefined;
+	}
+
+	const explicitlyCron = input.toLowerCase().startsWith("cron ");
+	const leadingCron = extractLeadingCron(input);
+	if (leadingCron) {
+		return {
+			prompt: leadingCron.prompt,
+			recurring: {
+				mode: "cron",
+				cronExpression: leadingCron.cronExpression,
+				note: leadingCron.note,
+			},
+		};
+	}
+	if (explicitlyCron) {
+		return undefined;
+	}
+
+	const leading = extractLeadingDuration(input);
+	if (leading) {
+		const normalized = normalizeDuration(leading.durationMs);
+		return {
+			prompt: leading.prompt,
+			recurring: {
+				mode: "interval",
+				durationMs: normalized.durationMs,
+				note: normalized.note,
+			},
+		};
+	}
+
+	const trailingEvery = input.match(/^(.*)\s+every\s+(.+)$/i);
+	if (trailingEvery) {
+		const prompt = trailingEvery[1].trim();
+		const parsed = parseDuration(trailingEvery[2]);
+		if (prompt && parsed) {
+			const normalized = normalizeDuration(parsed);
+			return {
+				prompt,
+				recurring: {
+					mode: "interval",
+					durationMs: normalized.durationMs,
+					note: normalized.note,
+				},
+			};
+		}
+	}
+
+	return {
+		prompt: input,
+		recurring: {
+			mode: "interval",
+			durationMs: DEFAULT_LOOP_INTERVAL,
+		},
+	};
+}
+
+export function parseRemindScheduleArgs(args: string): ReminderParseResult | undefined {
+	const input = args.trim();
+	if (!input) {
+		return undefined;
+	}
+
+	const value = input.toLowerCase().startsWith("in ") ? input.slice(3).trim() : input;
+	const parsed = extractLeadingDuration(value);
+	if (!parsed) {
+		return undefined;
+	}
+
+	const normalized = normalizeDuration(parsed.durationMs);
+	return {
+		prompt: parsed.prompt,
+		durationMs: normalized.durationMs,
+		note: normalized.note,
+	};
+}
+
+export function validateSchedulePromptAddInput(input: { kind?: TaskKind; duration?: string; cron?: string }):
+	| { ok: true; plan: SchedulePromptAddPlan }
+	| {
+			ok: false;
+			error:
+				| "missing_duration"
+				| "invalid_duration"
+				| "invalid_cron_for_once"
+				| "conflicting_schedule_inputs"
+				| "invalid_cron";
+	  } {
+	const kind: TaskKind = input.kind ?? "recurring";
+
+	if (kind === "once") {
+		if (input.cron) {
+			return { ok: false, error: "invalid_cron_for_once" };
+		}
+		if (!input.duration) {
+			return { ok: false, error: "missing_duration" };
+		}
+
+		const parsed = parseDuration(input.duration);
+		if (!parsed) {
+			return { ok: false, error: "invalid_duration" };
+		}
+		const normalized = normalizeDuration(parsed);
+		return { ok: true, plan: { kind: "once", durationMs: normalized.durationMs, note: normalized.note } };
+	}
+
+	if (input.cron && input.duration) {
+		return { ok: false, error: "conflicting_schedule_inputs" };
+	}
+
+	if (input.cron) {
+		const normalizedCron = normalizeCronExpression(input.cron);
+		if (!normalizedCron) {
+			return { ok: false, error: "invalid_cron" };
+		}
+		return {
+			ok: true,
+			plan: {
+				kind: "recurring",
+				mode: "cron",
+				cronExpression: normalizedCron.expression,
+				note: normalizedCron.note,
+			},
+		};
+	}
+
+	if (input.duration) {
+		const parsed = parseDuration(input.duration);
+		if (!parsed) {
+			return { ok: false, error: "invalid_duration" };
+		}
+		const normalized = normalizeDuration(parsed);
+		return {
+			ok: true,
+			plan: { kind: "recurring", mode: "interval", durationMs: normalized.durationMs, note: normalized.note },
+		};
+	}
+
+	return {
+		ok: true,
+		plan: { kind: "recurring", mode: "interval", durationMs: DEFAULT_LOOP_INTERVAL },
+	};
+}
+
+// ── Runtime ─────────────────────────────────────────────────────────────────
+
+export class SchedulerRuntime {
+	private readonly tasks = new Map<string, ScheduleTask>();
+	private schedulerTimer: ReturnType<typeof setInterval> | undefined;
+	private runtimeCtx: ExtensionContext | undefined;
+	private dispatching = false;
+	private storagePath: string | undefined;
+
+	constructor(private readonly pi: ExtensionAPI) {}
+
+	get taskCount(): number {
+		return this.tasks.size;
+	}
+
+	setRuntimeContext(ctx: ExtensionContext | undefined) {
+		this.runtimeCtx = ctx;
+		if (!ctx?.cwd) {
+			return;
+		}
+
+		const nextStorePath = path.join(ctx.cwd, ".pi", "scheduler.json");
+		if (nextStorePath !== this.storagePath) {
+			this.storagePath = nextStorePath;
+			this.loadTasksFromDisk();
+		}
+	}
+
+	clearStatus(ctx?: ExtensionContext) {
+		const target = ctx ?? this.runtimeCtx;
+		if (target?.hasUI) {
+			target.ui.setStatus("pi-scheduler", undefined);
+		}
+	}
+
+	getSortedTasks(): ScheduleTask[] {
+		return Array.from(this.tasks.values()).sort((a, b) => a.nextRunAt - b.nextRunAt);
+	}
+
+	getTask(id: string): ScheduleTask | undefined {
+		return this.tasks.get(id);
+	}
+
+	setTaskEnabled(id: string, enabled: boolean): boolean {
+		const task = this.tasks.get(id);
+		if (!task) {
+			return false;
+		}
+		task.enabled = enabled;
+		if (!enabled) {
+			task.pending = false;
+		}
+		this.persistTasks();
+		this.updateStatus();
+		return true;
+	}
+
+	deleteTask(id: string): boolean {
+		const removed = this.tasks.delete(id);
+		if (removed) {
+			this.persistTasks();
+			this.updateStatus();
+		}
+		return removed;
+	}
+
+	clearTasks(): number {
+		const count = this.tasks.size;
+		this.tasks.clear();
+		this.persistTasks();
+		this.updateStatus();
+		return count;
+	}
+
+	formatRelativeTime(timestamp: number): string {
+		const delta = timestamp - Date.now();
+		if (delta <= 0) {
+			return "due now";
+		}
+		const mins = Math.round(delta / ONE_MINUTE);
+		if (mins < 60) {
+			return `in ${Math.max(mins, 1)}m`;
+		}
+		const hours = Math.round(mins / 60);
+		if (hours < 48) {
+			return `in ${hours}h`;
+		}
+		const days = Math.round(hours / 24);
+		return `in ${days}d`;
+	}
+
+	formatTaskList(): string {
+		const list = this.getSortedTasks();
+		if (list.length === 0) {
+			return "No scheduled tasks.";
+		}
+
+		const lines = ["Scheduled tasks:", ""];
+		for (const task of list) {
+			const state = task.enabled ? "on" : "off";
+			const mode = this.taskMode(task);
+			const next = `${this.formatRelativeTime(task.nextRunAt)} (${this.formatClock(task.nextRunAt)})`;
+			const last = task.lastRunAt
+				? `${this.formatRelativeTime(task.lastRunAt)} (${this.formatClock(task.lastRunAt)})`
+				: "never";
+			const status = task.lastStatus ?? "pending";
+			const preview = task.prompt.length > 72 ? `${task.prompt.slice(0, 69)}...` : task.prompt;
+			lines.push(`${task.id}  ${state}  ${mode}  next ${next}`);
+			lines.push(`  runs=${task.runCount}  last=${last}  status=${status}`);
+			lines.push(`  ${preview}`);
+		}
+		return lines.join("\n");
+	}
+
+	addRecurringIntervalTask(prompt: string, intervalMs: number): ScheduleTask {
+		const id = this.createId();
+		const createdAt = Date.now();
+		const jitterMs = this.computeJitterMs(id, intervalMs);
+		const nextRunAt = createdAt + intervalMs + jitterMs;
+		const task: ScheduleTask = {
+			id,
+			prompt,
+			kind: "recurring",
+			enabled: true,
+			createdAt,
+			nextRunAt,
+			intervalMs,
+			expiresAt: createdAt + THREE_DAYS,
+			jitterMs,
+			runCount: 0,
+			pending: false,
+		};
+		this.tasks.set(id, task);
+		this.persistTasks();
+		this.updateStatus();
+		return task;
+	}
+
+	addRecurringCronTask(prompt: string, cronExpression: string): ScheduleTask | undefined {
+		const id = this.createId();
+		const createdAt = Date.now();
+		const nextRunAt = computeNextCronRunAt(cronExpression, createdAt);
+		if (!nextRunAt) {
+			return undefined;
+		}
+
+		const task: ScheduleTask = {
+			id,
+			prompt,
+			kind: "recurring",
+			enabled: true,
+			createdAt,
+			nextRunAt,
+			cronExpression,
+			expiresAt: createdAt + THREE_DAYS,
+			jitterMs: 0,
+			runCount: 0,
+			pending: false,
+		};
+		this.tasks.set(id, task);
+		this.persistTasks();
+		this.updateStatus();
+		return task;
+	}
+
+	addOneShotTask(prompt: string, delayMs: number): ScheduleTask {
+		const id = this.createId();
+		const createdAt = Date.now();
+		const task: ScheduleTask = {
+			id,
+			prompt,
+			kind: "once",
+			enabled: true,
+			createdAt,
+			nextRunAt: createdAt + delayMs,
+			jitterMs: 0,
+			runCount: 0,
+			pending: false,
+		};
+		this.tasks.set(id, task);
+		this.persistTasks();
+		this.updateStatus();
+		return task;
+	}
+
+	startScheduler() {
+		if (this.schedulerTimer) {
+			return;
+		}
+		this.schedulerTimer = setInterval(() => {
+			this.tickScheduler().catch(() => {
+				// Best-effort scheduler tick; errors are non-fatal.
+			});
+		}, 1000);
+	}
+
+	stopScheduler() {
+		if (!this.schedulerTimer) {
+			return;
+		}
+		clearInterval(this.schedulerTimer);
+		this.schedulerTimer = undefined;
+	}
+
+	updateStatus() {
+		if (!this.runtimeCtx?.hasUI) {
+			return;
+		}
+		if (this.tasks.size === 0) {
+			this.runtimeCtx.ui.setStatus("pi-scheduler", undefined);
+			return;
+		}
+
+		const enabled = Array.from(this.tasks.values()).filter((t) => t.enabled);
+		if (enabled.length === 0) {
+			this.runtimeCtx.ui.setStatus(
+				"pi-scheduler",
+				`⏸ ${this.tasks.size} task${this.tasks.size === 1 ? "" : "s"} paused`,
+			);
+			return;
+		}
+
+		const nextRunAt = Math.min(...enabled.map((t) => t.nextRunAt));
+		const next = new Date(nextRunAt).toLocaleTimeString([], { hour: "2-digit", minute: "2-digit" });
+		const text = `⏰ ${enabled.length} active • next ${next}`;
+		this.runtimeCtx.ui.setStatus("pi-scheduler", text);
+	}
+
+	async tickScheduler() {
+		if (!this.runtimeCtx) {
+			return;
+		}
+
+		const now = Date.now();
+		let mutated = false;
+
+		for (const task of Array.from(this.tasks.values())) {
+			if (task.kind === "recurring" && task.expiresAt && now >= task.expiresAt) {
+				this.tasks.delete(task.id);
+				mutated = true;
+				continue;
+			}
+
+			if (!task.enabled) {
+				continue;
+			}
+			if (now >= task.nextRunAt) {
+				task.pending = true;
+			}
+		}
+
+		if (mutated) {
+			this.persistTasks();
+		}
+		this.updateStatus();
+
+		if (this.dispatching) {
+			return;
+		}
+		if (!this.runtimeCtx.isIdle() || this.runtimeCtx.hasPendingMessages()) {
+			return;
+		}
+
+		const nextTask = Array.from(this.tasks.values())
+			.filter((task) => task.enabled && task.pending)
+			.sort((a, b) => a.nextRunAt - b.nextRunAt)[0];
+
+		if (!nextTask) {
+			return;
+		}
+
+		this.dispatching = true;
+		try {
+			this.dispatchTask(nextTask);
+		} finally {
+			this.dispatching = false;
+		}
+	}
+
+	async openTaskManager(ctx: ExtensionContext): Promise<void> {
+		if (!ctx.hasUI) {
+			this.pi.sendMessage({
+				customType: "pi-scheduler",
+				content: this.formatTaskList(),
+				display: true,
+			});
+			return;
+		}
+
+		while (true) {
+			const list = this.getSortedTasks();
+			if (list.length === 0) {
+				ctx.ui.notify("No scheduled tasks.", "info");
+				return;
+			}
+
+			const options = list.map((task) => this.taskOptionLabel(task));
+			options.push("➕ Close");
+
+			const selected = await ctx.ui.select("Scheduled tasks (select one)", options);
+			if (!selected || selected === "➕ Close") {
+				return;
+			}
+
+			const taskId = selected.slice(0, 8);
+			const task = this.tasks.get(taskId);
+			if (!task) {
+				ctx.ui.notify("Task no longer exists. Refreshing list...", "warning");
+				continue;
+			}
+
+			const closed = await this.openTaskActions(ctx, task.id);
+			if (closed) {
+				return;
+			}
+		}
+	}
+
+	// biome-ignore lint/complexity/noExcessiveCognitiveComplexity: TUI flow with multiple interactive branches.
+	private async openTaskActions(ctx: ExtensionContext, taskId: string): Promise<boolean> {
+		while (true) {
+			const task = this.tasks.get(taskId);
+			if (!task) {
+				ctx.ui.notify("Task no longer exists.", "warning");
+				return false;
+			}
+
+			const title = `${task.id} • ${this.taskMode(task)} • next ${this.formatRelativeTime(task.nextRunAt)} (${this.formatClock(task.nextRunAt)})`;
+			const options = [
+				task.kind === "recurring" ? "⏱ Change schedule" : "⏱ Change reminder delay",
+				task.enabled ? "⏸ Disable" : "▶ Enable",
+				"▶ Run now",
+				"🗑 Delete",
+				"↩ Back",
+				"✕ Close",
+			];
+			const action = await ctx.ui.select(title, options);
+
+			if (!action || action === "↩ Back") {
+				return false;
+			}
+			if (action === "✕ Close") {
+				return true;
+			}
+
+			if (action === "⏸ Disable" || action === "▶ Enable") {
+				const enabled = action === "▶ Enable";
+				this.setTaskEnabled(task.id, enabled);
+				ctx.ui.notify(`${enabled ? "Enabled" : "Disabled"} scheduled task ${task.id}.`, "info");
+				continue;
+			}
+
+			if (action === "🗑 Delete") {
+				const ok = await ctx.ui.confirm("Delete scheduled task?", `${task.id}: ${task.prompt}`);
+				if (!ok) {
+					continue;
+				}
+				this.tasks.delete(task.id);
+				this.persistTasks();
+				this.updateStatus();
+				ctx.ui.notify(`Deleted scheduled task ${task.id}.`, "info");
+				return false;
+			}
+
+			if (action === "▶ Run now") {
+				task.nextRunAt = Date.now();
+				task.pending = true;
+				this.persistTasks();
+				this.updateStatus();
+				this.tickScheduler().catch(() => {
+					// Best-effort immediate dispatch; errors are non-fatal.
+				});
+				ctx.ui.notify(`Queued ${task.id} to run now.`, "info");
+				continue;
+			}
+
+			if (action.startsWith("⏱")) {
+				await this.handleChangeSchedule(ctx, task);
+			}
+		}
+	}
+
+	private async handleChangeSchedule(ctx: ExtensionContext, task: ScheduleTask) {
+		const defaultValue =
+			task.kind === "recurring"
+				? (task.cronExpression ?? formatDurationShort(task.intervalMs ?? DEFAULT_LOOP_INTERVAL))
+				: formatDurationShort(Math.max(task.nextRunAt - Date.now(), ONE_MINUTE));
+
+		const raw = await ctx.ui.input(
+			task.kind === "recurring"
+				? "New interval or cron (e.g. 5m or 0 */10 * * * *)"
+				: "New delay from now (e.g. 30m, 2h)",
+			defaultValue,
+		);
+		if (!raw) {
+			return;
+		}
+
+		if (task.kind === "recurring") {
+			const parsedDuration = parseDuration(raw);
+			if (parsedDuration) {
+				const normalized = normalizeDuration(parsedDuration);
+				task.intervalMs = normalized.durationMs;
+				task.cronExpression = undefined;
+				task.jitterMs = this.computeJitterMs(task.id, normalized.durationMs);
+				task.nextRunAt = Date.now() + normalized.durationMs + task.jitterMs;
+				task.pending = false;
+				this.persistTasks();
+				ctx.ui.notify(`Updated ${task.id} to every ${formatDurationShort(normalized.durationMs)}.`, "info");
+				if (normalized.note) {
+					ctx.ui.notify(normalized.note, "info");
+				}
+				this.updateStatus();
+				return;
+			}
+
+			const normalizedCron = normalizeCronExpression(raw);
+			if (!normalizedCron) {
+				ctx.ui.notify("Invalid input. Use interval like 5m or cron like 0 */10 * * * *.", "warning");
+				return;
+			}
+
+			const nextRunAt = computeNextCronRunAt(normalizedCron.expression);
+			if (!nextRunAt) {
+				ctx.ui.notify("Could not compute next cron run time.", "warning");
+				return;
+			}
+
+			task.intervalMs = undefined;
+			task.cronExpression = normalizedCron.expression;
+			task.jitterMs = 0;
+			task.nextRunAt = nextRunAt;
+			task.pending = false;
+			this.persistTasks();
+			ctx.ui.notify(`Updated ${task.id} to cron ${normalizedCron.expression}.`, "info");
+			if (normalizedCron.note) {
+				ctx.ui.notify(normalizedCron.note, "info");
+			}
+			this.updateStatus();
+			return;
+		}
+
+		// One-shot task: update delay
+		const parsed = parseDuration(raw);
+		if (!parsed) {
+			ctx.ui.notify("Invalid duration. Try values like 5m, 2h, or 1 day.", "warning");
+			return;
+		}
+
+		const normalized = normalizeDuration(parsed);
+		task.nextRunAt = Date.now() + normalized.durationMs;
+		task.pending = false;
+		this.persistTasks();
+		ctx.ui.notify(`Updated ${task.id} reminder to ${this.formatRelativeTime(task.nextRunAt)}.`, "info");
+		if (normalized.note) {
+			ctx.ui.notify(normalized.note, "info");
+		}
+		this.updateStatus();
+	}
+
+	dispatchTask(task: ScheduleTask) {
+		if (!task.enabled) {
+			return;
+		}
+		const now = Date.now();
+
+		try {
+			this.pi.sendUserMessage(task.prompt);
+		} catch {
+			task.pending = true;
+			task.lastStatus = "error";
+			this.persistTasks();
+			return;
+		}
+
+		task.pending = false;
+		task.lastRunAt = now;
+		task.lastStatus = "success";
+		task.runCount += 1;
+
+		if (task.kind === "once") {
+			this.tasks.delete(task.id);
+			this.persistTasks();
+			this.updateStatus();
+			return;
+		}
+
+		if (task.cronExpression) {
+			const next = computeNextCronRunAt(task.cronExpression, now + 1_000);
+			if (!next) {
+				this.tasks.delete(task.id);
+				this.persistTasks();
+				this.updateStatus();
+				return;
+			}
+			task.nextRunAt = next;
+			this.persistTasks();
+			this.updateStatus();
+			return;
+		}
+
+		const intervalMs = task.intervalMs ?? DEFAULT_LOOP_INTERVAL;
+		let next = task.nextRunAt;
+		while (next <= now) {
+			next += intervalMs;
+		}
+		task.nextRunAt = next;
+		this.persistTasks();
+		this.updateStatus();
+	}
+
+	createId(): string {
+		let id = "";
+		do {
+			id = Math.random().toString(36).slice(2, 10);
+		} while (this.tasks.has(id));
+		return id;
+	}
+
+	taskMode(task: ScheduleTask): string {
+		if (task.kind === "once") {
+			return "once";
+		}
+		if (task.cronExpression) {
+			return `cron ${task.cronExpression}`;
+		}
+		return `every ${formatDurationShort(task.intervalMs ?? DEFAULT_LOOP_INTERVAL)}`;
+	}
+
+	private taskOptionLabel(task: ScheduleTask): string {
+		const state = task.enabled ? "✓" : "⏸";
+		return `${task.id} • ${state} ${this.taskMode(task)} • ${this.formatRelativeTime(task.nextRunAt)} • ${this.truncateText(task.prompt, 50)}`;
+	}
+
+	private truncateText(value: string, max = 64): string {
+		if (value.length <= max) {
+			return value;
+		}
+		return `${value.slice(0, Math.max(0, max - 3))}...`;
+	}
+
+	formatClock(timestamp: number): string {
+		return new Date(timestamp).toLocaleTimeString([], { hour: "2-digit", minute: "2-digit" });
+	}
+
+	hashString(input: string): number {
+		let hash = 2166136261;
+		for (let i = 0; i < input.length; i++) {
+			hash ^= input.charCodeAt(i);
+			hash += (hash << 1) + (hash << 4) + (hash << 7) + (hash << 8) + (hash << 24);
+		}
+		return hash >>> 0;
+	}
+
+	computeJitterMs(taskId: string, intervalMs: number): number {
+		const maxJitter = Math.min(Math.floor(intervalMs * 0.1), FIFTEEN_MINUTES);
+		if (maxJitter <= 0) {
+			return 0;
+		}
+		return this.hashString(taskId) % (maxJitter + 1);
+	}
+
+	loadTasksFromDisk() {
+		if (!this.storagePath) {
+			return;
+		}
+
+		this.tasks.clear();
+		try {
+			if (!fs.existsSync(this.storagePath)) {
+				return;
+			}
+			const raw = fs.readFileSync(this.storagePath, "utf-8");
+			const parsed = JSON.parse(raw) as SchedulerStore;
+			const list = Array.isArray(parsed?.tasks) ? parsed.tasks : [];
+			const now = Date.now();
+			for (const task of list) {
+				if (!(task?.id && task.prompt)) {
+					continue;
+				}
+				const normalized: ScheduleTask = {
+					...task,
+					enabled: task.enabled ?? true,
+					pending: false,
+					runCount: task.runCount ?? 0,
+				};
+				if (normalized.kind === "recurring" && normalized.expiresAt && now >= normalized.expiresAt) {
+					continue;
+				}
+				this.tasks.set(normalized.id, normalized);
+			}
+		} catch {
+			// Ignore corrupted store and continue with empty in-memory state.
+		}
+		this.updateStatus();
+	}
+
+	persistTasks() {
+		if (!this.storagePath) {
+			return;
+		}
+		try {
+			fs.mkdirSync(path.dirname(this.storagePath), { recursive: true });
+			const store: SchedulerStore = {
+				version: 1,
+				tasks: this.getSortedTasks(),
+			};
+			const tempPath = `${this.storagePath}.tmp`;
+			fs.writeFileSync(tempPath, JSON.stringify(store, null, 2), "utf-8");
+			fs.renameSync(tempPath, this.storagePath);
+		} catch {
+			// Best-effort persistence; runtime behavior should continue.
+		}
+	}
+}
+
+// ── Commands ────────────────────────────────────────────────────────────────
+
+function registerCommands(pi: ExtensionAPI, runtime: SchedulerRuntime) {
+	pi.registerCommand("loop", {
+		description: "Schedule recurring prompt: /loop 5m <prompt>, /loop <prompt> every 2h, or /loop cron <expr> <prompt>",
+		handler: async (args, ctx) => {
+			const parsed = parseLoopScheduleArgs(args);
+			if (!parsed) {
+				ctx.ui.notify("Usage: /loop 5m check build OR /loop cron '*/5 * * * *' check build", "warning");
+				return;
+			}
+
+			if (runtime.taskCount >= MAX_TASKS) {
+				ctx.ui.notify(`Task limit reached (${MAX_TASKS}). Delete one with /schedule delete <id>.`, "error");
+				return;
+			}
+
+			if (parsed.recurring.mode === "cron") {
+				const task = runtime.addRecurringCronTask(parsed.prompt, parsed.recurring.cronExpression);
+				if (!task) {
+					ctx.ui.notify("Invalid cron schedule; could not compute next run.", "error");
+					return;
+				}
+				ctx.ui.notify(`Scheduled cron ${task.cronExpression} (id: ${task.id}). Expires in 3 days.`, "info");
+				if (parsed.recurring.note) {
+					ctx.ui.notify(parsed.recurring.note, "info");
+				}
+				return;
+			}
+
+			const task = runtime.addRecurringIntervalTask(parsed.prompt, parsed.recurring.durationMs);
+			ctx.ui.notify(
+				`Scheduled every ${formatDurationShort(parsed.recurring.durationMs)} (id: ${task.id}). Expires in 3 days.`,
+				"info",
+			);
+			if (parsed.recurring.note) {
+				ctx.ui.notify(parsed.recurring.note, "info");
+			}
+		},
+	});
+
+	pi.registerCommand("remind", {
+		description: "Schedule one-time reminder: /remind in 45m <prompt>",
+		handler: async (args, ctx) => {
+			const parsed = parseRemindScheduleArgs(args);
+			if (!parsed) {
+				ctx.ui.notify("Usage: /remind in 45m check deployment", "warning");
+				return;
+			}
+
+			if (runtime.taskCount >= MAX_TASKS) {
+				ctx.ui.notify(`Task limit reached (${MAX_TASKS}). Delete one with /schedule delete <id>.`, "error");
+				return;
+			}
+
+			const task = runtime.addOneShotTask(parsed.prompt, parsed.durationMs);
+			ctx.ui.notify(`Reminder set for ${runtime.formatRelativeTime(task.nextRunAt)} (id: ${task.id}).`, "info");
+			if (parsed.note) {
+				ctx.ui.notify(parsed.note, "info");
+			}
+		},
+	});
+
+	pi.registerCommand("schedule", {
+		description:
+			"Manage schedules. No args opens TUI manager. Also: list | enable <id> | disable <id> | delete <id> | clear",
+		// biome-ignore lint/complexity/noExcessiveCognitiveComplexity: Command router with multiple subcommands.
+		handler: async (args, ctx) => {
+			const trimmed = args.trim();
+			if (!trimmed || trimmed === "tui") {
+				await runtime.openTaskManager(ctx);
+				return;
+			}
+
+			const [rawAction, rawArg] = trimmed.split(/\s+/, 2);
+			const action = rawAction.toLowerCase();
+
+			if (action === "list") {
+				pi.sendMessage({
+					customType: "pi-scheduler",
+					content: runtime.formatTaskList(),
+					display: true,
+				});
+				return;
+			}
+
+			if (action === "enable" || action === "disable") {
+				if (!rawArg) {
+					ctx.ui.notify(`Usage: /schedule ${action} <id>`, "warning");
+					return;
+				}
+				const enabled = action === "enable";
+				const ok = runtime.setTaskEnabled(rawArg, enabled);
+				if (!ok) {
+					ctx.ui.notify(`Task not found: ${rawArg}`, "warning");
+					return;
+				}
+				ctx.ui.notify(`${enabled ? "Enabled" : "Disabled"} scheduled task ${rawArg}.`, "info");
+				return;
+			}
+
+			if (action === "delete" || action === "remove" || action === "rm") {
+				if (!rawArg) {
+					ctx.ui.notify("Usage: /schedule delete <id>", "warning");
+					return;
+				}
+				const removed = runtime.deleteTask(rawArg);
+				if (!removed) {
+					ctx.ui.notify(`Task not found: ${rawArg}`, "warning");
+					return;
+				}
+				ctx.ui.notify(`Deleted scheduled task ${rawArg}.`, "info");
+				return;
+			}
+
+			if (action === "clear") {
+				const count = runtime.clearTasks();
+				ctx.ui.notify(`Cleared ${count} task${count === 1 ? "" : "s"}.`, "info");
+				return;
+			}
+
+			ctx.ui.notify("Usage: /schedule [tui|list|enable <id>|disable <id>|delete <id>|clear]", "warning");
+		},
+	});
+
+	pi.registerCommand("unschedule", {
+		description: "Alias for /schedule delete <id>",
+		handler: async (args, ctx) => {
+			const id = args.trim();
+			if (!id) {
+				ctx.ui.notify("Usage: /unschedule <id>", "warning");
+				return;
+			}
+			const removed = runtime.deleteTask(id);
+			if (!removed) {
+				ctx.ui.notify(`Task not found: ${id}`, "warning");
+				return;
+			}
+			ctx.ui.notify(`Deleted scheduled task ${id}.`, "info");
+		},
+	});
+}
+
+// ── Tool ────────────────────────────────────────────────────────────────────
+
+const SchedulePromptToolParams = Type.Object({
+	action: Type.Union(
+		[
+			Type.Literal("add"),
+			Type.Literal("list"),
+			Type.Literal("delete"),
+			Type.Literal("clear"),
+			Type.Literal("enable"),
+			Type.Literal("disable"),
+		],
+		{ description: "Action to perform" },
+	),
+	kind: Type.Optional(Type.Union([Type.Literal("recurring"), Type.Literal("once")], { description: "Task kind" })),
+	prompt: Type.Optional(Type.String({ description: "Prompt text to run when the task fires" })),
+	duration: Type.Optional(
+		Type.String({
+			description:
+				"Delay/interval like 5m, 2h, 1 day. For kind=once this is required. For kind=recurring this creates interval-based loops.",
+		}),
+	),
+	cron: Type.Optional(
+		Type.String({
+			description:
+				"Cron expression for recurring tasks. Accepts 5-field (minute hour dom month dow) or 6-field (sec minute hour dom month dow).",
+		}),
+	),
+	id: Type.Optional(Type.String({ description: "Task id for delete/enable/disable action" })),
+});
+
+function registerTools(pi: ExtensionAPI, runtime: SchedulerRuntime) {
+	pi.registerTool({
+		name: "schedule_prompt",
+		label: "Schedule Prompt",
+		description:
+			"Create/list/enable/disable/delete scheduled prompts. Use this when the user asks for reminders or recurring checks. add requires prompt; once tasks require duration; recurring supports interval (duration) or cron expression (cron).",
+		promptSnippet:
+			"Create/list/enable/disable/delete scheduled prompts. Supports recurring intervals/cron and one-time reminders (session-scoped).",
+		promptGuidelines: [
+			"Use this tool when user asks to remind/check back later.",
+			"For recurring tasks use kind='recurring' with duration like 5m or 2h, or provide cron.",
+			"For one-time reminders use kind='once' with duration like 30m or 1h.",
+		],
+		parameters: SchedulePromptToolParams,
+		execute: async (
+			_toolCallId,
+			params: { action: string; kind?: TaskKind; prompt?: string; duration?: string; cron?: string; id?: string },
+		): Promise<{ content: { type: "text"; text: string }[]; details: Record<string, unknown> }> => {
+			const { action } = params;
+
+			if (action === "list") {
+				return handleToolList(runtime);
+			}
+			if (action === "clear") {
+				return handleToolClear(runtime);
+			}
+			if (action === "delete") {
+				return handleToolDelete(params, runtime);
+			}
+			if (action === "enable" || action === "disable") {
+				return handleToolToggle(params, runtime);
+			}
+			if (action === "add") {
+				return handleToolAdd(params, runtime);
+			}
+
+			return {
+				content: [{ type: "text", text: `Error: unsupported action '${String(action)}'.` }],
+				details: { action, error: "unsupported_action" },
+			};
+		},
+	});
+}
+
+type ToolResult = { content: { type: "text"; text: string }[]; details: Record<string, unknown> };
+
+function handleToolList(runtime: SchedulerRuntime): ToolResult {
+	const list = runtime.getSortedTasks();
+	if (list.length === 0) {
+		return { content: [{ type: "text", text: "No scheduled tasks." }], details: { action: "list", tasks: [] } };
+	}
+
+	const lines = list.map((task) => {
+		const schedule =
+			task.kind === "once"
+				? "-"
+				: (task.cronExpression ?? formatDurationShort(task.intervalMs ?? DEFAULT_LOOP_INTERVAL));
+		const state = task.enabled ? "on" : "off";
+		const status = task.lastStatus ?? "pending";
+		const last = task.lastRunAt ? runtime.formatRelativeTime(task.lastRunAt) : "never";
+		return `${task.id}\t${state}\t${task.kind}\t${schedule}\t${runtime.formatRelativeTime(task.nextRunAt)}\t${task.runCount}\t${last}\t${status}\t${task.prompt}`;
+	});
+	return {
+		content: [
+			{
+				type: "text",
+				text: `Scheduled tasks (id\tstate\tkind\tschedule\tnext\truns\tlast\tstatus\tprompt):\n${lines.join("\n")}`,
+			},
+		],
+		details: { action: "list", tasks: list },
+	};
+}
+
+function handleToolClear(runtime: SchedulerRuntime): ToolResult {
+	const count = runtime.clearTasks();
+	return {
+		content: [{ type: "text", text: `Cleared ${count} scheduled task${count === 1 ? "" : "s"}.` }],
+		details: { action: "clear", cleared: count },
+	};
+}
+
+function handleToolDelete(params: { id?: string }, runtime: SchedulerRuntime): ToolResult {
+	const id = params.id?.trim();
+	if (!id) {
+		return {
+			content: [{ type: "text", text: "Error: id is required for delete action." }],
+			details: { action: "delete", error: "missing_id" },
+		};
+	}
+	const removed = runtime.deleteTask(id);
+	if (!removed) {
+		return {
+			content: [{ type: "text", text: `Task not found: ${id}` }],
+			details: { action: "delete", id, removed: false },
+		};
+	}
+	return {
+		content: [{ type: "text", text: `Deleted scheduled task ${id}.` }],
+		details: { action: "delete", id, removed: true },
+	};
+}
+
+function handleToolToggle(params: { action: string; id?: string }, runtime: SchedulerRuntime): ToolResult {
+	const { action } = params;
+	const id = params.id?.trim();
+	if (!id) {
+		return {
+			content: [{ type: "text", text: `Error: id is required for ${action} action.` }],
+			details: { action, error: "missing_id" },
+		};
+	}
+	const enabled = action === "enable";
+	const ok = runtime.setTaskEnabled(id, enabled);
+	if (!ok) {
+		return {
+			content: [{ type: "text", text: `Task not found: ${id}` }],
+			details: { action, id, updated: false },
+		};
+	}
+	return {
+		content: [{ type: "text", text: `${enabled ? "Enabled" : "Disabled"} scheduled task ${id}.` }],
+		details: { action, id, updated: true, enabled },
+	};
+}
+
+function validationErrorMessage(error: string): string {
+	switch (error) {
+		case "missing_duration":
+			return "Error: duration is required for one-time reminders.";
+		case "invalid_duration":
+			return "Error: invalid duration. Use values like 5m, 2h, 1 day.";
+		case "invalid_cron_for_once":
+			return "Error: cron is only valid for recurring tasks.";
+		case "conflicting_schedule_inputs":
+			return "Error: provide either duration or cron for recurring tasks, not both.";
+		case "invalid_cron":
+			return "Error: invalid cron expression.";
+		default:
+			return `Error: ${error}`;
+	}
+}
+
+function handleToolAdd(
+	params: { kind?: TaskKind; prompt?: string; duration?: string; cron?: string },
+	runtime: SchedulerRuntime,
+): ToolResult {
+	const prompt = params.prompt?.trim();
+	if (!prompt) {
+		return {
+			content: [{ type: "text", text: "Error: prompt is required for add action." }],
+			details: { action: "add", error: "missing_prompt" },
+		};
+	}
+
+	if (runtime.taskCount >= MAX_TASKS) {
+		return {
+			content: [{ type: "text", text: `Task limit reached (${MAX_TASKS}). Delete one first.` }],
+			details: { action: "add", error: "task_limit" },
+		};
+	}
+
+	const validated = validateSchedulePromptAddInput({
+		kind: params.kind,
+		duration: params.duration,
+		cron: params.cron,
+	});
+	if (!validated.ok) {
+		return {
+			content: [{ type: "text", text: validationErrorMessage(validated.error) }],
+			details: { action: "add", error: validated.error },
+		};
+	}
+
+	if (validated.plan.kind === "once") {
+		const task = runtime.addOneShotTask(prompt, validated.plan.durationMs);
+		return {
+			content: [
+				{
+					type: "text",
+					text: `Reminder scheduled (id: ${task.id}) for ${runtime.formatRelativeTime(task.nextRunAt)}.${
+						validated.plan.note ? ` ${validated.plan.note}` : ""
+					}`,
+				},
+			],
+			details: { action: "add", task },
+		};
+	}
+
+	if (validated.plan.mode === "cron") {
+		const task = runtime.addRecurringCronTask(prompt, validated.plan.cronExpression);
+		if (!task) {
+			return {
+				content: [{ type: "text", text: "Error: could not compute next run for this cron expression." }],
+				details: { action: "add", error: "cron_next_run_failed" },
+			};
+		}
+		return {
+			content: [
+				{
+					type: "text",
+					text: `Recurring cron task scheduled (id: ${task.id}) with '${task.cronExpression}'. Expires in 3 days.${
+						validated.plan.note ? ` ${validated.plan.note}` : ""
+					}`,
+				},
+			],
+			details: { action: "add", task },
+		};
+	}
+
+	const task = runtime.addRecurringIntervalTask(prompt, validated.plan.durationMs);
+	return {
+		content: [
+			{
+				type: "text",
+				text: `Recurring task scheduled (id: ${task.id}) every ${formatDurationShort(validated.plan.durationMs)}. Expires in 3 days.${
+					validated.plan.note ? ` ${validated.plan.note}` : ""
+				}`,
+			},
+		],
+		details: { action: "add", task },
+	};
+}
+
+// ── Events ──────────────────────────────────────────────────────────────────
+
+function registerEvents(pi: ExtensionAPI, runtime: SchedulerRuntime) {
+	pi.on("session_start", async (_event, ctx) => {
+		runtime.setRuntimeContext(ctx);
+		runtime.startScheduler();
+		runtime.updateStatus();
+	});
+
+	pi.on("session_switch", async (_event, ctx) => {
+		runtime.setRuntimeContext(ctx);
+		runtime.updateStatus();
+	});
+
+	pi.on("session_fork", async (_event, ctx) => {
+		runtime.setRuntimeContext(ctx);
+		runtime.updateStatus();
+	});
+
+	pi.on("session_tree", async (_event, ctx) => {
+		runtime.setRuntimeContext(ctx);
+		runtime.updateStatus();
+	});
+
+	pi.on("session_shutdown", async (_event, ctx) => {
+		runtime.setRuntimeContext(ctx);
+		runtime.stopScheduler();
+		runtime.clearStatus(ctx);
+	});
+}
+
+// ── Extension entry ─────────────────────────────────────────────────────────
+
+export default function schedulerExtension(pi: ExtensionAPI) {
+	const runtime = new SchedulerRuntime(pi);
+	registerEvents(pi, runtime);
+	registerCommands(pi, runtime);
+	registerTools(pi, runtime);
+}

--- a/packages/extensions/package.json
+++ b/packages/extensions/package.json
@@ -16,9 +16,12 @@
     "!**/*.test.ts"
   ],
   "license": "MIT",
+  "dependencies": {
+    "croner": "^10.0.1"
+  },
   "peerDependencies": {
-    "@mariozechner/pi-ai": "*",
     "@mariozechner/pi-agent-core": "*",
+    "@mariozechner/pi-ai": "*",
     "@mariozechner/pi-coding-agent": "*",
     "@mariozechner/pi-tui": "*",
     "@sinclair/typebox": "*"

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -100,6 +100,9 @@ importers:
       '@sinclair/typebox':
         specifier: '*'
         version: 0.34.48
+      croner:
+        specifier: ^10.0.1
+        version: 10.0.1
 
   packages/oh-pi:
     dependencies:
@@ -1185,6 +1188,10 @@ packages:
 
   color-name@1.1.4:
     resolution: {integrity: sha512-dOy+3AuW3a2wNbZHIuMZpTcgjGuLU/uBL/ubcZF9OXbDo8ff4O8yVp5Bf0efS8uEoYo5q4Fx7dY9OgQGXgAsQA==}
+
+  croner@10.0.1:
+    resolution: {integrity: sha512-ixNtAJndqh173VQ4KodSdJEI6nuioBWI0V1ITNKhZZsO0pEMoDxz539T4FTTbSZ/xIOSuDnzxLVRqBVSvPNE2g==}
+    engines: {node: '>=18.0'}
 
   cross-spawn@7.0.6:
     resolution: {integrity: sha512-uV2QOWP2nWzsy2aMp8aRibhi9dlzF5Hgh5SHaB9OiTGEyDTiJJyx0uy51QXdyWbtAHNua4XJzUKca3OzKUd3vA==}
@@ -3169,6 +3176,8 @@ snapshots:
       color-name: 1.1.4
 
   color-name@1.1.4: {}
+
+  croner@10.0.1: {}
 
   cross-spawn@7.0.6:
     dependencies:


### PR DESCRIPTION
## Summary

Adds a scheduler extension based on [pi-scheduler](https://github.com/manojlds/pi-scheduler) by @manojlds (MIT).

### Commands

| Command | Description |
|---------|-------------|
| `/loop 5m check build` | Recurring check every 5 minutes |
| `/loop cron */5 * * * * check ci` | Cron-based recurring check |
| `/loop check build status` | Defaults to every 10 minutes |
| `/remind in 45m check tests` | One-time reminder |
| `/schedule` | Opens TUI task manager |
| `/schedule list` | Lists all tasks |
| `/schedule enable/disable/delete <id>` | Task management |
| `/schedule clear` | Removes all tasks |
| `/unschedule <id>` | Quick delete alias |

### LLM Tool

Exposes `schedule_prompt` tool with actions: add, list, enable, disable, delete, clear.

### Key Features

- Tasks run only when pi is idle (between turns)
- Recurring tasks auto-expire after 3 days
- State persisted to `.pi/scheduler.json`
- Supports both interval (`5m`, `2h`) and cron expressions (5/6-field)
- Max 50 active tasks with jitter to prevent thundering herd
- Duration parsing with word forms (`30 minutes`, `2 hours`)

### Tests

204 tests covering:
- Duration parsing (19 tests)
- Duration normalization (5 tests)
- Cron normalization and scheduling (9 tests)
- `parseLoopScheduleArgs` parsing (10 tests)
- `parseRemindScheduleArgs` parsing (5 tests)
- `validateSchedulePromptAddInput` validation (10 tests)
- `SchedulerRuntime` lifecycle, task management, scheduler tick, dispatch, persistence, jitter, status bar (47 tests)
- Extension registration (3 tests)
- Command handlers: /loop, /remind, /schedule, /unschedule (27 tests)
- Tool schedule_prompt: add, list, delete, enable/disable, clear (18 tests)
- Event wiring (5 tests)
- Constants (5 tests)
- Edge cases and integration scenarios (10 tests)
- Format helpers (4 tests)

### Changes

- `packages/extensions/extensions/scheduler.ts` — New extension (single file, ~800 LOC)
- `packages/extensions/extensions/scheduler.test.ts` — Comprehensive tests (~1,200 LOC)
- `packages/extensions/package.json` — Added `croner` dependency
- `.changeset/scheduler-extension.md` — Changeset
