### PR TITLE
fix(extensions): restore anthropic and google rate-limit display

### DIFF
--- a/.changeset/fix-usage-tracker-anthropic-google-display.md
+++ b/.changeset/fix-usage-tracker-anthropic-google-display.md
@@ -1,0 +1,9 @@
+---
+default: patch
+---
+
+Fix usage-tracker provider display regressions:
+
+- Treat Anthropic OAuth `utilization` as percentage values (so `1.0` means 1% used, not 100% used).
+- Preserve last known provider windows when transient probe responses report rate-limited/unavailable with no windows.
+- For Google Cloud Code Assist tiers that explicitly state "unlimited", show a `Subscription quota` window at 100% instead of only showing "windows unavailable".

--- a/packages/extensions/extensions/usage-tracker.test.ts
+++ b/packages/extensions/extensions/usage-tracker.test.ts
@@ -639,6 +639,62 @@ describe("usage-tracker extension", () => {
 			expect(text).toContain("Plan: OAuth");
 		});
 
+		it("treats Anthropic utilization 1.0 as 1% used (99% left)", async () => {
+			mockFetch.mockResolvedValue(
+				makeFetchResponse({
+					body: {
+						seven_day_sonnet: {
+							utilization: 1.0,
+							resets_at: new Date(Date.now() + 86_400_000).toISOString(),
+						},
+					},
+				}),
+			);
+
+			usageTracker(pi as any);
+			pi._emit("session_start", { type: "session_start" }, ctx);
+
+			const tool = pi._tools.get("usage_report");
+			const result = await runWithTimers(() => tool.execute("id", { format: "detailed" }, undefined, undefined, ctx));
+			const text = result.content[0].text;
+			expect(text).toContain("7-day Sonnet");
+			expect(text).toContain("99% left");
+			expect(text).toContain("(1% used)");
+		});
+
+		it("keeps last Anthropic windows when a probe is rate-limited", async () => {
+			let anthropicCalls = 0;
+			mockFetch.mockImplementation((url: string) => {
+				if (url.includes("api.anthropic.com/api/oauth/usage")) {
+					anthropicCalls++;
+					if (anthropicCalls === 1) {
+						return Promise.resolve(
+							makeFetchResponse({
+								body: {
+									five_hour: {
+										utilization: 40,
+										resets_at: new Date(Date.now() + 30_000).toISOString(),
+									},
+								},
+							}),
+						);
+					}
+					return Promise.resolve(makeFetchResponse({ status: 429, ok: false, headers: { "retry-after": "5" } }));
+				}
+				return Promise.resolve(makeFetchResponse());
+			});
+
+			usageTracker(pi as any);
+			pi._emit("session_start", { type: "session_start" }, ctx);
+
+			const tool = pi._tools.get("usage_report");
+			const result = await runWithTimers(() => tool.execute("id", { format: "detailed" }, undefined, undefined, ctx));
+			const text = result.content[0].text;
+
+			expect(text).toContain("5-hour");
+			expect(text).toContain("60% left");
+		});
+
 		it("shows OpenAI windows from the ChatGPT usage endpoint", async () => {
 			ctx.model = { id: "gpt-4o" } as any;
 			mockFetch.mockImplementation((url: string) => {
@@ -722,6 +778,37 @@ describe("usage-tracker extension", () => {
 			expect(text).toContain("Plan: Gemini Code Assist (standard-tier)");
 			expect(text).toContain("Project: test-project");
 			expect(text).toContain("Account: test@example.com");
+		});
+
+		it("shows synthetic quota window when Google tier reports unlimited capacity", async () => {
+			ctx.model = { id: "gemini-2.5-pro" } as any;
+			mockFetch.mockImplementation((url: string) => {
+				if (url.includes("cloudcode-pa.googleapis.com/v1internal:loadCodeAssist")) {
+					return Promise.resolve(
+						makeFetchResponse({
+							body: {
+								currentTier: {
+									id: "standard-tier",
+									name: "Gemini Code Assist",
+									description: "Unlimited coding assistant with the most powerful Gemini models",
+								},
+								cloudaicompanionProject: "test-project",
+							},
+						}),
+					);
+				}
+				return Promise.resolve(makeFetchResponse());
+			});
+
+			usageTracker(pi as any);
+			pi._emit("session_start", { type: "session_start" }, ctx);
+
+			const tool = pi._tools.get("usage_report");
+			const result = await runWithTimers(() => tool.execute("id", { format: "detailed" }, undefined, undefined, ctx));
+			const text = result.content[0].text;
+			expect(text).toContain("Subscription quota");
+			expect(text).toContain("100% left");
+			expect(text).toContain("Tier reports unlimited coding assistant capacity");
 		});
 
 		it("shows auth expired error when API returns 401", async () => {

--- a/packages/extensions/extensions/usage-tracker.ts
+++ b/packages/extensions/extensions/usage-tracker.ts
@@ -647,7 +647,9 @@ function isAnthropicApiKeyToken(token: string): boolean {
 }
 
 function utilizationToPercentLeft(utilization: number): number {
-	const usedPercent = utilization <= 1 ? utilization * 100 : utilization;
+	// Anthropic OAuth usage reports utilization as a percentage in [0,100]
+	// (e.g. 1.0 means 1% used, not 100% used).
+	const usedPercent = utilization;
 	return clampPercent(100 - usedPercent);
 }
 
@@ -1070,15 +1072,25 @@ async function probeGoogleDirect(token: string, authEntry?: PiAuthEntry): Promis
 		}
 
 		const payload = (await response.json()) as Record<string, unknown>;
-		const currentTier = payload.currentTier as { id?: unknown; name?: unknown } | undefined;
+		const currentTier = payload.currentTier as { id?: unknown; name?: unknown; description?: unknown } | undefined;
 		const tierId = typeof currentTier?.id === "string" ? currentTier.id : null;
 		const tierName = typeof currentTier?.name === "string" ? currentTier.name : null;
+		const tierDescription = typeof currentTier?.description === "string" ? currentTier.description : null;
 		if (tierName && tierId) {
 			result.plan = `${tierName} (${tierId})`;
 		} else if (tierName) {
 			result.plan = tierName;
 		} else if (tierId) {
 			result.plan = tierId;
+		}
+		if (tierDescription?.toLowerCase().includes("unlimited")) {
+			upsertWindow(result.windows, {
+				label: "Subscription quota",
+				percentLeft: 100,
+				resetDescription: null,
+				windowMinutes: null,
+			});
+			result.note = appendNote(result.note, "Tier reports unlimited coding assistant capacity.");
 		}
 
 		const projectId =
@@ -1119,6 +1131,14 @@ async function probeGoogleDirect(token: string, authEntry?: PiAuthEntry): Promis
 
 function hasProviderDisplayData(rl: ProviderRateLimits): boolean {
 	return rl.windows.length > 0 || rl.credits !== null || Boolean(rl.account || rl.plan || rl.note || rl.error);
+}
+
+function shouldPreserveStaleWindows(previous: ProviderRateLimits | undefined, next: ProviderRateLimits): boolean {
+	if (!previous || previous.windows.length === 0 || next.windows.length > 0 || next.error) {
+		return false;
+	}
+	const note = next.note?.toLowerCase() ?? "";
+	return note.includes("rate-limited") || note.includes("unavailable");
 }
 
 /** Map from ProviderKey to human-readable display name. */
@@ -1515,6 +1535,7 @@ export default function usageTracker(pi: ExtensionAPI) {
 	 * Reads credentials from `~/.pi/agent/auth.json` and calls the provider
 	 * API directly — no external CLI tools required.
 	 */
+	// biome-ignore lint/complexity/noExcessiveCognitiveComplexity: provider probe handles auth discovery, refresh, and stale window fallback semantics.
 	async function probeProvider(provider: ProviderKey, force = false): Promise<void> {
 		const now = Date.now();
 		const last = lastProbeTime.get(provider) ?? 0;
@@ -1579,6 +1600,14 @@ export default function usageTracker(pi: ExtensionAPI) {
 				case "google":
 					limits = await probeGoogleDirect(fresh.token, fresh.entry);
 					break;
+			}
+
+			const previous = rateLimits.get(provider);
+			if (shouldPreserveStaleWindows(previous, limits)) {
+				limits.windows = previous?.windows.map((window) => ({ ...window })) ?? [];
+				limits.note = limits.note
+					? `${limits.note} Showing last known window values.`
+					: "Showing last known window values.";
 			}
 
 			rateLimits.set(provider, limits);


### PR DESCRIPTION
## Summary
- fix Anthropic OAuth utilization parsing so `1.0` means 1% used instead of 100% used
- preserve last known provider windows when a transient probe returns rate-limited/unavailable with no windows
- show a synthetic `Subscription quota` window for Google Cloud Code Assist tiers that explicitly report unlimited capacity
- add regression coverage for Anthropic and Google display behavior
- include a patch changeset

## Validation
- pnpm -s biome check packages/extensions/extensions/usage-tracker.ts packages/extensions/extensions/usage-tracker.test.ts
- pnpm -s vitest packages/extensions/extensions/usage-tracker.test.ts
- pnpm -s lint
