### PR TITLE
fix(ant-colony): harden JSON task plan parsing

### DIFF
--- a/.changeset/ant-colony-json-plan-parser.md
+++ b/.changeset/ant-colony-json-plan-parser.md
@@ -1,0 +1,11 @@
+---
+"@ifi/oh-pi-ant-colony": patch
+"@ifi/oh-pi": patch
+---
+
+Fix ant-colony JSON task-plan parsing so malformed scout output no longer produces invalid execution plans:
+
+- only accept fenced JSON plans when they are task arrays, nested `tasks` arrays, or single task-like objects
+- ignore JSON entries that omit both `title` and `description`
+- normalize JSON task titles/descriptions consistently with markdown task parsing
+- add parser regression tests for nested JSON plans and missing task fields

--- a/packages/ant-colony/extensions/ant-colony/parser.ts
+++ b/packages/ant-colony/extensions/ant-colony/parser.ts
@@ -53,21 +53,49 @@ function extractFileLike(value: string): string[] {
 	return [...new Set(fileish)];
 }
 
+function isRecord(value: unknown): value is Record<string, unknown> {
+	return typeof value === "object" && value !== null;
+}
+
+function hasNonEmptyText(value: unknown): boolean {
+	return typeof value === "string" && value.trim().length > 0;
+}
+
+function isJsonTaskLike(value: unknown): value is Record<string, unknown> {
+	return isRecord(value) && (hasNonEmptyText(value.title) || hasNonEmptyText(value.description));
+}
+
+function extractJsonTaskCandidates(parsed: unknown): Array<Record<string, unknown>> {
+	if (Array.isArray(parsed)) {
+		return parsed.filter(isJsonTaskLike);
+	}
+	if (isRecord(parsed) && Array.isArray(parsed.tasks)) {
+		return parsed.tasks.filter(isJsonTaskLike);
+	}
+	if (isJsonTaskLike(parsed)) {
+		return [parsed];
+	}
+	return [];
+}
+
 function normalizeJsonTasks(parsed: unknown): ParsedSubTask[] {
-	const arr = (Array.isArray(parsed) ? parsed : [parsed]) as Array<Record<string, unknown>>;
-	return arr.map((t) => ({
-		title: String(t.title || "Untitled"),
-		description: String(t.description || t.title || ""),
-		files: Array.isArray(t.files)
-			? t.files
-					.map(String)
-					.map((f) => f.trim())
-					.filter(Boolean)
-			: extractFileLike(String(t.files || "")),
-		caste: normalizeCaste(t.caste),
-		priority: normalizePriority(t.priority),
-		context: t.context ? String(t.context) : undefined,
-	}));
+	return extractJsonTaskCandidates(parsed).map((t) => {
+		const title = String(t.title || t.description || "Untitled").trim() || "Untitled";
+		const description = String(t.description || t.title || title).trim() || title;
+		return {
+			title,
+			description,
+			files: Array.isArray(t.files)
+				? t.files
+						.map(String)
+						.map((f) => f.trim())
+						.filter(Boolean)
+				: extractFileLike(String(t.files || "")),
+			caste: normalizeCaste(t.caste),
+			priority: normalizePriority(t.priority),
+			context: t.context ? String(t.context) : undefined,
+		};
+	});
 }
 
 // biome-ignore lint/complexity/noExcessiveCognitiveComplexity: Parser must handle many field variants (en/zh) and edge cases
@@ -173,7 +201,10 @@ export function parseSubTasks(output: string): ParsedSubTask[] {
 	const jsonMatch = output.match(/```json\s*([\s\S]*?)```/i);
 	if (jsonMatch?.[1]) {
 		try {
-			return normalizeJsonTasks(JSON.parse(jsonMatch[1].trim()));
+			const jsonTasks = normalizeJsonTasks(JSON.parse(jsonMatch[1].trim()));
+			if (jsonTasks.length > 0) {
+				return jsonTasks;
+			}
 		} catch {
 			/* fallback */
 		}

--- a/packages/ant-colony/tests/parser.test.ts
+++ b/packages/ant-colony/tests/parser.test.ts
@@ -49,6 +49,44 @@ describe("parseSubTasks", () => {
 		expect(tasks[0].caste).toBe("scout");
 	});
 
+	it("parses JSON task arrays nested under a tasks key", () => {
+		const output =
+			'```json\n{"discoveries":["parser.ts"],"tasks":[{"title":"Task A","description":"Do A","files":["a.ts"],"caste":"worker","priority":1}]}\n```';
+		const tasks = parseSubTasks(output);
+		expect(tasks).toHaveLength(1);
+		expect(tasks[0]).toMatchObject({
+			title: "Task A",
+			description: "Do A",
+			files: ["a.ts"],
+			caste: "worker",
+			priority: 1,
+		});
+	});
+
+	it("defaults missing JSON description to the task title", () => {
+		const tasks = parseSubTasks('```json\n[{"title":"Task A","files":["a.ts"]}]\n```');
+		expect(tasks).toHaveLength(1);
+		expect(tasks[0].title).toBe("Task A");
+		expect(tasks[0].description).toBe("Task A");
+	});
+
+	it("defaults missing JSON title to the description", () => {
+		const tasks = parseSubTasks('```json\n[{"description":"Do A","files":["a.ts"]}]\n```');
+		expect(tasks).toHaveLength(1);
+		expect(tasks[0].title).toBe("Do A");
+		expect(tasks[0].description).toBe("Do A");
+	});
+
+	it("ignores JSON task entries missing both title and description", () => {
+		const tasks = parseSubTasks('```json\n[{"files":["a.ts"],"caste":"worker","priority":1}]\n```');
+		expect(tasks).toEqual([]);
+	});
+
+	it("ignores fenced JSON objects that are not task plans", () => {
+		const tasks = parseSubTasks('```json\n{"discoveries":["parser.ts"],"warnings":["be careful"]}\n```');
+		expect(tasks).toEqual([]);
+	});
+
 	it("defaults caste to worker for invalid", () => {
 		const tasks = parseSubTasks('```json\n[{"title":"X","caste":"invalid"}]\n```');
 		expect(tasks[0].caste).toBe("worker");


### PR DESCRIPTION
## Summary
- harden fenced JSON task-plan parsing in the ant-colony parser
- ignore malformed JSON entries that omit both `title` and `description`
- support nested `{ tasks: [...] }` JSON plans and normalize missing title/description fields consistently
- add regression tests and a changeset

## Testing
- pnpm exec vitest run $(find packages/ant-colony/tests -name '*.test.ts' | tr '\\n' ' ')\n- pnpm exec tsgo --project packages/ant-colony/tsconfig.json --noEmit\n- pnpm exec biome check packages/ant-colony/extensions/ant-colony/parser.ts packages/ant-colony/tests/parser.test.ts .changeset/ant-colony-json-plan-parser.md