### PR TITLE
fix: restore BTW API key resolution compatibility

### DIFF
--- a/.changeset/fix-btw-api-key-resolution-compat.md
+++ b/.changeset/fix-btw-api-key-resolution-compat.md
@@ -1,0 +1,5 @@
+---
+default: patch
+---
+
+fix BTW API key resolution on older pi runtimes that do not expose `ctx.modelRegistry.getApiKey()`.

--- a/packages/extensions/extensions/btw.test.ts
+++ b/packages/extensions/extensions/btw.test.ts
@@ -1,0 +1,58 @@
+import { describe, expect, it, vi } from "vitest";
+
+vi.mock("@mariozechner/pi-ai", () => ({
+	completeSimple: vi.fn(),
+	streamSimple: vi.fn(),
+	getEnvApiKey: vi.fn((provider: string) => (provider === "openai" ? "env-openai-key" : undefined)),
+}));
+
+vi.mock("@mariozechner/pi-tui", () => ({
+	Text: class Text {},
+}));
+
+vi.mock("@mariozechner/pi-coding-agent", () => ({
+	buildSessionContext: vi.fn(() => ({ messages: [] })),
+	AuthStorage: {
+		create: vi.fn(() => ({ source: "auth-storage" })),
+	},
+	ModelRegistry: class ModelRegistry {
+		async getApiKey(model: { provider: string; id: string }) {
+			return `dynamic:${model.provider}/${model.id}`;
+		}
+	},
+}));
+
+import { resolveBtwApiKey } from "./btw.js";
+
+const model = {
+	provider: "anthropic",
+	id: "claude-sonnet-4",
+	api: "anthropic-messages",
+};
+
+describe("resolveBtwApiKey", () => {
+	it("uses modelRegistry.getApiKey when available", async () => {
+		const getApiKey = vi.fn().mockResolvedValue("direct-key");
+
+		await expect(resolveBtwApiKey(model as never, { getApiKey })).resolves.toBe("direct-key");
+		expect(getApiKey).toHaveBeenCalledWith(model);
+	});
+
+	it("falls back to modelRegistry.getApiKeyForProvider", async () => {
+		const getApiKeyForProvider = vi.fn().mockResolvedValue("provider-key");
+
+		await expect(resolveBtwApiKey(model as never, { getApiKeyForProvider })).resolves.toBe("provider-key");
+		expect(getApiKeyForProvider).toHaveBeenCalledWith("anthropic");
+	});
+
+	it("falls back to modelRegistry.authStorage.getApiKey", async () => {
+		const getApiKey = vi.fn().mockResolvedValue("auth-storage-key");
+
+		await expect(resolveBtwApiKey(model as never, { authStorage: { getApiKey } })).resolves.toBe("auth-storage-key");
+		expect(getApiKey).toHaveBeenCalledWith("anthropic");
+	});
+
+	it("reconstructs a registry when the runtime registry lacks getApiKey", async () => {
+		await expect(resolveBtwApiKey(model as never, {})).resolves.toBe("dynamic:anthropic/claude-sonnet-4");
+	});
+});

--- a/packages/extensions/extensions/btw.ts
+++ b/packages/extensions/extensions/btw.ts
@@ -96,6 +96,61 @@ function toReasoning(level: SessionThinkingLevel): AiThinkingLevel | undefined {
 	return level === "off" ? undefined : level;
 }
 
+type CompatibleModelRegistry = {
+	getApiKey?: (model: NonNullable<ExtensionContext["model"]>) => Promise<string | undefined> | string | undefined;
+	getApiKeyForProvider?: (provider: string) => Promise<string | undefined> | string | undefined;
+	authStorage?: {
+		getApiKey?: (provider: string) => Promise<string | undefined> | string | undefined;
+	};
+};
+
+export async function resolveBtwApiKey(
+	model: NonNullable<ExtensionContext["model"]>,
+	modelRegistry: ExtensionContext["modelRegistry"] | CompatibleModelRegistry | undefined,
+): Promise<string | undefined> {
+	const registry = modelRegistry as CompatibleModelRegistry | undefined;
+
+	if (typeof registry?.getApiKey === "function") {
+		return await registry.getApiKey(model);
+	}
+
+	if (typeof registry?.getApiKeyForProvider === "function") {
+		return await registry.getApiKeyForProvider(model.provider);
+	}
+
+	if (typeof registry?.authStorage?.getApiKey === "function") {
+		return await registry.authStorage.getApiKey(model.provider);
+	}
+
+	try {
+		const piModule = (await import("@mariozechner/pi-coding-agent")) as Record<string, unknown>;
+		const authStorageModule = Reflect.get(piModule, "AuthStorage") as { create?: () => unknown } | undefined;
+		const modelRegistryModule = Reflect.get(piModule, "ModelRegistry") as
+			| (new (
+					authStorage: unknown,
+			  ) => CompatibleModelRegistry)
+			| undefined;
+
+		if (typeof authStorageModule?.create === "function" && modelRegistryModule) {
+			const fallbackRegistry = new modelRegistryModule(authStorageModule.create());
+			if (typeof fallbackRegistry.getApiKey === "function") {
+				return await fallbackRegistry.getApiKey(model);
+			}
+		}
+	} catch {
+		// Ignore and fall back to environment-based resolution below.
+	}
+
+	try {
+		const aiModule = (await import("@mariozechner/pi-ai")) as {
+			getEnvApiKey?: (provider: string) => string | undefined;
+		};
+		return aiModule.getEnvApiKey?.(model.provider);
+	} catch {
+		return undefined;
+	}
+}
+
 function extractText(parts: AssistantMessage["content"], type: "text" | "thinking"): string {
 	const chunks: string[] = [];
 	for (const part of parts) {
@@ -413,7 +468,10 @@ export default function (pi: ExtensionAPI) {
 		question: string,
 	): Promise<AssistantMessage | "aborted"> {
 		const model = ctx.model!;
-		const apiKey = (await ctx.modelRegistry.getApiKey(model))!;
+		const apiKey = await resolveBtwApiKey(model, ctx.modelRegistry);
+		if (!apiKey) {
+			throw new Error(`No credentials available for ${model.provider}/${model.id}.`);
+		}
 		const thinkingLevel = pi.getThinkingLevel() as SessionThinkingLevel;
 
 		const stream = streamSimple(model, buildBtwContext(ctx, question, threadSnapshot), {
@@ -456,7 +514,7 @@ export default function (pi: ExtensionAPI) {
 			return;
 		}
 
-		const apiKey = await ctx.modelRegistry.getApiKey(model);
+		const apiKey = await resolveBtwApiKey(model, ctx.modelRegistry);
 		if (!apiKey) {
 			notify(ctx, `No credentials available for ${model.provider}/${model.id}.`, "error");
 			return;
@@ -531,7 +589,7 @@ export default function (pi: ExtensionAPI) {
 			throw new Error("No active model selected.");
 		}
 
-		const apiKey = await ctx.modelRegistry.getApiKey(model);
+		const apiKey = await resolveBtwApiKey(model, ctx.modelRegistry);
 		if (!apiKey) {
 			throw new Error(`No credentials available for ${model.provider}/${model.id}.`);
 		}


### PR DESCRIPTION
## Summary

- make the BTW extension tolerate older pi runtimes where ctx.modelRegistry lacks getApiKey()
- fall back through provider/auth storage/env-based API key resolution before failing
- add regression coverage for the compatibility resolution path

## Testing

- pnpm lint
- pnpm test