### PR TITLE
fix(scheduler): move scheduler state to shared pi storage

### DIFF
--- a/.changeset/move-scheduler-state-to-shared-pi-dir.md
+++ b/.changeset/move-scheduler-state-to-shared-pi-dir.md
@@ -1,0 +1,5 @@
+---
+default: patch
+---
+
+Move scheduler state out of repository-local `.pi/scheduler.json` files into a shared pi agent directory under `~/.pi/agent/scheduler/...`, using a path that mirrors each workspace path for uniqueness. Legacy repo-local scheduler files are migrated automatically when discovered, and defunct scheduler stores are cleaned up once all tasks expire or are removed.

--- a/packages/extensions/extensions/scheduler.test.ts
+++ b/packages/extensions/extensions/scheduler.test.ts
@@ -19,7 +19,16 @@ vi.mock("node:fs", async (importOriginal) => {
 		readFileSync: vi.fn().mockReturnValue("{}"),
 		writeFileSync: vi.fn(),
 		renameSync: vi.fn(),
+		copyFileSync: vi.fn(),
+		rmSync: vi.fn(),
+		readdirSync: vi.fn().mockReturnValue([]),
+		rmdirSync: vi.fn(),
 	};
+});
+
+vi.mock("node:os", async (importOriginal) => {
+	const actual = await importOriginal<typeof import("node:os")>();
+	return { ...actual, homedir: () => "/mock-home" };
 });
 
 vi.mock("@mariozechner/pi-coding-agent", () => ({}));
@@ -110,13 +119,24 @@ function createMockCtx(overrides: Record<string, any> = {}) {
 
 // ─── Imports ─────────────────────────────────────────────────────────────────
 
-import { existsSync, mkdirSync, readFileSync, renameSync, writeFileSync } from "node:fs";
+import {
+	copyFileSync,
+	existsSync,
+	mkdirSync,
+	readdirSync,
+	readFileSync,
+	renameSync,
+	rmdirSync,
+	rmSync,
+	writeFileSync,
+} from "node:fs";
 import schedulerExtension, {
 	computeNextCronRunAt,
 	DEFAULT_LOOP_INTERVAL,
 	DISPATCH_RATE_LIMIT_WINDOW_MS,
 	FIFTEEN_MINUTES,
 	formatDurationShort,
+	getSchedulerStoragePath,
 	MAX_DISPATCHES_PER_WINDOW,
 	MAX_TASKS,
 	MIN_RECURRING_INTERVAL,
@@ -567,6 +587,20 @@ describe("validateSchedulePromptAddInput", () => {
 
 // ─── SchedulerRuntime ────────────────────────────────────────────────────────
 
+describe("getSchedulerStoragePath", () => {
+	it("stores scheduler state under the shared pi agent directory", () => {
+		expect(getSchedulerStoragePath("/mock-project")).toBe(
+			"/mock-home/.pi/agent/scheduler/root/mock-project/scheduler.json",
+		);
+	});
+
+	it("mirrors nested repository paths for uniqueness", () => {
+		expect(getSchedulerStoragePath("/Users/test/work/repo")).toBe(
+			"/mock-home/.pi/agent/scheduler/root/Users/test/work/repo/scheduler.json",
+		);
+	});
+});
+
 describe("SchedulerRuntime", () => {
 	let pi: ReturnType<typeof createMockPi>;
 	let runtime: SchedulerRuntime;
@@ -579,6 +613,10 @@ describe("SchedulerRuntime", () => {
 		(mkdirSync as ReturnType<typeof vi.fn>).mockImplementation(() => undefined);
 		(writeFileSync as ReturnType<typeof vi.fn>).mockImplementation(() => undefined);
 		(renameSync as ReturnType<typeof vi.fn>).mockImplementation(() => undefined);
+		(copyFileSync as ReturnType<typeof vi.fn>).mockImplementation(() => undefined);
+		(rmSync as ReturnType<typeof vi.fn>).mockImplementation(() => undefined);
+		(readdirSync as ReturnType<typeof vi.fn>).mockReturnValue([]);
+		(rmdirSync as ReturnType<typeof vi.fn>).mockImplementation(() => undefined);
 		pi = createMockPi();
 		runtime = new SchedulerRuntime(pi as any);
 	});
@@ -1076,7 +1114,7 @@ describe("SchedulerRuntime", () => {
 	});
 
 	describe("persistence", () => {
-		it("persists tasks to disk on add", () => {
+		it("persists tasks to the shared pi scheduler store on add", () => {
 			const ctx = createMockCtx();
 			runtime.setRuntimeContext(ctx as any);
 			runtime.addRecurringIntervalTask("check", 5 * ONE_MINUTE);
@@ -1087,6 +1125,8 @@ describe("SchedulerRuntime", () => {
 				(c: unknown[]) => typeof c[0] === "string" && (c[0] as string).includes("scheduler.json"),
 			);
 			expect(schedulerWrite).toBeDefined();
+			expect(schedulerWrite?.[0]).toContain("/mock-home/.pi/agent/scheduler/root/mock-project/scheduler.json.tmp");
+			expect(String(schedulerWrite?.[0])).not.toContain("/mock-project/.pi/scheduler.json");
 		});
 
 		it("uses atomic write (tmp + rename)", () => {
@@ -1100,7 +1140,7 @@ describe("SchedulerRuntime", () => {
 			expect(renameSync).toHaveBeenCalled();
 		});
 
-		it("loads tasks from disk on context set", () => {
+		it("loads tasks from the shared store on context set", () => {
 			const now = Date.now();
 			(existsSync as ReturnType<typeof vi.fn>).mockReturnValue(true);
 			(readFileSync as ReturnType<typeof vi.fn>).mockReturnValue(
@@ -1132,6 +1172,7 @@ describe("SchedulerRuntime", () => {
 			expect(task).toBeDefined();
 			expect(task!.prompt).toBe("check build");
 			expect(task!.runCount).toBe(3);
+			expect(readFileSync).toHaveBeenCalledWith(getSchedulerStoragePath(ctx.cwd), "utf-8");
 		});
 
 		it("skips expired tasks when loading from disk", () => {
@@ -1161,6 +1202,7 @@ describe("SchedulerRuntime", () => {
 			const ctx = createMockCtx();
 			runtime.setRuntimeContext(ctx as any);
 			expect(runtime.taskCount).toBe(0);
+			expect(rmSync).toHaveBeenCalledWith(getSchedulerStoragePath(ctx.cwd), { force: true });
 		});
 
 		it("skips unsafe sub-minute cron tasks when loading from disk", () => {
@@ -1264,6 +1306,35 @@ describe("SchedulerRuntime", () => {
 			expect(task!.pending).toBe(false);
 		});
 
+		it("migrates legacy .pi/scheduler.json into the shared store", () => {
+			const ctx = createMockCtx();
+			const sharedPath = getSchedulerStoragePath(ctx.cwd);
+			const legacyPath = `${ctx.cwd}/.pi/scheduler.json`;
+			(existsSync as ReturnType<typeof vi.fn>).mockImplementation((filePath: string) => {
+				if (filePath === legacyPath) {
+					return true;
+				}
+				if (filePath === sharedPath) {
+					return false;
+				}
+				return false;
+			});
+
+			runtime.setRuntimeContext(ctx as any);
+			expect(copyFileSync).toHaveBeenCalledWith(legacyPath, sharedPath);
+		});
+
+		it("removes persisted scheduler files when tasks become defunct", () => {
+			const ctx = createMockCtx();
+			runtime.setRuntimeContext(ctx as any);
+			runtime.addRecurringIntervalTask("check", 5 * ONE_MINUTE);
+
+			(writeFileSync as ReturnType<typeof vi.fn>).mockClear();
+			runtime.clearTasks();
+
+			expect(rmSync).toHaveBeenCalledWith(getSchedulerStoragePath(ctx.cwd), { force: true });
+		});
+
 		it("does not persist without storage path", () => {
 			// Don't set runtime context (no storage path)
 			runtime.addRecurringIntervalTask("check", 5 * ONE_MINUTE);
@@ -1309,6 +1380,10 @@ describe("schedulerExtension registration", () => {
 		(mkdirSync as ReturnType<typeof vi.fn>).mockImplementation(() => undefined);
 		(writeFileSync as ReturnType<typeof vi.fn>).mockImplementation(() => undefined);
 		(renameSync as ReturnType<typeof vi.fn>).mockImplementation(() => undefined);
+		(copyFileSync as ReturnType<typeof vi.fn>).mockImplementation(() => undefined);
+		(rmSync as ReturnType<typeof vi.fn>).mockImplementation(() => undefined);
+		(readdirSync as ReturnType<typeof vi.fn>).mockReturnValue([]);
+		(rmdirSync as ReturnType<typeof vi.fn>).mockImplementation(() => undefined);
 		pi = createMockPi();
 	});
 
@@ -1353,6 +1428,10 @@ describe("command handlers", () => {
 		(mkdirSync as ReturnType<typeof vi.fn>).mockImplementation(() => undefined);
 		(writeFileSync as ReturnType<typeof vi.fn>).mockImplementation(() => undefined);
 		(renameSync as ReturnType<typeof vi.fn>).mockImplementation(() => undefined);
+		(copyFileSync as ReturnType<typeof vi.fn>).mockImplementation(() => undefined);
+		(rmSync as ReturnType<typeof vi.fn>).mockImplementation(() => undefined);
+		(readdirSync as ReturnType<typeof vi.fn>).mockReturnValue([]);
+		(rmdirSync as ReturnType<typeof vi.fn>).mockImplementation(() => undefined);
 		pi = createMockPi();
 		ctx = createMockCtx();
 		schedulerExtension(pi as any);
@@ -1565,6 +1644,10 @@ describe("schedule_prompt tool", () => {
 		(mkdirSync as ReturnType<typeof vi.fn>).mockImplementation(() => undefined);
 		(writeFileSync as ReturnType<typeof vi.fn>).mockImplementation(() => undefined);
 		(renameSync as ReturnType<typeof vi.fn>).mockImplementation(() => undefined);
+		(copyFileSync as ReturnType<typeof vi.fn>).mockImplementation(() => undefined);
+		(rmSync as ReturnType<typeof vi.fn>).mockImplementation(() => undefined);
+		(readdirSync as ReturnType<typeof vi.fn>).mockReturnValue([]);
+		(rmdirSync as ReturnType<typeof vi.fn>).mockImplementation(() => undefined);
 		pi = createMockPi();
 		ctx = createMockCtx();
 		schedulerExtension(pi as any);
@@ -1814,6 +1897,10 @@ describe("event wiring", () => {
 		(mkdirSync as ReturnType<typeof vi.fn>).mockImplementation(() => undefined);
 		(writeFileSync as ReturnType<typeof vi.fn>).mockImplementation(() => undefined);
 		(renameSync as ReturnType<typeof vi.fn>).mockImplementation(() => undefined);
+		(copyFileSync as ReturnType<typeof vi.fn>).mockImplementation(() => undefined);
+		(rmSync as ReturnType<typeof vi.fn>).mockImplementation(() => undefined);
+		(readdirSync as ReturnType<typeof vi.fn>).mockReturnValue([]);
+		(rmdirSync as ReturnType<typeof vi.fn>).mockImplementation(() => undefined);
 		pi = createMockPi();
 		schedulerExtension(pi as any);
 	});
@@ -1907,6 +1994,10 @@ describe("edge cases", () => {
 		(mkdirSync as ReturnType<typeof vi.fn>).mockImplementation(() => undefined);
 		(writeFileSync as ReturnType<typeof vi.fn>).mockImplementation(() => undefined);
 		(renameSync as ReturnType<typeof vi.fn>).mockImplementation(() => undefined);
+		(copyFileSync as ReturnType<typeof vi.fn>).mockImplementation(() => undefined);
+		(rmSync as ReturnType<typeof vi.fn>).mockImplementation(() => undefined);
+		(readdirSync as ReturnType<typeof vi.fn>).mockReturnValue([]);
+		(rmdirSync as ReturnType<typeof vi.fn>).mockImplementation(() => undefined);
 		pi = createMockPi();
 		ctx = createMockCtx();
 		schedulerExtension(pi as any);

--- a/packages/extensions/extensions/scheduler.ts
+++ b/packages/extensions/extensions/scheduler.ts
@@ -9,10 +9,12 @@
  * Based on pi-scheduler by @manojlds (MIT).
  *
  * Tasks run only while pi is active and idle. Recurring tasks auto-expire
- * after 3 days. State is persisted to `.pi/scheduler.json`.
+ * after 3 days. State is persisted under `~/.pi/agent/scheduler/.../scheduler.json`
+ * using a path that mirrors the current workspace path.
  */
 
 import * as fs from "node:fs";
+import { homedir } from "node:os";
 import * as path from "node:path";
 import type { ExtensionAPI, ExtensionContext } from "@mariozechner/pi-coding-agent";
 import { Type } from "@sinclair/typebox";
@@ -74,6 +76,27 @@ export type SchedulePromptAddPlan =
 interface SchedulerStore {
 	version: 1;
 	tasks: ScheduleTask[];
+}
+
+function getSchedulerStorageRoot(): string {
+	return path.join(homedir(), ".pi", "agent", "scheduler");
+}
+
+export function getSchedulerStoragePath(cwd: string): string {
+	const resolved = path.resolve(cwd);
+	const parsed = path.parse(resolved);
+	const relativeSegments = resolved.slice(parsed.root.length).split(path.sep).filter(Boolean);
+	const rootSegment = parsed.root
+		? parsed.root
+				.replaceAll(/[^a-zA-Z0-9]+/g, "-")
+				.replaceAll(/^-+|-+$/g, "")
+				.toLowerCase() || "root"
+		: "root";
+	return path.join(getSchedulerStorageRoot(), rootSegment, ...relativeSegments, "scheduler.json");
+}
+
+function getLegacySchedulerStoragePath(cwd: string): string {
+	return path.join(cwd, ".pi", "scheduler.json");
 }
 
 // ── Scheduling helpers ──────────────────────────────────────────────────────
@@ -456,9 +479,10 @@ export class SchedulerRuntime {
 			return;
 		}
 
-		const nextStorePath = path.join(ctx.cwd, ".pi", "scheduler.json");
+		const nextStorePath = getSchedulerStoragePath(ctx.cwd);
 		if (nextStorePath !== this.storagePath) {
 			this.storagePath = nextStorePath;
+			this.migrateLegacyStore(ctx.cwd);
 			this.loadTasksFromDisk();
 		}
 	}
@@ -1062,6 +1086,55 @@ export class SchedulerRuntime {
 		return this.hashString(taskId) % (maxJitter + 1);
 	}
 
+	private migrateLegacyStore(cwd: string) {
+		if (!this.storagePath) {
+			return;
+		}
+		const legacyPath = getLegacySchedulerStoragePath(cwd);
+		if (legacyPath === this.storagePath) {
+			return;
+		}
+		try {
+			if (!fs.existsSync(legacyPath) || fs.existsSync(this.storagePath)) {
+				return;
+			}
+			fs.mkdirSync(path.dirname(this.storagePath), { recursive: true });
+			fs.copyFileSync(legacyPath, this.storagePath);
+		} catch {
+			// Best-effort migration; runtime can continue from either empty state or new store.
+		}
+	}
+
+	private cleanupPersistedStore() {
+		if (!this.storagePath) {
+			return;
+		}
+		try {
+			fs.rmSync(this.storagePath, { force: true });
+		} catch {
+			// Best-effort cleanup.
+		}
+
+		const schedulerRoot = getSchedulerStorageRoot();
+		let currentDir = path.dirname(this.storagePath);
+		while (currentDir.startsWith(schedulerRoot) && currentDir !== schedulerRoot) {
+			try {
+				if (!fs.existsSync(currentDir)) {
+					currentDir = path.dirname(currentDir);
+					continue;
+				}
+				const entries = fs.readdirSync(currentDir);
+				if (entries.length > 0) {
+					break;
+				}
+				fs.rmdirSync(currentDir);
+				currentDir = path.dirname(currentDir);
+			} catch {
+				break;
+			}
+		}
+	}
+
 	// biome-ignore lint/complexity/noExcessiveCognitiveComplexity: Deserializes backward-compatible task shapes with runtime normalization guards.
 	loadTasksFromDisk() {
 		if (!this.storagePath) {
@@ -1069,6 +1142,7 @@ export class SchedulerRuntime {
 		}
 
 		this.tasks.clear();
+		let mutated = false;
 		try {
 			if (!fs.existsSync(this.storagePath)) {
 				return;
@@ -1079,9 +1153,11 @@ export class SchedulerRuntime {
 			const now = Date.now();
 			for (const task of list) {
 				if (this.tasks.size >= MAX_TASKS) {
+					mutated = true;
 					break;
 				}
 				if (!(task?.id && task.prompt)) {
+					mutated = true;
 					continue;
 				}
 
@@ -1092,25 +1168,35 @@ export class SchedulerRuntime {
 					runCount: task.runCount ?? 0,
 				};
 				if (normalized.kind === "recurring" && normalized.expiresAt && now >= normalized.expiresAt) {
+					mutated = true;
 					continue;
 				}
 
 				if (normalized.kind === "recurring" && normalized.cronExpression) {
 					const cron = normalizeCronExpression(normalized.cronExpression);
 					if (!cron) {
+						mutated = true;
 						continue;
+					}
+					if (cron.expression !== normalized.cronExpression) {
+						mutated = true;
 					}
 					normalized.cronExpression = cron.expression;
 				}
 
 				if (normalized.kind === "recurring" && !normalized.cronExpression) {
 					const rawIntervalMs = normalized.intervalMs ?? DEFAULT_LOOP_INTERVAL;
-					normalized.intervalMs = Number.isFinite(rawIntervalMs)
+					const safeIntervalMs = Number.isFinite(rawIntervalMs)
 						? Math.max(rawIntervalMs, MIN_RECURRING_INTERVAL)
 						: DEFAULT_LOOP_INTERVAL;
+					if (normalized.intervalMs !== safeIntervalMs) {
+						mutated = true;
+					}
+					normalized.intervalMs = safeIntervalMs;
 				}
 
 				if (!Number.isFinite(normalized.nextRunAt)) {
+					mutated = true;
 					if (normalized.kind === "recurring" && normalized.cronExpression) {
 						normalized.nextRunAt = computeNextCronRunAt(normalized.cronExpression, now) ?? now + DEFAULT_LOOP_INTERVAL;
 					} else {
@@ -1125,6 +1211,9 @@ export class SchedulerRuntime {
 		} catch {
 			// Ignore corrupted store and continue with empty in-memory state.
 		}
+		if (mutated) {
+			this.persistTasks();
+		}
 		this.updateStatus();
 	}
 
@@ -1133,10 +1222,15 @@ export class SchedulerRuntime {
 			return;
 		}
 		try {
+			const tasks = this.getSortedTasks();
+			if (tasks.length === 0) {
+				this.cleanupPersistedStore();
+				return;
+			}
 			fs.mkdirSync(path.dirname(this.storagePath), { recursive: true });
 			const store: SchedulerStore = {
 				version: 1,
-				tasks: this.getSortedTasks(),
+				tasks,
 			};
 			const tempPath = `${this.storagePath}.tmp`;
 			fs.writeFileSync(tempPath, JSON.stringify(store, null, 2), "utf-8");


### PR DESCRIPTION
## Summary
- move scheduler persistence out of repo-local `.pi/scheduler.json` into `~/.pi/agent/scheduler/...`
- mirror workspace paths in the shared storage path so scheduler state stays globally unique per repo/worktree
- migrate legacy repo-local scheduler stores automatically when present
- clean up defunct scheduler stores when all tasks expire or are removed
- add regression coverage for shared storage, migration, and cleanup behavior

## Validation
- pnpm -s biome check packages/extensions/extensions/scheduler.ts packages/extensions/extensions/scheduler.test.ts
- pnpm -s vitest packages/extensions/extensions/scheduler.test.ts
