### PR TITLE
feat(plan): add pi-plan planning mode package

### DIFF
--- a/.changeset/pi-plan.md
+++ b/.changeset/pi-plan.md
@@ -1,0 +1,12 @@
+---
+default: minor
+---
+
+Add a new planning mode package, `@ifi/pi-plan`, plus a shared first-party `@ifi/pi-shared-qna`
+library in the monorepo.
+
+- vendor the `plan-md` workflow from `sids/pi-extensions` into `packages/plan` and adapt it to the `/plan` command
+- back plan research tasks with the in-repo subagent runtime from `@ifi/pi-extension-subagents`
+- vendor the shared Q&A TUI component into `packages/shared-qna` to avoid third-party pi package dependencies
+- include `@ifi/pi-plan` in the `@ifi/oh-pi` bundle and monorepo docs
+- add Vitest coverage for plan flow, prompts, state, request-user-input, task agents, utilities, and shared Q&A helpers

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -103,6 +103,8 @@ packages/
   skills/                 → @ifi/oh-pi-skills (skill directories)
   agents/                 → @ifi/oh-pi-agents (AGENTS.md templates)
   subagents/              → @ifi/pi-extension-subagents (raw .ts: subagent orchestration package)
+  shared-qna/             → @ifi/pi-shared-qna (shared TUI helper library)
+  plan/                   → @ifi/pi-plan (raw .ts: planning mode extension)
   oh-pi/                  → @ifi/oh-pi (installer CLI: `npx @ifi/oh-pi`)
 ```
 
@@ -115,7 +117,7 @@ root, so extensions must be installed separately for peer-dep imports
 
 ```bash
 npx @ifi/oh-pi                      # install all packages (latest, global)
-npx @ifi/oh-pi --version 0.2.12     # pin to a specific version
+npx @ifi/oh-pi --version 0.2.13     # pin to a specific version
 npx @ifi/oh-pi --local              # install to project .pi/settings.json
 npx @ifi/oh-pi --remove             # uninstall all oh-pi packages from pi
 ```
@@ -130,6 +132,7 @@ pi install npm:@ifi/oh-pi-themes
 pi install npm:@ifi/oh-pi-prompts
 pi install npm:@ifi/oh-pi-skills
 pi install npm:@ifi/pi-extension-subagents
+pi install npm:@ifi/pi-plan
 ```
 
 **Do not use `bundledDependencies`** in the oh-pi package — pnpm's isolated linker does not support

--- a/README.md
+++ b/README.md
@@ -45,6 +45,8 @@ This is a monorepo. Install everything at once with `npx @ifi/oh-pi`, or pick in
 | [`@ifi/oh-pi-extensions`](./packages/extensions)          | 9 extensions (see below)                    | `pi install npm:@ifi/oh-pi-extensions`      |
 | [`@ifi/oh-pi-ant-colony`](./packages/ant-colony)          | Multi-agent swarm extension                 | `pi install npm:@ifi/oh-pi-ant-colony`      |
 | [`@ifi/pi-extension-subagents`](./packages/subagents)     | Full-featured subagent delegation extension | `pi install npm:@ifi/pi-extension-subagents` |
+| [`@ifi/pi-plan`](./packages/plan)                         | Branch-aware planning mode extension        | `pi install npm:@ifi/pi-plan`               |
+| [`@ifi/pi-shared-qna`](./packages/shared-qna)             | Shared Q&A TUI helpers                      | (library, not installed directly)           |
 | [`@ifi/oh-pi-themes`](./packages/themes)                  | 6 color themes                              | `pi install npm:@ifi/oh-pi-themes`          |
 | [`@ifi/oh-pi-prompts`](./packages/prompts)                | 10 prompt templates                         | `pi install npm:@ifi/oh-pi-prompts`         |
 | [`@ifi/oh-pi-skills`](./packages/skills)                  | 12 skill packs                              | `pi install npm:@ifi/oh-pi-skills`          |
@@ -54,7 +56,7 @@ This is a monorepo. Install everything at once with `npx @ifi/oh-pi`, or pick in
 
 ```bash
 npx @ifi/oh-pi                      # install latest versions (global)
-npx @ifi/oh-pi --version 0.2.12     # pin to a specific version
+npx @ifi/oh-pi --version 0.2.13     # pin to a specific version
 npx @ifi/oh-pi --local              # install to project .pi/settings.json
 npx @ifi/oh-pi --remove             # uninstall all oh-pi packages from pi
 ```
@@ -436,6 +438,8 @@ oh-pi/
 │   ├── extensions/             9 pi extensions (raw .ts)
 │   ├── ant-colony/             Multi-agent swarm extension (raw .ts)
 │   ├── subagents/              Subagent orchestration package (raw .ts)
+│   ├── shared-qna/             Shared Q&A TUI helper library (raw .ts)
+│   ├── plan/                   Planning mode extension (raw .ts)
 │   ├── themes/                 6 JSON theme files
 │   ├── prompts/                10 markdown prompt templates
 │   ├── skills/                 12 skill directories

--- a/biome.json
+++ b/biome.json
@@ -14,7 +14,9 @@
 			"packages/extensions/extensions/**/*.ts",
 			"packages/ant-colony/extensions/**/*.ts",
 			"packages/ant-colony/tests/**/*.ts",
-			"packages/subagents/tests/**/*.ts"
+			"packages/subagents/tests/**/*.ts",
+			"packages/plan/tests/**/*.ts",
+			"packages/shared-qna/tests/**/*.ts"
 		]
 	},
 	"formatter": {

--- a/knope.toml
+++ b/knope.toml
@@ -16,6 +16,8 @@ versioned_files = [
   "packages/skills/package.json",
   "packages/agents/package.json",
   "packages/subagents/package.json",
+  "packages/shared-qna/package.json",
+  "packages/plan/package.json",
   "packages/oh-pi/package.json",
 ]
 changelog = "CHANGELOG.md"

--- a/packages/oh-pi/README.md
+++ b/packages/oh-pi/README.md
@@ -15,7 +15,7 @@ can load extensions with proper module resolution.
 
 ```bash
 npx @ifi/oh-pi                      # install latest versions (global)
-npx @ifi/oh-pi --version 0.2.12     # pin to a specific version
+npx @ifi/oh-pi --version 0.2.13     # pin to a specific version
 npx @ifi/oh-pi --local              # install to project .pi/settings.json
 npx @ifi/oh-pi --remove             # uninstall all oh-pi packages from pi
 ```
@@ -25,9 +25,10 @@ npx @ifi/oh-pi --remove             # uninstall all oh-pi packages from pi
 | Package                 | Contents                                                                                    |
 | ----------------------- | ------------------------------------------------------------------------------------------- |
 | `@ifi/oh-pi-extensions`      | safe-guard, git-guard, auto-session, custom-footer, compact-header, auto-update, bg-process |
-| `@ifi/oh-pi-ant-colony`      | Multi-agent swarm extension (`/colony`, colony commands)                                    |
+| `@ifi/oh-pi-ant-colony`       | Multi-agent swarm extension (`/colony`, colony commands)                                     |
 | `@ifi/pi-extension-subagents` | Subagent orchestration extension (`subagent`, `subagent_status`, `/run`, `/chain`, `/parallel`) |
-| `@ifi/oh-pi-themes`          | cyberpunk, nord, gruvbox, tokyo-night, catppuccin, oh-p-dark                                |
+| `@ifi/pi-plan`                | Planning mode extension (`/plan`, `Alt+P`, `task_agents`, `set_plan`)                       |
+| `@ifi/oh-pi-themes`           | cyberpunk, nord, gruvbox, tokyo-night, catppuccin, oh-p-dark                                 |
 | `@ifi/oh-pi-prompts`         | review, fix, explain, refactor, test, commit, pr, and more                                  |
 | `@ifi/oh-pi-skills`          | web-search, debug-helper, git-workflow, rust-workspace-bootstrap, and more                  |
 | `@ifi/oh-pi-agents`          | AGENTS.md templates for common roles                                                        |

--- a/packages/oh-pi/bin/oh-pi.mjs
+++ b/packages/oh-pi/bin/oh-pi.mjs
@@ -5,7 +5,7 @@
  *
  * Usage:
  *   npx @ifi/oh-pi              # install latest versions
- *   npx @ifi/oh-pi --version 0.2.12  # install a specific version
+ *   npx @ifi/oh-pi --version 0.2.13  # install a specific version
  *   npx @ifi/oh-pi --local      # install to project .pi/settings.json
  *   npx @ifi/oh-pi --remove     # uninstall all oh-pi packages from pi
  */
@@ -16,6 +16,7 @@ const PACKAGES = [
 	"@ifi/oh-pi-extensions",
 	"@ifi/oh-pi-ant-colony",
 	"@ifi/pi-extension-subagents",
+	"@ifi/pi-plan",
 	"@ifi/oh-pi-themes",
 	"@ifi/oh-pi-prompts",
 	"@ifi/oh-pi-skills",

--- a/packages/oh-pi/package.json
+++ b/packages/oh-pi/package.json
@@ -21,6 +21,7 @@
     "@ifi/oh-pi-extensions": "workspace:*",
     "@ifi/oh-pi-ant-colony": "workspace:*",
     "@ifi/pi-extension-subagents": "workspace:*",
+    "@ifi/pi-plan": "workspace:*",
     "@ifi/oh-pi-themes": "workspace:*",
     "@ifi/oh-pi-prompts": "workspace:*",
     "@ifi/oh-pi-skills": "workspace:*",

--- a/packages/plan/README.md
+++ b/packages/plan/README.md
@@ -1,0 +1,78 @@
+# @ifi/pi-plan
+
+Planning mode extension for pi.
+
+Built on top of the planning workflow from
+[`sids/pi-extensions/plan-md`](https://github.com/sids/pi-extensions/tree/main/plan-md) and adapted for
+oh-pi.
+
+## Installation
+
+```bash
+pi install npm:@ifi/pi-plan
+```
+
+Or install it as part of the full oh-pi bundle:
+
+```bash
+npx @ifi/oh-pi
+```
+
+Or use the package installer directly:
+
+```bash
+npx @ifi/pi-plan
+npx @ifi/pi-plan --local
+```
+
+To remove:
+
+```bash
+npx @ifi/pi-plan --remove
+```
+
+## What it does
+
+- `/plan` starts planning when inactive and opens plan-mode actions when already active.
+- `Alt+P` runs the same plan-mode toggle flow as `/plan` without sending `/plan` as chat text.
+- Start location picker (shown when the session has branchable history):
+  - `Empty branch`
+  - `Current branch`
+- If a session plan already exists with content, startup offers:
+  - `Continue planning`
+  - `Empty branch` / `Current branch` when branchable history is available
+  - `Start fresh` when no branchable history is available
+- `/plan` accepts an optional location argument:
+  - file path → use that exact file as the plan file
+  - directory path → create `<timestamp>-<sessionId>.plan.md` in that directory
+- Shows a persistent banner while active with the active plan file path.
+- Running `/plan` while active shows:
+  - `Exit`
+  - `Exit & summarize branch`
+- Running `/plan <location>` while active moves the current plan file to the resolved location.
+- Exiting plan mode prefills the editor only when the active plan file has content.
+- After exit, a `Plan mode ended.` message is shown with the plan file and an expandable plan preview when available.
+
+## Commands
+
+- `/plan [location]`
+
+## Tools in plan mode
+
+Plan mode adds planning-specific tools only while active:
+
+- `task_agents` — run isolated research tasks using the bundled subagent runtime (concurrency: 1-4)
+- `steer_task_agent` — rerun one task from a previous `task_agents` run with extra guidance
+- `request_user_input` — ask clarifying questions with optional choices and optional freeform answers
+- `set_plan` — overwrite the active plan file with the complete latest plan text
+
+When plan mode ends, these tools are removed again.
+
+## Notes
+
+- By default, plan mode uses one plan file per session in the same directory as the session file, replacing the session extension with `.plan.md`.
+- `/plan [location]` can override the plan file path.
+- Plan files are kept after exiting so planning can be resumed later.
+- The default plan-mode prompt is stored in `packages/plan/prompts/PLAN.prompt.md`.
+- You can override that prompt globally by creating `~/.pi/agent/PLAN.prompt.md`.
+- If the override file is missing or blank, the bundled prompt is used.

--- a/packages/plan/flow.ts
+++ b/packages/plan/flow.ts
@@ -1,0 +1,667 @@
+import path from "node:path";
+import {
+	BorderedLoader,
+	type ExtensionAPI,
+	type ExtensionCommandContext,
+	type ExtensionContext,
+} from "@mariozechner/pi-coding-agent";
+import {
+	buildImplementationPrefill,
+	PLAN_MODE_END_OPTIONS,
+	PLAN_MODE_START_OPTIONS,
+	PLAN_MODE_SUMMARY_PROMPT,
+} from "./utils";
+import {
+	createFreshPlanFilePath,
+	ensurePlanFileExists,
+	movePlanFile,
+	pathExists,
+	readPlanFile,
+	resolveActivePlanFilePath,
+	resolvePlanLocationInput,
+	resetPlanFile,
+} from "./plan-files";
+import { getFirstUserMessageId, hasEntryInSession } from "./state";
+import type { PlanModeState } from "./types";
+
+type PlanModeStateManager = {
+	getState: () => PlanModeState;
+	setState: (ctx: ExtensionContext, nextState: PlanModeState) => void;
+	startPlanMode: (
+		ctx: ExtensionContext,
+		options: {
+			originLeafId?: string;
+			planFilePath: string;
+		},
+	) => void;
+};
+
+type PlanModeExitSummary = {
+	planFilePath: string;
+	planText?: string;
+};
+
+async function navigateToFreshPlanningBranch(
+	ctx: ExtensionContext,
+	cancelMessage: string,
+): Promise<boolean> {
+	const firstUserMessageId = getFirstUserMessageId(ctx);
+	if (!firstUserMessageId) {
+		ctx.ui.notify("No user message found to branch planning from.", "error");
+		return false;
+	}
+
+	try {
+		const navigateResult = await ctx.navigateTree(firstUserMessageId, {
+			summarize: false,
+			label: "plan",
+		});
+		if (navigateResult.cancelled) {
+			ctx.ui.notify(cancelMessage, "info");
+			return false;
+		}
+	} catch (error) {
+		ctx.ui.notify(
+			`Failed to create a fresh planning branch: ${error instanceof Error ? error.message : String(error)}`,
+			"error",
+		);
+		return false;
+	}
+
+	if (ctx.hasUI) {
+		ctx.ui.setEditorText("");
+	}
+	return true;
+}
+
+async function navigateToSavedPlanningBranch(
+	ctx: ExtensionContext,
+	options: {
+		savedLeafId?: string;
+		currentLeafId?: string;
+		cancelMessage: string;
+	},
+): Promise<boolean> {
+	if (!options.savedLeafId || options.savedLeafId === options.currentLeafId) {
+		return true;
+	}
+
+	if (!hasEntryInSession(ctx, options.savedLeafId)) {
+		ctx.ui.notify("Saved planning branch is unavailable. Continuing from the current branch tip.", "warning");
+		return true;
+	}
+
+	try {
+		const navigateResult = await ctx.navigateTree(options.savedLeafId, {
+			summarize: false,
+			label: "plan",
+		});
+		if (navigateResult.cancelled) {
+			ctx.ui.notify(options.cancelMessage, "info");
+			return false;
+		}
+		if (ctx.hasUI) {
+			ctx.ui.notify("Resumed previous planning branch.", "info");
+		}
+	} catch (error) {
+		ctx.ui.notify(
+			`Failed to resume the saved planning branch: ${error instanceof Error ? error.message : String(error)}`,
+			"error",
+		);
+		return false;
+	}
+
+	return true;
+}
+
+async function confirmMoveOverwriteIfNeeded(
+	ctx: ExtensionContext,
+	sourcePath: string | undefined,
+	targetPath: string,
+): Promise<boolean> {
+	if (!sourcePath || sourcePath === targetPath) {
+		return true;
+	}
+
+	const [sourceExists, targetExists] = await Promise.all([pathExists(sourcePath), pathExists(targetPath)]);
+	if (!sourceExists || !targetExists) {
+		return true;
+	}
+
+	if (!ctx.hasUI) {
+		ctx.ui.notify(
+			`Refusing to overwrite existing plan file without interactive confirmation: ${targetPath}`,
+			"error",
+		);
+		return false;
+	}
+
+	const shouldOverwrite = await ctx.ui.confirm(
+		"Overwrite existing plan file?",
+		`Target already exists:\n${targetPath}\n\nMove current plan file and overwrite target contents?`,
+	);
+	if (!shouldOverwrite) {
+		ctx.ui.notify("Plan file move cancelled.", "info");
+		return false;
+	}
+
+	return true;
+}
+
+async function updateActivePlanFileLocation(
+	ctx: ExtensionContext,
+	stateManager: PlanModeStateManager,
+	rawLocation: string,
+): Promise<{ previousPath: string; nextPath: string } | undefined> {
+	const previousPath = resolveActivePlanFilePath(ctx, stateManager.getState().planFilePath);
+
+	let nextPath: string | null;
+	try {
+		nextPath = await resolvePlanLocationInput(ctx, rawLocation);
+	} catch (error) {
+		ctx.ui.notify(
+			`Failed to resolve plan file location: ${error instanceof Error ? error.message : String(error)}`,
+			"error",
+		);
+		return undefined;
+	}
+
+	if (!nextPath) {
+		ctx.ui.notify("Please enter a valid plan file location.", "warning");
+		return undefined;
+	}
+
+	let shouldMove: boolean;
+	try {
+		shouldMove = await confirmMoveOverwriteIfNeeded(ctx, previousPath, nextPath);
+	} catch (error) {
+		ctx.ui.notify(
+			`Failed to check target path: ${error instanceof Error ? error.message : String(error)}`,
+			"error",
+		);
+		return undefined;
+	}
+	if (!shouldMove) {
+		return undefined;
+	}
+
+	try {
+		await movePlanFile(previousPath, nextPath);
+	} catch (error) {
+		ctx.ui.notify(`Failed to move plan file: ${error instanceof Error ? error.message : String(error)}`, "error");
+		return undefined;
+	}
+
+	const state = stateManager.getState();
+	if (state.planFilePath !== nextPath) {
+		stateManager.setState(ctx, {
+			...state,
+			planFilePath: nextPath,
+		});
+	}
+
+	return {
+		previousPath,
+		nextPath,
+	};
+}
+
+async function exitPlanMode(
+	ctx: ExtensionContext,
+	stateManager: PlanModeStateManager,
+	wantsSummary: boolean,
+	onPlanModeExited?: (summary: PlanModeExitSummary) => void,
+): Promise<boolean> {
+	const state = stateManager.getState();
+	if (!state.active) {
+		ctx.ui.notify("Plan mode is not active.", "info");
+		return false;
+	}
+	if (!ctx.hasUI) {
+		ctx.ui.notify("Exiting plan mode requires interactive mode.", "error");
+		return false;
+	}
+
+	const activeState = state;
+	const planningLeafId = ctx.sessionManager.getLeafId();
+	const originLeafId = activeState.originLeafId;
+	const planFilePath = resolveActivePlanFilePath(ctx, activeState.planFilePath);
+
+	const canNavigateToOrigin = Boolean(originLeafId && hasEntryInSession(ctx, originLeafId));
+	if (canNavigateToOrigin && originLeafId) {
+		if (wantsSummary) {
+			const result = await ctx.ui.custom<{ cancelled: boolean; error?: string } | null>((tui, theme, _kb, done) => {
+				const loader = new BorderedLoader(tui, theme, "Summarizing planning branch...");
+				loader.onAbort = () => done(null);
+
+				ctx.navigateTree(originLeafId, {
+					summarize: true,
+					customInstructions: PLAN_MODE_SUMMARY_PROMPT,
+					replaceInstructions: true,
+				})
+					.then(done)
+					.catch((error) => done({ cancelled: false, error: error instanceof Error ? error.message : String(error) }));
+
+				return loader;
+			});
+
+			if (result === null) {
+				ctx.ui.notify("Summarization cancelled. Use /plan to try again.", "info");
+				return false;
+			}
+			if (result.error) {
+				ctx.ui.notify(`Summarization failed: ${result.error}`, "error");
+				return false;
+			}
+			if (result.cancelled) {
+				ctx.ui.notify("Returning from plan mode was cancelled. Use /plan to try again.", "info");
+				return false;
+			}
+		} else {
+			try {
+				const navigateResult = await ctx.navigateTree(originLeafId, { summarize: false });
+				if (navigateResult.cancelled) {
+					ctx.ui.notify("Returning from plan mode was cancelled. Use /plan to try again.", "info");
+					return false;
+				}
+			} catch (error) {
+				ctx.ui.notify(
+					`Failed to restore origin point: ${error instanceof Error ? error.message : String(error)}`,
+					"error",
+				);
+				return false;
+			}
+		}
+	} else if (originLeafId) {
+		ctx.ui.notify("Origin point is unavailable. Ended planning at the current branch tip.", "warning");
+	}
+
+	stateManager.setState(ctx, {
+		version: activeState.version,
+		active: false,
+		planFilePath,
+		lastPlanLeafId: planningLeafId ?? activeState.lastPlanLeafId,
+	});
+	const planText = (await readPlanFile(planFilePath))?.trim();
+	if (planText) {
+		ctx.ui.setEditorText(buildImplementationPrefill(planFilePath));
+	}
+
+	onPlanModeExited?.({
+		planFilePath,
+		planText,
+	});
+	return true;
+}
+
+async function endPlanMode(
+	ctx: ExtensionContext,
+	stateManager: PlanModeStateManager,
+	onPlanModeExited?: (summary: PlanModeExitSummary) => void,
+) {
+	const state = stateManager.getState();
+	if (!state.active) {
+		ctx.ui.notify("Plan mode is not active.", "info");
+		return;
+	}
+	if (!ctx.hasUI) {
+		ctx.ui.notify("Exiting plan mode requires interactive mode.", "error");
+		return;
+	}
+
+	await ctx.waitForIdle();
+
+	const choice = await ctx.ui.select("Plan mode action (Esc stays in Plan mode)", [...PLAN_MODE_END_OPTIONS]);
+	if (choice === undefined) {
+		ctx.ui.notify("Continuing in Plan mode (Esc).", "info");
+		return;
+	}
+
+	const wantsSummary = choice === PLAN_MODE_END_OPTIONS[1];
+	await exitPlanMode(ctx, stateManager, wantsSummary, onPlanModeExited);
+}
+
+function canOfferEmptyBranchStart(ctx: ExtensionContext, originLeafId: string | undefined): boolean {
+	const firstUserMessageId = getFirstUserMessageId(ctx);
+	return Boolean(originLeafId && firstUserMessageId && firstUserMessageId !== originLeafId);
+}
+
+async function waitForIdleInShortcutContext(ctx: ExtensionContext): Promise<void> {
+	while (!ctx.isIdle()) {
+		await new Promise<void>((resolve) => {
+			setTimeout(resolve, 25);
+		});
+	}
+}
+
+function extractTextFromMessageContent(content: unknown): string {
+	if (typeof content === "string") {
+		return content;
+	}
+	if (!Array.isArray(content)) {
+		return "";
+	}
+
+	let text = "";
+	for (const part of content) {
+		if (!part || typeof part !== "object") {
+			continue;
+		}
+		const typedPart = part as { type?: unknown; text?: unknown };
+		if (typedPart.type === "text" && typeof typedPart.text === "string") {
+			text += typedPart.text;
+		}
+	}
+	return text;
+}
+
+async function navigateTreeInShortcutContext(
+	ctx: ExtensionContext,
+	targetId: string,
+	options?: {
+		summarize?: boolean;
+		label?: string;
+	},
+): Promise<{ cancelled: boolean }> {
+	if (options?.summarize) {
+		ctx.ui.notify("Alt+P exited plan mode without branch summarization. Use /plan for summarize-on-exit.", "warning");
+	}
+
+	const sessionManager = ctx.sessionManager as ExtensionContext["sessionManager"] & {
+		getEntry?: (entryId: string) =>
+			| {
+				type?: string;
+				parentId?: string | null;
+				message?: {
+					role?: string;
+					content?: unknown;
+				};
+				content?: unknown;
+			}
+			| undefined;
+		branch?: (entryId: string) => void;
+		resetLeaf?: () => void;
+		appendLabelChange?: (targetId: string, label: string | undefined) => void;
+	};
+
+	if (typeof sessionManager.getEntry !== "function") {
+		return { cancelled: true };
+	}
+
+	const targetEntry = sessionManager.getEntry(targetId);
+	if (!targetEntry) {
+		return { cancelled: true };
+	}
+
+	let newLeafId: string | null = targetId;
+	let editorText: string | undefined;
+
+	if (targetEntry.type === "message" && targetEntry.message?.role === "user") {
+		newLeafId = targetEntry.parentId ?? null;
+		editorText = extractTextFromMessageContent(targetEntry.message.content);
+	} else if (targetEntry.type === "custom_message") {
+		newLeafId = targetEntry.parentId ?? null;
+		editorText = extractTextFromMessageContent(targetEntry.content);
+	}
+
+	if (newLeafId === null) {
+		if (typeof sessionManager.resetLeaf !== "function") {
+			return { cancelled: true };
+		}
+		sessionManager.resetLeaf();
+	} else {
+		if (typeof sessionManager.branch !== "function") {
+			return { cancelled: true };
+		}
+		sessionManager.branch(newLeafId);
+	}
+
+	if (options?.label && typeof sessionManager.appendLabelChange === "function") {
+		sessionManager.appendLabelChange(targetId, options.label);
+	}
+
+	if (editorText && ctx.hasUI && !ctx.ui.getEditorText().trim()) {
+		ctx.ui.setEditorText(editorText);
+	}
+
+	return { cancelled: false };
+}
+
+function createShortcutCommandContext(ctx: ExtensionContext): ExtensionCommandContext {
+	return {
+		...ctx,
+		waitForIdle: async () => {
+			await waitForIdleInShortcutContext(ctx);
+		},
+		newSession: async () => ({ cancelled: true }),
+		fork: async () => ({ cancelled: true }),
+		navigateTree: async (targetId, options) => navigateTreeInShortcutContext(ctx, targetId, options),
+		switchSession: async () => ({ cancelled: true }),
+		reload: async () => {},
+	};
+}
+
+export function registerPlanModeCommand(
+	pi: ExtensionAPI,
+	dependencies: {
+		stateManager: PlanModeStateManager;
+		onPlanModeExited?: (summary: PlanModeExitSummary) => void;
+	},
+) {
+	const handlePlanModeCommand = async (args: string, ctx: ExtensionCommandContext) => {
+		const rawLocation = args.trim();
+		const state = dependencies.stateManager.getState();
+
+		if (state.active) {
+			if (rawLocation.length > 0) {
+				const moved = await updateActivePlanFileLocation(ctx, dependencies.stateManager, rawLocation);
+				if (!moved) {
+					return;
+				}
+				if (moved.previousPath === moved.nextPath) {
+					ctx.ui.notify("Plan file location unchanged.", "info");
+				} else {
+					ctx.ui.notify(`Plan file moved to ${moved.nextPath}.`, "info");
+				}
+				return;
+			}
+
+			await endPlanMode(ctx, dependencies.stateManager, dependencies.onPlanModeExited);
+			return;
+		}
+
+		await ctx.waitForIdle();
+
+		let requestedPlanFilePath: string | undefined;
+		if (rawLocation.length > 0) {
+			try {
+				requestedPlanFilePath = (await resolvePlanLocationInput(ctx, rawLocation)) ?? undefined;
+			} catch (error) {
+				ctx.ui.notify(
+					`Failed to resolve plan file location: ${error instanceof Error ? error.message : String(error)}`,
+					"error",
+				);
+				return;
+			}
+			if (!requestedPlanFilePath) {
+				ctx.ui.notify("Please provide a valid plan file location.", "warning");
+				return;
+			}
+		}
+
+		const originLeafId = ctx.sessionManager.getLeafId();
+		const canStartFromEmptyBranch = canOfferEmptyBranchStart(ctx, originLeafId);
+		const currentState = dependencies.stateManager.getState();
+		const sessionPlanFilePath = resolveActivePlanFilePath(ctx, currentState.planFilePath);
+		const existingSessionPlanText = (await readPlanFile(sessionPlanFilePath))?.trim();
+		const savedPlanLeafId = currentState.lastPlanLeafId;
+		let planFilePath = requestedPlanFilePath ?? sessionPlanFilePath;
+
+		type StartIntent = "continue" | "empty-branch" | "current-branch";
+		let startIntent: StartIntent = existingSessionPlanText ? "continue" : "current-branch";
+
+		if (ctx.hasUI) {
+			if (existingSessionPlanText) {
+				const continueOption = "Continue planning";
+				const startFreshOption = "Start fresh";
+				const choices = canStartFromEmptyBranch
+					? [continueOption, ...PLAN_MODE_START_OPTIONS]
+					: [continueOption, startFreshOption];
+				const choice = await ctx.ui.select(`Start planning:\nPlan file: ${sessionPlanFilePath}`, choices);
+				if (choice === undefined) {
+					ctx.ui.notify("Plan mode activation cancelled.", "info");
+					return;
+				}
+				if (choice === continueOption) {
+					startIntent = "continue";
+				} else if (choice === PLAN_MODE_START_OPTIONS[0]) {
+					startIntent = "empty-branch";
+				} else {
+					startIntent = "current-branch";
+				}
+			} else if (canStartFromEmptyBranch) {
+				const choice = await ctx.ui.select("Start planning in:", [...PLAN_MODE_START_OPTIONS]);
+				if (choice === undefined) {
+					ctx.ui.notify("Plan mode activation cancelled.", "info");
+					return;
+				}
+				startIntent = choice === PLAN_MODE_START_OPTIONS[0] ? "empty-branch" : "current-branch";
+			}
+		}
+
+		if (startIntent === "continue") {
+			const resumedSavedPlanningBranch = await navigateToSavedPlanningBranch(ctx, {
+				savedLeafId: savedPlanLeafId,
+				currentLeafId: originLeafId,
+				cancelMessage: "Plan mode activation cancelled.",
+			});
+			if (!resumedSavedPlanningBranch) {
+				return;
+			}
+
+			if (requestedPlanFilePath && requestedPlanFilePath !== sessionPlanFilePath) {
+				let shouldMove: boolean;
+				try {
+					shouldMove = await confirmMoveOverwriteIfNeeded(ctx, sessionPlanFilePath, requestedPlanFilePath);
+				} catch (error) {
+					ctx.ui.notify(
+						`Failed to check target path: ${error instanceof Error ? error.message : String(error)}`,
+						"error",
+					);
+					return;
+				}
+				if (!shouldMove) {
+					return;
+				}
+
+				try {
+					await movePlanFile(sessionPlanFilePath, requestedPlanFilePath);
+					planFilePath = requestedPlanFilePath;
+				} catch (error) {
+					ctx.ui.notify(
+						`Failed to move existing plan file: ${error instanceof Error ? error.message : String(error)}`,
+						"error",
+					);
+					return;
+				}
+			} else {
+				planFilePath = sessionPlanFilePath;
+			}
+		} else {
+			if (startIntent === "empty-branch") {
+				if (!originLeafId) {
+					ctx.ui.notify("Could not determine origin point for returning from planning.", "error");
+					return;
+				}
+
+				const movedToFreshBranch = await navigateToFreshPlanningBranch(ctx, "Plan mode activation cancelled.");
+				if (!movedToFreshBranch) {
+					return;
+				}
+			}
+
+			if (requestedPlanFilePath) {
+				planFilePath = requestedPlanFilePath;
+			} else if (existingSessionPlanText) {
+				try {
+					planFilePath = await createFreshPlanFilePath(ctx, path.dirname(sessionPlanFilePath));
+				} catch (error) {
+					ctx.ui.notify(
+						`Failed to allocate a fresh plan file path: ${error instanceof Error ? error.message : String(error)}`,
+						"error",
+					);
+					return;
+				}
+			} else {
+				planFilePath = sessionPlanFilePath;
+			}
+
+			if (requestedPlanFilePath) {
+				let requestedPathExists = false;
+				try {
+					requestedPathExists = await pathExists(planFilePath);
+				} catch (error) {
+					ctx.ui.notify(
+						`Failed to check requested plan path: ${error instanceof Error ? error.message : String(error)}`,
+						"error",
+					);
+					return;
+				}
+
+				if (requestedPathExists) {
+					if (!ctx.hasUI) {
+						ctx.ui.notify(
+							`Refusing to overwrite existing plan file without interactive confirmation: ${planFilePath}`,
+							"error",
+						);
+						return;
+					}
+
+					const shouldOverwriteRequestedPath = await ctx.ui.confirm(
+						"Overwrite existing plan file?",
+						`Plan file already exists:\n${planFilePath}\n\nStart fresh planning and overwrite this file?`,
+					);
+					if (!shouldOverwriteRequestedPath) {
+						ctx.ui.notify("Plan mode activation cancelled.", "info");
+						return;
+					}
+				}
+			}
+
+			try {
+				await resetPlanFile(planFilePath);
+			} catch (error) {
+				ctx.ui.notify(`Failed to reset plan file: ${error instanceof Error ? error.message : String(error)}`, "error");
+				return;
+			}
+		}
+
+		try {
+			await ensurePlanFileExists(planFilePath);
+		} catch (error) {
+			ctx.ui.notify(
+				`Failed to initialize plan file: ${error instanceof Error ? error.message : String(error)}`,
+				"error",
+			);
+			return;
+		}
+
+		dependencies.stateManager.startPlanMode(ctx, {
+			originLeafId,
+			planFilePath,
+		});
+	};
+
+	pi.registerCommand("plan", {
+		description: "Start /plan, end it, or pass a plan file location.",
+		handler: handlePlanModeCommand,
+	});
+
+	pi.registerShortcut("alt+p", {
+		description: "Toggle /plan",
+		handler: async (ctx) => {
+			const shortcutCommandContext = createShortcutCommandContext(ctx);
+			await handlePlanModeCommand("", shortcutCommandContext);
+		},
+	});
+}

--- a/packages/plan/index.ts
+++ b/packages/plan/index.ts
@@ -1,0 +1,199 @@
+import { mkdir, writeFile } from "node:fs/promises";
+import path from "node:path";
+import type { AgentToolResult } from "@mariozechner/pi-agent-core";
+import { keyHint, type ExtensionAPI } from "@mariozechner/pi-coding-agent";
+import { Text } from "@mariozechner/pi-tui";
+import { registerPlanModeCommand } from "./flow";
+import { resolveActivePlanFilePath } from "./plan-files";
+import { loadPlanModePrompt } from "./prompts";
+import { registerRequestUserInputTool } from "./request-user-input";
+import { RequestUserInputSchema, SetPlanSchema, SteerTaskAgentSchema, TaskAgentsSchema } from "./schemas";
+import { CONTEXT_ENTRY_TYPE, createPlanModeStateManager } from "./state";
+import { registerTaskAgentTools } from "./task-agents";
+
+function summarizeSnippet(text: string, maxLength: number = 120): string {
+	const singleLine = text.replace(/\s+/g, " ").trim();
+	if (!singleLine) {
+		return "";
+	}
+	if (singleLine.length <= maxLength) {
+		return singleLine;
+	}
+	return `${singleLine.slice(0, maxLength - 3)}...`;
+}
+
+interface SetPlanDetails {
+	plan: string;
+}
+
+interface PlanModeExitDetails {
+	planFilePath: string;
+	planText?: string;
+}
+
+const PLAN_MODE_EXIT_ENTRY_TYPE = "pi-plan:exit";
+
+export default function (pi: ExtensionAPI) {
+	const stateManager = createPlanModeStateManager(pi);
+
+	pi.registerMessageRenderer(PLAN_MODE_EXIT_ENTRY_TYPE, (message, { expanded }, theme) => {
+		const render = (text: string) => new Text(text, 1, 0, (segment) => theme.bg("customMessageBg", segment));
+		const details = message.details as PlanModeExitDetails | undefined;
+		const title = String(message.content || "Plan mode ended.");
+		const lines = [theme.fg("accent", theme.bold(title))];
+
+		if (!details?.planFilePath) {
+			return render(lines.join("\n"));
+		}
+
+		if (!details.planText?.trim()) {
+			lines.push(theme.fg("warning", "No plan created."));
+			return render(lines.join("\n"));
+		}
+
+		lines.push(theme.fg("muted", `Plan file: ${details.planFilePath}`));
+		if (!expanded) {
+			lines.push(theme.fg("dim", keyHint("expandTools", "to expand")));
+			return render(lines.join("\n"));
+		}
+
+		lines.push("");
+		lines.push(details.planText);
+		return render(lines.join("\n"));
+	});
+
+	pi.registerTool({
+		name: "set_plan",
+		label: "set_plan",
+		description:
+			"Overwrite the plan file with the full latest plan text. Call this whenever the plan changes so the plan file stays canonical.",
+		parameters: SetPlanSchema,
+		renderCall(args, theme) {
+			const preview = summarizeSnippet(String(args.plan ?? ""), 90);
+			return new Text(
+				`${theme.fg("toolTitle", theme.bold("set_plan "))}${theme.fg("muted", preview || "(empty)")}`,
+				0,
+				0,
+			);
+		},
+		renderResult(result, { expanded, isPartial }, theme) {
+			if (isPartial) {
+				return new Text(theme.fg("muted", "Writing plan..."), 0, 0);
+			}
+
+			const details = result.details as SetPlanDetails | undefined;
+			if (!details?.plan) {
+				const text = result.content.find((item) => item.type === "text");
+				return new Text(text?.type === "text" ? text.text : "(no output)", 0, 0);
+			}
+
+			if (!expanded) {
+				return new Text(
+					`${theme.fg("success", "Plan written.")}\n${theme.fg("dim", keyHint("expandTools", "to view plan"))}`,
+					0,
+					0,
+				);
+			}
+
+			return new Text(`${theme.fg("success", "Plan written.")}\n${details.plan}`, 0, 0);
+		},
+		async execute(_toolCallId, params: { plan: string }, _signal, _onUpdate, ctx): Promise<AgentToolResult<SetPlanDetails>> {
+			if (!stateManager.getState().active) {
+				return {
+					isError: true,
+					content: [{ type: "text", text: "set_plan is only available while plan mode is active." }],
+				};
+			}
+
+			const planFilePath = resolveActivePlanFilePath(ctx, stateManager.getState().planFilePath);
+			if (!planFilePath) {
+				return {
+					isError: true,
+					content: [{ type: "text", text: "No active plan file. Restart plan mode and try again." }],
+				};
+			}
+
+			const plan = String(params.plan ?? "").trim();
+			if (!plan) {
+				return {
+					isError: true,
+					content: [{ type: "text", text: "set_plan requires non-empty plan text." }],
+				};
+			}
+
+			await mkdir(path.dirname(planFilePath), { recursive: true });
+			await writeFile(planFilePath, `${plan}\n`, "utf8");
+
+			if (stateManager.getState().planFilePath !== planFilePath) {
+				stateManager.setState(ctx, {
+					...stateManager.getState(),
+					planFilePath,
+				});
+			}
+			return {
+				content: [{ type: "text", text: "Plan written." }],
+				details: {
+					plan,
+				},
+			};
+		},
+	});
+
+	registerRequestUserInputTool(pi, {
+		getState: stateManager.getState,
+		requestUserInputSchema: RequestUserInputSchema,
+	});
+
+	registerTaskAgentTools(pi, {
+		getState: stateManager.getState,
+		taskAgentsSchema: TaskAgentsSchema,
+		steerTaskAgentSchema: SteerTaskAgentSchema,
+	});
+
+	registerPlanModeCommand(pi, {
+		stateManager,
+		onPlanModeExited: ({ planFilePath, planText }) => {
+			pi.sendMessage({
+				customType: PLAN_MODE_EXIT_ENTRY_TYPE,
+				content: "Plan mode ended.",
+				display: true,
+				details: {
+					planFilePath,
+					planText,
+				},
+			});
+		},
+	});
+
+	pi.on("before_agent_start", async () => {
+		stateManager.syncTools();
+		if (!stateManager.getState().active) {
+			return;
+		}
+
+		const prompt = await loadPlanModePrompt();
+		return {
+			message: {
+				customType: CONTEXT_ENTRY_TYPE,
+				content: prompt,
+				display: false,
+			},
+		};
+	});
+
+	pi.on("session_start", async (_event, ctx) => {
+		stateManager.refresh(ctx);
+	});
+
+	pi.on("session_switch", async (_event, ctx) => {
+		stateManager.refresh(ctx);
+	});
+
+	pi.on("session_tree", async (_event, ctx) => {
+		stateManager.refresh(ctx);
+	});
+
+	pi.on("session_fork", async (_event, ctx) => {
+		stateManager.refresh(ctx);
+	});
+}

--- a/packages/plan/install.mjs
+++ b/packages/plan/install.mjs
@@ -1,0 +1,97 @@
+#!/usr/bin/env node
+
+import { execFileSync } from "node:child_process";
+
+const PACKAGE_NAME = "@ifi/pi-plan";
+
+function parseArgs(argv) {
+	const args = argv.slice(2);
+	let local = false;
+	let remove = false;
+	let help = false;
+
+	for (const arg of args) {
+		if (arg === "--local" || arg === "-l") {
+			local = true;
+		} else if (arg === "--remove" || arg === "-r") {
+			remove = true;
+		} else if (arg === "--help" || arg === "-h") {
+			help = true;
+		} else {
+			console.error(`Unknown argument: ${arg}`);
+			process.exit(1);
+		}
+	}
+
+	return { local, remove, help };
+}
+
+function printHelp() {
+	console.log(`
+pi-plan — install the @ifi planning extension into pi
+
+Usage:
+  npx @ifi/pi-plan            Install globally
+  npx @ifi/pi-plan --local    Install into project .pi/settings.json
+  npx @ifi/pi-plan --remove   Remove from pi
+
+Options:
+  -l, --local    Install project-locally instead of globally
+  -r, --remove   Remove the package from pi
+  -h, --help     Show this help
+
+Direct install:
+  pi install npm:${PACKAGE_NAME}
+`.trim());
+}
+
+function findPi() {
+	try {
+		execFileSync("pi", ["--version"], { stdio: "ignore" });
+		return "pi";
+	} catch {
+		console.error("Error: 'pi' command not found. Install pi-coding-agent first:");
+		console.error("  npm install -g @mariozechner/pi-coding-agent");
+		process.exit(1);
+	}
+}
+
+function run(pi, command, args) {
+	try {
+		execFileSync(pi, [command, ...args], { stdio: "pipe", timeout: 60_000 });
+		return { ok: true, status: "ok" };
+	} catch (error) {
+		const stderr = error?.stderr?.toString?.().trim?.() ?? "";
+		if (stderr.includes("already installed") || stderr.includes("already exists")) {
+			return { ok: true, status: "already-installed" };
+		}
+		if (stderr.includes("not installed") || stderr.includes("not found") || stderr.includes("No such")) {
+			return { ok: true, status: "already-removed" };
+		}
+		if (stderr) {
+			console.error(stderr.split("\n")[0]);
+		}
+		return { ok: false, status: "error" };
+	}
+}
+
+const opts = parseArgs(process.argv);
+if (opts.help) {
+	printHelp();
+	process.exit(0);
+}
+
+const pi = findPi();
+const source = `npm:${PACKAGE_NAME}`;
+const localFlag = opts.local ? ["-l"] : [];
+const result = opts.remove ? run(pi, "remove", [source, ...localFlag]) : run(pi, "install", [source, ...localFlag]);
+
+if (!result.ok) {
+	process.exit(1);
+}
+
+if (opts.remove) {
+	console.log(result.status === "already-removed" ? "\n✅ @ifi/pi-plan is already absent from pi." : "\n✅ Removed @ifi/pi-plan from pi.");
+} else {
+	console.log(result.status === "already-installed" ? "\n✅ @ifi/pi-plan is already installed in pi." : "\n✅ Installed @ifi/pi-plan into pi. Restart pi to load it.");
+}

--- a/packages/plan/package.json
+++ b/packages/plan/package.json
@@ -1,0 +1,51 @@
+{
+  "name": "@ifi/pi-plan",
+  "version": "0.2.13",
+  "description": "Planning mode extension for pi with persistent plan files, branch-aware planning, and delegated research tasks.",
+  "type": "module",
+  "keywords": [
+    "pi-package",
+    "pi",
+    "pi-coding-agent",
+    "planning",
+    "plan-mode",
+    "tui"
+  ],
+  "bin": {
+    "pi-plan": "install.mjs"
+  },
+  "pi": {
+    "extensions": [
+      "./index.ts"
+    ]
+  },
+  "files": [
+    "*.ts",
+    "*.mjs",
+    "prompts",
+    "README.md",
+    "!**/*.test.ts",
+    "!tests/**"
+  ],
+  "license": "MIT",
+  "repository": {
+    "type": "git",
+    "url": "git+https://github.com/ifiokjr/oh-pi.git",
+    "directory": "packages/plan"
+  },
+  "homepage": "https://github.com/ifiokjr/oh-pi/tree/main/packages/plan",
+  "bugs": {
+    "url": "https://github.com/ifiokjr/oh-pi/issues"
+  },
+  "dependencies": {
+    "@ifi/pi-extension-subagents": "workspace:*",
+    "@ifi/pi-shared-qna": "workspace:*"
+  },
+  "peerDependencies": {
+    "@mariozechner/pi-agent-core": "*",
+    "@mariozechner/pi-ai": "*",
+    "@mariozechner/pi-coding-agent": "*",
+    "@mariozechner/pi-tui": "*",
+    "@sinclair/typebox": "*"
+  }
+}

--- a/packages/plan/plan-files.ts
+++ b/packages/plan/plan-files.ts
@@ -1,0 +1,152 @@
+import { mkdir, readFile, rename, stat, unlink, writeFile } from "node:fs/promises";
+import path from "node:path";
+import type { ExtensionContext } from "@mariozechner/pi-coding-agent";
+import { resolvePlanFilePath } from "./utils";
+
+export function getPlanFilePathForSession(ctx: ExtensionContext): string {
+	const sessionFile = ctx.sessionManager.getSessionFile();
+	if (!sessionFile) {
+		return path.join(ctx.sessionManager.getSessionDir(), `${ctx.sessionManager.getSessionId()}.plan.md`);
+	}
+
+	const parsed = path.parse(sessionFile);
+	return path.join(parsed.dir, `${parsed.name}.plan.md`);
+}
+
+export function resolveActivePlanFilePath(ctx: ExtensionContext, planFilePath: string | undefined): string {
+	if (planFilePath && planFilePath.trim().length > 0) {
+		return planFilePath;
+	}
+	return getPlanFilePathForSession(ctx);
+}
+
+export function buildTimestampedPlanFilename(sessionId: string): string {
+	const timestamp = new Date().toISOString().replace(/[.:]/g, "-");
+	const safeSessionId = sessionId.replace(/[^a-zA-Z0-9._-]/g, "-");
+	return `${timestamp}-${safeSessionId}.plan.md`;
+}
+
+export async function createFreshPlanFilePath(ctx: ExtensionContext, baseDir: string): Promise<string> {
+	const baseFilename = buildTimestampedPlanFilename(ctx.sessionManager.getSessionId());
+	let candidate = path.join(baseDir, baseFilename);
+	if (!(await pathExists(candidate))) {
+		return candidate;
+	}
+
+	const parsed = path.parse(baseFilename);
+	for (let counter = 1; counter <= 999; counter++) {
+		candidate = path.join(baseDir, `${parsed.name}-${counter}${parsed.ext}`);
+		if (!(await pathExists(candidate))) {
+			return candidate;
+		}
+	}
+
+	return path.join(baseDir, `${parsed.name}-${Date.now()}${parsed.ext}`);
+}
+
+export async function resolvePlanLocationInput(ctx: ExtensionContext, rawLocation: string): Promise<string | null> {
+	const trimmed = rawLocation.trim();
+	if (!trimmed) {
+		return null;
+	}
+
+	const resolvedPath = resolvePlanFilePath(ctx.cwd, trimmed);
+	if (!resolvedPath) {
+		return null;
+	}
+
+	let isDirectory = /[\\/]$/.test(trimmed);
+	try {
+		const pathStats = await stat(resolvedPath);
+		if (pathStats.isDirectory()) {
+			isDirectory = true;
+		}
+	} catch (error) {
+		const code = (error as { code?: string }).code;
+		if (code !== "ENOENT") {
+			throw error;
+		}
+	}
+
+	if (isDirectory) {
+		return path.join(resolvedPath, buildTimestampedPlanFilename(ctx.sessionManager.getSessionId()));
+	}
+
+	return resolvedPath;
+}
+
+export async function movePlanFile(sourcePath: string | undefined, targetPath: string): Promise<void> {
+	await mkdir(path.dirname(targetPath), { recursive: true });
+
+	if (!sourcePath) {
+		await ensurePlanFileExists(targetPath);
+		return;
+	}
+
+	if (sourcePath === targetPath) {
+		await ensurePlanFileExists(targetPath);
+		return;
+	}
+
+	try {
+		await rename(sourcePath, targetPath);
+		return;
+	} catch (error) {
+		const code = (error as { code?: string }).code;
+		if (code === "ENOENT") {
+			await ensurePlanFileExists(targetPath);
+			return;
+		}
+		if (code === "EXDEV") {
+			const existingContent = await readFile(sourcePath, "utf8");
+			await writeFile(targetPath, existingContent, "utf8");
+			try {
+				await unlink(sourcePath);
+			} catch (unlinkError) {
+				const unlinkCode = (unlinkError as { code?: string }).code;
+				if (unlinkCode !== "ENOENT") {
+					throw unlinkError;
+				}
+			}
+			return;
+		}
+		throw error;
+	}
+}
+
+export async function ensurePlanFileExists(planFilePath: string): Promise<void> {
+	await mkdir(path.dirname(planFilePath), { recursive: true });
+	await writeFile(planFilePath, "", { encoding: "utf8", flag: "a" });
+}
+
+export async function resetPlanFile(planFilePath: string): Promise<void> {
+	await mkdir(path.dirname(planFilePath), { recursive: true });
+	await writeFile(planFilePath, "", "utf8");
+}
+
+export async function readPlanFile(planFilePath: string | undefined): Promise<string | undefined> {
+	if (!planFilePath) {
+		return undefined;
+	}
+	try {
+		return await readFile(planFilePath, "utf8");
+	} catch {
+		return undefined;
+	}
+}
+
+export async function pathExists(filePath: string | undefined): Promise<boolean> {
+	if (!filePath) {
+		return false;
+	}
+	try {
+		await stat(filePath);
+		return true;
+	} catch (error) {
+		const code = (error as { code?: string }).code;
+		if (code === "ENOENT") {
+			return false;
+		}
+		throw error;
+	}
+}

--- a/packages/plan/prompts.ts
+++ b/packages/plan/prompts.ts
@@ -1,0 +1,45 @@
+import { readFile } from "node:fs/promises";
+import os from "node:os";
+import path from "node:path";
+import { fileURLToPath } from "node:url";
+
+const PLAN_MODE_PROMPT_FILENAME = "PLAN.prompt.md";
+
+function getBundledPromptPath(): string {
+	return path.join(path.dirname(fileURLToPath(import.meta.url)), "prompts", PLAN_MODE_PROMPT_FILENAME);
+}
+
+async function readNonEmptyFile(filePath: string): Promise<string | null> {
+	try {
+		const content = await readFile(filePath, "utf8");
+		const trimmed = content.trim();
+		return trimmed.length > 0 ? trimmed : null;
+	} catch (error) {
+		const code = (error as NodeJS.ErrnoException).code;
+		if (code === "ENOENT") {
+			return null;
+		}
+		throw error;
+	}
+}
+
+export async function loadPlanModePrompt(options?: {
+	agentDirPath?: string;
+	bundledPromptPath?: string;
+}): Promise<string> {
+	const agentDirPath = options?.agentDirPath ?? path.join(os.homedir(), ".pi", "agent");
+	const bundledPromptPath = options?.bundledPromptPath ?? getBundledPromptPath();
+	const overridePromptPath = path.join(agentDirPath, PLAN_MODE_PROMPT_FILENAME);
+
+	const overridePrompt = await readNonEmptyFile(overridePromptPath);
+	if (overridePrompt) {
+		return overridePrompt;
+	}
+
+	const bundledPrompt = await readNonEmptyFile(bundledPromptPath);
+	if (bundledPrompt) {
+		return bundledPrompt;
+	}
+
+	throw new Error(`Plan mode prompt is missing or empty: ${bundledPromptPath}`);
+}

--- a/packages/plan/prompts/PLAN.prompt.md
+++ b/packages/plan/prompts/PLAN.prompt.md
@@ -1,0 +1,14 @@
+[PLAN MODE ACTIVE]
+Create a concrete implementation plan only.
+
+Guidance:
+- Focus on planning and analysis; do not write implementation code in this mode.
+- Start with direct local inspection for obvious, self-contained questions.
+- Use task_agents when it helps (e.g. parallel codebase exploration, independent validation, or external best-practice/documentation research).
+- Use web_search/fetch_url when external references are needed (directly or via task_agents).
+- Use steer_task_agent when a specific task from a previous task_agents run needs deeper follow-up without rerunning everything.
+- Ask clarifying questions when requirements or constraints are unclear, preferably via request_user_input for short multiple-choice questions.
+- Avoid pedantic questions about obvious defaults; make reasonable assumptions and continue.
+- Keep a single up-to-date plan in the plan file by calling set_plan whenever the plan changes.
+- Include the goal at the top of the plan.
+- Before exiting plan mode, ensure set_plan has the full latest plan text.

--- a/packages/plan/request-user-input.ts
+++ b/packages/plan/request-user-input.ts
@@ -1,0 +1,247 @@
+import { createRequire } from "node:module";
+import os from "node:os";
+import path from "node:path";
+import type { AgentToolResult } from "@mariozechner/pi-agent-core";
+import type { ExtensionAPI, ExtensionContext } from "@mariozechner/pi-coding-agent";
+import { QnATuiComponent, type QnAResponse, type QnAResult } from "@ifi/pi-shared-qna";
+import type {
+	NormalizedRequestUserInputQuestion,
+	PlanModeState,
+	RequestUserInputAnswer,
+	RequestUserInputDetails,
+	RequestUserInputQuestion,
+	RequestUserInputResponse,
+} from "./types";
+import { findDuplicateId } from "./utils";
+
+const require = createRequire(import.meta.url);
+
+function requirePiTui() {
+	try {
+		return require("@mariozechner/pi-tui");
+	} catch (error) {
+		const code = (error as { code?: string }).code;
+		if (code !== "MODULE_NOT_FOUND") {
+			throw error;
+		}
+		return require(path.join(os.homedir(), ".bun", "install", "global", "node_modules", "@mariozechner", "pi-tui"));
+	}
+}
+
+function createText(text: string) {
+	const { Text } = requirePiTui() as {
+		Text: new (text: string, x: number, y: number) => unknown;
+	};
+	return new Text(text, 0, 0);
+}
+
+export function normalizeRequestUserInputQuestions(
+	rawQuestions: RequestUserInputQuestion[],
+): { questions: NormalizedRequestUserInputQuestion[] } | { error: string } {
+	const questions: NormalizedRequestUserInputQuestion[] = rawQuestions.map((question) => ({
+		...question,
+		id: question.id.trim(),
+		options: question.options ?? [],
+	}));
+
+	for (const question of questions) {
+		if (!question.id) {
+			return { error: "request_user_input question ids must be non-empty." };
+		}
+	}
+
+	const duplicateQuestionId = findDuplicateId(questions.map((question) => question.id));
+	if (duplicateQuestionId) {
+		return {
+			error: `request_user_input question ids must be unique. Duplicate id: ${duplicateQuestionId}`,
+		};
+	}
+
+	return { questions };
+}
+
+export function buildRequestUserInputAnswer(
+	question: NormalizedRequestUserInputQuestion,
+	response: QnAResponse,
+): RequestUserInputAnswer {
+	const hasOptions = question.options.length > 0;
+	const otherIndex = question.options.length;
+	const trimmed = response.customText.trim();
+
+	if (!hasOptions) {
+		if (trimmed.length === 0) {
+			return { answers: [] };
+		}
+		return { answers: [`user_note: ${trimmed}`] };
+	}
+
+	if (response.selectedOptionIndex === otherIndex) {
+		if (trimmed.length === 0) {
+			return { answers: [] };
+		}
+		return { answers: ["Other", `user_note: ${trimmed}`] };
+	}
+
+	const label = question.options[response.selectedOptionIndex]?.label;
+	if (!label) {
+		return { answers: [] };
+	}
+	return { answers: [label] };
+}
+
+export function buildRequestUserInputResponse(
+	questions: NormalizedRequestUserInputQuestion[],
+	responses: QnAResponse[],
+): RequestUserInputResponse {
+	const answers: Record<string, RequestUserInputAnswer> = {};
+	for (let i = 0; i < questions.length; i++) {
+		answers[questions[i].id] = buildRequestUserInputAnswer(questions[i], responses[i]);
+	}
+	return { answers };
+}
+
+export function summarizeRequestUserInputAnswer(answer: RequestUserInputAnswer | undefined): string {
+	const entries = answer?.answers ?? [];
+	if (entries.length === 0) {
+		return "(no answer)";
+	}
+
+	const notes = entries
+		.filter((entry) => entry.startsWith("user_note: "))
+		.map((entry) => entry.slice("user_note: ".length).trim())
+		.filter((entry) => entry.length > 0);
+	const selected = entries
+		.filter((entry) => !entry.startsWith("user_note: "))
+		.map((entry) => entry.trim())
+		.filter((entry) => entry.length > 0);
+
+	if (selected.length === 0 && notes.length > 0) {
+		return notes.join(" · ");
+	}
+
+	if (selected.length > 0 && notes.length > 0) {
+		return `${selected.join(", ")} (${notes.join(" · ")})`;
+	}
+
+	return selected.join(", ") || "(no answer)";
+}
+
+export function buildRequestUserInputSummary(details: RequestUserInputDetails): string {
+	const lines: string[] = [];
+	for (let i = 0; i < details.questions.length; i++) {
+		const question = details.questions[i];
+		const answer = details.response.answers[question.id];
+		lines.push(`${i + 1}. ${question.question}`);
+		lines.push(`   Answer: ${summarizeRequestUserInputAnswer(answer)}`);
+	}
+	return lines.join("\n");
+}
+
+async function collectRequestUserInputAnswers(
+	ctx: ExtensionContext,
+	questions: NormalizedRequestUserInputQuestion[],
+): Promise<RequestUserInputResponse | null> {
+	const result = await ctx.ui.custom<QnAResult | null>((tui, theme, _kb, done) => {
+		return new QnATuiComponent(questions, tui, done, {
+			title: "Questions",
+			questionSummaryLabel: (question) => question.header?.trim() || question.question,
+			accentColor: (text) => theme.fg("accent", text),
+			successColor: (text) => theme.fg("success", text),
+			warningColor: (text) => theme.fg("warning", text),
+			mutedColor: (text) => theme.fg("muted", text),
+			dimColor: (text) => theme.fg("dim", text),
+			boldText: (text) => theme.bold(text),
+		});
+	});
+
+	if (!result) {
+		return null;
+	}
+
+	return buildRequestUserInputResponse(questions, result.responses);
+}
+
+export function registerRequestUserInputTool(
+	pi: ExtensionAPI,
+	dependencies: {
+		getState: () => PlanModeState;
+		requestUserInputSchema: unknown;
+	},
+) {
+	pi.registerTool({
+		name: "request_user_input",
+		label: "request_user_input",
+		description:
+			"Request user input for one to three short questions and wait for the response. This tool is only available in Plan mode.",
+		parameters: dependencies.requestUserInputSchema,
+		renderCall(args, theme) {
+			const questions = ((args.questions as RequestUserInputQuestion[] | undefined) ?? []).length;
+			const label = `${questions} question${questions === 1 ? "" : "s"}`;
+			return createText(
+				`${theme.fg("toolTitle", theme.bold("request_user_input "))}${theme.fg("muted", label)}`,
+			);
+		},
+		renderResult(result, { isPartial }, theme) {
+			if (isPartial) {
+				return createText(theme.fg("muted", "Waiting for user input..."));
+			}
+
+			const details = result.details as RequestUserInputDetails | undefined;
+			if (!details) {
+				const text = result.content.find((item) => item.type === "text");
+				return createText(text?.type === "text" ? text.text : "(no output)");
+			}
+
+			const lines: string[] = [];
+			for (let i = 0; i < details.questions.length; i++) {
+				const question = details.questions[i];
+				const answer = summarizeRequestUserInputAnswer(details.response.answers[question.id]);
+				lines.push(`${theme.fg("accent", `${i + 1}.`)} ${question.question}`);
+				if (answer === "(no answer)") {
+					lines.push(`   ${theme.fg("muted", "Answer:")} ${theme.fg("warning", answer)}`);
+				} else {
+					lines.push(`   ${theme.fg("muted", "Answer:")} ${answer}`);
+				}
+			}
+
+			return createText(lines.join("\n"));
+		},
+		async execute(_toolCallId, params, _signal, _onUpdate, ctx): Promise<AgentToolResult<RequestUserInputDetails>> {
+			if (!dependencies.getState().active) {
+				return {
+					isError: true,
+					content: [{ type: "text", text: "request_user_input is unavailable when plan mode is inactive" }],
+				};
+			}
+
+			if (!ctx.hasUI) {
+				return {
+					isError: true,
+					content: [{ type: "text", text: "request_user_input requires interactive mode" }],
+				};
+			}
+
+			const normalized = normalizeRequestUserInputQuestions(params.questions as RequestUserInputQuestion[]);
+			if ("error" in normalized) {
+				return {
+					isError: true,
+					content: [{ type: "text", text: normalized.error }],
+				};
+			}
+
+			const response = await collectRequestUserInputAnswers(ctx, normalized.questions);
+			if (!response) {
+				return {
+					isError: true,
+					content: [{ type: "text", text: "request_user_input was cancelled before receiving a response" }],
+				};
+			}
+
+			const details: RequestUserInputDetails = { questions: normalized.questions, response };
+			return {
+				content: [{ type: "text", text: buildRequestUserInputSummary(details) }],
+				details,
+			};
+		},
+	});
+}

--- a/packages/plan/schemas.ts
+++ b/packages/plan/schemas.ts
@@ -1,0 +1,85 @@
+import { Type } from "@sinclair/typebox";
+
+export const TaskSchema = Type.Object(
+	{
+		id: Type.Optional(
+			Type.String({
+				description: "Optional stable task ID (e.g. auth-scan) for tracing and steering.",
+			}),
+		),
+		prompt: Type.String({ description: "Task prompt for the delegated task agent." }),
+		cwd: Type.Optional(Type.String({ description: "Optional working directory for this task." })),
+	},
+	{ additionalProperties: false },
+);
+
+export const TaskAgentsSchema = Type.Object(
+	{
+		tasks: Type.Array(TaskSchema, {
+			minItems: 1,
+			maxItems: 6,
+			description: "One or more tasks to run via isolated task agents.",
+		}),
+		concurrency: Type.Optional(
+			Type.Integer({
+				minimum: 1,
+				maximum: 4,
+				description: "How many tasks to run in parallel (default: 2).",
+			}),
+		),
+	},
+	{ additionalProperties: false },
+);
+
+export const SteerTaskAgentSchema = Type.Object(
+	{
+		runId: Type.String({ description: "Run ID from a previous task_agents result." }),
+		taskId: Type.String({ description: "Task ID from that run to rerun with steering." }),
+		instruction: Type.String({ description: "Additional steering instruction for the selected task." }),
+	},
+	{ additionalProperties: false },
+);
+
+export const SetPlanSchema = Type.Object(
+	{
+		plan: Type.String({
+			description:
+				"Full plan document text. This overwrites the current plan file and should include the complete latest plan.",
+		}),
+	},
+	{ additionalProperties: false },
+);
+
+export const RequestUserInputOptionSchema = Type.Object(
+	{
+		label: Type.String({ description: "User-facing label (1-5 words)." }),
+		description: Type.String({ description: "One short sentence explaining impact/tradeoff if selected." }),
+	},
+	{ additionalProperties: false },
+);
+
+export const RequestUserInputQuestionSchema = Type.Object(
+	{
+		id: Type.String({ description: "Stable identifier for mapping answers (snake_case)." }),
+		header: Type.String({ description: "Short header label shown in the UI (12 or fewer chars)." }),
+		question: Type.String({ description: "Single-sentence prompt shown to the user." }),
+		options: Type.Optional(
+			Type.Array(RequestUserInputOptionSchema, {
+				description:
+					'Optional multiple-choice options. When omitted or empty, the question is treated as open-ended and accepts freeform input.',
+			}),
+		),
+	},
+	{ additionalProperties: false },
+);
+
+export const RequestUserInputSchema = Type.Object(
+	{
+		questions: Type.Array(RequestUserInputQuestionSchema, {
+			minItems: 1,
+			maxItems: 3,
+			description: "Questions to show the user. Prefer 1 and do not exceed 3.",
+		}),
+	},
+	{ additionalProperties: false },
+);

--- a/packages/plan/state.ts
+++ b/packages/plan/state.ts
@@ -1,0 +1,175 @@
+import { createRequire } from "node:module";
+import os from "node:os";
+import path from "node:path";
+import type { ExtensionAPI, ExtensionContext } from "@mariozechner/pi-coding-agent";
+import { resolveActivePlanFilePath } from "./plan-files";
+import type { PlanModeState } from "./types";
+import { createInactivePlanModeState, isPlanModeState } from "./utils";
+
+const require = createRequire(import.meta.url);
+
+function requirePiTui() {
+	try {
+		return require("@mariozechner/pi-tui");
+	} catch (error) {
+		const code = (error as { code?: string }).code;
+		if (code !== "MODULE_NOT_FOUND") {
+			throw error;
+		}
+		return require(path.join(os.homedir(), ".bun", "install", "global", "node_modules", "@mariozechner", "pi-tui"));
+	}
+}
+
+function getPiTui() {
+	return requirePiTui() as {
+		truncateToWidth: (text: string, width: number) => string;
+		wrapTextWithAnsi: (text: string, width: number) => string[];
+	};
+}
+
+export const STATE_ENTRY_TYPE = "pi-plan:state";
+export const CONTEXT_ENTRY_TYPE = "pi-plan:context";
+const BANNER_WIDGET_KEY = "pi-plan-banner";
+const PLAN_MODE_TOOL_NAMES = ["task_agents", "steer_task_agent", "request_user_input", "set_plan"] as const;
+const PLAN_MODE_TOOL_NAME_SET = new Set<string>(PLAN_MODE_TOOL_NAMES);
+
+export function getLatestState(ctx: ExtensionContext): PlanModeState {
+	const entries = ctx.sessionManager.getEntries();
+	for (let i = entries.length - 1; i >= 0; i--) {
+		const entry = entries[i];
+		if (entry.type !== "custom" || entry.customType !== STATE_ENTRY_TYPE) {
+			continue;
+		}
+		if (isPlanModeState(entry.data)) {
+			return entry.data;
+		}
+	}
+	return createInactivePlanModeState();
+}
+
+export function hasEntryInSession(ctx: ExtensionContext, entryId: string | undefined): boolean {
+	if (!entryId) {
+		return false;
+	}
+	for (const entry of ctx.sessionManager.getEntries()) {
+		if (entry.id === entryId) {
+			return true;
+		}
+	}
+	return false;
+}
+
+export function getFirstUserMessageId(ctx: ExtensionContext): string | undefined {
+	for (const entry of ctx.sessionManager.getEntries()) {
+		if (entry.type === "message" && entry.message.role === "user") {
+			return entry.id;
+		}
+	}
+	return undefined;
+}
+
+export function createPlanModeStateManager(pi: ExtensionAPI) {
+	let state: PlanModeState = createInactivePlanModeState();
+
+	const persistState = () => {
+		pi.appendEntry(STATE_ENTRY_TYPE, state);
+	};
+
+	const areSameToolLists = (left: string[], right: string[]) => {
+		if (left.length !== right.length) {
+			return false;
+		}
+		for (let i = 0; i < left.length; i++) {
+			if (left[i] !== right[i]) {
+				return false;
+			}
+		}
+		return true;
+	};
+
+	const syncPlanModeTools = () => {
+		const activeTools = pi.getActiveTools();
+		const nextTools = state.active
+			? [
+				...activeTools,
+				...PLAN_MODE_TOOL_NAMES.filter((toolName) => !activeTools.includes(toolName)),
+			]
+			: activeTools.filter((toolName) => !PLAN_MODE_TOOL_NAME_SET.has(toolName));
+
+		if (areSameToolLists(activeTools, nextTools)) {
+			return;
+		}
+
+		pi.setActiveTools(nextTools);
+	};
+
+	const applyBanner = (ctx: ExtensionContext) => {
+		if (!ctx.hasUI) {
+			return;
+		}
+
+		if (!state.active) {
+			ctx.ui.setWidget(BANNER_WIDGET_KEY, undefined, { placement: "aboveEditor" });
+			return;
+		}
+
+		ctx.ui.setWidget(
+			BANNER_WIDGET_KEY,
+			(_tui, theme) => ({
+				render: (width: number) => {
+					const { truncateToWidth, wrapTextWithAnsi } = getPiTui();
+					const safeWidth = Math.max(1, width);
+					const activePlanFilePath = resolveActivePlanFilePath(ctx, state.planFilePath);
+					const lines = [
+						truncateToWidth(
+							`${theme.fg("warning", theme.bold(" Plan mode active"))}${theme.fg("muted", "; `/plan` to exit. `/plan <location>` to move plan file.")}`,
+							safeWidth,
+						),
+						...wrapTextWithAnsi(theme.fg("dim", ` Plan file: ${activePlanFilePath}`), safeWidth),
+					];
+					return lines;
+				},
+				invalidate: () => {},
+			}),
+			{ placement: "aboveEditor" },
+		);
+	};
+
+	const setState = (ctx: ExtensionContext, nextState: PlanModeState) => {
+		state = nextState;
+		persistState();
+		syncPlanModeTools();
+		applyBanner(ctx);
+	};
+
+	const startPlanMode = (
+		ctx: ExtensionContext,
+		options: {
+			originLeafId?: string;
+			planFilePath: string;
+		},
+	) => {
+		setState(ctx, {
+			version: state.version,
+			active: true,
+			originLeafId: options.originLeafId,
+			planFilePath: options.planFilePath,
+			lastPlanLeafId: state.lastPlanLeafId,
+		});
+	};
+
+	const refresh = (ctx: ExtensionContext) => {
+		state = getLatestState(ctx);
+		syncPlanModeTools();
+		applyBanner(ctx);
+	};
+
+	return {
+		getState: () => state,
+		setState,
+		startPlanMode,
+		refresh,
+		syncTools: syncPlanModeTools,
+		applyBanner,
+	};
+}

--- a/packages/plan/task-agents.ts
+++ b/packages/plan/task-agents.ts
@@ -1,0 +1,786 @@
+import { randomBytes } from "node:crypto";
+import { createRequire } from "node:module";
+import os from "node:os";
+import path from "node:path";
+import type { AgentToolResult } from "@mariozechner/pi-agent-core";
+import type { ExtensionAPI } from "@mariozechner/pi-coding-agent";
+import { runSync } from "@ifi/pi-extension-subagents/execution.ts";
+import { getFinalOutput } from "@ifi/pi-extension-subagents/utils.ts";
+import type {
+	NormalizedTaskAgentTask,
+	PlanModeState,
+	TaskAgentActivity,
+	TaskAgentActivityKind,
+	TaskAgentProgressDetails,
+	TaskAgentRunDetails,
+	TaskAgentRunRecord,
+	TaskAgentTask,
+	TaskAgentTaskProgress,
+	TaskAgentTaskResult,
+} from "./types.js";
+import { resolveTaskAgentConcurrency } from "./utils.js";
+
+type PlanningAgentConfig = {
+	name: string;
+	description: string;
+	systemPrompt: string;
+	source: "builtin";
+	filePath: string;
+	tools?: string[];
+	model?: string;
+	thinking?: string;
+	skills?: string[];
+	extensions?: string[];
+	mcpDirectTools?: string[];
+};
+
+type TaskAgentProgressSnapshot = {
+	currentTool?: string;
+	currentToolArgs?: string;
+	recentOutput?: string[];
+};
+
+type RunTaskAgentTaskOptions = {
+	signal?: AbortSignal;
+	onActivity?: (activity: TaskAgentActivity) => void;
+	steeringInstruction?: string;
+	previousOutput?: string;
+	steeringNotes?: string[];
+	runId: string;
+	index: number;
+};
+
+const require = createRequire(import.meta.url);
+
+function requirePiTui() {
+	try {
+		return require("@mariozechner/pi-tui");
+	} catch (error) {
+		const code = (error as { code?: string }).code;
+		if (code !== "MODULE_NOT_FOUND") {
+			throw error;
+		}
+		return require(path.join(os.homedir(), ".bun", "install", "global", "node_modules", "@mariozechner", "pi-tui"));
+	}
+}
+
+function createRenderText(text: string) {
+	const { Text } = requirePiTui() as {
+		Text: new (text: string, x: number, y: number) => unknown;
+	};
+	return new Text(text, 0, 0);
+}
+
+function createTextContent(text: string) {
+	return {
+		type: "text" as const,
+		text,
+	};
+}
+
+const TASK_AGENT_PREVIEW_LIMIT = 4;
+const PLANNING_AGENT_NAME = "plan-researcher";
+const PLANNING_AGENT_DESCRIPTION = "Focused read-only research subagent for plan mode";
+const PLANNING_AGENT_FILE_PATH = "virtual:@ifi/pi-plan/plan-researcher.md";
+const PLANNING_AGENT_TOOL_ALLOWLIST = [
+	"read",
+	"grep",
+	"find",
+	"ls",
+	"bash",
+	"web_search",
+	"fetch_content",
+	"get_search_content",
+	"mcp",
+] as const;
+
+function summarizeSnippet(text: string, maxLength: number = 120): string {
+	const singleLine = text.replace(/\s+/g, " ").trim();
+	if (!singleLine) {
+		return "";
+	}
+	if (singleLine.length <= maxLength) {
+		return singleLine;
+	}
+	return `${singleLine.slice(0, maxLength - 3)}...`;
+}
+
+function indentMultiline(text: string, indent: string): string[] {
+	return text.replace(/\r\n/g, "\n").split("\n").map((line) => `${indent}${line}`);
+}
+
+function formatTaskAgentDuration(result: TaskAgentTaskResult): string {
+	const durationMs = Math.max(0, result.finishedAt - result.startedAt);
+	if (durationMs < 1_000) {
+		return `${durationMs}ms`;
+	}
+	if (durationMs < 60_000) {
+		return `${(durationMs / 1_000).toFixed(1)}s`;
+	}
+	return `${(durationMs / 60_000).toFixed(1)}m`;
+}
+
+function formatTaskAgentActivity(activity: TaskAgentActivity): string {
+	switch (activity.kind) {
+		case "tool":
+			return `→ ${activity.text}`;
+		case "assistant":
+			return `✎ ${activity.text}`;
+		case "toolResult":
+			return `↳ ${activity.text}`;
+		case "stderr":
+			return `! ${activity.text}`;
+		default:
+			return `• ${activity.text}`;
+	}
+}
+
+function cloneTaskAgentProgress(tasks: TaskAgentTaskProgress[]): TaskAgentTaskProgress[] {
+	return tasks.map((task) => ({ ...task }));
+}
+
+function buildTaskAgentProgressText(
+	runId: string,
+	tasks: TaskAgentTaskProgress[],
+	completed: number,
+	total: number,
+): string {
+	const lines: string[] = [`Task agent run ${runId}: ${completed}/${total} complete`];
+	for (const task of tasks) {
+		const status = task.status.padEnd(9, " ");
+		const latest = task.latestActivity ? ` — ${task.latestActivity}` : "";
+		lines.push(`[${task.taskId}] ${status}${latest}`);
+	}
+	return lines.join("\n");
+}
+
+function resolvePlanningAgentTools(pi: ExtensionAPI): string[] | undefined {
+	const activeTools = new Set(pi.getActiveTools());
+	const tools = PLANNING_AGENT_TOOL_ALLOWLIST.filter((toolName) => activeTools.has(toolName));
+	return tools.length > 0 ? [...tools] : undefined;
+}
+
+function buildPlanningAgentConfig(pi: ExtensionAPI): PlanningAgentConfig {
+	return {
+		name: PLANNING_AGENT_NAME,
+		description: PLANNING_AGENT_DESCRIPTION,
+		systemPrompt: [
+			"You are a focused research subagent working for a planning workflow.",
+			"Stay read-only. Do not edit files or write patches.",
+			"Prefer direct local inspection before making assumptions.",
+			"Return markdown with the sections: Summary and References.",
+			"In References, include concrete file paths, symbols, commands, and URLs you relied on. If none, write 'None'.",
+		].join("\n\n"),
+		source: "builtin",
+		filePath: PLANNING_AGENT_FILE_PATH,
+		tools: resolvePlanningAgentTools(pi),
+	};
+}
+
+function extractReferences(text: string): string[] {
+	const references = new Set<string>();
+	for (const match of text.matchAll(/https?:\/\/\S+/g)) {
+		references.add(match[0].replace(/[),.;]+$/, ""));
+	}
+
+	const lines = text.replace(/\r\n/g, "\n").split("\n");
+	let insideReferences = false;
+	for (const line of lines) {
+		const trimmed = line.trim();
+		if (/^#{1,6}\s*references\b/i.test(trimmed) || /^references\s*:?[\s]*$/i.test(trimmed)) {
+			insideReferences = true;
+			continue;
+		}
+		if (!insideReferences) {
+			continue;
+		}
+		if (/^#{1,6}\s+/.test(trimmed)) {
+			break;
+		}
+		const bullet = trimmed.match(/^[-*]\s+(.+)$/) ?? trimmed.match(/^\d+\.\s+(.+)$/);
+		if (bullet?.[1]) {
+			references.add(bullet[1].trim());
+		}
+	}
+
+	return Array.from(references);
+}
+
+function createTaskAgentRunId(): string {
+	return `run-${randomBytes(4).toString("hex")}`;
+}
+
+function normalizeTaskAgentTaskId(rawId: string | undefined, index: number, used: Set<string>): string {
+	const fallback = `task-${index + 1}`;
+	const base =
+		rawId
+			?.trim()
+			.toLowerCase()
+			.replace(/[^a-z0-9_-]+/g, "-")
+			.replace(/-+/g, "-")
+			.replace(/^[-_]+|[-_]+$/g, "") || fallback;
+
+	let id = base;
+	let suffix = 2;
+	while (used.has(id)) {
+		id = `${base}-${suffix}`;
+		suffix += 1;
+	}
+
+	used.add(id);
+	return id;
+}
+
+export function normalizeTaskAgentTasks(tasks: TaskAgentTask[]): NormalizedTaskAgentTask[] {
+	const used = new Set<string>();
+	return tasks.map((task, index) => ({
+		id: normalizeTaskAgentTaskId(task.id, index, used),
+		prompt: task.prompt,
+		cwd: task.cwd,
+	}));
+}
+
+async function runWithConcurrencyLimit<TIn, TOut>(
+	items: TIn[],
+	concurrency: number,
+	runner: (item: TIn, index: number) => Promise<TOut>,
+): Promise<TOut[]> {
+	if (items.length === 0) {
+		return [];
+	}
+
+	const normalizedConcurrency = Number.isFinite(concurrency) ? Math.floor(concurrency) : 1;
+	const limit = Math.max(1, Math.min(normalizedConcurrency, items.length));
+	const results = new Array<TOut>(items.length);
+	let nextIndex = 0;
+
+	const workers = new Array(limit).fill(null).map(async () => {
+		while (true) {
+			const index = nextIndex++;
+			if (index >= items.length) {
+				return;
+			}
+			results[index] = await runner(items[index], index);
+		}
+	});
+
+	await Promise.all(workers);
+	return results;
+}
+
+function buildTaskAgentPrompt(task: NormalizedTaskAgentTask, options?: RunTaskAgentTaskOptions): string {
+	const promptParts = [
+		"You are helping produce an implementation plan.",
+		`Task ID: ${task.id}`,
+		`Task: ${task.prompt}`,
+		"Return markdown with the sections Summary and References.",
+	];
+
+	if (options?.steeringInstruction?.trim()) {
+		promptParts.push(`Steering update from the main planning agent:\n${options.steeringInstruction.trim()}`);
+		if (options.previousOutput?.trim()) {
+			promptParts.push(`Most recent output for this task:\n${options.previousOutput.trim()}`);
+		}
+	}
+
+	return promptParts.join("\n\n");
+}
+
+function recordTaskAgentActivity(
+	activities: TaskAgentActivity[],
+	kind: TaskAgentActivityKind,
+	text: string,
+	onActivity?: (activity: TaskAgentActivity) => void,
+): void {
+	const normalized = summarizeSnippet(text, 180);
+	if (!normalized) {
+		return;
+	}
+	const last = activities[activities.length - 1];
+	if (last?.kind === kind && last.text === normalized) {
+		return;
+	}
+
+	const activity: TaskAgentActivity = {
+		kind,
+		text: normalized,
+		timestamp: Date.now(),
+	};
+	activities.push(activity);
+	if (activities.length > 120) {
+		activities.shift();
+	}
+	onActivity?.(activity);
+}
+
+async function runTaskAgentTask(
+	pi: ExtensionAPI,
+	task: NormalizedTaskAgentTask,
+	defaultCwd: string,
+	options: RunTaskAgentTaskOptions,
+): Promise<TaskAgentTaskResult> {
+	const activities: TaskAgentActivity[] = [];
+	const cwd = task.cwd?.trim() ? task.cwd : defaultCwd;
+	const startedAt = Date.now();
+	let latestProgress: TaskAgentProgressSnapshot | undefined;
+
+	recordTaskAgentActivity(activities, "status", "started", options.onActivity);
+
+	const result = await runSync(
+		defaultCwd,
+		[buildPlanningAgentConfig(pi)],
+		PLANNING_AGENT_NAME,
+		buildTaskAgentPrompt(task, options),
+		{
+			cwd,
+			runId: `${options.runId}-${task.id}`,
+			index: options.index,
+			signal: options.signal,
+			onUpdate: (update) => {
+				const details = update.details as { progress?: TaskAgentProgressSnapshot[] } | undefined;
+				const progress = details?.progress?.[0];
+				if (!progress) {
+					return;
+				}
+
+				if (progress.currentTool) {
+					const argsPreview = progress.currentToolArgs?.trim();
+					const toolSummary = argsPreview ? `${progress.currentTool} ${argsPreview}` : progress.currentTool;
+					recordTaskAgentActivity(activities, "tool", toolSummary, options.onActivity);
+				}
+
+				const latestOutput = progress.recentOutput?.[progress.recentOutput.length - 1];
+				if (latestOutput) {
+					recordTaskAgentActivity(activities, "assistant", latestOutput, options.onActivity);
+				}
+
+				latestProgress = progress;
+			},
+		},
+	);
+
+	const output = getFinalOutput(result.messages).trim();
+	if (output) {
+		recordTaskAgentActivity(activities, "assistant", output, options.onActivity);
+	}
+	if (result.error?.trim()) {
+		recordTaskAgentActivity(activities, "stderr", result.error.trim(), options.onActivity);
+	}
+	if (latestProgress?.currentTool) {
+		recordTaskAgentActivity(activities, "toolResult", `finished ${latestProgress.currentTool}`, options.onActivity);
+	}
+	recordTaskAgentActivity(
+		activities,
+		"status",
+		`finished (${result.exitCode === 0 ? "ok" : "failed"})`,
+		options.onActivity,
+	);
+
+	return {
+		taskId: task.id,
+		task: task.prompt,
+		cwd,
+		output,
+		references: extractReferences(output),
+		exitCode: result.exitCode,
+		stderr: result.error?.trim() ?? "",
+		activities,
+		startedAt,
+		finishedAt: Date.now(),
+		steeringNotes: options.steeringNotes ?? [],
+	};
+}
+
+function formatTaskAgentResult(result: TaskAgentTaskResult, index: number): string {
+	const status = result.exitCode === 0 ? "completed" : "failed";
+	const header = `Task ${index + 1} (${result.taskId}): ${status}`;
+	const output = result.output.trim().length > 0 ? result.output.trim() : "(no output)";
+	const refs = result.references.length > 0 ? result.references.map((ref) => `- ${ref}`).join("\n") : "- None";
+	const recentActivities = result.activities.slice(-6);
+	const activityText =
+		recentActivities.length > 0
+			? recentActivities.map((activity) => `- ${formatTaskAgentActivity(activity)}`).join("\n")
+			: "- (no activity captured)";
+
+	if (result.exitCode !== 0) {
+		const stderr = result.stderr.trim().length > 0 ? result.stderr.trim() : "unknown error";
+		return `${header}\nPrompt: ${result.task}\nCWD: ${result.cwd}\nDuration: ${formatTaskAgentDuration(result)}\nRecent activity:\n${activityText}\nError: ${stderr}`;
+	}
+
+	return `${header}\nPrompt: ${result.task}\nCWD: ${result.cwd}\nDuration: ${formatTaskAgentDuration(result)}\nRecent activity:\n${activityText}\n\n${output}\n\nReferences:\n${refs}`;
+}
+
+export function buildTaskAgentRunDetails(runId: string, results: TaskAgentTaskResult[]): TaskAgentRunDetails {
+	const successCount = results.filter((result) => result.exitCode === 0).length;
+	return {
+		runId,
+		tasks: results,
+		successCount,
+		totalCount: results.length,
+	};
+}
+
+function isTaskAgentProgressDetails(details: unknown): details is TaskAgentProgressDetails {
+	if (!details || typeof details !== "object") {
+		return false;
+	}
+	const value = details as Partial<TaskAgentProgressDetails>;
+	return (
+		typeof value.runId === "string" &&
+		typeof value.completed === "number" &&
+		typeof value.total === "number" &&
+		Array.isArray(value.tasks)
+	);
+}
+
+function isTaskAgentRunDetails(details: unknown): details is TaskAgentRunDetails {
+	if (!details || typeof details !== "object") {
+		return false;
+	}
+	const value = details as Partial<TaskAgentRunDetails>;
+	return (
+		typeof value.runId === "string" &&
+		typeof value.successCount === "number" &&
+		typeof value.totalCount === "number" &&
+		Array.isArray(value.tasks)
+	);
+}
+
+function statusIcon(status: TaskAgentTaskProgress["status"]): string {
+	switch (status) {
+		case "completed":
+			return "✓";
+		case "failed":
+			return "✗";
+		case "running":
+			return "⏳";
+		default:
+			return "○";
+	}
+}
+
+export function registerTaskAgentTools(
+	pi: ExtensionAPI,
+	dependencies: {
+		getState: () => PlanModeState;
+		taskAgentsSchema: unknown;
+		steerTaskAgentSchema: unknown;
+	},
+) {
+	const taskAgentRuns = new Map<string, TaskAgentRunRecord>();
+
+	const rememberTaskAgentRun = (run: TaskAgentRunRecord) => {
+		taskAgentRuns.set(run.runId, run);
+		while (taskAgentRuns.size > 20) {
+			const oldestRunId = taskAgentRuns.keys().next().value;
+			if (!oldestRunId) {
+				break;
+			}
+			taskAgentRuns.delete(oldestRunId);
+		}
+	};
+
+	pi.registerTool({
+		name: "task_agents",
+		label: "task agents",
+		description:
+			"Run one or more isolated research task agents in parallel using the bundled subagent runtime, with activity traces and run IDs for follow-up steering.",
+		parameters: dependencies.taskAgentsSchema,
+		renderCall(args, theme) {
+			const tasks = (args.tasks as TaskAgentTask[] | undefined) ?? [];
+			const lines: string[] = [
+				`${theme.fg("toolTitle", theme.bold("task agents "))}${theme.fg("accent", `${tasks.length} task${tasks.length === 1 ? "" : "s"}`)}`,
+			];
+			for (const task of tasks.slice(0, TASK_AGENT_PREVIEW_LIMIT)) {
+				const taskId = task.id?.trim() || "(auto-id)";
+				lines.push(`${theme.fg("muted", `- ${taskId}:`)} ${summarizeSnippet(task.prompt, 90)}`);
+			}
+			if (tasks.length > TASK_AGENT_PREVIEW_LIMIT) {
+				lines.push(theme.fg("muted", `... +${tasks.length - TASK_AGENT_PREVIEW_LIMIT} more (Ctrl+O to expand after start)`));
+			}
+			return createRenderText(lines.join("\n"));
+		},
+		renderResult(result, { expanded, isPartial }, theme) {
+			const details = result.details;
+			if (isPartial && isTaskAgentProgressDetails(details)) {
+				const lines: string[] = [
+					`${theme.fg("toolTitle", theme.bold("task agents "))}${theme.fg("accent", details.runId)} ${theme.fg("muted", `${details.completed}/${details.total}`)}`,
+				];
+				const visibleTasks = expanded ? details.tasks : details.tasks.slice(0, TASK_AGENT_PREVIEW_LIMIT);
+				for (const task of visibleTasks) {
+					const color = task.status === "failed" ? "error" : task.status === "completed" ? "success" : "warning";
+					const suffix = task.latestActivity ? ` ${theme.fg("dim", summarizeSnippet(task.latestActivity, 80))}` : "";
+					lines.push(`${theme.fg(color, statusIcon(task.status))} ${theme.fg("accent", task.taskId)} ${theme.fg("muted", task.status)}${suffix}`);
+				}
+				if (!expanded && details.tasks.length > TASK_AGENT_PREVIEW_LIMIT) {
+					lines.push(theme.fg("muted", `... +${details.tasks.length - TASK_AGENT_PREVIEW_LIMIT} more running tasks`));
+					lines.push(theme.fg("muted", "Press Ctrl+O to expand and show every task."));
+				}
+				return createRenderText(lines.join("\n"));
+			}
+
+			if (!isTaskAgentRunDetails(details)) {
+				const text = result.content.find((item) => item.type === "text");
+				return createRenderText(text?.type === "text" ? text.text : "(no output)");
+			}
+
+			const lines: string[] = [
+				`${theme.fg("toolTitle", theme.bold("task agents "))}${theme.fg("accent", details.runId)} ${theme.fg("muted", `${details.successCount}/${details.totalCount} succeeded`)}`,
+			];
+			const visibleTasks = expanded ? details.tasks : details.tasks.slice(0, TASK_AGENT_PREVIEW_LIMIT);
+			for (const task of visibleTasks) {
+				const icon = task.exitCode === 0 ? theme.fg("success", "✓") : theme.fg("error", "✗");
+				if (!expanded) {
+					lines.push(`${icon} ${theme.fg("accent", task.taskId)} ${theme.fg("muted", summarizeSnippet(task.task, 80))}`);
+					continue;
+				}
+
+				const taskStatus = task.exitCode === 0 ? theme.fg("success", "completed") : theme.fg("error", "failed");
+				lines.push(`${icon} ${theme.fg("accent", task.taskId)} ${taskStatus}`);
+				lines.push(...indentMultiline(`Prompt: ${task.task}`, "  "));
+				lines.push(`  ${theme.fg("muted", "CWD:")} ${task.cwd}`);
+				lines.push(`  ${theme.fg("muted", "Duration:")} ${formatTaskAgentDuration(task)}`);
+
+				if (task.steeringNotes.length > 0) {
+					lines.push(`  ${theme.fg("muted", "Steering notes:")}`);
+					for (const note of task.steeringNotes) {
+						lines.push(...indentMultiline(`- ${note}`, "    "));
+					}
+				}
+
+				lines.push(`  ${theme.fg("muted", "Activity:")}`);
+				if (task.activities.length === 0) {
+					lines.push(`    ${theme.fg("dim", "(no activity captured)")}`);
+				} else {
+					for (const activity of task.activities) {
+						lines.push(`    ${theme.fg("dim", formatTaskAgentActivity(activity))}`);
+					}
+				}
+
+				if (task.exitCode !== 0) {
+					const stderr = task.stderr.trim().length > 0 ? task.stderr.trim() : "unknown error";
+					lines.push(`  ${theme.fg("error", "Error:")}`);
+					lines.push(...indentMultiline(stderr, "    "));
+					continue;
+				}
+
+				const output = task.output.trim().length > 0 ? task.output.trim() : "(no output)";
+				lines.push(`  ${theme.fg("muted", "Output:")}`);
+				lines.push(...indentMultiline(output, "    "));
+				lines.push(`  ${theme.fg("muted", "References:")}`);
+				if (task.references.length === 0) {
+					lines.push("    - None");
+				} else {
+					for (const reference of task.references) {
+						lines.push(`    - ${reference}`);
+					}
+				}
+			}
+
+			if (!expanded) {
+				if (details.tasks.length > TASK_AGENT_PREVIEW_LIMIT) {
+					lines.push(theme.fg("muted", `... +${details.tasks.length - TASK_AGENT_PREVIEW_LIMIT} more tasks`));
+				}
+				lines.push(theme.fg("muted", "Press Ctrl+O to expand and show all tasks, outputs, and activity traces."));
+			} else {
+				lines.push(theme.fg("muted", "Ctrl+O to collapse."));
+			}
+			return createRenderText(lines.join("\n"));
+		},
+		async execute(_toolCallId, params, signal, onUpdate, ctx): Promise<AgentToolResult<TaskAgentRunDetails>> {
+			if (!dependencies.getState().active) {
+				return {
+					isError: true,
+					content: [createTextContent("task_agents is only available while plan mode is active.")],
+				};
+			}
+
+			const tasks = normalizeTaskAgentTasks(params.tasks as TaskAgentTask[]);
+			const concurrency = resolveTaskAgentConcurrency(params.concurrency);
+			if (concurrency === null) {
+				return {
+					isError: true,
+					content: [createTextContent("concurrency must be an integer between 1 and 4.")],
+				};
+			}
+			const runId = createTaskAgentRunId();
+			let completed = 0;
+
+			const progress: TaskAgentTaskProgress[] = tasks.map((task) => ({
+				taskId: task.id,
+				prompt: task.prompt,
+				status: "queued",
+				activityCount: 0,
+			}));
+
+			const emitProgress = () => {
+				onUpdate?.({
+					content: [createTextContent(buildTaskAgentProgressText(runId, progress, completed, tasks.length))],
+					details: {
+						runId,
+						completed,
+						total: tasks.length,
+						tasks: cloneTaskAgentProgress(progress),
+					} satisfies TaskAgentProgressDetails,
+				});
+			};
+
+			emitProgress();
+
+			const results = await runWithConcurrencyLimit(tasks, concurrency, async (task, index) => {
+				progress[index] = {
+					...progress[index],
+					status: "running",
+					latestActivity: "started",
+				};
+				emitProgress();
+
+				const result = await runTaskAgentTask(pi, task, ctx.cwd, {
+					signal,
+					runId,
+					index,
+					onActivity: (activity) => {
+						progress[index] = {
+							...progress[index],
+							latestActivity: formatTaskAgentActivity(activity),
+							activityCount: progress[index].activityCount + 1,
+						};
+						emitProgress();
+					},
+				});
+
+				completed += 1;
+				progress[index] = {
+					...progress[index],
+					status: result.exitCode === 0 ? "completed" : "failed",
+					latestActivity: `finished (${result.exitCode === 0 ? "ok" : "failed"})`,
+				};
+				emitProgress();
+				return result;
+			});
+
+			const details = buildTaskAgentRunDetails(runId, results);
+			rememberTaskAgentRun({
+				runId,
+				createdAt: Date.now(),
+				tasks: results,
+			});
+
+			const formatted = results.map((result, index) => formatTaskAgentResult(result, index)).join("\n\n---\n\n");
+			const summaryHeader = `Task agent research run ${runId}: ${details.successCount}/${details.totalCount} tasks succeeded.`;
+			const steeringHint =
+				`Use steer_task_agent with runId "${runId}" and a taskId to rerun a specific task with extra instruction.`;
+
+			return {
+				content: [createTextContent(`${summaryHeader}\n${steeringHint}\n\n${formatted}`)],
+				details,
+				isError: details.successCount !== details.totalCount,
+			};
+		},
+	});
+
+	pi.registerTool({
+		name: "steer_task_agent",
+		label: "steer task agent",
+		description:
+			"Rerun one task from a previous task_agents run using the subagent runtime with an extra steering instruction.",
+		parameters: dependencies.steerTaskAgentSchema,
+		renderCall(args, theme) {
+			const instruction = summarizeSnippet(args.instruction ?? "", 90);
+			return createRenderText(
+				`${theme.fg("toolTitle", theme.bold("steer task agent "))}${theme.fg("accent", `${args.runId}/${args.taskId}`)}\n${theme.fg("muted", instruction)}`,
+			);
+		},
+		async execute(_toolCallId, params, signal, onUpdate, ctx): Promise<AgentToolResult<TaskAgentRunDetails>> {
+			if (!dependencies.getState().active) {
+				return {
+					isError: true,
+					content: [createTextContent("steer_task_agent is only available while plan mode is active.")],
+				};
+			}
+
+			const runId = String(params.runId ?? "").trim();
+			const taskId = String(params.taskId ?? "").trim();
+			const instruction = String(params.instruction ?? "").trim();
+			if (!runId || !taskId || !instruction) {
+				return {
+					isError: true,
+					content: [createTextContent("runId, taskId, and instruction are required.")],
+				};
+			}
+
+			const run = taskAgentRuns.get(runId);
+			if (!run) {
+				const knownRunIds = Array.from(taskAgentRuns.keys());
+				return {
+					isError: true,
+					content: [
+						createTextContent(
+							knownRunIds.length > 0
+								? `Unknown runId "${runId}". Known runIds: ${knownRunIds.join(", ")}`
+								: `Unknown runId "${runId}". No prior task agent runs are available.`,
+						),
+					],
+				};
+			}
+
+			const taskIndex = run.tasks.findIndex((task) => task.taskId === taskId);
+			if (taskIndex === -1) {
+				const knownTaskIds = run.tasks.map((task) => task.taskId).join(", ");
+				return {
+					isError: true,
+					content: [createTextContent(`Unknown taskId "${taskId}" for run ${runId}. Known taskIds: ${knownTaskIds}`)],
+				};
+			}
+
+			const previousTask = run.tasks[taskIndex];
+			onUpdate?.({
+				content: [createTextContent(`Steering ${taskId} in ${runId}...`)],
+				details: {
+					runId,
+					completed: run.tasks.filter((task) => task.exitCode === 0).length,
+					total: run.tasks.length,
+					tasks: run.tasks.map((task, index) => ({
+						taskId: task.taskId,
+						prompt: task.task,
+						status: index === taskIndex ? "running" : task.exitCode === 0 ? "completed" : "failed",
+						latestActivity: index === taskIndex ? "re-running with steering" : undefined,
+						activityCount: task.activities.length,
+					})),
+				} satisfies TaskAgentProgressDetails,
+			});
+
+			const steeringNotes = [...previousTask.steeringNotes, instruction];
+			const rerunTask: NormalizedTaskAgentTask = {
+				id: previousTask.taskId,
+				prompt: previousTask.task,
+				cwd: previousTask.cwd,
+			};
+
+			const rerunResult = await runTaskAgentTask(pi, rerunTask, ctx.cwd, {
+				signal,
+				runId,
+				index: taskIndex,
+				steeringInstruction: instruction,
+				previousOutput: previousTask.output,
+				steeringNotes,
+				onActivity: (activity) => {
+					onUpdate?.({
+						content: [createTextContent(`Steering ${taskId}: ${formatTaskAgentActivity(activity)}`)],
+					});
+				},
+			});
+
+			run.tasks[taskIndex] = rerunResult;
+			rememberTaskAgentRun(run);
+			const details = buildTaskAgentRunDetails(runId, run.tasks);
+			const summaryHeader = `Steered ${taskId} in run ${runId}. Run status: ${details.successCount}/${details.totalCount} succeeded.`;
+
+			return {
+				content: [createTextContent(`${summaryHeader}\n\n${formatTaskAgentResult(rerunResult, taskIndex)}`)],
+				details,
+				isError: rerunResult.exitCode !== 0,
+			};
+		},
+	});
+}

--- a/packages/plan/tests/flow.test.ts
+++ b/packages/plan/tests/flow.test.ts
@@ -1,0 +1,574 @@
+import { mkdtemp, rm, writeFile } from "node:fs/promises";
+import os from "node:os";
+import path from "node:path";
+import { afterEach, describe, expect, test, vi } from "vitest";
+
+vi.mock("@mariozechner/pi-coding-agent", () => ({
+	BorderedLoader: class BorderedLoader {
+		onAbort?: () => void;
+	},
+}));
+
+const { registerPlanModeCommand } = await import("../flow");
+
+const tempDirs: string[] = [];
+
+afterEach(async () => {
+	while (tempDirs.length > 0) {
+		const dir = tempDirs.pop();
+		if (!dir) {
+			continue;
+		}
+		await rm(dir, { recursive: true, force: true });
+	}
+});
+
+function createRegisteredBindings(stateManager: {
+	getState: () => any;
+	setState: (ctx: any, nextState: any) => void;
+	startPlanMode: (ctx: any, options: { originLeafId?: string; planFilePath: string }) => void;
+}) {
+	let handler: ((args: string, ctx: any) => Promise<void>) | undefined;
+	let shortcutHandler: ((ctx: any) => Promise<void>) | undefined;
+	const shortcutKeys: string[] = [];
+
+	registerPlanModeCommand(
+		{
+			registerCommand: (_name: string, command: { handler: (args: string, ctx: any) => Promise<void> }) => {
+				handler = command.handler;
+			},
+			registerShortcut: (shortcut: string, options: { handler: (ctx: any) => Promise<void> }) => {
+				shortcutKeys.push(shortcut);
+				shortcutHandler = options.handler;
+			},
+		} as any,
+		{ stateManager },
+	);
+
+	if (!handler) {
+		throw new Error("Failed to register /plan handler");
+	}
+	if (!shortcutHandler) {
+		throw new Error("Failed to register Alt+P shortcut handler");
+	}
+
+	return {
+		handler,
+		shortcutHandler,
+		shortcutKeys,
+	};
+}
+
+function createRegisteredHandler(stateManager: {
+	getState: () => any;
+	setState: (ctx: any, nextState: any) => void;
+	startPlanMode: (ctx: any, options: { originLeafId?: string; planFilePath: string }) => void;
+}) {
+	return createRegisteredBindings(stateManager).handler;
+}
+
+describe("/plan Alt+P shortcut", () => {
+	test("registers alt+p", () => {
+		const { shortcutKeys } = createRegisteredBindings({
+			getState: () => ({ version: 1, active: false }),
+			setState: () => {},
+			startPlanMode: () => {},
+		});
+
+		expect(shortcutKeys).toEqual(["alt+p"]);
+	});
+
+	test("starts plan mode without sending /plan text", async () => {
+		const tmpDir = await mkdtemp(path.join(os.tmpdir(), "plan-md-flow-"));
+		tempDirs.push(tmpDir);
+		const planFilePath = path.join(tmpDir, "session-1.plan.md");
+		const startCalls: Array<{ originLeafId?: string; planFilePath: string }> = [];
+		let state = {
+			version: 1,
+			active: false,
+			planFilePath,
+			lastPlanLeafId: undefined,
+		};
+
+		const { shortcutHandler } = createRegisteredBindings({
+			getState: () => state,
+			setState: (_ctx, nextState) => {
+				state = nextState;
+			},
+			startPlanMode: (_ctx, options) => {
+				startCalls.push(options);
+			},
+		});
+
+		await shortcutHandler({
+			cwd: tmpDir,
+			hasUI: false,
+			isIdle: () => true,
+			ui: {
+				notify: () => {},
+			},
+			sessionManager: {
+				getLeafId: () => "leaf-1",
+				getEntries: () => [{ id: "leaf-1", type: "message", message: { role: "user" } }],
+				getSessionFile: () => undefined,
+				getSessionDir: () => tmpDir,
+				getSessionId: () => "session-1",
+			},
+		});
+
+		expect(startCalls).toEqual([
+			{
+				originLeafId: "leaf-1",
+				planFilePath,
+			},
+		]);
+	});
+
+	test("shows start location choices when shortcut enters plan mode from branchable history", async () => {
+		const tmpDir = await mkdtemp(path.join(os.tmpdir(), "plan-md-flow-"));
+		tempDirs.push(tmpDir);
+		const planFilePath = path.join(tmpDir, "session-1.plan.md");
+		const startCalls: Array<{ originLeafId?: string; planFilePath: string }> = [];
+		let state = {
+			version: 1,
+			active: false,
+			planFilePath,
+			lastPlanLeafId: undefined,
+		};
+
+		const { shortcutHandler } = createRegisteredBindings({
+			getState: () => state,
+			setState: (_ctx, nextState) => {
+				state = nextState;
+			},
+			startPlanMode: (_ctx, options) => {
+				startCalls.push(options);
+			},
+		});
+
+		const selectCalls: Array<{ prompt: string; choices: string[] }> = [];
+		await shortcutHandler({
+			cwd: tmpDir,
+			hasUI: true,
+			isIdle: () => true,
+			ui: {
+				select: (prompt: string, choices: string[]) => {
+					selectCalls.push({ prompt, choices });
+					return "Current branch";
+				},
+				notify: () => {},
+			},
+			sessionManager: {
+				getLeafId: () => "leaf-2",
+				getEntries: () => [
+					{ id: "user-1", type: "message", message: { role: "user" } },
+					{ id: "leaf-2", type: "message", message: { role: "assistant" } },
+				],
+				getSessionFile: () => undefined,
+				getSessionDir: () => tmpDir,
+				getSessionId: () => "session-1",
+			},
+		});
+
+		expect(selectCalls).toEqual([
+			{
+				prompt: "Start planning in:",
+				choices: ["Empty branch", "Current branch"],
+			},
+		]);
+		expect(startCalls).toEqual([
+			{
+				originLeafId: "leaf-2",
+				planFilePath,
+			},
+		]);
+	});
+
+	test("uses the same end flow when shortcut is pressed in active mode", async () => {
+		const tmpDir = await mkdtemp(path.join(os.tmpdir(), "plan-md-flow-"));
+		tempDirs.push(tmpDir);
+		const planFilePath = path.join(tmpDir, "session-1.plan.md");
+		await writeFile(planFilePath, "# Existing plan\n", "utf8");
+		let state = {
+			version: 1,
+			active: true,
+			originLeafId: "origin-leaf",
+			planFilePath,
+			lastPlanLeafId: undefined,
+		};
+		const setStateCalls: any[] = [];
+		const setEditorTextCalls: string[] = [];
+		const branchCalls: string[] = [];
+		const selectCalls: Array<{ prompt: string; choices: string[] }> = [];
+
+		const { shortcutHandler } = createRegisteredBindings({
+			getState: () => state,
+			setState: (_ctx, nextState) => {
+				setStateCalls.push(nextState);
+				state = nextState;
+			},
+			startPlanMode: () => {},
+		});
+
+		await shortcutHandler({
+			cwd: tmpDir,
+			hasUI: true,
+			isIdle: () => true,
+			ui: {
+				select: (prompt: string, choices: string[]) => {
+					selectCalls.push({ prompt, choices });
+					return "Exit";
+				},
+				notify: () => {},
+				setEditorText: (text: string) => {
+					setEditorTextCalls.push(text);
+				},
+				getEditorText: () => "",
+			},
+			sessionManager: {
+				getLeafId: () => "planning-leaf",
+				getEntries: () => [
+					{ id: "origin-leaf", type: "message", message: { role: "assistant" } },
+					{ id: "planning-leaf", type: "message", message: { role: "assistant" } },
+				],
+				getEntry: (entryId: string) =>
+					entryId === "origin-leaf"
+						? { id: "origin-leaf", type: "message", parentId: "user-1", message: { role: "assistant" } }
+						: undefined,
+				branch: (entryId: string) => {
+					branchCalls.push(entryId);
+				},
+				getSessionFile: () => undefined,
+				getSessionDir: () => tmpDir,
+				getSessionId: () => "session-1",
+			},
+		});
+
+		expect(selectCalls).toEqual([
+			{
+				prompt: "Plan mode action (Esc stays in Plan mode)",
+				choices: ["Exit", "Exit & summarize branch"],
+			},
+		]);
+		expect(branchCalls).toEqual(["origin-leaf"]);
+		expect(setStateCalls.at(-1)).toEqual({
+			version: 1,
+			active: false,
+			planFilePath,
+			lastPlanLeafId: "planning-leaf",
+		});
+		expect(setEditorTextCalls).toEqual([
+			`Plan file: ${planFilePath}\nImplement the approved plan in this file. Keep changes focused, update tests, and summarize what was implemented.`,
+		]);
+	});
+});
+
+describe("/plan continue planning", () => {
+	test("navigates to saved planning leaf before activating plan mode", async () => {
+		const tmpDir = await mkdtemp(path.join(os.tmpdir(), "plan-md-flow-"));
+		tempDirs.push(tmpDir);
+		const planFilePath = path.join(tmpDir, "session-1.plan.md");
+		await writeFile(planFilePath, "# Existing plan\n", "utf8");
+
+		const startCalls: Array<{ originLeafId?: string; planFilePath: string }> = [];
+		let state = {
+			version: 1,
+			active: false,
+			planFilePath,
+			lastPlanLeafId: "planning-leaf",
+		};
+		const handler = createRegisteredHandler({
+			getState: () => state,
+			setState: (_ctx, nextState) => {
+				state = nextState;
+			},
+			startPlanMode: (_ctx, options) => {
+				startCalls.push(options);
+			},
+		});
+
+		const navigateCalls: Array<{ entryId: string; options: any }> = [];
+		await handler("", {
+			cwd: tmpDir,
+			hasUI: false,
+			waitForIdle: () => undefined,
+			navigateTree: (entryId: string, options: any) => {
+				navigateCalls.push({ entryId, options });
+				return { cancelled: false };
+			},
+			ui: {
+				notify: () => {},
+			},
+			sessionManager: {
+				getLeafId: () => "current-leaf",
+				getEntries: () => [
+					{ id: "user-1", type: "message", message: { role: "user" } },
+					{ id: "planning-leaf", type: "message", message: { role: "assistant" } },
+				],
+				getSessionFile: () => undefined,
+				getSessionDir: () => tmpDir,
+				getSessionId: () => "session-1",
+			},
+		});
+
+		expect(navigateCalls).toEqual([
+			{
+				entryId: "planning-leaf",
+				options: {
+					summarize: false,
+					label: "plan",
+				},
+			},
+		]);
+		expect(startCalls).toEqual([
+			{
+				originLeafId: "current-leaf",
+				planFilePath,
+			},
+		]);
+	});
+
+	test("shows an info notification when continue resumes saved planning branch in UI mode", async () => {
+		const tmpDir = await mkdtemp(path.join(os.tmpdir(), "plan-md-flow-"));
+		tempDirs.push(tmpDir);
+		const planFilePath = path.join(tmpDir, "session-1.plan.md");
+		await writeFile(planFilePath, "# Existing plan\n", "utf8");
+
+		const startCalls: Array<{ originLeafId?: string; planFilePath: string }> = [];
+		let state = {
+			version: 1,
+			active: false,
+			planFilePath,
+			lastPlanLeafId: "planning-leaf",
+		};
+		const handler = createRegisteredHandler({
+			getState: () => state,
+			setState: (_ctx, nextState) => {
+				state = nextState;
+			},
+			startPlanMode: (_ctx, options) => {
+				startCalls.push(options);
+			},
+		});
+
+		const navigateCalls: Array<{ entryId: string; options: any }> = [];
+		const notifications: Array<{ message: string; level: string }> = [];
+		await handler("", {
+			cwd: tmpDir,
+			hasUI: true,
+			waitForIdle: () => undefined,
+			navigateTree: (entryId: string, options: any) => {
+				navigateCalls.push({ entryId, options });
+				return { cancelled: false };
+			},
+			ui: {
+				select: () => "Continue planning",
+				notify: (message: string, level: string) => {
+					notifications.push({ message, level });
+				},
+			},
+			sessionManager: {
+				getLeafId: () => "current-leaf",
+				getEntries: () => [
+					{ id: "user-1", type: "message", message: { role: "user" } },
+					{ id: "planning-leaf", type: "message", message: { role: "assistant" } },
+				],
+				getSessionFile: () => undefined,
+				getSessionDir: () => tmpDir,
+				getSessionId: () => "session-1",
+			},
+		});
+
+		expect(navigateCalls).toEqual([
+			{
+				entryId: "planning-leaf",
+				options: {
+					summarize: false,
+					label: "plan",
+				},
+			},
+		]);
+		expect(notifications).toContainEqual({
+			message: "Resumed previous planning branch.",
+			level: "info",
+		});
+		expect(startCalls).toEqual([
+			{
+				originLeafId: "current-leaf",
+				planFilePath,
+			},
+		]);
+	});
+
+	test("falls back to current leaf when saved planning leaf is unavailable", async () => {
+		const tmpDir = await mkdtemp(path.join(os.tmpdir(), "plan-md-flow-"));
+		tempDirs.push(tmpDir);
+		const planFilePath = path.join(tmpDir, "session-1.plan.md");
+		await writeFile(planFilePath, "# Existing plan\n", "utf8");
+
+		const startCalls: Array<{ originLeafId?: string; planFilePath: string }> = [];
+		let state = {
+			version: 1,
+			active: false,
+			planFilePath,
+			lastPlanLeafId: "missing-leaf",
+		};
+		const handler = createRegisteredHandler({
+			getState: () => state,
+			setState: (_ctx, nextState) => {
+				state = nextState;
+			},
+			startPlanMode: (_ctx, options) => {
+				startCalls.push(options);
+			},
+		});
+
+		const navigateCalls: Array<{ entryId: string; options: any }> = [];
+		const notifications: Array<{ message: string; level: string }> = [];
+		await handler("", {
+			cwd: tmpDir,
+			hasUI: false,
+			waitForIdle: () => undefined,
+			navigateTree: (entryId: string, options: any) => {
+				navigateCalls.push({ entryId, options });
+				return { cancelled: false };
+			},
+			ui: {
+				notify: (message: string, level: string) => {
+					notifications.push({ message, level });
+				},
+			},
+			sessionManager: {
+				getLeafId: () => "current-leaf",
+				getEntries: () => [{ id: "user-1", type: "message", message: { role: "user" } }],
+				getSessionFile: () => undefined,
+				getSessionDir: () => tmpDir,
+				getSessionId: () => "session-1",
+			},
+		});
+
+		expect(navigateCalls.length).toBe(0);
+		expect(notifications).toContainEqual({
+			message: "Saved planning branch is unavailable. Continuing from the current branch tip.",
+			level: "warning",
+		});
+		expect(startCalls).toEqual([
+			{
+				originLeafId: "current-leaf",
+				planFilePath,
+			},
+		]);
+	});
+});
+
+describe("/plan start location prompt", () => {
+	test("skips empty-vs-current selection when there is no prior history", async () => {
+		const tmpDir = await mkdtemp(path.join(os.tmpdir(), "plan-md-flow-"));
+		tempDirs.push(tmpDir);
+		const planFilePath = path.join(tmpDir, "session-1.plan.md");
+
+		const startCalls: Array<{ originLeafId?: string; planFilePath: string }> = [];
+		let state = {
+			version: 1,
+			active: false,
+			planFilePath,
+			lastPlanLeafId: undefined,
+		};
+		const handler = createRegisteredHandler({
+			getState: () => state,
+			setState: (_ctx, nextState) => {
+				state = nextState;
+			},
+			startPlanMode: (_ctx, options) => {
+				startCalls.push(options);
+			},
+		});
+
+		const selectCalls: Array<{ prompt: string; choices: string[] }> = [];
+		await handler("", {
+			cwd: tmpDir,
+			hasUI: true,
+			waitForIdle: () => undefined,
+			ui: {
+				select: (prompt: string, choices: string[]) => {
+					selectCalls.push({ prompt, choices });
+					return "Current branch";
+				},
+				notify: () => {},
+			},
+			sessionManager: {
+				getLeafId: () => "leaf-1",
+				getEntries: () => [{ id: "leaf-1", type: "message", message: { role: "user" } }],
+				getSessionFile: () => undefined,
+				getSessionDir: () => tmpDir,
+				getSessionId: () => "session-1",
+			},
+		});
+
+		expect(selectCalls).toEqual([]);
+		expect(startCalls).toEqual([
+			{
+				originLeafId: "leaf-1",
+				planFilePath,
+			},
+		]);
+	});
+
+	test("offers start-fresh without branch chooser when an existing plan is present", async () => {
+		const tmpDir = await mkdtemp(path.join(os.tmpdir(), "plan-md-flow-"));
+		tempDirs.push(tmpDir);
+		const planFilePath = path.join(tmpDir, "session-1.plan.md");
+		await writeFile(planFilePath, "# Existing plan\n", "utf8");
+
+		const startCalls: Array<{ originLeafId?: string; planFilePath: string }> = [];
+		let state = {
+			version: 1,
+			active: false,
+			planFilePath,
+			lastPlanLeafId: undefined,
+		};
+		const handler = createRegisteredHandler({
+			getState: () => state,
+			setState: (_ctx, nextState) => {
+				state = nextState;
+			},
+			startPlanMode: (_ctx, options) => {
+				startCalls.push(options);
+			},
+		});
+
+		const selectCalls: Array<{ prompt: string; choices: string[] }> = [];
+		await handler("", {
+			cwd: tmpDir,
+			hasUI: true,
+			waitForIdle: () => undefined,
+			ui: {
+				select: (prompt: string, choices: string[]) => {
+					selectCalls.push({ prompt, choices });
+					return "Start fresh";
+				},
+				notify: () => {},
+			},
+			sessionManager: {
+				getLeafId: () => "leaf-1",
+				getEntries: () => [{ id: "leaf-1", type: "message", message: { role: "user" } }],
+				getSessionFile: () => undefined,
+				getSessionDir: () => tmpDir,
+				getSessionId: () => "session-1",
+			},
+		});
+
+		expect(selectCalls).toEqual([
+			{
+				prompt: `Start planning:\nPlan file: ${planFilePath}`,
+				choices: ["Continue planning", "Start fresh"],
+			},
+		]);
+		expect(startCalls).toHaveLength(1);
+		expect(startCalls[0]).toEqual({
+			originLeafId: "leaf-1",
+			planFilePath: expect.any(String),
+		});
+		expect(startCalls[0].planFilePath).not.toBe(planFilePath);
+	});
+});

--- a/packages/plan/tests/plan-files.test.ts
+++ b/packages/plan/tests/plan-files.test.ts
@@ -1,0 +1,66 @@
+import { mkdir, mkdtemp, rm } from "node:fs/promises";
+import os from "node:os";
+import path from "node:path";
+import { afterEach, describe, expect, test } from "vitest";
+import { buildTimestampedPlanFilename, resolveActivePlanFilePath, resolvePlanLocationInput } from "../plan-files";
+
+const tempDirs: string[] = [];
+
+afterEach(async () => {
+	while (tempDirs.length > 0) {
+		const dir = tempDirs.pop();
+		if (!dir) {
+			continue;
+		}
+		await rm(dir, { recursive: true, force: true });
+	}
+});
+
+function createCtx(cwd: string, sessionId: string) {
+	return {
+		cwd,
+		sessionManager: {
+			getSessionId: () => sessionId,
+			getSessionFile: () => undefined,
+			getSessionDir: () => cwd,
+		},
+	} as any;
+}
+
+describe("buildTimestampedPlanFilename", () => {
+	test("sanitizes session id and keeps plan suffix", () => {
+		const name = buildTimestampedPlanFilename("session/id:1");
+		expect(name.endsWith(".plan.md")).toBe(true);
+		expect(name).toContain("session-id-1");
+	});
+});
+
+describe("resolvePlanLocationInput", () => {
+	test("keeps explicit file path", async () => {
+		const tmpDir = await mkdtemp(path.join(os.tmpdir(), "plan-md-files-"));
+		tempDirs.push(tmpDir);
+		const ctx = createCtx(tmpDir, "session-1");
+
+		const resolved = await resolvePlanLocationInput(ctx, "plans/next.plan.md");
+		expect(resolved).toBe(path.join(tmpDir, "plans/next.plan.md"));
+	});
+
+	test("creates timestamped file for directory input", async () => {
+		const tmpDir = await mkdtemp(path.join(os.tmpdir(), "plan-md-files-"));
+		tempDirs.push(tmpDir);
+		const plansDir = path.join(tmpDir, "plans");
+		await mkdir(plansDir, { recursive: true });
+		const ctx = createCtx(tmpDir, "session-2");
+
+		const resolved = await resolvePlanLocationInput(ctx, "plans/");
+		expect(resolved?.startsWith(plansDir)).toBe(true);
+		expect(resolved?.endsWith(".plan.md")).toBe(true);
+	});
+});
+
+describe("resolveActivePlanFilePath", () => {
+	test("uses explicit state path when available", () => {
+		const ctx = createCtx("/tmp/demo", "session-3");
+		expect(resolveActivePlanFilePath(ctx, "/tmp/custom.plan.md")).toBe("/tmp/custom.plan.md");
+	});
+});

--- a/packages/plan/tests/prompts.test.ts
+++ b/packages/plan/tests/prompts.test.ts
@@ -1,0 +1,72 @@
+import { mkdir, mkdtemp, rm, writeFile } from "node:fs/promises";
+import os from "node:os";
+import path from "node:path";
+import { fileURLToPath } from "node:url";
+import { afterEach, describe, expect, test } from "vitest";
+import { loadPlanModePrompt } from "../prompts";
+
+const tempDirs: string[] = [];
+
+afterEach(async () => {
+	while (tempDirs.length > 0) {
+		const dir = tempDirs.pop();
+		if (!dir) {
+			continue;
+		}
+		await rm(dir, { recursive: true, force: true });
+	}
+});
+
+async function createPromptPaths() {
+	const tempDir = await mkdtemp(path.join(os.tmpdir(), "plan-md-prompts-"));
+	tempDirs.push(tempDir);
+
+	const agentDirPath = path.join(tempDir, "agent");
+	await mkdir(agentDirPath, { recursive: true });
+
+	const bundledPromptPath = path.join(tempDir, "bundled", "PLAN.prompt.md");
+	await mkdir(path.dirname(bundledPromptPath), { recursive: true });
+
+	return {
+		agentDirPath,
+		bundledPromptPath,
+	};
+}
+
+describe("loadPlanModePrompt", () => {
+	test("loads bundled prompt when override is missing", async () => {
+		const paths = await createPromptPaths();
+		await writeFile(paths.bundledPromptPath, "bundled prompt\n", "utf8");
+
+		const prompt = await loadPlanModePrompt(paths);
+		expect(prompt).toBe("bundled prompt");
+	});
+
+	test("prefers override prompt when present", async () => {
+		const paths = await createPromptPaths();
+		await writeFile(paths.bundledPromptPath, "bundled prompt\n", "utf8");
+		await writeFile(path.join(paths.agentDirPath, "PLAN.prompt.md"), "override prompt\n", "utf8");
+
+		const prompt = await loadPlanModePrompt(paths);
+		expect(prompt).toBe("override prompt");
+	});
+
+	test("falls back to bundled prompt when override is blank", async () => {
+		const paths = await createPromptPaths();
+		await writeFile(paths.bundledPromptPath, "bundled prompt\n", "utf8");
+		await writeFile(path.join(paths.agentDirPath, "PLAN.prompt.md"), "  \n\t\n", "utf8");
+
+		const prompt = await loadPlanModePrompt(paths);
+		expect(prompt).toBe("bundled prompt");
+	});
+
+	test("bundled prompt tells the model to put the goal at the top of the plan", async () => {
+		const paths = await createPromptPaths();
+		const prompt = await loadPlanModePrompt({
+			agentDirPath: paths.agentDirPath,
+			bundledPromptPath: fileURLToPath(new URL("../prompts/PLAN.prompt.md", import.meta.url)),
+		});
+
+		expect(prompt).toContain("Include the goal at the top of the plan.");
+	});
+});

--- a/packages/plan/tests/request-user-input.test.ts
+++ b/packages/plan/tests/request-user-input.test.ts
@@ -1,0 +1,103 @@
+import type { QnAResponse } from "@ifi/pi-shared-qna";
+import { describe, expect, test } from "vitest";
+import {
+	buildRequestUserInputResponse,
+	buildRequestUserInputSummary,
+	normalizeRequestUserInputQuestions,
+	summarizeRequestUserInputAnswer,
+} from "../request-user-input";
+
+describe("normalizeRequestUserInputQuestions", () => {
+	test("trims ids and defaults options", () => {
+		const result = normalizeRequestUserInputQuestions([
+			{ id: " runtime ", header: "Runtime", question: "Which runtime?" },
+		]);
+
+		if ("error" in result) {
+			throw new Error(result.error);
+		}
+
+		expect(result.questions[0]).toEqual({
+			id: "runtime",
+			header: "Runtime",
+			question: "Which runtime?",
+			options: [],
+		});
+	});
+
+	test("rejects duplicate ids", () => {
+		const result = normalizeRequestUserInputQuestions([
+			{ id: "runtime", header: "One", question: "Q1" },
+			{ id: "runtime", header: "Two", question: "Q2" },
+		]);
+
+		expect("error" in result).toBe(true);
+		if ("error" in result) {
+			expect(result.error).toContain("Duplicate id: runtime");
+		}
+	});
+});
+
+describe("buildRequestUserInputResponse", () => {
+	test("preserves option, other, and note semantics", () => {
+		const normalized = normalizeRequestUserInputQuestions([
+			{
+				id: "runtime",
+				header: "Runtime",
+				question: "Which runtime?",
+				options: [
+					{ label: "Node", description: "Use Node.js" },
+					{ label: "Bun", description: "Use Bun" },
+				],
+			},
+			{
+				id: "notes",
+				header: "Notes",
+				question: "Any constraints?",
+			},
+		]);
+		if ("error" in normalized) {
+			throw new Error(normalized.error);
+		}
+
+		const responses: QnAResponse[] = [
+			{
+				selectedOptionIndex: 2,
+				customText: "Need Bun APIs",
+				selectionTouched: true,
+				committed: true,
+			},
+			{
+				selectedOptionIndex: 0,
+				customText: "Ship in two phases",
+				selectionTouched: true,
+				committed: true,
+			},
+		];
+
+		const response = buildRequestUserInputResponse(normalized.questions, responses);
+		expect(response.answers.runtime.answers).toEqual(["Other", "user_note: Need Bun APIs"]);
+		expect(response.answers.notes.answers).toEqual(["user_note: Ship in two phases"]);
+	});
+});
+
+describe("summary helpers", () => {
+	test("formats missing answer marker", () => {
+		expect(summarizeRequestUserInputAnswer({ answers: [] })).toBe("(no answer)");
+	});
+
+	test("builds readable summary lines", () => {
+		const details = {
+			questions: [{ id: "runtime", header: "Runtime", question: "Which runtime?", options: [] }],
+			response: {
+				answers: {
+					runtime: { answers: ["user_note: Bun for startup"] },
+				},
+			},
+		};
+
+		const summary = buildRequestUserInputSummary(details);
+		expect(summary).toContain("1. Which runtime?");
+		expect(summary).toContain("Bun for startup");
+	});
+});

--- a/packages/plan/tests/state.test.ts
+++ b/packages/plan/tests/state.test.ts
@@ -1,0 +1,110 @@
+import { describe, expect, test } from "vitest";
+import { createPlanModeStateManager, getLatestState } from "../state";
+
+describe("getLatestState", () => {
+	test("returns inactive state when no persisted state exists", () => {
+		const ctx = {
+			sessionManager: {
+				getEntries: () => [],
+				getBranch: () => [],
+			},
+		} as any;
+
+		const state = getLatestState(ctx);
+		expect(state.active).toBe(false);
+		expect(state.version).toBe(1);
+	});
+
+	test("prefers latest session state even when current branch has stale active state", () => {
+		const ctx = {
+			sessionManager: {
+				getEntries: () => [
+					{
+						type: "custom",
+						customType: "pi-plan:state",
+						data: { version: 1, active: true, planFilePath: "/tmp/old.plan.md", lastPlanLeafId: "leaf-old" },
+					},
+					{
+						type: "custom",
+						customType: "pi-plan:state",
+						data: { version: 1, active: false, planFilePath: "/tmp/new.plan.md", lastPlanLeafId: "leaf-new" },
+					},
+				],
+				getBranch: () => [
+					{
+						type: "custom",
+						customType: "pi-plan:state",
+						data: { version: 1, active: true, planFilePath: "/tmp/old.plan.md" },
+					},
+				],
+			},
+		} as any;
+
+		const state = getLatestState(ctx);
+		expect(state.active).toBe(false);
+		expect(state.planFilePath).toBe("/tmp/new.plan.md");
+		expect(state.lastPlanLeafId).toBe("leaf-new");
+	});
+});
+
+describe("createPlanModeStateManager tool visibility", () => {
+	function createContext(entries: any[] = []) {
+		return {
+			hasUI: false,
+			sessionManager: {
+				getEntries: () => entries,
+				getSessionFile: () => undefined,
+				getSessionDir: () => "/tmp",
+				getSessionId: () => "session-1",
+			},
+		} as any;
+	}
+
+	test("adds plan mode tools when plan mode starts", () => {
+		let activeTools = ["read", "bash", "edit", "write"];
+		const setActiveToolsCalls: string[][] = [];
+
+		const manager = createPlanModeStateManager({
+			appendEntry: () => {},
+			getActiveTools: () => activeTools,
+			setActiveTools: (nextTools: string[]) => {
+				setActiveToolsCalls.push(nextTools);
+				activeTools = nextTools;
+			},
+		} as any);
+
+		manager.startPlanMode(createContext(), {
+			planFilePath: "/tmp/session.plan.md",
+		});
+
+		expect(setActiveToolsCalls).toEqual([
+			["read", "bash", "edit", "write", "task_agents", "steer_task_agent", "request_user_input", "set_plan"],
+		]);
+	});
+
+	test("removes plan mode tools when refreshed state is inactive", () => {
+		let activeTools = ["read", "bash", "set_plan", "task_agents", "steer_task_agent", "request_user_input"];
+		const setActiveToolsCalls: string[][] = [];
+
+		const manager = createPlanModeStateManager({
+			appendEntry: () => {},
+			getActiveTools: () => activeTools,
+			setActiveTools: (nextTools: string[]) => {
+				setActiveToolsCalls.push(nextTools);
+				activeTools = nextTools;
+			},
+		} as any);
+
+		manager.refresh(
+			createContext([
+				{
+					type: "custom",
+					customType: "pi-plan:state",
+					data: { version: 1, active: false, planFilePath: "/tmp/session.plan.md" },
+				},
+			]),
+		);
+
+		expect(setActiveToolsCalls).toEqual([["read", "bash"]]);
+	});
+});

--- a/packages/plan/tests/task-agents.test.ts
+++ b/packages/plan/tests/task-agents.test.ts
@@ -1,0 +1,220 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+vi.mock("@ifi/pi-extension-subagents/execution.ts", () => ({
+	runSync: vi.fn(),
+}));
+
+vi.mock("@ifi/pi-extension-subagents/utils.ts", () => ({
+	getFinalOutput: vi.fn(),
+}));
+
+import { runSync } from "@ifi/pi-extension-subagents/execution.ts";
+import { getFinalOutput } from "@ifi/pi-extension-subagents/utils.ts";
+import { buildTaskAgentRunDetails, normalizeTaskAgentTasks, registerTaskAgentTools } from "../task-agents.js";
+
+type MockRunSync = typeof runSync & ReturnType<typeof vi.fn>;
+type MockGetFinalOutput = typeof getFinalOutput & ReturnType<typeof vi.fn>;
+
+function makeSingleResult(exitCode: number, error?: string) {
+	return {
+		agent: "plan-researcher",
+		task: "Task",
+		exitCode,
+		messages: [],
+		usage: { input: 0, output: 0, cacheRead: 0, cacheWrite: 0, cost: 0, turns: 0 },
+		error,
+	};
+}
+
+function registerTools(getState = () => ({ active: true })) {
+	const tools = new Map<string, any>();
+	registerTaskAgentTools(
+		{
+			getActiveTools: () => ["read", "grep", "find", "ls", "bash", "web_search"],
+			registerTool: (tool: { name: string }) => {
+				tools.set(tool.name, tool);
+			},
+		} as any,
+		{
+			getState,
+			taskAgentsSchema: {},
+			steerTaskAgentSchema: {},
+		},
+	);
+	return tools;
+}
+
+beforeEach(() => {
+	vi.clearAllMocks();
+});
+
+describe("normalizeTaskAgentTasks", () => {
+	it("sanitizes and deduplicates task ids", () => {
+		const normalized = normalizeTaskAgentTasks([
+			{ id: "Auth Scan", prompt: "Inspect auth" },
+			{ id: "Auth Scan", prompt: "Inspect auth tests" },
+			{ prompt: "Inspect docs" },
+		]);
+
+		expect(normalized.map((task) => task.id)).toEqual(["auth-scan", "auth-scan-2", "task-3"]);
+	});
+});
+
+describe("buildTaskAgentRunDetails", () => {
+	it("counts successful tasks", () => {
+		const details = buildTaskAgentRunDetails("run-1", [
+			{
+				taskId: "task-1",
+				task: "One",
+				cwd: "/tmp",
+				output: "ok",
+				references: [],
+				exitCode: 0,
+				stderr: "",
+				activities: [],
+				startedAt: 1,
+				finishedAt: 2,
+				steeringNotes: [],
+			},
+			{
+				taskId: "task-2",
+				task: "Two",
+				cwd: "/tmp",
+				output: "",
+				references: [],
+				exitCode: 1,
+				stderr: "failed",
+				activities: [],
+				startedAt: 1,
+				finishedAt: 2,
+				steeringNotes: [],
+			},
+		]);
+
+		expect(details.successCount).toBe(1);
+		expect(details.totalCount).toBe(2);
+	});
+});
+
+describe("task agent tool registration", () => {
+	it("registers both planning task tools", () => {
+		const tools = registerTools();
+		expect(Array.from(tools.keys()).sort()).toEqual(["steer_task_agent", "task_agents"]);
+	});
+
+	it("rejects task_agents when plan mode is inactive", async () => {
+		const tools = registerTools(() => ({ active: false }));
+		const taskAgentsTool = tools.get("task_agents");
+		const result = await taskAgentsTool.execute(
+			"call-1",
+			{ tasks: [{ prompt: "Inspect auth" }] },
+			undefined,
+			undefined,
+			{ cwd: "/repo" },
+		);
+
+		expect(result.isError).toBe(true);
+		expect(result.content[0]?.text).toContain("only available while plan mode is active");
+	});
+});
+
+describe("task_agents tool", () => {
+	it("runs planning tasks through the bundled subagent runtime", async () => {
+		const tools = registerTools();
+		const taskAgentsTool = tools.get("task_agents");
+		(runSync as MockRunSync).mockResolvedValueOnce(makeSingleResult(0)).mockResolvedValueOnce(makeSingleResult(0));
+		(getFinalOutput as MockGetFinalOutput)
+			.mockReturnValueOnce("Summary A\n\nReferences:\n- src/auth.ts")
+			.mockReturnValueOnce("Summary B\n\nReferences:\n- docs/plan.md");
+
+		const result = await taskAgentsTool.execute(
+			"call-1",
+			{
+				tasks: [
+					{ id: "task-a", prompt: "Inspect auth", cwd: "/repo" },
+					{ id: "task-b", prompt: "Inspect docs", cwd: "/repo/docs" },
+				],
+				concurrency: 2,
+			},
+			undefined,
+			undefined,
+			{ cwd: "/repo" },
+		);
+
+		expect(result.isError).toBe(false);
+		expect(runSync).toHaveBeenCalledTimes(2);
+		expect((runSync as MockRunSync).mock.calls[0]?.[2]).toBe("plan-researcher");
+		expect((runSync as MockRunSync).mock.calls[0]?.[3]).toContain("Task ID: task-a");
+		expect((runSync as MockRunSync).mock.calls[0]?.[0]).toBe("/repo");
+		expect((runSync as MockRunSync).mock.calls[0]?.[4]).toMatchObject({ cwd: "/repo", index: 0 });
+		expect(result.details.successCount).toBe(2);
+		expect(result.details.tasks[0]?.taskId).toBe("task-a");
+		expect(result.details.tasks[0]?.references).toContain("src/auth.ts");
+		expect(result.content[0]?.text).toContain("Use steer_task_agent");
+	});
+
+	it("marks the overall result as error when any delegated task fails", async () => {
+		const tools = registerTools();
+		const taskAgentsTool = tools.get("task_agents");
+		(runSync as MockRunSync)
+			.mockResolvedValueOnce(makeSingleResult(0))
+			.mockResolvedValueOnce(makeSingleResult(1, "failed to inspect"));
+		(getFinalOutput as MockGetFinalOutput).mockReturnValueOnce("Summary A").mockReturnValueOnce("Partial output");
+
+		const result = await taskAgentsTool.execute(
+			"call-1",
+			{
+				tasks: [{ prompt: "Inspect auth" }, { prompt: "Inspect docs" }],
+				concurrency: 2,
+			},
+			undefined,
+			undefined,
+			{ cwd: "/repo" },
+		);
+
+		expect(result.isError).toBe(true);
+		expect(result.details.successCount).toBe(1);
+		expect(result.details.tasks[1]?.stderr).toBe("failed to inspect");
+	});
+});
+
+describe("steer_task_agent", () => {
+	it("reruns a previous task with extra steering via the subagent runtime", async () => {
+		const tools = registerTools();
+		const taskAgentsTool = tools.get("task_agents");
+		const steerTaskAgentTool = tools.get("steer_task_agent");
+
+		(runSync as MockRunSync).mockResolvedValueOnce(makeSingleResult(0)).mockResolvedValueOnce(makeSingleResult(0));
+		(getFinalOutput as MockGetFinalOutput)
+			.mockReturnValueOnce("Initial summary")
+			.mockReturnValueOnce("Steered summary\n\nReferences:\n- src/auth.ts");
+
+		const firstRun = await taskAgentsTool.execute(
+			"call-1",
+			{ tasks: [{ id: "auth-scan", prompt: "Inspect auth" }], concurrency: 1 },
+			undefined,
+			undefined,
+			{ cwd: "/repo" },
+		);
+
+		const steerResult = await steerTaskAgentTool.execute(
+			"call-2",
+			{
+				runId: firstRun.details.runId,
+				taskId: "auth-scan",
+				instruction: "Focus on auth middleware ordering",
+			},
+			undefined,
+			undefined,
+			{ cwd: "/repo" },
+		);
+
+		expect(runSync).toHaveBeenCalledTimes(2);
+		expect((runSync as MockRunSync).mock.calls[1]?.[3]).toContain("Steering update from the main planning agent");
+		expect((runSync as MockRunSync).mock.calls[1]?.[3]).toContain("Focus on auth middleware ordering");
+		expect(steerResult.isError).toBe(false);
+		expect(steerResult.details.tasks[0]?.steeringNotes).toEqual(["Focus on auth middleware ordering"]);
+		expect(steerResult.details.tasks[0]?.references).toContain("src/auth.ts");
+		expect(steerResult.content[0]?.text).toContain("Steered auth-scan");
+	});
+});

--- a/packages/plan/tests/utils.test.ts
+++ b/packages/plan/tests/utils.test.ts
@@ -1,0 +1,75 @@
+import { describe, expect, test } from "vitest";
+import {
+	buildImplementationPrefill,
+	findDuplicateId,
+	PLAN_MODE_END_OPTIONS,
+	PLAN_MODE_START_OPTIONS,
+	PLAN_MODE_SUMMARY_PROMPT,
+	resolvePlanFilePath,
+	resolveTaskAgentConcurrency,
+} from "../utils";
+
+describe("resolvePlanFilePath", () => {
+	test("returns absolute path for relative input", () => {
+		const resolved = resolvePlanFilePath("/tmp/project", "plans/next.md");
+		expect(resolved).toBe("/tmp/project/plans/next.md");
+	});
+
+	test("returns null for empty input", () => {
+		expect(resolvePlanFilePath("/tmp/project", "   ")).toBeNull();
+	});
+});
+
+describe("resolveTaskAgentConcurrency", () => {
+	test("defaults to two workers", () => {
+		expect(resolveTaskAgentConcurrency(undefined)).toBe(2);
+	});
+
+	test("accepts integers in range", () => {
+		expect(resolveTaskAgentConcurrency(1)).toBe(1);
+		expect(resolveTaskAgentConcurrency(4)).toBe(4);
+	});
+
+	test("rejects fractional and out-of-range values", () => {
+		expect(resolveTaskAgentConcurrency(1.5)).toBeNull();
+		expect(resolveTaskAgentConcurrency(0)).toBeNull();
+		expect(resolveTaskAgentConcurrency(5)).toBeNull();
+	});
+});
+
+describe("findDuplicateId", () => {
+	test("returns null when ids are unique", () => {
+		expect(findDuplicateId(["a", "b", "c"])).toBeNull();
+	});
+
+	test("returns the first duplicate id", () => {
+		expect(findDuplicateId(["a", "b", "a", "c"])).toBe("a");
+	});
+});
+
+describe("plan mode review-style choices", () => {
+	test("exposes start options matching review-style flow", () => {
+		expect(PLAN_MODE_START_OPTIONS).toEqual(["Empty branch", "Current branch"]);
+	});
+
+	test("exposes concise end options", () => {
+		expect(PLAN_MODE_END_OPTIONS).toEqual(["Exit", "Exit & summarize branch"]);
+	});
+
+	test("includes summarize-on-navigation instructions", () => {
+		expect(PLAN_MODE_SUMMARY_PROMPT).toContain("switching from a planning branch back to implementation");
+		expect(PLAN_MODE_SUMMARY_PROMPT).toContain("Ordered implementation steps");
+	});
+});
+
+describe("buildImplementationPrefill", () => {
+	test("returns a short implementation instruction", () => {
+		expect(buildImplementationPrefill()).toContain("Implement the approved plan");
+	});
+
+	test("includes saved plan path when provided", () => {
+		const prefill = buildImplementationPrefill("/tmp/plan.md");
+		expect(prefill).toContain("Plan file: /tmp/plan.md");
+		expect(prefill).toContain("\nImplement the approved plan in this file.");
+	});
+});

--- a/packages/plan/types.ts
+++ b/packages/plan/types.ts
@@ -1,0 +1,98 @@
+export type PlanModeState = {
+	version: number;
+	active: boolean;
+	originLeafId?: string;
+	planFilePath?: string;
+	lastPlanLeafId?: string;
+};
+
+export type TaskAgentTask = {
+	id?: string;
+	prompt: string;
+	cwd?: string;
+};
+
+export type NormalizedTaskAgentTask = {
+	id: string;
+	prompt: string;
+	cwd?: string;
+};
+
+export type TaskAgentActivityKind = "status" | "tool" | "assistant" | "toolResult" | "stderr";
+
+export type TaskAgentActivity = {
+	kind: TaskAgentActivityKind;
+	text: string;
+	timestamp: number;
+};
+
+export type TaskAgentTaskResult = {
+	taskId: string;
+	task: string;
+	cwd: string;
+	output: string;
+	references: string[];
+	exitCode: number;
+	stderr: string;
+	activities: TaskAgentActivity[];
+	startedAt: number;
+	finishedAt: number;
+	steeringNotes: string[];
+};
+
+export type TaskAgentTaskProgress = {
+	taskId: string;
+	prompt: string;
+	status: "queued" | "running" | "completed" | "failed";
+	latestActivity?: string;
+	activityCount: number;
+};
+
+export type TaskAgentRunDetails = {
+	runId: string;
+	tasks: TaskAgentTaskResult[];
+	successCount: number;
+	totalCount: number;
+};
+
+export type TaskAgentProgressDetails = {
+	runId: string;
+	completed: number;
+	total: number;
+	tasks: TaskAgentTaskProgress[];
+};
+
+export type TaskAgentRunRecord = {
+	runId: string;
+	createdAt: number;
+	tasks: TaskAgentTaskResult[];
+};
+
+export type RequestUserInputOption = {
+	label: string;
+	description: string;
+};
+
+export type RequestUserInputQuestion = {
+	id: string;
+	header: string;
+	question: string;
+	options?: RequestUserInputOption[];
+};
+
+export type NormalizedRequestUserInputQuestion = Omit<RequestUserInputQuestion, "options"> & {
+	options: RequestUserInputOption[];
+};
+
+export type RequestUserInputAnswer = {
+	answers: string[];
+};
+
+export type RequestUserInputResponse = {
+	answers: Record<string, RequestUserInputAnswer>;
+};
+
+export type RequestUserInputDetails = {
+	questions: NormalizedRequestUserInputQuestion[];
+	response: RequestUserInputResponse;
+};

--- a/packages/plan/utils.ts
+++ b/packages/plan/utils.ts
@@ -1,0 +1,74 @@
+import path from "node:path";
+import type { PlanModeState } from "./types";
+
+export const PLAN_MODE_STATE_VERSION = 1;
+
+export type { PlanModeState };
+
+export const PLAN_MODE_START_OPTIONS = ["Empty branch", "Current branch"] as const;
+export const PLAN_MODE_END_OPTIONS = ["Exit", "Exit & summarize branch"] as const;
+
+export const PLAN_MODE_SUMMARY_PROMPT = `We are switching from a planning branch back to implementation work.
+Summarize this planning branch so implementation can begin immediately.
+
+Include:
+1. Goal and scope
+2. Key decisions and assumptions
+3. Ordered implementation steps
+4. Risks, validations, and open questions
+5. Important file paths, commands, and references gathered during planning
+
+Use concise bullet points and preserve exact technical identifiers when relevant.`;
+
+export function createInactivePlanModeState(): PlanModeState {
+	return {
+		version: PLAN_MODE_STATE_VERSION,
+		active: false,
+	};
+}
+
+export function isPlanModeState(value: unknown): value is PlanModeState {
+	if (!value || typeof value !== "object") {
+		return false;
+	}
+
+	const state = value as Partial<PlanModeState>;
+	return state.version === PLAN_MODE_STATE_VERSION && typeof state.active === "boolean";
+}
+
+export function resolvePlanFilePath(cwd: string, filePath: string): string | null {
+	const trimmed = filePath.trim();
+	if (!trimmed) {
+		return null;
+	}
+	return path.resolve(cwd, trimmed);
+}
+
+export function resolveTaskAgentConcurrency(value: number | undefined): number | null {
+	const concurrency = value ?? 2;
+	if (!Number.isFinite(concurrency) || !Number.isInteger(concurrency)) {
+		return null;
+	}
+	if (concurrency < 1 || concurrency > 4) {
+		return null;
+	}
+	return concurrency;
+}
+
+export function findDuplicateId(ids: string[]): string | null {
+	const seen = new Set<string>();
+	for (const id of ids) {
+		if (seen.has(id)) {
+			return id;
+		}
+		seen.add(id);
+	}
+	return null;
+}
+
+export function buildImplementationPrefill(planPath?: string): string {
+	if (planPath) {
+		return `Plan file: ${planPath}\nImplement the approved plan in this file. Keep changes focused, update tests, and summarize what was implemented.`;
+	}
+	return "Implement the approved plan step by step. Keep changes focused, update tests, and summarize what was implemented.";
+}

--- a/packages/shared-qna/README.md
+++ b/packages/shared-qna/README.md
@@ -1,0 +1,7 @@
+# @ifi/pi-shared-qna
+
+Shared question-and-answer TUI helpers for pi extensions.
+
+This package vendors the `shared/qna-tui.ts` component from
+[`sids/pi-extensions`](https://github.com/sids/pi-extensions) into the oh-pi monorepo so other
+first-party packages can reuse it without depending on third-party pi packages at runtime.

--- a/packages/shared-qna/index.ts
+++ b/packages/shared-qna/index.ts
@@ -1,0 +1,1 @@
+export * from "./qna-tui.js";

--- a/packages/shared-qna/package.json
+++ b/packages/shared-qna/package.json
@@ -1,0 +1,32 @@
+{
+  "name": "@ifi/pi-shared-qna",
+  "version": "0.2.13",
+  "description": "Shared TUI question-and-answer component for pi extensions.",
+  "type": "module",
+  "keywords": [
+    "pi-package",
+    "pi",
+    "pi-coding-agent",
+    "tui",
+    "qna"
+  ],
+  "files": [
+    "*.ts",
+    "README.md",
+    "!**/*.test.ts",
+    "!tests/**"
+  ],
+  "license": "MIT",
+  "repository": {
+    "type": "git",
+    "url": "git+https://github.com/ifiokjr/oh-pi.git",
+    "directory": "packages/shared-qna"
+  },
+  "homepage": "https://github.com/ifiokjr/oh-pi/tree/main/packages/shared-qna",
+  "bugs": {
+    "url": "https://github.com/ifiokjr/oh-pi/issues"
+  },
+  "peerDependencies": {
+    "@mariozechner/pi-tui": "*"
+  }
+}

--- a/packages/shared-qna/qna-tui.ts
+++ b/packages/shared-qna/qna-tui.ts
@@ -1,0 +1,826 @@
+import { createRequire } from "node:module";
+import os from "node:os";
+import path from "node:path";
+
+const require = createRequire(import.meta.url);
+
+function requirePiTui() {
+	try {
+		return require("@mariozechner/pi-tui");
+	} catch (error) {
+		const code = (error as { code?: string }).code;
+		if (code !== "MODULE_NOT_FOUND") {
+			throw error;
+		}
+		return require(path.join(os.homedir(), ".bun", "install", "global", "node_modules", "@mariozechner", "pi-tui"));
+	}
+}
+
+type Component = {
+	handleInput: (data: string) => void;
+	render: (width: number) => string[];
+	invalidate: () => void;
+};
+
+type TUI = {
+	requestRender: () => void;
+};
+
+type EditorTheme = {
+	borderColor: (text: string) => string;
+	selectList: {
+		matchHighlight?: (text: string) => string;
+		itemSecondary?: (text: string) => string;
+	};
+};
+
+function getPiTui() {
+	return requirePiTui() as {
+		Editor: new (tui: TUI, theme: EditorTheme) => {
+			disableSubmit?: boolean;
+			onChange?: () => void;
+			setText: (text: string) => void;
+			getText: () => string;
+			render: (width: number) => string[];
+			handleInput: (data: string) => void;
+		};
+		Key: {
+			enter: string;
+			tab: string;
+			escape: string;
+			up: string;
+			down: string;
+			ctrl: (key: string) => string;
+			shift: (key: string) => string;
+		};
+		matchesKey: (input: string, key: string) => boolean;
+		truncateToWidth: (text: string, width: number) => string;
+		visibleWidth: (text: string) => number;
+		wrapTextWithAnsi: (text: string, width: number) => string[];
+	};
+}
+
+export interface QnAOption {
+	label: string;
+	description: string;
+}
+
+export interface QnAQuestion {
+	header?: string;
+	question: string;
+	context?: string;
+	options?: QnAOption[];
+}
+
+export interface QnATemplate {
+	label: string;
+	template: string;
+}
+
+export interface QnAResponse {
+	selectedOptionIndex: number;
+	customText: string;
+	selectionTouched: boolean;
+	committed: boolean;
+}
+
+export interface QnAResult {
+	text: string;
+	answers: string[];
+	responses: QnAResponse[];
+}
+
+export interface QnATemplateData {
+	question: string;
+	context?: string;
+	answer: string;
+	index: number;
+	total: number;
+}
+
+export function getQuestionOptions(question: QnAQuestion): QnAOption[] {
+	return question.options ?? [];
+}
+
+export function formatResponseAnswer(question: QnAQuestion, response: QnAResponse): string {
+	const options = getQuestionOptions(question);
+	if (options.length === 0) {
+		return response.customText;
+	}
+
+	const otherIndex = options.length;
+	if (response.selectedOptionIndex === otherIndex) {
+		return response.customText;
+	}
+
+	if (!response.selectionTouched) {
+		return "";
+	}
+
+	return options[response.selectedOptionIndex]?.label ?? "";
+}
+
+export function normalizeResponseForQuestion(
+	question: QnAQuestion,
+	response: Partial<QnAResponse> | undefined,
+	fallbackAnswer: string | undefined,
+	inferCommittedFromContent: boolean,
+): QnAResponse {
+	const options = getQuestionOptions(question);
+	const rawFallback = fallbackAnswer ?? "";
+	const rawCustomText = response?.customText ?? rawFallback;
+	let selectedOptionIndex =
+		typeof response?.selectedOptionIndex === "number" && Number.isFinite(response.selectedOptionIndex)
+			? Math.trunc(response.selectedOptionIndex)
+			: undefined;
+	let selectionTouched = response?.selectionTouched ?? false;
+
+	if (options.length === 0) {
+		selectedOptionIndex = 0;
+		if (response?.selectionTouched === undefined && rawCustomText.trim().length > 0) {
+			selectionTouched = true;
+		}
+	} else if (selectedOptionIndex === undefined) {
+		const fallbackTrimmed = rawFallback.trim();
+		if (fallbackTrimmed.length === 0) {
+			selectedOptionIndex = 0;
+			if (response?.selectionTouched === undefined) {
+				selectionTouched = false;
+			}
+		} else {
+			const optionIndex = options.findIndex((option) => option.label === fallbackTrimmed);
+			selectedOptionIndex = optionIndex >= 0 ? optionIndex : options.length;
+			if (response?.selectionTouched === undefined) {
+				selectionTouched = true;
+			}
+		}
+	} else if (response?.selectionTouched === undefined) {
+		selectionTouched = response?.committed === true;
+		if (!selectionTouched) {
+			const fallbackTrimmed = rawFallback.trim();
+			if (fallbackTrimmed.length > 0) {
+				const optionIndex = options.findIndex((option) => option.label === fallbackTrimmed);
+				if (optionIndex >= 0) {
+					selectionTouched = optionIndex === selectedOptionIndex && optionIndex !== 0;
+				} else {
+					selectionTouched = selectedOptionIndex === options.length;
+				}
+			}
+		}
+	}
+
+	const maxIndex = options.length;
+	const normalizedIndex = Math.max(0, Math.min(maxIndex, selectedOptionIndex ?? 0));
+	const useCustomText = options.length === 0 || normalizedIndex === options.length;
+	const normalizedCustomText = useCustomText ? rawCustomText : "";
+
+	let committed = response?.committed ?? false;
+	if (response?.committed === undefined && inferCommittedFromContent) {
+		committed = formatResponseAnswer(question, {
+			selectedOptionIndex: normalizedIndex,
+			customText: normalizedCustomText,
+			selectionTouched,
+			committed: false,
+		}).trim().length > 0;
+	}
+
+	return {
+		selectedOptionIndex: normalizedIndex,
+		customText: normalizedCustomText,
+		selectionTouched,
+		committed,
+	};
+}
+
+export function normalizeResponses(
+	questions: QnAQuestion[],
+	responses: Array<Partial<QnAResponse>> | undefined,
+	fallbackAnswers: string[] | undefined,
+	inferCommittedFromContent: boolean,
+): QnAResponse[] {
+	return questions.map((question, index) =>
+		normalizeResponseForQuestion(
+			question,
+			responses?.[index],
+			fallbackAnswers?.[index],
+			inferCommittedFromContent,
+		),
+	);
+}
+
+export function cloneResponses(responses: QnAResponse[]): QnAResponse[] {
+	return responses.map((response) => ({ ...response }));
+}
+
+export function deriveAnswersFromResponses(questions: QnAQuestion[], responses: QnAResponse[]): string[] {
+	return questions.map((question, index) => formatResponseAnswer(question, responses[index]));
+}
+
+export function hasResponseContent(question: QnAQuestion, response: QnAResponse): boolean {
+	return formatResponseAnswer(question, response).trim().length > 0;
+}
+
+function defaultResolveNumericShortcut(
+	input: string,
+	maxOptionIndex: number,
+	usingCustomEditor: boolean,
+): number | null {
+	if (usingCustomEditor) {
+		return null;
+	}
+
+	if (!/^[1-9]$/.test(input)) {
+		return null;
+	}
+
+	const selectedIndex = Number(input) - 1;
+	if (selectedIndex > maxOptionIndex) {
+		return null;
+	}
+
+	return selectedIndex;
+}
+
+function defaultApplyTemplate(template: string, data: QnATemplateData): string {
+	const replacements: Record<string, string> = {
+		question: data.question,
+		context: data.context ?? "",
+		answer: data.answer,
+		index: String(data.index + 1),
+		total: String(data.total),
+	};
+
+	return template.replace(/\{\{(question|context|answer|index|total)\}\}/g, (_match, key: string) => {
+		return replacements[key] ?? "";
+	});
+}
+
+function summarizeAnswer(text: string, maxLength: number = 60): string {
+	const singleLine = text.replace(/\s+/g, " ").trim();
+	if (singleLine.length <= maxLength) {
+		return singleLine;
+	}
+	return `${singleLine.slice(0, maxLength - 1)}…`;
+}
+
+export class QnATuiComponent<TQuestion extends QnAQuestion> implements Component {
+	private questions: TQuestion[];
+	private responses: QnAResponse[];
+	private currentIndex = 0;
+	private editor: {
+		disableSubmit?: boolean;
+		onChange?: () => void;
+		setText: (text: string) => void;
+		getText: () => string;
+		render: (width: number) => string[];
+		handleInput: (data: string) => void;
+	};
+	private tui: TUI;
+	private onDone: (result: QnAResult | null) => void;
+	private showingConfirmation = false;
+	private templates: QnATemplate[];
+	private templateIndex = 0;
+	private onResponsesChange?: (responses: QnAResponse[]) => void;
+	private title: string;
+	private resolveNumericShortcut: (
+		input: string,
+		maxOptionIndex: number,
+		usingCustomEditor: boolean,
+	) => number | null;
+	private applyTemplate: (template: string, data: QnATemplateData) => string;
+	private questionSummaryLabel: (question: TQuestion, index: number) => string;
+
+	private cachedWidth?: number;
+	private cachedLines?: string[];
+
+	private dim = (s: string) => s;
+	private bold = (s: string) => s;
+	private italic = (s: string) => `\x1b[3m${s}\x1b[0m`;
+	private cyan = (s: string) => s;
+	private green = (s: string) => s;
+	private yellow = (s: string) => s;
+	private gray = (s: string) => s;
+
+	constructor(
+		questions: TQuestion[],
+		tui: TUI,
+		onDone: (result: QnAResult | null) => void,
+		options?: {
+			title?: string;
+			templates?: QnATemplate[];
+			initialResponses?: Array<Partial<QnAResponse>>;
+			fallbackAnswers?: string[];
+			inferCommittedFromContent?: boolean;
+			onResponsesChange?: (responses: QnAResponse[]) => void;
+			resolveNumericShortcut?: (
+				input: string,
+				maxOptionIndex: number,
+				usingCustomEditor: boolean,
+			) => number | null;
+			applyTemplate?: (template: string, data: QnATemplateData) => string;
+			questionSummaryLabel?: (question: TQuestion, index: number) => string;
+			accentColor?: (text: string) => string;
+			successColor?: (text: string) => string;
+			warningColor?: (text: string) => string;
+			mutedColor?: (text: string) => string;
+			dimColor?: (text: string) => string;
+			boldText?: (text: string) => string;
+			italicText?: (text: string) => string;
+		},
+	) {
+		this.questions = questions;
+		this.templates = options?.templates ?? [];
+		this.responses = normalizeResponses(
+			questions,
+			options?.initialResponses,
+			options?.fallbackAnswers,
+			options?.inferCommittedFromContent ?? false,
+		);
+		this.tui = tui;
+		this.onDone = onDone;
+		this.onResponsesChange = options?.onResponsesChange;
+		this.title = options?.title ?? "Questions";
+		this.resolveNumericShortcut = options?.resolveNumericShortcut ?? defaultResolveNumericShortcut;
+		this.applyTemplate = options?.applyTemplate ?? defaultApplyTemplate;
+		this.questionSummaryLabel =
+			options?.questionSummaryLabel ??
+			((question) => {
+				return question.header?.trim() || question.question;
+			});
+		this.cyan = options?.accentColor ?? this.cyan;
+		this.green = options?.successColor ?? this.green;
+		this.yellow = options?.warningColor ?? this.yellow;
+		this.gray = options?.mutedColor ?? this.gray;
+		this.dim = options?.dimColor ?? this.dim;
+		this.bold = options?.boldText ?? this.bold;
+		this.italic = options?.italicText ?? this.italic;
+
+		const editorTheme: EditorTheme = {
+			borderColor: this.dim,
+			selectList: {
+				matchHighlight: this.cyan,
+				itemSecondary: this.gray,
+			},
+		};
+
+		const { Editor } = getPiTui();
+		this.editor = new Editor(tui, editorTheme);
+		this.editor.disableSubmit = true;
+		this.editor.onChange = () => {
+			this.saveCurrentResponse();
+			this.invalidate();
+			this.tui.requestRender();
+		};
+
+		this.loadEditorForCurrentQuestion();
+	}
+
+	private getCurrentQuestion(): TQuestion {
+		return this.questions[this.currentIndex];
+	}
+
+	private isPrintableInput(data: string): boolean {
+		if (data.length !== 1) {
+			return false;
+		}
+
+		const code = data.charCodeAt(0);
+		return code >= 32 && code !== 127;
+	}
+
+	private shouldUseEditor(index: number = this.currentIndex): boolean {
+		const question = this.questions[index];
+		const options = getQuestionOptions(question);
+		if (options.length === 0) {
+			return true;
+		}
+
+		return this.responses[index].selectedOptionIndex === options.length;
+	}
+
+	private getCurrentAnswerText(): string {
+		const question = this.getCurrentQuestion();
+		const response = this.responses[this.currentIndex];
+		return formatResponseAnswer(question, response);
+	}
+
+	private getAnswerText(index: number): string {
+		return formatResponseAnswer(this.questions[index], this.responses[index]);
+	}
+
+	private emitResponseChange(): void {
+		this.onResponsesChange?.(cloneResponses(this.responses));
+	}
+
+	private loadEditorForCurrentQuestion(): void {
+		if (!this.shouldUseEditor()) {
+			this.editor.setText("");
+			return;
+		}
+
+		this.editor.setText(this.responses[this.currentIndex].customText ?? "");
+	}
+
+	private saveCurrentResponse(emit: boolean = true): void {
+		if (this.shouldUseEditor()) {
+			const text = this.editor.getText();
+			this.responses[this.currentIndex].customText = text;
+			const question = this.questions[this.currentIndex];
+			if (getQuestionOptions(question).length === 0 || text.trim().length > 0) {
+				this.responses[this.currentIndex].selectionTouched = true;
+			}
+		}
+
+		if (emit) {
+			this.emitResponseChange();
+		}
+	}
+
+	private navigateTo(index: number): void {
+		if (index < 0 || index >= this.questions.length) {
+			return;
+		}
+
+		this.saveCurrentResponse();
+		this.currentIndex = index;
+		this.showingConfirmation = false;
+		this.loadEditorForCurrentQuestion();
+		this.invalidate();
+	}
+
+	private selectOption(index: number): void {
+		const question = this.getCurrentQuestion();
+		const options = getQuestionOptions(question);
+		if (options.length === 0) {
+			return;
+		}
+
+		const maxIndex = options.length;
+		const normalized = Math.max(0, Math.min(maxIndex, index));
+		const currentResponse = this.responses[this.currentIndex];
+		if (normalized === currentResponse.selectedOptionIndex && currentResponse.selectionTouched) {
+			return;
+		}
+
+		this.saveCurrentResponse(false);
+		currentResponse.selectedOptionIndex = normalized;
+		currentResponse.selectionTouched = true;
+		this.loadEditorForCurrentQuestion();
+		this.emitResponseChange();
+		this.invalidate();
+		this.tui.requestRender();
+	}
+
+	private applyNextTemplate(): void {
+		if (this.templates.length === 0) {
+			return;
+		}
+
+		const question = this.getCurrentQuestion();
+		const options = getQuestionOptions(question);
+		if (options.length > 0 && !this.shouldUseEditor()) {
+			this.selectOption(options.length);
+		}
+
+		const template = this.templates[this.templateIndex];
+		const updated = this.applyTemplate(template.template, {
+			question: question.question,
+			context: question.context,
+			answer: this.getCurrentAnswerText(),
+			index: this.currentIndex,
+			total: this.questions.length,
+		});
+
+		this.editor.setText(updated);
+		this.saveCurrentResponse();
+		this.templateIndex = (this.templateIndex + 1) % this.templates.length;
+		this.invalidate();
+		this.tui.requestRender();
+	}
+
+	private submit(): void {
+		this.saveCurrentResponse();
+
+		const answers = deriveAnswersFromResponses(this.questions, this.responses);
+		const parts: string[] = [];
+		for (let i = 0; i < this.questions.length; i++) {
+			const question = this.questions[i];
+			const rawAnswer = answers[i] ?? "";
+			if (rawAnswer.trim().length === 0) {
+				continue;
+			}
+
+			parts.push(`Q: ${question.question}`);
+			parts.push(`A: ${rawAnswer}`);
+			parts.push("");
+		}
+
+		this.onDone({
+			text: parts.join("\n").trim(),
+			answers,
+			responses: cloneResponses(this.responses),
+		});
+	}
+
+	private cancel(): void {
+		this.onDone(null);
+	}
+
+	invalidate(): void {
+		this.cachedWidth = undefined;
+		this.cachedLines = undefined;
+	}
+
+	handleInput(data: string): void {
+		const { Key, matchesKey } = getPiTui();
+
+		if (this.showingConfirmation) {
+			if (matchesKey(data, Key.enter)) {
+				this.submit();
+				return;
+			}
+			if (matchesKey(data, Key.ctrl("c"))) {
+				this.cancel();
+				return;
+			}
+			if (matchesKey(data, Key.escape)) {
+				this.showingConfirmation = false;
+				this.invalidate();
+				this.tui.requestRender();
+				return;
+			}
+			return;
+		}
+
+		if (matchesKey(data, Key.ctrl("c"))) {
+			this.cancel();
+			return;
+		}
+
+		if (matchesKey(data, Key.ctrl("t"))) {
+			this.applyNextTemplate();
+			return;
+		}
+
+		if (matchesKey(data, Key.tab)) {
+			if (this.currentIndex < this.questions.length - 1) {
+				this.navigateTo(this.currentIndex + 1);
+				this.tui.requestRender();
+			}
+			return;
+		}
+
+		if (matchesKey(data, Key.shift("tab"))) {
+			if (this.currentIndex > 0) {
+				this.navigateTo(this.currentIndex - 1);
+				this.tui.requestRender();
+			}
+			return;
+		}
+
+		const question = this.getCurrentQuestion();
+		const options = getQuestionOptions(question);
+		const usingEditor = this.shouldUseEditor();
+		if (options.length > 0) {
+			const otherIndex = options.length;
+			const isOnOther = this.responses[this.currentIndex].selectedOptionIndex === otherIndex;
+			const canSwitchFromCustomInput = usingEditor && isOnOther && this.editor.getText().length === 0;
+			const allowOptionNavigation = !usingEditor || canSwitchFromCustomInput;
+
+			if (allowOptionNavigation && matchesKey(data, Key.up)) {
+				this.selectOption(this.responses[this.currentIndex].selectedOptionIndex - 1);
+				return;
+			}
+
+			if (allowOptionNavigation && matchesKey(data, Key.down)) {
+				this.selectOption(this.responses[this.currentIndex].selectedOptionIndex + 1);
+				return;
+			}
+
+			const selectedIndex = this.resolveNumericShortcut(data, otherIndex, usingEditor);
+			if (selectedIndex !== null) {
+				this.selectOption(selectedIndex);
+				return;
+			}
+		}
+
+		if (matchesKey(data, Key.enter) && !matchesKey(data, Key.shift("enter"))) {
+			const currentResponse = this.responses[this.currentIndex];
+			if (options.length > 0 && !this.shouldUseEditor() && !currentResponse.selectionTouched) {
+				currentResponse.selectionTouched = true;
+			}
+
+			this.saveCurrentResponse();
+			currentResponse.committed = true;
+			this.emitResponseChange();
+			if (this.currentIndex < this.questions.length - 1) {
+				this.navigateTo(this.currentIndex + 1);
+			} else {
+				this.showingConfirmation = true;
+			}
+			this.invalidate();
+			this.tui.requestRender();
+			return;
+		}
+
+		if (this.shouldUseEditor()) {
+			this.editor.handleInput(data);
+			this.invalidate();
+			this.tui.requestRender();
+			return;
+		}
+
+		if (this.isPrintableInput(data)) {
+			this.selectOption(getQuestionOptions(question).length);
+			this.editor.handleInput(data);
+			this.saveCurrentResponse();
+			this.invalidate();
+			this.tui.requestRender();
+		}
+	}
+
+	render(width: number): string[] {
+		const { truncateToWidth, visibleWidth, wrapTextWithAnsi } = getPiTui();
+
+		if (this.cachedLines && this.cachedWidth === width) {
+			return this.cachedLines;
+		}
+
+		const lines: string[] = [];
+		const boxWidth = Math.max(40, Math.min(width - 4, 120));
+		const contentWidth = boxWidth - 4;
+
+		const horizontalLine = (count: number) => "─".repeat(count);
+
+		const boxLine = (content: string, leftPad: number = 2): string => {
+			const paddedContent = " ".repeat(leftPad) + content;
+			const contentLen = visibleWidth(paddedContent);
+			const rightPad = Math.max(0, boxWidth - contentLen - 2);
+			return this.dim("│") + paddedContent + " ".repeat(rightPad) + this.dim("│");
+		};
+
+		const emptyBoxLine = (): string => {
+			return this.dim("│") + " ".repeat(boxWidth - 2) + this.dim("│");
+		};
+
+		const padToWidth = (line: string): string => {
+			const len = visibleWidth(line);
+			return line + " ".repeat(Math.max(0, width - len));
+		};
+
+		const question = this.getCurrentQuestion();
+		const response = this.responses[this.currentIndex];
+		const options = getQuestionOptions(question);
+		const usesEditor = this.shouldUseEditor();
+
+		lines.push(padToWidth(this.dim(`╭${horizontalLine(boxWidth - 2)}╮`)));
+		const title = `${this.title} ${this.dim(`(${this.currentIndex + 1}/${this.questions.length})`)}`;
+		lines.push(padToWidth(boxLine(title)));
+		lines.push(padToWidth(this.dim(`├${horizontalLine(boxWidth - 2)}┤`)));
+
+		const progressParts: string[] = [];
+		for (let i = 0; i < this.questions.length; i++) {
+			const current = i === this.currentIndex;
+			const answered = hasResponseContent(this.questions[i], this.responses[i]);
+			if (current) {
+				progressParts.push(this.cyan("●"));
+			} else if (answered) {
+				progressParts.push(this.green("●"));
+			} else {
+				progressParts.push(this.dim("○"));
+			}
+		}
+		lines.push(padToWidth(boxLine(progressParts.join(" "))));
+
+		if (!this.showingConfirmation) {
+			if (question.header) {
+				lines.push(padToWidth(boxLine(this.cyan(question.header))));
+			}
+			lines.push(padToWidth(emptyBoxLine()));
+
+			const wrappedQuestion = wrapTextWithAnsi(`${this.bold("Q:")} ${this.bold(question.question)}`, contentWidth);
+			for (const line of wrappedQuestion) {
+				lines.push(padToWidth(boxLine(line)));
+			}
+
+			if (question.context) {
+				lines.push(padToWidth(emptyBoxLine()));
+				for (const line of wrapTextWithAnsi(this.gray(`> ${question.context}`), contentWidth - 2)) {
+					lines.push(padToWidth(boxLine(line)));
+				}
+			}
+
+			if (options.length > 0) {
+				lines.push(padToWidth(emptyBoxLine()));
+				for (let i = 0; i <= options.length; i++) {
+					const isOther = i === options.length;
+					const optionLabel = isOther ? "Other" : options[i].label;
+					const description = isOther ? "Type your own answer" : options[i].description;
+					const selected = response.selectedOptionIndex === i;
+					const marker = selected ? "▶" : " ";
+					const optionPrefix = `${marker} ${i + 1}. `;
+					const line = `${optionPrefix}${optionLabel}`;
+					const styledLine = selected
+						? response.selectionTouched
+							? this.green(line)
+							: this.cyan(line)
+						: line;
+					lines.push(padToWidth(boxLine(truncateToWidth(styledLine, contentWidth))));
+
+					if (selected && description && description.trim().length > 0) {
+						const descriptionIndent = " ".repeat(visibleWidth(optionPrefix));
+						const wrappedDescription = wrapTextWithAnsi(
+							description,
+							Math.max(10, contentWidth - visibleWidth(descriptionIndent)),
+						);
+						for (const wrapped of wrappedDescription) {
+							lines.push(padToWidth(boxLine(`${descriptionIndent}${this.gray(wrapped)}`)));
+						}
+					}
+				}
+			}
+
+			lines.push(padToWidth(emptyBoxLine()));
+			if (usesEditor) {
+				const answerPrefix = this.bold("A: ");
+				const editorWidth = Math.max(20, contentWidth - 7);
+				const editorLines = this.editor.render(editorWidth);
+				for (let i = 1; i < editorLines.length - 1; i++) {
+					if (i === 1) {
+						lines.push(padToWidth(boxLine(answerPrefix + editorLines[i])));
+					} else {
+						lines.push(padToWidth(boxLine("   " + editorLines[i])));
+					}
+				}
+			} else {
+				const selectedLabel = response.selectionTouched
+					? options[response.selectedOptionIndex]?.label ?? ""
+					: this.dim("(select an option)");
+				lines.push(padToWidth(boxLine(`${this.bold("A:")} ${selectedLabel}`)));
+			}
+			lines.push(padToWidth(emptyBoxLine()));
+		}
+
+		if (this.showingConfirmation) {
+			lines.push(padToWidth(this.dim(`├${horizontalLine(boxWidth - 2)}┤`)));
+			lines.push(padToWidth(boxLine(this.bold("Review before submit:"))));
+			for (let i = 0; i < this.questions.length; i++) {
+				const summaryLabel = this.questionSummaryLabel(this.questions[i], i);
+				const answerText = this.getAnswerText(i);
+				const hasAnswer = answerText.trim().length > 0;
+				const answerPreview = hasAnswer
+					? this.green(summarizeAnswer(answerText))
+					: this.yellow("(no answer)");
+				const questionLine = `${this.bold(`${i + 1}.`)} ${this.cyan(summaryLabel)}`;
+				const answerLine = `   ${this.dim("Answer:")} ${answerPreview}`;
+				lines.push(padToWidth(boxLine(truncateToWidth(questionLine, contentWidth))));
+				lines.push(padToWidth(boxLine(truncateToWidth(answerLine, contentWidth))));
+			}
+			lines.push(padToWidth(emptyBoxLine()));
+			const confirmMsg = `${this.yellow("Submit all answers?")} ${this.dim("(Enter submit, Esc keep editing)")}`;
+			lines.push(padToWidth(boxLine(truncateToWidth(confirmMsg, contentWidth))));
+			const separator = this.cyan(" · ");
+			const formatHint = (shortcut: string, action: string) => `${this.bold(shortcut)} ${this.italic(action)}`;
+			const confirmControls = `${formatHint("Enter", "submit")}${separator}${formatHint("Esc", "back")}${separator}${formatHint("Ctrl+C", "cancel")}`;
+			lines.push(padToWidth(boxLine(truncateToWidth(confirmControls, contentWidth))));
+		} else {
+			lines.push(padToWidth(this.dim(`├${horizontalLine(boxWidth - 2)}┤`)));
+
+			const separator = this.cyan(" · ");
+			const formatHint = (shortcut: string, action: string) => `${this.bold(shortcut)} ${this.italic(action)}`;
+			const joinHints = (parts: string[]) => parts.join(separator);
+			const canFit = (parts: string[]) => visibleWidth(joinHints(parts)) <= contentWidth;
+
+			const tabHint = formatHint("Tab/⇧Tab", "next/prev");
+			const enterHint = formatHint("Enter", "commit + next");
+			const cancelHint = formatHint("Ctrl+C", "cancel");
+
+			const optionalHints: string[] = [];
+			if (options.length > 0 && !usesEditor) {
+				optionalHints.push(formatHint("↑/↓/1-9", "pick option"));
+			}
+			if (usesEditor) {
+				optionalHints.push(formatHint("⇧Enter", "newline"));
+			}
+			if (this.templates.length > 0) {
+				optionalHints.push(formatHint("Ctrl+T", "template"));
+			}
+
+			const trailingHints = [enterHint, tabHint, cancelHint];
+			const controls: string[] = [];
+			for (const hint of optionalHints) {
+				if (canFit([...controls, hint, ...trailingHints])) {
+					controls.push(hint);
+				}
+			}
+			controls.push(...trailingHints);
+
+			lines.push(padToWidth(boxLine(truncateToWidth(joinHints(controls), contentWidth))));
+		}
+		lines.push(padToWidth(this.dim(`╰${horizontalLine(boxWidth - 2)}╯`)));
+
+		this.cachedWidth = width;
+		this.cachedLines = lines;
+		return lines;
+	}
+}

--- a/packages/shared-qna/tests/qna-tui.test.ts
+++ b/packages/shared-qna/tests/qna-tui.test.ts
@@ -1,0 +1,104 @@
+import { describe, expect, it } from "vitest";
+import {
+	deriveAnswersFromResponses,
+	formatResponseAnswer,
+	getQuestionOptions,
+	hasResponseContent,
+	normalizeResponseForQuestion,
+	normalizeResponses,
+} from "../index.js";
+
+describe("getQuestionOptions", () => {
+	it("defaults missing options to an empty array", () => {
+		expect(getQuestionOptions({ question: "Which runtime?" })).toEqual([]);
+	});
+});
+
+describe("formatResponseAnswer", () => {
+	it("returns the selected option label", () => {
+		const answer = formatResponseAnswer(
+			{
+				question: "Which runtime?",
+				options: [
+					{ label: "Node", description: "Use Node.js" },
+					{ label: "Bun", description: "Use Bun" },
+				],
+			},
+			{ selectedOptionIndex: 1, customText: "", selectionTouched: true, committed: true },
+		);
+		expect(answer).toBe("Bun");
+	});
+
+	it("returns custom text for freeform questions", () => {
+		const answer = formatResponseAnswer(
+			{ question: "Any constraints?" },
+			{ selectedOptionIndex: 0, customText: "Two-phase rollout", selectionTouched: true, committed: true },
+		);
+		expect(answer).toBe("Two-phase rollout");
+	});
+});
+
+describe("normalizeResponseForQuestion", () => {
+	it("infers the other option when fallback text does not match a listed option", () => {
+		const normalized = normalizeResponseForQuestion(
+			{
+				question: "Which runtime?",
+				options: [
+					{ label: "Node", description: "Use Node.js" },
+					{ label: "Bun", description: "Use Bun" },
+				],
+			},
+			undefined,
+			"Use Deno",
+			true,
+		);
+		expect(normalized.selectedOptionIndex).toBe(2);
+		expect(normalized.customText).toBe("Use Deno");
+		expect(normalized.selectionTouched).toBe(true);
+		expect(normalized.committed).toBe(true);
+	});
+	it("treats freeform fallback text as committed content", () => {
+		const normalized = normalizeResponseForQuestion({ question: "Any constraints?" }, undefined, "Need Bun APIs", true);
+		expect(normalized.selectedOptionIndex).toBe(0);
+		expect(normalized.customText).toBe("Need Bun APIs");
+		expect(normalized.selectionTouched).toBe(true);
+		expect(normalized.committed).toBe(true);
+	});
+});
+
+describe("normalizeResponses", () => {
+	it("normalizes every question/response pair", () => {
+		const responses = normalizeResponses(
+			[
+				{ question: "Which runtime?", options: [{ label: "Node", description: "Use Node.js" }] },
+				{ question: "Any constraints?" },
+			],
+			[
+				{ selectedOptionIndex: 0, committed: true },
+				{ customText: "Keep SSR", committed: true },
+			],
+			undefined,
+			true,
+		);
+		expect(responses).toHaveLength(2);
+		expect(responses[0]?.selectedOptionIndex).toBe(0);
+		expect(responses[1]?.customText).toBe("Keep SSR");
+	});
+});
+
+describe("deriveAnswersFromResponses and hasResponseContent", () => {
+	it("derives answers and detects whether content exists", () => {
+		const questions = [
+			{ question: "Which runtime?", options: [{ label: "Node", description: "Use Node.js" }] },
+			{ question: "Any constraints?" },
+		] as const;
+		const responses = [
+			{ selectedOptionIndex: 0, customText: "", selectionTouched: true, committed: true },
+			{ selectedOptionIndex: 0, customText: "Keep SSR", selectionTouched: true, committed: true },
+		];
+		const answers = deriveAnswersFromResponses(questions, responses);
+		expect(answers).toEqual(["Node", "Keep SSR"]);
+		expect(hasResponseContent(questions[0], responses[0])).toBe(true);
+		expect(hasResponseContent(questions[1], responses[1])).toBe(true);
+	});
+});

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -130,8 +130,41 @@ importers:
       '@ifi/pi-extension-subagents':
         specifier: workspace:*
         version: link:../subagents
+      '@ifi/pi-plan':
+        specifier: workspace:*
+        version: link:../plan
+
+  packages/plan:
+    dependencies:
+      '@ifi/pi-extension-subagents':
+        specifier: workspace:*
+        version: link:../subagents
+      '@ifi/pi-shared-qna':
+        specifier: workspace:*
+        version: link:../shared-qna
+      '@mariozechner/pi-agent-core':
+        specifier: '*'
+        version: 0.56.1(ws@8.19.0)(zod@3.25.76)
+      '@mariozechner/pi-ai':
+        specifier: '*'
+        version: 0.56.1(ws@8.19.0)(zod@3.25.76)
+      '@mariozechner/pi-coding-agent':
+        specifier: '*'
+        version: 0.56.1(ws@8.19.0)(zod@3.25.76)
+      '@mariozechner/pi-tui':
+        specifier: '*'
+        version: 0.56.1
+      '@sinclair/typebox':
+        specifier: '*'
+        version: 0.34.48
 
   packages/prompts: {}
+
+  packages/shared-qna:
+    dependencies:
+      '@mariozechner/pi-tui':
+        specifier: '*'
+        version: 0.56.1
 
   packages/skills: {}
 

--- a/vitest.config.ts
+++ b/vitest.config.ts
@@ -7,6 +7,8 @@ export default defineConfig({
 			"packages/extensions/extensions/**/*.test.ts",
 			"packages/ant-colony/tests/**/*.test.ts",
 			"packages/subagents/tests/**/*.test.ts",
+			"packages/plan/tests/**/*.test.ts",
+			"packages/shared-qna/tests/**/*.test.ts",
 		],
 	},
 });


### PR DESCRIPTION
## Summary
- add a new `@ifi/pi-plan` planning mode package under `packages/plan` based on the upstream plan-md workflow
- vendor the shared Q&A TUI into a new first-party `@ifi/pi-shared-qna` package and switch plan mode to use it
- wire plan mode into the monorepo bundle, docs, lockstep versioning, and test configuration

## Details
- rename the user-facing command from `/plan-md` to `/plan`
- back `task_agents` and steering flows with the in-repo `@ifi/pi-extension-subagents` runtime
- add plan-mode and shared-qna Vitest coverage
- include a changeset for the new packages

## Validation
- `pnpm build`
- `pnpm test`
- `pnpm lint`
- `pnpm typecheck`