### PR TITLE
build: pin picomatch to patched version

### DIFF
--- a/.changeset/pin-picomatch-security-fix.md
+++ b/.changeset/pin-picomatch-security-fix.md
@@ -1,0 +1,5 @@
+---
+default: patch
+---
+
+Pin `picomatch` to `4.0.4` via pnpm overrides so CI security audits pass with the patched version of the transitive dependency used by the Vitest toolchain.

--- a/package.json
+++ b/package.json
@@ -32,7 +32,8 @@
 			"undici": "7.24.0",
 			"yauzl@<3.2.1": ">=3.2.1",
 			"file-type@>=20.0.0 <=21.3.1": ">=21.3.2",
-			"fast-xml-parser": "5.5.6"
+			"fast-xml-parser": "5.5.6",
+			"picomatch": "4.0.4"
 		}
 	}
 }

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -10,6 +10,7 @@ overrides:
   yauzl@<3.2.1: '>=3.2.1'
   file-type@>=20.0.0 <=21.3.1: '>=21.3.2'
   fast-xml-parser: 5.5.6
+  picomatch: 4.0.4
 
 importers:
 
@@ -1439,7 +1440,7 @@ packages:
     resolution: {integrity: sha512-tIbYtZbucOs0BRGqPJkshJUYdL+SDH7dVM8gjy+ERp3WAUjLEFJE+02kanyHtwjWOnwrKYBiwAmM0p4kLJAnXg==}
     engines: {node: '>=12.0.0'}
     peerDependencies:
-      picomatch: ^3 || ^4
+      picomatch: 4.0.4
     peerDependenciesMeta:
       picomatch:
         optional: true
@@ -1719,8 +1720,8 @@ packages:
   picocolors@1.1.1:
     resolution: {integrity: sha512-xceH2snhtb5M9liqDsmEw56le376mTZkEX/jEb/RxNFyegNul7eNslCXP9FDj/Lcu0X8KEyMceP2ntpaHrDEVA==}
 
-  picomatch@4.0.3:
-    resolution: {integrity: sha512-5gTmgEY/sqK6gFXLIsQNH19lWb4ebPDLA4SdLP7dsWkIXHWlG66oPuVvXSGFPppYZz8ZDZq0dYYrbHfBCVUb1Q==}
+  picomatch@4.0.4:
+    resolution: {integrity: sha512-QP88BAKvMam/3NxH6vj2o21R6MjxZUAd6nlwAS/pnGvN9IVLocLHxGYIzFhg6fUQ+5th6P4dv4eW9jX3DSIj7A==}
     engines: {node: '>=12'}
 
   postcss@8.5.8:
@@ -3446,9 +3447,9 @@ snapshots:
       path-expression-matcher: 1.2.0
       strnum: 2.2.0
 
-  fdir@6.5.0(picomatch@4.0.3):
+  fdir@6.5.0(picomatch@4.0.4):
     optionalDependencies:
-      picomatch: 4.0.3
+      picomatch: 4.0.4
 
   fetch-blob@3.2.0:
     dependencies:
@@ -3726,7 +3727,7 @@ snapshots:
 
   picocolors@1.1.1: {}
 
-  picomatch@4.0.3: {}
+  picomatch@4.0.4: {}
 
   postcss@8.5.8:
     dependencies:
@@ -3906,8 +3907,8 @@ snapshots:
 
   tinyglobby@0.2.15:
     dependencies:
-      fdir: 6.5.0(picomatch@4.0.3)
-      picomatch: 4.0.3
+      fdir: 6.5.0(picomatch@4.0.4)
+      picomatch: 4.0.4
 
   tinypool@1.1.1: {}
 
@@ -3957,8 +3958,8 @@ snapshots:
   vite@7.3.1(@types/node@22.19.13)(yaml@2.8.2):
     dependencies:
       esbuild: 0.27.3
-      fdir: 6.5.0(picomatch@4.0.3)
-      picomatch: 4.0.3
+      fdir: 6.5.0(picomatch@4.0.4)
+      picomatch: 4.0.4
       postcss: 8.5.8
       rollup: 4.59.0
       tinyglobby: 0.2.15
@@ -3982,7 +3983,7 @@ snapshots:
       expect-type: 1.3.0
       magic-string: 0.30.21
       pathe: 2.0.3
-      picomatch: 4.0.3
+      picomatch: 4.0.4
       std-env: 3.10.0
       tinybench: 2.9.0
       tinyexec: 0.3.2


### PR DESCRIPTION
## Summary
- pin `picomatch` to `4.0.4` via pnpm overrides
- refresh the lockfile so Vitest-related transitive deps resolve to the patched version
- restore passing CI security audits on main

## Validation
- pnpm security:check
- pnpm lint
- pnpm typecheck
- pnpm test