### PR TITLE
fix(ant-colony): avoid shortcut conflict with subagents

### DIFF
--- a/.changeset/ant-colony-shortcut-conflict.md
+++ b/.changeset/ant-colony-shortcut-conflict.md
@@ -1,0 +1,5 @@
+---
+default: patch
+---
+
+Change the ant-colony details shortcut from `Ctrl+Shift+A` to `Ctrl+Shift+C` so it no longer conflicts with the subagents extension shortcut.

--- a/packages/ant-colony/extensions/ant-colony/index.ts
+++ b/packages/ant-colony/extensions/ant-colony/index.ts
@@ -690,8 +690,8 @@ export default function antColonyExtension(pi: ExtensionAPI) {
 		return container;
 	});
 
-	// ═══ Shortcut: Ctrl+Shift+A opens colony details panel ═══
-	pi.registerShortcut("ctrl+shift+a", {
+	// ═══ Shortcut: Ctrl+Shift+C opens colony details panel ═══
+	pi.registerShortcut("ctrl+shift+c", {
 		description: "Show ant colony details",
 		async handler(ctx) {
 			if (colonies.size === 0) {

--- a/packages/ant-colony/tests/index.test.ts
+++ b/packages/ant-colony/tests/index.test.ts
@@ -289,6 +289,14 @@ describe("ant-colony extension commands", () => {
 		}
 	});
 
+	it("registers a non-conflicting shortcut for the colony details panel", () => {
+		expect(pi.registerShortcut).toHaveBeenCalledWith(
+			"ctrl+shift+c",
+			expect.objectContaining({ description: "Show ant colony details" }),
+		);
+		expect(pi.registerShortcut).not.toHaveBeenCalledWith("ctrl+shift+a", expect.anything());
+	});
+
 	it("/colony-stop all aborts all running colonies", async () => {
 		const colonyCmd = pi._commands.get("colony");
 		await colonyCmd.handler("First swarm goal", ctx);


### PR DESCRIPTION
## Summary
- move the ant-colony details shortcut from `Ctrl+Shift+A` to `Ctrl+Shift+C`
- avoid the runtime shortcut collision with `@ifi/pi-extension-subagents`, which keeps `Ctrl+Shift+A`
- add regression coverage for the ant-colony shortcut registration

## Validation
- `pnpm exec biome check packages/ant-colony/extensions/ant-colony/index.ts packages/ant-colony/tests/index.test.ts .changeset/ant-colony-shortcut-conflict.md`
- `pnpm exec tsgo --project packages/ant-colony/tsconfig.json --noEmit`
- `pnpm exec vitest run $(find packages/ant-colony/tests -name '*.test.ts' | tr '\n' ' ') --config vitest.config.ts`
