### PR TITLE
chore: add package discovery keywords

### DIFF
--- a/.changeset/add-package-keywords-for-discovery.md
+++ b/.changeset/add-package-keywords-for-discovery.md
@@ -1,0 +1,5 @@
+---
+default: patch
+---
+
+add and refine npm keywords across the remaining published packages to improve discovery on pi.dev/packages.

--- a/packages/agents/package.json
+++ b/packages/agents/package.json
@@ -6,5 +6,13 @@
     "agents",
     "README.md"
   ],
-  "license": "MIT"
+  "license": "MIT",
+  "keywords": [
+    "pi",
+    "pi-coding-agent",
+    "agents",
+    "agents-md",
+    "agent-templates",
+    "prompts"
+  ]
 }

--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -37,5 +37,14 @@
   },
   "engines": {
     "node": ">=20.0.0"
-  }
+  },
+  "keywords": [
+    "pi",
+    "pi-coding-agent",
+    "oh-pi",
+    "cli",
+    "tui",
+    "configuration",
+    "installer"
+  ]
 }

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -28,5 +28,14 @@
   },
   "engines": {
     "node": ">=20.0.0"
-  }
+  },
+  "keywords": [
+    "pi",
+    "pi-coding-agent",
+    "oh-pi",
+    "core",
+    "types",
+    "registry",
+    "i18n"
+  ]
 }

--- a/packages/plan/package.json
+++ b/packages/plan/package.json
@@ -9,7 +9,8 @@
     "pi-coding-agent",
     "planning",
     "plan-mode",
-    "tui"
+    "branch-planning",
+    "research"
   ],
   "bin": {
     "pi-plan": "install.mjs"

--- a/packages/shared-qna/package.json
+++ b/packages/shared-qna/package.json
@@ -4,11 +4,12 @@
   "description": "Shared TUI question-and-answer component for pi extensions.",
   "type": "module",
   "keywords": [
-    "pi-package",
     "pi",
     "pi-coding-agent",
     "tui",
-    "qna"
+    "qna",
+    "components",
+    "extension-library"
   ],
   "exports": {
     ".": "./index.ts",

--- a/packages/spec/package.json
+++ b/packages/spec/package.json
@@ -8,9 +8,9 @@
     "pi",
     "pi-coding-agent",
     "spec",
-    "spec-kit",
-    "planning",
-    "requirements"
+    "spec-driven-development",
+    "requirements",
+    "workflow"
   ],
   "pi": {
     "extensions": [

--- a/packages/subagents/package.json
+++ b/packages/subagents/package.json
@@ -8,9 +8,9 @@
     "pi",
     "pi-coding-agent",
     "subagents",
-    "agents",
-    "async",
-    "tui"
+    "multi-agent",
+    "chains",
+    "delegation"
   ],
   "bin": {
     "pi-extension-subagents": "install.mjs"

--- a/packages/web-client/package.json
+++ b/packages/web-client/package.json
@@ -24,5 +24,14 @@
   "license": "MIT",
   "engines": {
     "node": ">=20.0.0"
-  }
+  },
+  "keywords": [
+    "pi",
+    "pi-coding-agent",
+    "web",
+    "remote",
+    "client",
+    "websocket",
+    "typescript"
+  ]
 }

--- a/packages/web-remote/package.json
+++ b/packages/web-remote/package.json
@@ -8,7 +8,9 @@
     "pi",
     "pi-coding-agent",
     "remote",
-    "web"
+    "web",
+    "session-sharing",
+    "browser"
   ],
   "pi": {
     "extensions": [

--- a/packages/web-server/package.json
+++ b/packages/web-server/package.json
@@ -38,5 +38,14 @@
   },
   "engines": {
     "node": ">=20.0.0"
-  }
+  },
+  "keywords": [
+    "pi",
+    "pi-coding-agent",
+    "web",
+    "remote",
+    "server",
+    "websocket",
+    "http"
+  ]
 }


### PR DESCRIPTION
## Summary\n- add npm keywords to packages that were missing them entirely\n- refine keyword sets on supporting packages so pi.dev/packages can surface them more accurately\n- add a changeset for the metadata update\n\n## Testing\n- pnpm lint\n- validate all packages/*/package.json files parse successfully\n