### PR TITLE
feat: add option to disable emoji icons with plain ASCII fallbacks

### DIFF
--- a/.changes/plain-icons.md
+++ b/.changes/plain-icons.md
@@ -1,0 +1,15 @@
+---
+default: minor
+---
+
+Add option to disable emoji icons and use plain ASCII fallbacks.
+
+Three ways to enable plain icon mode (in priority order):
+
+1. **Environment variable**: `OH_PI_PLAIN_ICONS=1`
+2. **CLI flag**: `pi --plain-icons`
+3. **settings.json**: `{ "plainIcons": true }` (global `~/.pi/agent/settings.json` or project-local `.pi/settings.json`)
+
+This replaces all emoji icons (🐜, ✅, ❌, 🚀, etc.) with ASCII-safe equivalents (`[ant]`, `[ok]`, `[ERR]`, `[>>]`, etc.) across all oh-pi extensions — helpful for terminals or fonts that don't render Unicode emoji correctly.
+
+Closes #24.

--- a/README.md
+++ b/README.md
@@ -75,6 +75,52 @@ npx @ifi/oh-pi --remove             # uninstall all oh-pi packages from pi
 
 ---
 
+## Configuration
+
+### Plain Icons (disable emoji)
+
+If emoji icons render poorly in your terminal (wrong font, garbled glyphs, misaligned widths), you
+can switch to ASCII-safe fallbacks. All emoji like 🐜 ✅ ❌ 🚀 become plain text like `[ant]`
+`[ok]` `[ERR]` `[>>]`.
+
+Three ways to enable (in priority order):
+
+**1. Environment variable** (highest priority)
+
+```bash
+export OH_PI_PLAIN_ICONS=1    # add to ~/.bashrc or ~/.zshrc
+```
+
+**2. CLI flag** (per session)
+
+```bash
+pi --plain-icons
+```
+
+**3. settings.json** (persistent, recommended)
+
+Add `"plainIcons": true` to your global or project-local settings:
+
+```bash
+# Global — applies to all projects
+echo '  "plainIcons": true' >> ~/.pi/agent/settings.json
+
+# Or project-local — applies only to this repo
+echo '  "plainIcons": true' >> .pi/settings.json
+```
+
+```jsonc
+// ~/.pi/agent/settings.json
+{
+  "defaultProvider": "anthropic",
+  "defaultModel": "claude-sonnet-4",
+  "plainIcons": true
+  // ...
+}
+```
+
+---
+
 ## Extensions
 
 ### 🛡️ Safe Guard (`safe-guard`) — **default: off (opt-in)**

--- a/packages/ant-colony/extensions/ant-colony/index.ts
+++ b/packages/ant-colony/extensions/ant-colony/index.ts
@@ -1,5 +1,5 @@
 /**
- * 🐜 Ant Colony Extension — pi extension entry point.
+ * Ant Colony Extension — pi extension entry point.
  *
  * Background non-blocking colony:
  * - Colony runs in the background without blocking the main conversation
@@ -26,8 +26,12 @@ import type {
 	ColonyWorkspace,
 } from "./types.js";
 import {
+	antIcon,
+	boltIcon,
 	buildReport,
 	casteIcon,
+	checkMark,
+	crossMark,
 	formatCost,
 	formatDuration,
 	formatTokens,
@@ -281,10 +285,10 @@ export default function antColonyExtension(pi: ExtensionAPI) {
 				const pct = `${Math.round(progress * 100)}%`;
 				const active = colony.antStreams.size;
 
-				const parts = [`🐜[${colonyIdentity(colony)}] ${statusIcon(phase)} ${statusLabel(phase)}`];
+				const parts = [`${antIcon()}[${colonyIdentity(colony)}] ${statusIcon(phase)} ${statusLabel(phase)}`];
 				parts.push(m ? `${m.tasksDone}/${m.tasksTotal} (${pct})` : `0/0 (${pct})`);
-				parts.push(`⚡${active}`);
-				parts.push(colony.workspace.mode === "worktree" ? "🧪wt" : "🧪shared");
+				parts.push(`${boltIcon()}${active}`);
+				parts.push(colony.workspace.mode === "worktree" ? "wt" : "shared");
 				if (m) {
 					parts.push(formatCost(m.totalCost));
 				}
@@ -452,7 +456,7 @@ export default function antColonyExtension(pi: ExtensionAPI) {
 					pi.sendMessage(
 						{
 							customType: "ant-colony-progress",
-							content: `[COLONY_SIGNAL:${signal.phase.toUpperCase()}] 🐜[${colonyIdentity(colony)}] ${signal.message} (${pct}%, ${formatCost(signal.cost)})`,
+							content: `[COLONY_SIGNAL:${signal.phase.toUpperCase()}] ${antIcon()}[${colonyIdentity(colony)}] ${signal.message} (${pct}%, ${formatCost(signal.cost)})`,
 							display: true,
 						},
 						{ triggerTurn: false, deliverAs: "followUp" },
@@ -481,7 +485,7 @@ export default function antColonyExtension(pi: ExtensionAPI) {
 				colony.antStreams.delete(ant.id);
 				// Inject a one-liner to main process on each task completion
 				const m = colony.state?.metrics;
-				const icon = ant.status === "done" ? "✓" : "✗";
+				const icon = ant.status === "done" ? checkMark() : crossMark();
 				const progress = m ? `${m.tasksDone}/${m.tasksTotal}` : "";
 				const cost = m ? formatCost(m.totalCost) : "";
 				pushLog(colony, {
@@ -491,7 +495,7 @@ export default function antColonyExtension(pi: ExtensionAPI) {
 				pi.sendMessage(
 					{
 						customType: "ant-colony-progress",
-						content: `[COLONY_SIGNAL:TASK_DONE] 🐜[${colonyIdentity(colony)}] ${icon} ${task.title.slice(0, 60)} (${progress}, ${cost})`,
+						content: `[COLONY_SIGNAL:TASK_DONE] ${antIcon()}[${colonyIdentity(colony)}] ${icon} ${task.title.slice(0, 60)} (${progress}, ${cost})`,
 						display: true,
 					},
 					{ triggerTurn: false, deliverAs: "followUp" },
@@ -604,7 +608,7 @@ export default function antColonyExtension(pi: ExtensionAPI) {
 				);
 
 				pi.events.emit("ant-colony:notify", {
-					msg: `🐜[${colonyIdentityVerbose(colony)}] Colony ${ok ? "completed" : phase.replace(/_/g, " ")}: ${m.tasksDone}/${m.tasksTotal} tasks │ ${formatCost(m.totalCost)} │ ${formatWorkspaceSummary(workspace)}`,
+					msg: `${antIcon()}[${colonyIdentityVerbose(colony)}] Colony ${ok ? "completed" : phase.replace(/_/g, " ")}: ${m.tasksDone}/${m.tasksTotal} tasks │ ${formatCost(m.totalCost)} │ ${formatWorkspaceSummary(workspace)}`,
 					level: ok ? "success" : "error",
 				});
 			})
@@ -616,10 +620,10 @@ export default function antColonyExtension(pi: ExtensionAPI) {
 					pi.events.emit("ant-colony:clear-ui");
 				}
 				pi.events.emit("ant-colony:notify", {
-					msg: `🐜[${colonyIdentityVerbose(colony)}] Colony crashed: ${e} │ ${formatWorkspaceSummary(workspace)}`,
+					msg: `${antIcon()}[${colonyIdentityVerbose(colony)}] Colony crashed: ${e} │ ${formatWorkspaceSummary(workspace)}`,
 					level: "error",
 				});
-				const crashReport = withWorkspaceReport(workspace, `## 🐜 Colony Crashed\n${e}`);
+				const crashReport = withWorkspaceReport(workspace, `## ${antIcon()} Colony Crashed\n${e}`);
 				pi.sendMessage(
 					{
 						customType: "ant-colony-report",
@@ -665,13 +669,13 @@ export default function antColonyExtension(pi: ExtensionAPI) {
 		// Extract key info for rendering
 		const _statusMatch = content.match(/\*\*Status:\*\* (.+)/);
 		const durationMatch = content.match(/\*\*Duration:\*\* (.+)/);
-		const ok = content.includes("✅ done");
+		const ok = content.includes("done") && (content.includes("✅") || content.includes("[ok]"));
 
 		container.addChild(
 			new Text(
-				(ok ? theme.fg("success", "✓") : theme.fg("error", "✗")) +
+				(ok ? theme.fg("success", checkMark()) : theme.fg("error", crossMark())) +
 					" " +
-					theme.fg("toolTitle", theme.bold("🐜 Ant Colony Report")) +
+					theme.fg("toolTitle", theme.bold(`${antIcon()} Ant Colony Report`)) +
 					(durationMatch ? theme.fg("muted", ` │ ${durationMatch[1]}`) : ""),
 				0,
 				0,
@@ -679,9 +683,11 @@ export default function antColonyExtension(pi: ExtensionAPI) {
 		);
 
 		// Render task results
-		const taskLines = content.split("\n").filter((l) => l.startsWith("- ✓") || l.startsWith("- ✗"));
+		const ck = checkMark();
+		const cx = crossMark();
+		const taskLines = content.split("\n").filter((l) => l.startsWith(`- ${ck}`) || l.startsWith(`- ${cx}`));
 		for (const l of taskLines.slice(0, 8)) {
-			const icon = l.startsWith("- ✓") ? theme.fg("success", "✓") : theme.fg("error", "✗");
+			const icon = l.startsWith(`- ${ck}`) ? theme.fg("success", ck) : theme.fg("error", cx);
 			container.addChild(new Text(`  ${icon} ${theme.fg("muted", l.slice(4).trim().slice(0, 70))}`, 0, 0));
 		}
 		if (taskLines.length > 8) {
@@ -691,7 +697,9 @@ export default function antColonyExtension(pi: ExtensionAPI) {
 		// Metrics line
 		const metricsLines = content
 			.split("\n")
-			.filter((l) => l.startsWith("- ") && !l.startsWith("- ✓") && !l.startsWith("- ✗") && !l.startsWith("- ["));
+			.filter(
+				(l) => l.startsWith("- ") && !l.startsWith(`- ${ck}`) && !l.startsWith(`- ${cx}`) && !l.startsWith("- ["),
+			);
 		if (metricsLines.length > 0) {
 			container.addChild(new Text(theme.fg("muted", `  ${metricsLines.map((l) => l.slice(2)).join(" │ ")}`), 0, 0));
 		}
@@ -760,7 +768,7 @@ export default function antColonyExtension(pi: ExtensionAPI) {
 						}
 
 						lines.push(
-							theme.fg("accent", theme.bold(`  🐜 Colony [${colonyIdentity(c)}]`)) +
+							theme.fg("accent", theme.bold(`  ${antIcon()} Colony [${colonyIdentity(c)}]`)) +
 								theme.fg("muted", ` │ ${elapsed} │ ${cost}`),
 						);
 						lines.push(theme.fg("muted", `  Goal: ${trim(c.goal, w - 8)}`));
@@ -769,7 +777,7 @@ export default function antColonyExtension(pi: ExtensionAPI) {
 							lines.push(theme.fg("muted", `  Stable ID: ${trim(c.identity.stableId, w - 14)}`));
 						}
 						lines.push(
-							`  ${statusIcon(phase)} ${theme.bold(statusLabel(phase))} │ ${m ? `${m.tasksDone}/${m.tasksTotal}` : "0/0"} │ ${pct}% │ ⚡${activeAnts}`,
+							`  ${statusIcon(phase)} ${theme.bold(statusLabel(phase))} │ ${m ? `${m.tasksDone}/${m.tasksTotal}` : "0/0"} │ ${pct}% │ ${boltIcon()}${activeAnts}`,
 						);
 						lines.push(theme.fg("muted", `  ${progressBar(progress, barWidth)} ${pct}%`));
 						if (c.phase && c.phase !== "initializing") {
@@ -834,12 +842,12 @@ export default function antColonyExtension(pi: ExtensionAPI) {
 								for (const t of filtered.slice(0, 16)) {
 									const icon =
 										t.status === "done"
-											? theme.fg("success", "✓")
+											? theme.fg("success", checkMark())
 											: t.status === "failed"
-												? theme.fg("error", "✗")
+												? theme.fg("error", crossMark())
 												: t.status === "active"
-													? theme.fg("warning", "●")
-													: theme.fg("dim", "○");
+													? theme.fg("warning", "*")
+													: theme.fg("dim", ".");
 									const dur =
 										t.finishedAt && t.startedAt
 											? theme.fg("dim", ` ${formatDuration(t.finishedAt - t.startedAt)}`)
@@ -880,7 +888,7 @@ export default function antColonyExtension(pi: ExtensionAPI) {
 							if (failedTasks.length > 0) {
 								lines.push(theme.fg("warning", `  Warnings (${failedTasks.length})`));
 								for (const t of failedTasks.slice(0, 4)) {
-									lines.push(`  ${theme.fg("error", "✗")} ${theme.fg("text", trim(t.title, w - 8))}`);
+									lines.push(`  ${theme.fg("error", crossMark())} ${theme.fg("text", trim(t.title, w - 8))}`);
 								}
 								if (failedTasks.length > 4) {
 									lines.push(theme.fg("muted", `  ⋯ +${failedTasks.length - 4} more failed tasks`));
@@ -898,10 +906,10 @@ export default function antColonyExtension(pi: ExtensionAPI) {
 									const age = formatDuration(Math.max(0, now - log.timestamp));
 									const levelIcon =
 										log.level === "error"
-											? theme.fg("error", "✗")
+											? theme.fg("error", crossMark())
 											: log.level === "warning"
 												? theme.fg("warning", "!")
-												: theme.fg("muted", "•");
+												: theme.fg("muted", ".");
 									lines.push(`  ${levelIcon} ${theme.fg("muted", age)} ${theme.fg("text", trim(log.text, w - 12))}`);
 								}
 							}
@@ -1072,7 +1080,7 @@ export default function antColonyExtension(pi: ExtensionAPI) {
 				content: [
 					{
 						type: "text",
-						text: `[COLONY_SIGNAL:LAUNCHED] [${launched.id}]\n🐜 Colony [${launched.id}] launched in background (${colonies.size} active).\nGoal: ${params.goal}\nWorkspace: ${formatWorkspaceSummary(launched.workspace)}\n\nThe colony runs autonomously in passive mode. Progress is pushed via [COLONY_SIGNAL:*] follow-up messages. Do not poll bg_colony_status unless the user explicitly asks for a manual snapshot.`,
+						text: `[COLONY_SIGNAL:LAUNCHED] [${launched.id}]\n${antIcon()} Colony [${launched.id}] launched in background (${colonies.size} active).\nGoal: ${params.goal}\nWorkspace: ${formatWorkspaceSummary(launched.workspace)}\n\nThe colony runs autonomously in passive mode. Progress is pushed via [COLONY_SIGNAL:*] follow-up messages. Do not poll bg_colony_status unless the user explicitly asks for a manual snapshot.`,
 					},
 				],
 			};
@@ -1080,7 +1088,7 @@ export default function antColonyExtension(pi: ExtensionAPI) {
 
 		renderCall(args, theme) {
 			const goal = args.goal?.length > 70 ? `${args.goal.slice(0, 67)}...` : args.goal;
-			let text = theme.fg("toolTitle", theme.bold("🐜 ant_colony"));
+			let text = theme.fg("toolTitle", theme.bold(`${antIcon()} ant_colony`));
 			if (args.maxAnts) {
 				text += theme.fg("muted", ` ×${args.maxAnts}`);
 			}
@@ -1105,11 +1113,15 @@ export default function antColonyExtension(pi: ExtensionAPI) {
 			}
 			const container = new Container();
 			container.addChild(
-				new Text(theme.fg("success", "✓ ") + theme.fg("toolTitle", theme.bold("Colony launched in background")), 0, 0),
+				new Text(
+					theme.fg("success", `${checkMark()} `) + theme.fg("toolTitle", theme.bold("Colony launched in background")),
+					0,
+					0,
+				),
 			);
 			if (colonies.size > 0) {
 				for (const colony of colonies.values()) {
-					const workspaceTag = colony.workspace.mode === "worktree" ? "🧪wt" : "🧪shared";
+					const workspaceTag = colony.workspace.mode === "worktree" ? "wt" : "shared";
 					container.addChild(
 						new Text(
 							theme.fg("muted", `  [${colonyIdentity(colony)}] ${workspaceTag} ${colony.goal.slice(0, 58)}`),
@@ -1143,10 +1155,10 @@ export default function antColonyExtension(pi: ExtensionAPI) {
 		const activeAnts = c.antStreams.size;
 
 		const lines: string[] = [
-			`🐜 ${statusIcon(phase)} ${trim(c.goal, 80)}`,
+			`${antIcon()} ${statusIcon(phase)} ${trim(c.goal, 80)}`,
 			`ID: ${colonyIdentityVerbose(c)}`,
 			`Workspace: ${trim(formatWorkspaceSummary(c.workspace), 100)}`,
-			`${statusLabel(phase)} │ ${m ? `${m.tasksDone}/${m.tasksTotal} tasks` : "starting"} │ ${pct}% │ ⚡${activeAnts} │ ${m ? formatCost(m.totalCost) : "$0"} │ ${elapsed}`,
+			`${statusLabel(phase)} │ ${m ? `${m.tasksDone}/${m.tasksTotal} tasks` : "starting"} │ ${pct}% │ ${boltIcon()}${activeAnts} │ ${m ? formatCost(m.totalCost) : "$0"} │ ${elapsed}`,
 			`${progressBar(progress, 18)} ${pct}%`,
 		];
 
@@ -1161,7 +1173,7 @@ export default function antColonyExtension(pi: ExtensionAPI) {
 			lines.push(`Last: ${trim(lastLog.text, 100)}`);
 		}
 		if (m && m.tasksFailed > 0) {
-			lines.push(`⚠ ${m.tasksFailed} failed`);
+			lines.push(`${m.tasksFailed} failed`);
 		}
 
 		return lines.join("\n");
@@ -1277,7 +1289,7 @@ export default function antColonyExtension(pi: ExtensionAPI) {
 				modelRegistry: ctx.modelRegistry ?? undefined,
 			});
 			ctx.ui.notify(
-				`🐜[${launched.id}] Colony launched (${colonies.size} active): ${goal.slice(0, 70)}${goal.length > 70 ? "..." : ""}\nWorkspace: ${formatWorkspaceSummary(launched.workspace)}`,
+				`${antIcon()}[${launched.id}] Colony launched (${colonies.size} active): ${goal.slice(0, 70)}${goal.length > 70 ? "..." : ""}\nWorkspace: ${formatWorkspaceSummary(launched.workspace)}`,
 				"info",
 			);
 		},
@@ -1342,7 +1354,7 @@ export default function antColonyExtension(pi: ExtensionAPI) {
 				for (const colony of colonies.values()) {
 					colony.abortController.abort();
 				}
-				ctx.ui.notify(`🐜 Abort signal sent to ${count} ${count === 1 ? "colony" : "colonies"}.`, "warning");
+				ctx.ui.notify(`${antIcon()} Abort signal sent to ${count} ${count === 1 ? "colony" : "colonies"}.`, "warning");
 			} else {
 				const colony = resolveColony(idArg);
 				if (!colony) {
@@ -1351,7 +1363,7 @@ export default function antColonyExtension(pi: ExtensionAPI) {
 				}
 				colony.abortController.abort();
 				ctx.ui.notify(
-					`🐜[${colonyIdentityVerbose(colony)}] Abort signal sent. Waiting for ants to finish...`,
+					`${antIcon()}[${colonyIdentityVerbose(colony)}] Abort signal sent. Waiting for ants to finish...`,
 					"warning",
 				);
 			}
@@ -1390,7 +1402,7 @@ export default function antColonyExtension(pi: ExtensionAPI) {
 					{ resume: true, stableIdHint: found.colonyId, workspaceHint: found.state.workspace ?? null },
 				);
 				ctx.ui.notify(
-					`🐜[${launched.id}|${found.colonyId}] Resuming: ${found.state.goal.slice(0, 60)}...\nWorkspace: ${formatWorkspaceSummary(launched.workspace)}`,
+					`${antIcon()}[${launched.id}|${found.colonyId}] Resuming: ${found.state.goal.slice(0, 60)}...\nWorkspace: ${formatWorkspaceSummary(launched.workspace)}`,
 					"info",
 				);
 			}

--- a/packages/ant-colony/extensions/ant-colony/ui.ts
+++ b/packages/ant-colony/extensions/ant-colony/ui.ts
@@ -8,8 +8,16 @@
  * and the `COLONY_SIGNAL:*` protocol identifiers (e.g. `planning_recovery`,
  * `budget_exceeded`, `task_done`). These are wire-format constants, not
  * arbitrary variable names.
+ *
+ * Icon mode is controlled by the `OH_PI_PLAIN_ICONS` environment variable.
+ * When set to `"1"` or `"true"`, all icons fall back to ASCII-safe glyphs.
  */
 import type { ColonyState } from "./types.js";
+
+/** Check whether plain (ASCII-safe) icon mode is active. */
+function isPlain(): boolean {
+	return process.env.OH_PI_PLAIN_ICONS === "1" || process.env.OH_PI_PLAIN_ICONS === "true";
+}
 
 /**
  * Format a millisecond duration into a human-readable string like `42s` or `3m12s`.
@@ -41,7 +49,7 @@ export function formatTokens(n: number): string {
 	return n < 1000000 ? `${(n / 1000).toFixed(1)}k` : `${(n / 1000000).toFixed(1)}M`;
 }
 
-const STATUS_ICONS: Record<string, string> = {
+const EMOJI_STATUS_ICONS: Record<string, string> = {
 	launched: "🚀",
 	scouting: "🔍",
 	// biome-ignore lint/style/useNamingConvention: Wire-format protocol key
@@ -55,6 +63,22 @@ const STATUS_ICONS: Record<string, string> = {
 	failed: "❌",
 	// biome-ignore lint/style/useNamingConvention: Wire-format protocol key
 	budget_exceeded: "💰",
+};
+
+const PLAIN_STATUS_ICONS: Record<string, string> = {
+	launched: "[>>]",
+	scouting: "[?]",
+	// biome-ignore lint/style/useNamingConvention: Wire-format protocol key
+	planning_recovery: "[~]",
+	working: "[w]",
+	reviewing: "[!]",
+	// biome-ignore lint/style/useNamingConvention: Wire-format protocol key
+	task_done: "[ok]",
+	done: "[ok]",
+	complete: "[ok]",
+	failed: "[ERR]",
+	// biome-ignore lint/style/useNamingConvention: Wire-format protocol key
+	budget_exceeded: "[$]",
 };
 
 const STATUS_LABELS: Record<string, string> = {
@@ -73,12 +97,26 @@ const STATUS_LABELS: Record<string, string> = {
 	budget_exceeded: "BUDGET_EXCEEDED",
 };
 
+const EMOJI_CASTE_ICONS: Record<string, string> = {
+	scout: "🔍",
+	soldier: "🛡️",
+	drone: "⚙️",
+};
+
+const PLAIN_CASTE_ICONS: Record<string, string> = {
+	scout: "[?]",
+	soldier: "[!]",
+	drone: "[d]",
+};
+
 /**
- * Get the emoji icon for a colony status/phase string.
- * Falls back to 🐜 for unknown statuses.
+ * Get the icon for a colony status/phase string.
+ * Falls back to 🐜 / `[ant]` for unknown statuses.
  */
 export function statusIcon(status: string): string {
-	return STATUS_ICONS[status] || "🐜";
+	const map = isPlain() ? PLAIN_STATUS_ICONS : EMOJI_STATUS_ICONS;
+	const fallback = isPlain() ? "[ant]" : "🐜";
+	return map[status] || fallback;
 }
 
 /**
@@ -102,19 +140,32 @@ export function progressBar(progress: number, width = 14): string {
 }
 
 /**
- * Get the emoji icon for an ant caste (scout, worker, soldier, drone).
+ * Get the icon for an ant caste (scout, worker, soldier, drone).
  */
 export function casteIcon(caste: string): string {
-	if (caste === "scout") {
-		return "🔍";
-	}
-	if (caste === "soldier") {
-		return "🛡️";
-	}
-	if (caste === "drone") {
-		return "⚙️";
-	}
-	return "⚒️";
+	const map = isPlain() ? PLAIN_CASTE_ICONS : EMOJI_CASTE_ICONS;
+	const fallback = isPlain() ? "[w]" : "⚒️";
+	return map[caste] || fallback;
+}
+
+/** Ant icon — 🐜 or `[ant]` depending on icon mode. */
+export function antIcon(): string {
+	return isPlain() ? "[ant]" : "🐜";
+}
+
+/** Check mark — ✓ or `[ok]`. */
+export function checkMark(): string {
+	return isPlain() ? "[ok]" : "✓";
+}
+
+/** Cross mark — ✗ or `[x]`. */
+export function crossMark(): string {
+	return isPlain() ? "[x]" : "✗";
+}
+
+/** Lightning bolt — ⚡ or `!`. */
+export function boltIcon(): string {
+	return isPlain() ? "!" : "⚡";
 }
 
 /**
@@ -125,15 +176,15 @@ export function buildReport(state: ColonyState): string {
 	const m = state.metrics;
 	const elapsed = state.finishedAt ? formatDuration(state.finishedAt - state.createdAt) : "?";
 	return [
-		"## 🐜 Ant Colony Report",
+		`## ${antIcon()} Ant Colony Report`,
 		`**Goal:** ${state.goal}`,
 		`**Status:** ${statusIcon(state.status)} ${state.status} │ ${formatCost(m.totalCost)}`,
 		`**Duration:** ${elapsed}`,
 		`**Tasks:** ${m.tasksDone}/${m.tasksTotal} done${m.tasksFailed > 0 ? `, ${m.tasksFailed} failed` : ""}`,
 		"",
-		...state.tasks.filter((t) => t.status === "done").map((t) => `- ✓ **${t.title}**`),
+		...state.tasks.filter((t) => t.status === "done").map((t) => `- ${checkMark()} **${t.title}**`),
 		...state.tasks
 			.filter((t) => t.status === "failed")
-			.map((t) => `- ✗ **${t.title}** — ${t.error?.slice(0, 80) || "unknown"}`),
+			.map((t) => `- ${crossMark()} **${t.title}** — ${t.error?.slice(0, 80) || "unknown"}`),
 	].join("\n");
 }

--- a/packages/ant-colony/tests/ui.test.ts
+++ b/packages/ant-colony/tests/ui.test.ts
@@ -1,8 +1,12 @@
-import { describe, expect, it } from "vitest";
+import { afterEach, describe, expect, it } from "vitest";
 import type { ColonyState } from "../extensions/ant-colony/types.js";
 import {
+	antIcon,
+	boltIcon,
 	buildReport,
 	casteIcon,
+	checkMark,
+	crossMark,
 	formatCost,
 	formatDuration,
 	formatTokens,
@@ -34,6 +38,10 @@ describe("formatTokens", () => {
 });
 
 describe("statusIcon", () => {
+	afterEach(() => {
+		process.env.OH_PI_PLAIN_ICONS = "";
+	});
+
 	it("launched", () => expect(statusIcon("launched")).toBe("🚀"));
 	it("scouting", () => expect(statusIcon("scouting")).toBe("🔍"));
 	it("working", () => expect(statusIcon("working")).toBe("⚒️"));
@@ -44,6 +52,19 @@ describe("statusIcon", () => {
 	it("failed", () => expect(statusIcon("failed")).toBe("❌"));
 	it("budget_exceeded", () => expect(statusIcon("budget_exceeded")).toBe("💰"));
 	it("unknown", () => expect(statusIcon("xyz")).toBe("🐜"));
+
+	it("plain mode: launched", () => {
+		process.env.OH_PI_PLAIN_ICONS = "1";
+		expect(statusIcon("launched")).toBe("[>>]");
+	});
+	it("plain mode: scouting", () => {
+		process.env.OH_PI_PLAIN_ICONS = "1";
+		expect(statusIcon("scouting")).toBe("[?]");
+	});
+	it("plain mode: unknown", () => {
+		process.env.OH_PI_PLAIN_ICONS = "1";
+		expect(statusIcon("xyz")).toBe("[ant]");
+	});
 });
 
 describe("statusLabel", () => {
@@ -62,14 +83,71 @@ describe("progressBar", () => {
 });
 
 describe("casteIcon", () => {
+	afterEach(() => {
+		process.env.OH_PI_PLAIN_ICONS = "";
+	});
+
 	it("scout", () => expect(casteIcon("scout")).toBe("🔍"));
 	it("soldier", () => expect(casteIcon("soldier")).toBe("🛡️"));
 	it("drone", () => expect(casteIcon("drone")).toBe("⚙️"));
 	it("worker", () => expect(casteIcon("worker")).toBe("⚒️"));
 	it("unknown", () => expect(casteIcon("xyz")).toBe("⚒️"));
+
+	it("plain mode: scout", () => {
+		process.env.OH_PI_PLAIN_ICONS = "1";
+		expect(casteIcon("scout")).toBe("[?]");
+	});
+	it("plain mode: worker", () => {
+		process.env.OH_PI_PLAIN_ICONS = "1";
+		expect(casteIcon("worker")).toBe("[w]");
+	});
+});
+
+describe("antIcon", () => {
+	afterEach(() => {
+		process.env.OH_PI_PLAIN_ICONS = "";
+	});
+
+	it("emoji mode", () => expect(antIcon()).toBe("🐜"));
+	it("plain mode", () => {
+		process.env.OH_PI_PLAIN_ICONS = "1";
+		expect(antIcon()).toBe("[ant]");
+	});
+});
+
+describe("checkMark / crossMark", () => {
+	afterEach(() => {
+		process.env.OH_PI_PLAIN_ICONS = "";
+	});
+
+	it("emoji mode", () => {
+		expect(checkMark()).toBe("✓");
+		expect(crossMark()).toBe("✗");
+	});
+	it("plain mode", () => {
+		process.env.OH_PI_PLAIN_ICONS = "1";
+		expect(checkMark()).toBe("[ok]");
+		expect(crossMark()).toBe("[x]");
+	});
+});
+
+describe("boltIcon", () => {
+	afterEach(() => {
+		process.env.OH_PI_PLAIN_ICONS = "";
+	});
+
+	it("emoji mode", () => expect(boltIcon()).toBe("⚡"));
+	it("plain mode", () => {
+		process.env.OH_PI_PLAIN_ICONS = "1";
+		expect(boltIcon()).toBe("!");
+	});
 });
 
 describe("buildReport", () => {
+	afterEach(() => {
+		process.env.OH_PI_PLAIN_ICONS = "";
+	});
+
 	it("builds report with goal, status, cost, tasks", () => {
 		const state: ColonyState = {
 			id: "c-1",
@@ -136,5 +214,55 @@ describe("buildReport", () => {
 		expect(report).toContain("Task A");
 		expect(report).toContain("Task B");
 		expect(report).toContain("some error");
+	});
+
+	it("builds plain report when OH_PI_PLAIN_ICONS is set", () => {
+		process.env.OH_PI_PLAIN_ICONS = "1";
+		const state: ColonyState = {
+			id: "c-2",
+			goal: "Plain test",
+			status: "done",
+			tasks: [
+				{
+					id: "t1",
+					parentId: null,
+					title: "Task A",
+					description: "",
+					caste: "worker",
+					status: "done",
+					priority: 3,
+					files: [],
+					claimedBy: null,
+					result: null,
+					error: null,
+					spawnedTasks: [],
+					createdAt: 0,
+					startedAt: 0,
+					finishedAt: 1000,
+				},
+			],
+			ants: [],
+			pheromones: [],
+			concurrency: { current: 1, min: 1, max: 4, optimal: 1, history: [] },
+			metrics: {
+				tasksTotal: 1,
+				tasksDone: 1,
+				tasksFailed: 0,
+				antsSpawned: 1,
+				totalCost: 0.01,
+				totalTokens: 500,
+				startTime: 0,
+				throughputHistory: [],
+			},
+			maxCost: null,
+			modelOverrides: {},
+			createdAt: 0,
+			finishedAt: 5000,
+		};
+		const report = buildReport(state);
+		expect(report).toContain("[ant]");
+		expect(report).toContain("[ok]");
+		expect(report).not.toContain("🐜");
+		expect(report).not.toContain("✅");
 	});
 });

--- a/packages/cli/src/tui/config-wizard.ts
+++ b/packages/cli/src/tui/config-wizard.ts
@@ -26,7 +26,7 @@ interface WizardState {
 }
 
 function sectionLabel(label: string, done: boolean): string {
-	return done ? `${label} ${chalk.green("✓")}` : `${label} ${chalk.yellow("•")}`;
+	return done ? `${label} ${chalk.green("+")}` : `${label} ${chalk.yellow("•")}`;
 }
 
 function summarizeAppearance(theme: string, keybindings: string): string {

--- a/packages/cli/src/tui/confirm-apply.ts
+++ b/packages/cli/src/tui/confirm-apply.ts
@@ -126,7 +126,7 @@ export async function confirmApply(config: OhPConfig, env: EnvInfo) {
 	// ═══ Result ═══
 	const tree = [
 		`${chalk.gray("~/.pi/agent/")}`,
-		`${chalk.gray("├── ")}auth.json ${chalk.dim("🔒")}`,
+		`${chalk.gray("├── ")}auth.json ${chalk.dim("")}`,
 		`${chalk.gray("├── ")}settings.json`,
 		...(config.keybindings !== "default" ? [`${chalk.gray("├── ")}keybindings.json`] : []),
 		`${chalk.gray("├── ")}AGENTS.md ${chalk.dim(config.agents)}`,

--- a/packages/core/src/icons.test.ts
+++ b/packages/core/src/icons.test.ts
@@ -1,0 +1,70 @@
+import { afterEach, describe, expect, it } from "vitest";
+import { icon, isPlainIcons, setPlainIcons } from "./icons.js";
+
+describe("icons", () => {
+	afterEach(() => {
+		process.env.OH_PI_PLAIN_ICONS = "";
+	});
+
+	describe("isPlainIcons", () => {
+		it("returns false by default", () => {
+			expect(isPlainIcons()).toBe(false);
+		});
+
+		it('returns true when OH_PI_PLAIN_ICONS is "1"', () => {
+			process.env.OH_PI_PLAIN_ICONS = "1";
+			expect(isPlainIcons()).toBe(true);
+		});
+
+		it('returns true when OH_PI_PLAIN_ICONS is "true"', () => {
+			process.env.OH_PI_PLAIN_ICONS = "true";
+			expect(isPlainIcons()).toBe(true);
+		});
+
+		it("returns false for other values", () => {
+			process.env.OH_PI_PLAIN_ICONS = "0";
+			expect(isPlainIcons()).toBe(false);
+		});
+	});
+
+	describe("setPlainIcons", () => {
+		it("enables plain mode", () => {
+			setPlainIcons(true);
+			expect(process.env.OH_PI_PLAIN_ICONS).toBe("1");
+			expect(isPlainIcons()).toBe(true);
+		});
+
+		it("disables plain mode", () => {
+			process.env.OH_PI_PLAIN_ICONS = "1";
+			setPlainIcons(false);
+			expect(isPlainIcons()).toBe(false);
+		});
+	});
+
+	describe("icon", () => {
+		it("returns emoji by default", () => {
+			expect(icon("check")).toBe("✓");
+			expect(icon("cross")).toBe("✗");
+			expect(icon("ant")).toBe("🐜");
+			expect(icon("rocket")).toBe("🚀");
+			expect(icon("warning")).toBe("⚠️");
+		});
+
+		it("returns plain text when plain mode is enabled", () => {
+			process.env.OH_PI_PLAIN_ICONS = "1";
+			expect(icon("check")).toBe("[ok]");
+			expect(icon("cross")).toBe("[x]");
+			expect(icon("ant")).toBe("[ant]");
+			expect(icon("rocket")).toBe("[>>]");
+			expect(icon("warning")).toBe("[!]");
+		});
+
+		it("responds dynamically to env var changes", () => {
+			expect(icon("shield")).toBe("🛡️");
+			process.env.OH_PI_PLAIN_ICONS = "1";
+			expect(icon("shield")).toBe("[!]");
+			process.env.OH_PI_PLAIN_ICONS = "";
+			expect(icon("shield")).toBe("🛡️");
+		});
+	});
+});

--- a/packages/core/src/icons.ts
+++ b/packages/core/src/icons.ts
@@ -1,0 +1,179 @@
+/**
+ * Centralized icon registry with emoji and plain-text (ASCII) variants.
+ *
+ * When plain icon mode is enabled (via `OH_PI_PLAIN_ICONS=1` environment
+ * variable or `plainIcons: true` in settings.json), all icon lookups return
+ * ASCII-safe equivalents that render correctly in any terminal regardless
+ * of font or Unicode support.
+ *
+ * @see https://github.com/ifiokjr/oh-pi/issues/24
+ */
+
+/** The two icon rendering modes. */
+export type IconMode = "emoji" | "plain";
+
+/** Check whether plain icon mode is active. */
+export function isPlainIcons(): boolean {
+	return process.env.OH_PI_PLAIN_ICONS === "1" || process.env.OH_PI_PLAIN_ICONS === "true";
+}
+
+/** Set plain icon mode via environment variable. */
+export function setPlainIcons(enabled: boolean): void {
+	if (enabled) {
+		process.env.OH_PI_PLAIN_ICONS = "1";
+	} else {
+		process.env.OH_PI_PLAIN_ICONS = "";
+	}
+}
+
+/** All known icon names used across oh-pi packages. */
+export type IconName =
+	| "ant"
+	| "bolt"
+	| "budget"
+	| "cancel"
+	| "chart"
+	| "check"
+	| "circle"
+	| "clock"
+	| "colony"
+	| "cost"
+	| "cross"
+	| "custom"
+	| "drone"
+	| "error"
+	| "gear"
+	| "hammer"
+	| "info"
+	| "keyboard"
+	| "list"
+	| "lock"
+	| "map"
+	| "memo"
+	| "package"
+	| "pause"
+	| "pencil"
+	| "plus"
+	| "recycle"
+	| "robot"
+	| "rocket"
+	| "running"
+	| "scaffold"
+	| "scope"
+	| "search"
+	| "shield"
+	| "skip"
+	| "sparkle"
+	| "spec"
+	| "star"
+	| "unchecked"
+	| "update"
+	| "vim"
+	| "emacs"
+	| "warning"
+	| "wrench";
+
+const EMOJI_ICONS: Record<IconName, string> = {
+	ant: "🐜",
+	bolt: "⚡",
+	budget: "💰",
+	cancel: "✖",
+	chart: "📊",
+	check: "✓",
+	circle: "⚫",
+	clock: "⏳",
+	colony: "🐜",
+	cost: "💰",
+	cross: "✗",
+	custom: "🎛️",
+	drone: "⚙️",
+	error: "❌",
+	gear: "⚙️",
+	hammer: "⚒️",
+	info: "ℹ️",
+	keyboard: "⌨️",
+	list: "📋",
+	lock: "🔒",
+	map: "🗺️",
+	memo: "📝",
+	package: "📦",
+	pause: "⏸",
+	pencil: "📝",
+	plus: "➕",
+	recycle: "♻️",
+	robot: "🤖",
+	rocket: "🚀",
+	running: "🟢",
+	scaffold: "🏗️",
+	scope: "📐",
+	search: "🔍",
+	shield: "🛡️",
+	skip: "⏭",
+	sparkle: "✨",
+	spec: "📐",
+	star: "⭐",
+	unchecked: "⬜",
+	update: "🔄",
+	vim: "🟢",
+	emacs: "🔵",
+	warning: "⚠️",
+	wrench: "🔧",
+};
+
+const PLAIN_ICONS: Record<IconName, string> = {
+	ant: "[ant]",
+	bolt: "[!]",
+	budget: "[$]",
+	cancel: "[x]",
+	chart: "[~]",
+	check: "[ok]",
+	circle: "[*]",
+	clock: "[..]",
+	colony: "[ant]",
+	cost: "[$]",
+	cross: "[x]",
+	custom: "[=]",
+	drone: "[d]",
+	error: "[ERR]",
+	gear: "[*]",
+	hammer: "[w]",
+	info: "[i]",
+	keyboard: "[kb]",
+	list: "[#]",
+	lock: "[!]",
+	map: "[m]",
+	memo: "[>]",
+	package: "[+]",
+	pause: "[||]",
+	pencil: "[>]",
+	plus: "[+]",
+	recycle: "[~]",
+	robot: "[ai]",
+	rocket: "[>>]",
+	running: "[ok]",
+	scaffold: "[^]",
+	scope: "[:]",
+	search: "[?]",
+	shield: "[!]",
+	skip: "[>>]",
+	sparkle: "[*]",
+	spec: "[:]",
+	star: "[*]",
+	unchecked: "[ ]",
+	update: "[~]",
+	vim: "[v]",
+	emacs: "[e]",
+	warning: "[!]",
+	wrench: "[#]",
+};
+
+/**
+ * Look up an icon by name, returning either an emoji or plain-text variant
+ * depending on the `OH_PI_PLAIN_ICONS` environment variable.
+ *
+ * @param name - The icon name (e.g. `"check"`, `"rocket"`, `"ant"`)
+ * @returns The icon string for the current mode
+ */
+export function icon(name: IconName): string {
+	return isPlainIcons() ? PLAIN_ICONS[name] : EMOJI_ICONS[name];
+}

--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -1,4 +1,6 @@
 export { getLocale, selectLanguage, setLocale, t } from "./i18n.js";
+export type { IconMode, IconName } from "./icons.js";
+export { icon, isPlainIcons, setPlainIcons } from "./icons.js";
 export { EXTENSIONS, KEYBINDING_SCHEMES, MODEL_CAPABILITIES, PROVIDERS, THEMES } from "./registry.js";
 export type {
 	DiscoveredModel,

--- a/packages/core/src/registry.ts
+++ b/packages/core/src/registry.ts
@@ -1,3 +1,4 @@
+import { icon } from "./icons.js";
 import type { ModelCapabilities } from "./types.js";
 
 /** Model capability lookup table — maps model IDs to their context window, output limits, and features. */
@@ -58,41 +59,83 @@ export const THEMES = [
 	{ name: "light", label: "Pi Default Light", style: "light" },
 ];
 
-/** Available extensions — each has a name, label, and whether it's enabled by default. */
+/** Available extensions — each has a name, label function, and whether it's enabled by default. */
 export const EXTENSIONS = [
-	{ name: "safe-guard", label: "🛡️  Safe Guard — Dangerous command confirm + path protection", default: false },
-	{ name: "git-guard", label: "📦 Git Guard — Auto stash checkpoint + dirty repo warning + notify", default: true },
-	{ name: "auto-session-name", label: "📝 Auto Session Name — Name sessions from first message", default: true },
 	{
-		name: "custom-footer",
-		label: "📊 Custom Footer — Enhanced status bar with tokens, cost, time, git, cwd",
+		name: "safe-guard",
+		get label() {
+			return `${icon("shield")}  Safe Guard — Dangerous command confirm + path protection`;
+		},
+		default: false,
+	},
+	{
+		name: "git-guard",
+		get label() {
+			return `${icon("package")} Git Guard — Auto stash checkpoint + dirty repo warning + notify`;
+		},
 		default: true,
 	},
-	{ name: "compact-header", label: "⚡ Compact Header — Dense startup info replacing verbose output", default: true },
+	{
+		name: "auto-session-name",
+		get label() {
+			return `${icon("memo")} Auto Session Name — Name sessions from first message`;
+		},
+		default: true,
+	},
+	{
+		name: "custom-footer",
+		get label() {
+			return `${icon("chart")} Custom Footer — Enhanced status bar with tokens, cost, time, git, cwd`;
+		},
+		default: true,
+	},
+	{
+		name: "compact-header",
+		get label() {
+			return `${icon("bolt")} Compact Header — Dense startup info replacing verbose output`;
+		},
+		default: true,
+	},
 	{
 		name: "ant-colony",
-		label: "🐜 Ant Colony — Autonomous multi-agent swarm with adaptive concurrency",
+		get label() {
+			return `${icon("ant")} Ant Colony — Autonomous multi-agent swarm with adaptive concurrency`;
+		},
 		default: false,
 	},
 	{
 		name: "plan",
-		label: "🗺️ Plan Mode — Branch-aware planning and delegated research via /plan",
+		get label() {
+			return `${icon("map")} Plan Mode — Branch-aware planning and delegated research via /plan`;
+		},
 		default: false,
 	},
 	{
 		name: "spec",
-		label: "📐 Spec Workflow — Native spec-driven planning and implementation via /spec",
+		get label() {
+			return `${icon("spec")} Spec Workflow — Native spec-driven planning and implementation via /spec`;
+		},
 		default: false,
 	},
-	{ name: "auto-update", label: "🔄 Auto Update — Check for oh-pi updates on startup and notify", default: true },
+	{
+		name: "auto-update",
+		get label() {
+			return `${icon("update")} Auto Update — Check for oh-pi updates on startup and notify`;
+		},
+		default: true,
+	},
 	{
 		name: "bg-process",
-		label: "⏳ Bg Process — Auto-background long-running commands (dev servers, etc.)",
+		get label() {
+			return `${icon("clock")} Bg Process — Auto-background long-running commands (dev servers, etc.)`;
+		},
 		default: false,
 	},
 	{
 		name: "usage-tracker",
-		label: "💰 Usage Tracker — Real-time per-model token & cost monitoring with /usage command",
+		get label() {
+			return `${icon("cost")} Usage Tracker — Real-time per-model token & cost monitoring with /usage command`;
+		},
 		default: false,
 	},
 ];

--- a/packages/extensions/extensions/bg-process.ts
+++ b/packages/extensions/extensions/bg-process.ts
@@ -143,7 +143,7 @@ export default function (pi: ExtensionAPI) {
 					});
 
 					const preview = (stdout + stderr).slice(0, 500);
-					const text = `Command still running after ${effectiveTimeout / 1000}s, moved to background.\nPID: ${childPid}\nLog: ${logFile}\nStop: kill ${childPid}\n\nOutput so far:\n${preview}\n\n⏳ You will be notified automatically when it finishes. No need to poll.`;
+					const text = `Command still running after ${effectiveTimeout / 1000}s, moved to background.\nPID: ${childPid}\nLog: ${logFile}\nStop: kill ${childPid}\n\nOutput so far:\n${preview}\n\nYou will be notified automatically when it finishes. No need to poll.`;
 
 					resolve({ content: [{ type: "text", text }], details: {} });
 				}, effectiveTimeout);
@@ -216,7 +216,7 @@ export default function (pi: ExtensionAPI) {
 					const status = p.finished
 						? `⚪ stopped (exit ${p.exitCode ?? "?"})`
 						: isAlive(p.pid)
-							? "🟢 running"
+							? "running"
 							: "⚪ stopped";
 					return `PID: ${p.pid} | ${status} | Log: ${p.logFile}\n  Cmd: ${p.command}`;
 				});

--- a/packages/extensions/extensions/btw.ts
+++ b/packages/extensions/extensions/btw.ts
@@ -319,7 +319,7 @@ function renderSlotLines(slot: BtwSlot, parts: string[], helpers: WidgetThemeHel
 			parts[parts.length - 1] += warning(" ▍");
 		}
 	} else if (!slot.done) {
-		parts.push(`${dim("│ ")}${warning("⏳ thinking...")}`);
+		parts.push(`${dim("│ ")}${warning("thinking...")}`);
 	}
 
 	parts.push(`${dim("│ ")}${dim(`model: ${slot.modelLabel}`)}`);
@@ -576,7 +576,7 @@ export default function (pi: ExtensionAPI) {
 				return;
 			}
 
-			slot.answer = `❌ ${error instanceof Error ? error.message : String(error)}`;
+			slot.answer = `[ERR] ${error instanceof Error ? error.message : String(error)}`;
 			slot.done = true;
 			renderWidget(ctx);
 			notify(ctx, error instanceof Error ? error.message : String(error), "error");
@@ -725,7 +725,7 @@ export default function (pi: ExtensionAPI) {
 			return;
 		}
 
-		widgetStatus = "⏳ summarizing...";
+		widgetStatus = "summarizing...";
 		renderWidget(ctx);
 
 		try {

--- a/packages/extensions/extensions/compact-header.ts
+++ b/packages/extensions/extensions/compact-header.ts
@@ -1,11 +1,50 @@
 /**
  * oh-pi Compact Header — table-style startup info with dynamic column widths
+ *
+ * Also bootstraps the plain-icons setting: reads `plainIcons` from
+ * settings.json and/or the `--plain-icons` CLI flag, and bridges it
+ * to the `OH_PI_PLAIN_ICONS` env var so all oh-pi packages pick it up.
  */
+import { readFileSync } from "node:fs";
+import { join } from "node:path";
 import type { ExtensionAPI } from "@mariozechner/pi-coding-agent";
-import { VERSION } from "@mariozechner/pi-coding-agent";
+import { getAgentDir, VERSION } from "@mariozechner/pi-coding-agent";
 import { truncateToWidth, visibleWidth } from "@mariozechner/pi-tui";
 
+/** Read `plainIcons` from settings.json (global or project-local). */
+function loadPlainIconsSetting(): boolean {
+	for (const dir of [join(process.cwd(), ".pi"), getAgentDir()]) {
+		try {
+			const raw = readFileSync(join(dir, "settings.json"), "utf8");
+			const settings = JSON.parse(raw);
+			if (settings.plainIcons === true) {
+				return true;
+			}
+		} catch {
+			/* file missing or unparseable — skip */
+		}
+	}
+	return false;
+}
+
 export default function (pi: ExtensionAPI) {
+	// Register --plain-icons CLI flag
+	pi.registerFlag("plain-icons", {
+		description: "Use ASCII-safe icons instead of emoji (same as OH_PI_PLAIN_ICONS=1 or plainIcons in settings.json)",
+		type: "boolean",
+		default: false,
+	});
+
+	// Bridge settings.json and --plain-icons flag to the env var
+	// (env var takes precedence, then flag, then settings.json)
+	if (!process.env.OH_PI_PLAIN_ICONS) {
+		const fromFlag = pi.getFlag("plain-icons");
+		if (fromFlag === true) {
+			process.env.OH_PI_PLAIN_ICONS = "1";
+		} else if (loadPlainIconsSetting()) {
+			process.env.OH_PI_PLAIN_ICONS = "1";
+		}
+	}
 	pi.on("session_start", async (_event, ctx) => {
 		if (!ctx.hasUI) {
 			return;

--- a/packages/extensions/extensions/git-guard.ts
+++ b/packages/extensions/extensions/git-guard.ts
@@ -37,7 +37,7 @@ export default function (pi: ExtensionAPI) {
 			const { stdout } = await pi.exec("git", ["status", "--porcelain"]);
 			if (stdout.trim() && ctx.hasUI) {
 				const lines = stdout.trim().split("\n").length;
-				ctx.ui.notify(`⚠️ Dirty repo: ${lines} uncommitted change(s)`, "warning");
+				ctx.ui.notify(`Dirty repo: ${lines} uncommitted change(s)`, "warning");
 			}
 		} catch {
 			// Not a git repo — nothing to warn about

--- a/packages/extensions/extensions/safe-guard.ts
+++ b/packages/extensions/extensions/safe-guard.ts
@@ -35,7 +35,7 @@ export default function (pi: ExtensionAPI) {
 			const cmd = (event.input as { command?: string }).command ?? "";
 			const match = DANGEROUS_PATTERNS.find((p) => p.test(cmd));
 			if (match && ctx.hasUI) {
-				const ok = await ctx.ui.confirm("⚠️ Dangerous Command", `Execute: ${cmd}?`);
+				const ok = await ctx.ui.confirm("Dangerous Command", `Execute: ${cmd}?`);
 				if (!ok) {
 					return { block: true, reason: "Blocked by user" };
 				}
@@ -48,7 +48,7 @@ export default function (pi: ExtensionAPI) {
 			const hit = PROTECTED_PATHS.find((p) => filePath.includes(p));
 			if (hit) {
 				if (ctx.hasUI) {
-					const ok = await ctx.ui.confirm("🛡️ Protected Path", `Allow write to ${filePath}?`);
+					const ok = await ctx.ui.confirm("Protected Path", `Allow write to ${filePath}?`);
 					if (!ok) {
 						return { block: true, reason: `Protected path: ${hit}` };
 					}

--- a/packages/extensions/extensions/scheduler.test.ts
+++ b/packages/extensions/extensions/scheduler.test.ts
@@ -1092,7 +1092,7 @@ describe("SchedulerRuntime", () => {
 			runtime.setRuntimeContext(ctx as any);
 			runtime.addRecurringIntervalTask("check", 5 * ONE_MINUTE);
 			runtime.updateStatus();
-			expect(ctx._statusMap.get("pi-scheduler")).toContain("⏰ 1 active");
+			expect(ctx._statusMap.get("pi-scheduler")).toContain("1 active");
 		});
 
 		it("shows paused message when all tasks disabled", () => {
@@ -1101,7 +1101,7 @@ describe("SchedulerRuntime", () => {
 			const task = runtime.addRecurringIntervalTask("check", 5 * ONE_MINUTE);
 			runtime.setTaskEnabled(task.id, false);
 			runtime.updateStatus();
-			expect(ctx._statusMap.get("pi-scheduler")).toContain("⏸");
+			expect(ctx._statusMap.get("pi-scheduler")).toContain("paused");
 		});
 
 		it("does not update without UI", () => {

--- a/packages/extensions/extensions/scheduler.ts
+++ b/packages/extensions/extensions/scheduler.ts
@@ -682,16 +682,13 @@ export class SchedulerRuntime {
 
 		const enabled = Array.from(this.tasks.values()).filter((t) => t.enabled);
 		if (enabled.length === 0) {
-			this.runtimeCtx.ui.setStatus(
-				"pi-scheduler",
-				`⏸ ${this.tasks.size} task${this.tasks.size === 1 ? "" : "s"} paused`,
-			);
+			this.runtimeCtx.ui.setStatus("pi-scheduler", `${this.tasks.size} task${this.tasks.size === 1 ? "" : "s"} paused`);
 			return;
 		}
 
 		const nextRunAt = Math.min(...enabled.map((t) => t.nextRunAt));
 		const next = new Date(nextRunAt).toLocaleTimeString([], { hour: "2-digit", minute: "2-digit" });
-		const text = `⏰ ${enabled.length} active • next ${next}`;
+		const text = `${enabled.length} active • next ${next}`;
 		this.runtimeCtx.ui.setStatus("pi-scheduler", text);
 	}
 
@@ -799,10 +796,10 @@ export class SchedulerRuntime {
 			}
 
 			const options = list.map((task) => this.taskOptionLabel(task));
-			options.push("➕ Close");
+			options.push("+ Close");
 
 			const selected = await ctx.ui.select("Scheduled tasks (select one)", options);
-			if (!selected || selected === "➕ Close") {
+			if (!selected || selected === "+ Close") {
 				return;
 			}
 
@@ -832,8 +829,8 @@ export class SchedulerRuntime {
 			const title = `${task.id} • ${this.taskMode(task)} • next ${this.formatRelativeTime(task.nextRunAt)} (${this.formatClock(task.nextRunAt)})`;
 			const options = [
 				task.kind === "recurring" ? "⏱ Change schedule" : "⏱ Change reminder delay",
-				task.enabled ? "⏸ Disable" : "▶ Enable",
-				"▶ Run now",
+				task.enabled ? "Disable" : "Enable",
+				"Run now",
 				"🗑 Delete",
 				"↩ Back",
 				"✕ Close",
@@ -847,8 +844,8 @@ export class SchedulerRuntime {
 				return true;
 			}
 
-			if (action === "⏸ Disable" || action === "▶ Enable") {
-				const enabled = action === "▶ Enable";
+			if (action === "Disable" || action === "Enable") {
+				const enabled = action === "Enable";
 				this.setTaskEnabled(task.id, enabled);
 				ctx.ui.notify(`${enabled ? "Enabled" : "Disabled"} scheduled task ${task.id}.`, "info");
 				continue;
@@ -866,7 +863,7 @@ export class SchedulerRuntime {
 				return false;
 			}
 
-			if (action === "▶ Run now") {
+			if (action === "Run now") {
 				task.nextRunAt = Date.now();
 				task.pending = true;
 				this.persistTasks();
@@ -1054,7 +1051,7 @@ export class SchedulerRuntime {
 	}
 
 	private taskOptionLabel(task: ScheduleTask): string {
-		const state = task.enabled ? "✓" : "⏸";
+		const state = task.enabled ? "+" : "-";
 		return `${task.id} • ${state} ${this.taskMode(task)} • ${this.formatRelativeTime(task.nextRunAt)} • ${this.truncateText(task.prompt, 50)}`;
 	}
 

--- a/packages/extensions/extensions/usage-tracker.test.ts
+++ b/packages/extensions/extensions/usage-tracker.test.ts
@@ -902,7 +902,7 @@ describe("usage-tracker extension", () => {
 			expect(widgetFactory).toBeDefined();
 			const component = widgetFactory?.({ requestRender: vi.fn() }, { fg: (_color: string, text: string) => text });
 			const rendered = component?.render(200).join("\n") ?? "";
-			expect(rendered).toContain("💰");
+			expect(rendered).toContain("$");
 			expect(rendered).toContain("30d:");
 		});
 

--- a/packages/extensions/extensions/usage-tracker.ts
+++ b/packages/extensions/extensions/usage-tracker.ts
@@ -1505,7 +1505,7 @@ export default function usageTracker(pi: ExtensionAPI) {
 		for (let i = COST_THRESHOLDS.length - 1; i >= 0; i--) {
 			if (cost >= COST_THRESHOLDS[i] && i > lastThresholdIndex) {
 				lastThresholdIndex = i;
-				ctx.ui.notify(`💰 Session cost reached ${fmtCost(COST_THRESHOLDS[i])} (now ${fmtCost(cost)})`, "warning");
+				ctx.ui.notify(`Session cost reached ${fmtCost(COST_THRESHOLDS[i])} (now ${fmtCost(cost)})`, "warning");
 				return;
 			}
 		}
@@ -1784,7 +1784,7 @@ export default function usageTracker(pi: ExtensionAPI) {
 			const windows = [...rl.windows].sort((a, b) => a.percentLeft - b.percentLeft);
 			lines.push(`  ${theme.fg("accent", `▸ ${name} Rate Limits`)}`);
 			if (rl.error) {
-				lines.push(`    ${theme.fg("error", "⚠ Error:")} ${theme.fg("dim", rl.error)}`);
+				lines.push(`    ${theme.fg("error", "Error:")} ${theme.fg("dim", rl.error)}`);
 			}
 
 			for (const w of windows) {
@@ -2076,7 +2076,7 @@ export default function usageTracker(pi: ExtensionAPI) {
 
 		// Session + rolling 30d cost (only if we have data)
 		if (totals.turns > 0) {
-			parts.push(theme.fg("warning", `💰${fmtCost(totals.cost)}`));
+			parts.push(theme.fg("warning", `$${fmtCost(totals.cost)}`));
 			parts.push(theme.fg("dim", `30d: ${fmtCost(totals.rolling30dCost)}`));
 			parts.push(`${theme.fg("success", fmtTokens(totals.input))}/${theme.fg("warning", fmtTokens(totals.output))}`);
 		}
@@ -2084,7 +2084,7 @@ export default function usageTracker(pi: ExtensionAPI) {
 		const externalSources = getExternalSources();
 		if (externalSources.length > 0) {
 			const externalCost = externalSources.reduce((sum, source) => sum + source.costTotal, 0);
-			parts.push(theme.fg("warning", `🐜${fmtCost(externalCost)}`));
+			parts.push(theme.fg("warning", `$${fmtCost(externalCost)}`));
 		}
 
 		if (parts.length === 0) {

--- a/packages/plan/task-agents.ts
+++ b/packages/plan/task-agents.ts
@@ -449,11 +449,11 @@ function isTaskAgentRunDetails(details: unknown): details is TaskAgentRunDetails
 function statusIcon(status: TaskAgentTaskProgress["status"]): string {
 	switch (status) {
 		case "completed":
-			return "✓";
+			return "+";
 		case "failed":
-			return "✗";
+			return "x";
 		case "running":
-			return "⏳";
+			return "..";
 		default:
 			return "○";
 	}
@@ -529,7 +529,7 @@ export function registerTaskAgentTools(
 			];
 			const visibleTasks = expanded ? details.tasks : details.tasks.slice(0, TASK_AGENT_PREVIEW_LIMIT);
 			for (const task of visibleTasks) {
-				const icon = task.exitCode === 0 ? theme.fg("success", "✓") : theme.fg("error", "✗");
+				const icon = task.exitCode === 0 ? theme.fg("success", "+") : theme.fg("error", "x");
 				if (!expanded) {
 					lines.push(`${icon} ${theme.fg("accent", task.taskId)} ${theme.fg("muted", summarizeSnippet(task.task, 80))}`);
 					continue;

--- a/packages/spec/extension/status.ts
+++ b/packages/spec/extension/status.ts
@@ -178,7 +178,7 @@ export function formatWorkflowStatus(status: WorkflowStatus): string {
 	];
 
 	for (const artifact of status.artifacts) {
-		lines.push(`- ${artifact.exists ? "✅" : "⬜"} ${artifact.label} — ${artifact.path}`);
+		lines.push(`- ${artifact.exists ? "[x]" : "[ ]"} ${artifact.label} — ${artifact.path}`);
 	}
 
 	lines.push("", "## Checklist status");
@@ -187,7 +187,7 @@ export function formatWorkflowStatus(status: WorkflowStatus): string {
 	} else {
 		for (const checklist of status.checklists) {
 			lines.push(
-				`- ${checklist.status === "pass" ? "✅" : "⚠️"} ${checklist.name}: ${checklist.completed}/${checklist.total} complete (${checklist.incomplete} incomplete)`,
+				`- ${checklist.status === "pass" ? "[ok]" : "[!]"} ${checklist.name}: ${checklist.completed}/${checklist.total} complete (${checklist.incomplete} incomplete)`,
 			);
 		}
 	}

--- a/packages/subagents/agent-manager-detail.ts
+++ b/packages/subagents/agent-manager-detail.ts
@@ -91,7 +91,7 @@ function buildDetailLines(
 
 	for (const run of recentRuns) {
 		const when = pad(formatRelativeTime(run.ts), 8);
-		const status = run.status === "ok" ? "✓" : "✗";
+		const status = run.status === "ok" ? "+" : "x";
 		const task = truncateToWidth(`"${run.task}"`, 34);
 		const tail = run.status === "ok" ? formatDuration(run.duration) : `exit ${run.exit ?? 1}`;
 		lines.push(truncateToWidth(`  ${when} ${status} ${task} ${tail}`, contentWidth));

--- a/packages/subagents/agent-manager-list.ts
+++ b/packages/subagents/agent-manager-list.ts
@@ -201,7 +201,7 @@ export function renderList(
 
 			const cursorChar = isCursor ? theme.fg("accent", "▸") : " ";
 			const selectBadge =
-				count > 1 ? theme.fg("accent", `×${count}`.padStart(2)) : count === 1 ? theme.fg("accent", " ✓") : "  ";
+				count > 1 ? theme.fg("accent", `×${count}`.padStart(2)) : count === 1 ? theme.fg("accent", " +") : "  ";
 			const shadowMarker = isShadowed ? theme.fg("warning", "●") : " ";
 			const prefix = `${cursorChar}${selectBadge}${shadowMarker} `;
 

--- a/packages/subagents/chain-clarify.ts
+++ b/packages/subagents/chain-clarify.ts
@@ -1047,7 +1047,7 @@ export class ChainClarifyComponent implements Component {
 				const prefix = isSelected ? th.fg("accent", "→ ") : "  ";
 				const modelText = isSelected ? th.fg("accent", model.id) : model.id;
 				const providerBadge = th.fg("dim", ` [${model.provider}]`);
-				const currentBadge = isCurrent ? th.fg("success", " ✓") : "";
+				const currentBadge = isCurrent ? th.fg("success", " +") : "";
 
 				lines.push(this.row(` ${prefix}${modelText}${providerBadge}${currentBadge}`));
 			}
@@ -1358,7 +1358,7 @@ export class ChainClarifyComponent implements Component {
 
 		// Chain-wide progress setting
 		const progressEnabled = this.agentConfigs.some((_, i) => this.getEffectiveBehavior(i).progress);
-		const progressValue = progressEnabled ? th.fg("success", "✓ enabled") : th.fg("dim", "✗ disabled");
+		const progressValue = progressEnabled ? th.fg("success", "+ enabled") : th.fg("dim", "- disabled");
 		lines.push(this.row(` Progress: ${progressValue} ${th.fg("dim", "(press [p] to toggle)")}`));
 		lines.push(this.row(""));
 

--- a/packages/subagents/chain-execution.ts
+++ b/packages/subagents/chain-execution.ts
@@ -537,7 +537,7 @@ export async function executeChain(params: ChainExecutionParams): Promise<ChainE
 								? `Agent wrote to different file(s): ${mdFiles.join(", ")} instead of ${behavior.output}`
 								: `Agent did not create expected output file: ${behavior.output}`;
 						// Add warning to result but don't fail
-						r.error = r.error ? `${r.error}\n⚠️ ${warning}` : `⚠️ ${warning}`;
+						r.error = r.error ? `${r.error}\n[!] ${warning}` : `[!] ${warning}`;
 					}
 				} catch {
 					// Ignore validation errors - this is just a diagnostic

--- a/packages/subagents/formatters.ts
+++ b/packages/subagents/formatters.ts
@@ -65,20 +65,20 @@ export function buildChainSummary(
 	for (const r of results) {
 		if (r.skills) r.skills.forEach((s) => allSkills.add(s));
 	}
-	const skillsLine = allSkills.size > 0 ? `🔧 Skills: ${[...allSkills].join(", ")}` : "";
+	const skillsLine = allSkills.size > 0 ? `Skills: ${[...allSkills].join(", ")}` : "";
 
 	if (status === "completed") {
 		const stepWord = results.length === 1 ? "step" : "steps";
-		return `✅ Chain completed: ${stepNames} (${results.length} ${stepWord}, ${durationStr})${skillsLine ? `\n${skillsLine}` : ""}
+		return `Chain completed: ${stepNames} (${results.length} ${stepWord}, ${durationStr})${skillsLine ? `\n${skillsLine}` : ""}
 
-📋 Progress: ${hasProgress ? progressPath : "(none)"}
+Progress: ${hasProgress ? progressPath : "(none)"}
 📁 Artifacts: ${chainDir}`;
 	} else {
 		const stepInfo = failedStep ? ` at step ${failedStep.index + 1}` : "";
 		const errorInfo = failedStep?.error ? `: ${failedStep.error}` : "";
-		return `❌ Chain failed${stepInfo}${errorInfo}${skillsLine ? `\n${skillsLine}` : ""}
+		return `Chain failed${stepInfo}${errorInfo}${skillsLine ? `\n${skillsLine}` : ""}
 
-📋 Progress: ${hasProgress ? progressPath : "(none)"}
+Progress: ${hasProgress ? progressPath : "(none)"}
 📁 Artifacts: ${chainDir}`;
 	}
 }

--- a/packages/subagents/index.ts
+++ b/packages/subagents/index.ts
@@ -717,11 +717,11 @@ MANAGEMENT (use action field — omit agent/task/chain/tasks):
 						const hasOutput = Boolean(output?.trim());
 						const status =
 							r.exitCode !== 0
-								? `⚠️ FAILED (exit code ${r.exitCode})${r.error ? `: ${r.error}` : ""}`
+								? `[!] FAILED (exit code ${r.exitCode})${r.error ? `: ${r.error}` : ""}`
 								: r.error
-									? `⚠️ WARNING: ${r.error}`
+									? `[!] WARNING: ${r.error}`
 									: !hasOutput
-										? "⚠️ EMPTY OUTPUT"
+										? "[!] EMPTY OUTPUT"
 										: "";
 						const body = status ? (hasOutput ? `${status}\n${output}` : status) : output;
 						return `${header}\n${body}`;

--- a/packages/subagents/parallel-utils.ts
+++ b/packages/subagents/parallel-utils.ts
@@ -84,9 +84,9 @@ export function aggregateParallelOutputs(
 				r.exitCode === -1
 					? "⏭️ SKIPPED"
 					: r.exitCode !== 0
-						? `⚠️ FAILED (exit code ${r.exitCode})${r.error ? `: ${r.error}` : ""}`
+						? `[!] FAILED (exit code ${r.exitCode})${r.error ? `: ${r.error}` : ""}`
 						: !hasOutput
-							? "⚠️ EMPTY OUTPUT"
+							? "[!] EMPTY OUTPUT"
 							: "";
 			const body = status ? (hasOutput ? `${status}\n${r.output}` : status) : r.output;
 			return `${header}\n${body}`;

--- a/packages/subagents/render.ts
+++ b/packages/subagents/render.ts
@@ -229,7 +229,7 @@ export function renderSubagentResult(
 			c.addChild(new Text(truncLine(theme.fg("dim", `Skills: ${r.skills.join(", ")}`), w), 0, 0));
 		}
 		if (r.skillsWarning) {
-			c.addChild(new Text(truncLine(theme.fg("warning", `⚠️ ${r.skillsWarning}`), w), 0, 0));
+			c.addChild(new Text(truncLine(theme.fg("warning", `[!] ${r.skillsWarning}`), w), 0, 0));
 		}
 		c.addChild(new Text(truncLine(theme.fg("dim", formatUsage(r.usage, r.model)), w), 0, 0));
 		if (r.sessionFile) {
@@ -259,7 +259,7 @@ export function renderSubagentResult(
 	const icon = hasRunning
 		? theme.fg("warning", "...")
 		: hasEmptyWithoutTarget
-			? theme.fg("warning", "⚠")
+			? theme.fg("warning", "!")
 			: ok === d.results.length
 				? theme.fg("success", "ok")
 				: theme.fg("error", "X");
@@ -310,11 +310,11 @@ export function renderSubagentResult(
 							hasEmptyTextOutputWithoutOutputTarget(result.task, getFinalOutput(result.messages));
 						const isCurrent = i === (d.currentStepIndex ?? d.results.length);
 						const stepIcon = isFailed
-							? theme.fg("error", "✗")
+							? theme.fg("error", "x")
 							: isEmptyWithoutTarget
-								? theme.fg("warning", "⚠")
+								? theme.fg("warning", "!")
 								: isComplete
-									? theme.fg("success", "✓")
+									? theme.fg("success", "+")
 									: isCurrent && hasRunning
 										? theme.fg("warning", "●")
 										: theme.fg("dim", "○");
@@ -365,10 +365,10 @@ export function renderSubagentResult(
 		const statusIcon = rRunning
 			? theme.fg("warning", "●")
 			: r.exitCode !== 0
-				? theme.fg("error", "✗")
+				? theme.fg("error", "x")
 				: hasEmptyTextOutputWithoutOutputTarget(r.task, resultOutput)
-					? theme.fg("warning", "⚠")
-					: theme.fg("success", "✓");
+					? theme.fg("warning", "!")
+					: theme.fg("success", "+");
 		const stats = rProg ? ` | ${rProg.toolCount} tools, ${formatDuration(rProg.durationMs)}` : "";
 		const modelDisplay = r.model ? theme.fg("dim", ` (${r.model})`) : "";
 		const stepHeader = rRunning
@@ -389,7 +389,7 @@ export function renderSubagentResult(
 			c.addChild(new Text(truncLine(theme.fg("dim", `    skills: ${r.skills.join(", ")}`), w), 0, 0));
 		}
 		if (r.skillsWarning) {
-			c.addChild(new Text(truncLine(theme.fg("warning", `    ⚠️ ${r.skillsWarning}`), w), 0, 0));
+			c.addChild(new Text(truncLine(theme.fg("warning", `    [!] ${r.skillsWarning}`), w), 0, 0));
 		}
 
 		if (rRunning && rProg) {

--- a/packages/subagents/settings.ts
+++ b/packages/subagents/settings.ts
@@ -353,13 +353,13 @@ export function aggregateParallelOutputs(results: ParallelTaskResult[]): string 
 				r.exitCode === -1
 					? "⏭️ SKIPPED"
 					: r.exitCode !== 0
-						? `⚠️ FAILED (exit code ${r.exitCode})${r.error ? `: ${r.error}` : ""}`
+						? `[!] FAILED (exit code ${r.exitCode})${r.error ? `: ${r.error}` : ""}`
 						: r.error
-							? `⚠️ WARNING: ${r.error}`
+							? `[!] WARNING: ${r.error}`
 							: !hasTextOutput && r.outputTargetPath && r.outputTargetExists === false
-								? `⚠️ EMPTY OUTPUT (expected output file missing: ${r.outputTargetPath})`
+								? `[!] EMPTY OUTPUT (expected output file missing: ${r.outputTargetPath})`
 								: !hasTextOutput && !r.outputTargetPath
-									? "⚠️ EMPTY OUTPUT (no textual response returned)"
+									? "[!] EMPTY OUTPUT (no textual response returned)"
 									: "";
 			const body = status ? (hasTextOutput ? `${status}\n${r.output}` : status) : r.output;
 			return `${header}\n${body}`;

--- a/packages/subagents/single-output.ts
+++ b/packages/subagents/single-output.ts
@@ -49,7 +49,7 @@ export function finalizeSingleOutput(params: {
 			return { displayOutput, savedPath: save.savedPath };
 		}
 		if (save.error) {
-			displayOutput += `\n\n⚠️ Failed to save output to: ${params.outputPath}\n${save.error}`;
+			displayOutput += `\n\n[!] Failed to save output to: ${params.outputPath}\n${save.error}`;
 			return { displayOutput, saveError: save.error };
 		}
 	}

--- a/packages/subagents/subagent-runner.ts
+++ b/packages/subagents/subagent-runner.ts
@@ -366,8 +366,8 @@ async function runSingleStep(
 				: `📄 Output saved to: ${persisted.savedPath}`;
 		} else if (persisted.error) {
 			outputForSummary = output
-				? `${output}\n\n⚠️ Failed to save output to: ${step.outputPath}\n${persisted.error}`
-				: `⚠️ Failed to save output to: ${step.outputPath}\n${persisted.error}`;
+				? `${output}\n\n[!] Failed to save output to: ${step.outputPath}\n${persisted.error}`
+				: `[!] Failed to save output to: ${step.outputPath}\n${persisted.error}`;
 		}
 	}
 

--- a/packages/subagents/tests/parallel-utils.test.ts
+++ b/packages/subagents/tests/parallel-utils.test.ts
@@ -189,17 +189,17 @@ describe("aggregateParallelOutputs", () => {
 
 	it("marks failed tasks", () => {
 		const result = aggregateParallelOutputs([{ agent: "agent-a", output: "partial output", exitCode: 1 }]);
-		expect(result).toContain("⚠️ FAILED (exit code 1)");
+		expect(result).toContain("[!] FAILED (exit code 1)");
 	});
 
 	it("marks empty output", () => {
 		const result = aggregateParallelOutputs([{ agent: "agent-a", output: "", exitCode: 0 }]);
-		expect(result).toContain("⚠️ EMPTY OUTPUT");
+		expect(result).toContain("[!] EMPTY OUTPUT");
 	});
 
 	it("treats whitespace-only output as empty", () => {
 		const result = aggregateParallelOutputs([{ agent: "agent-a", output: "   \n  ", exitCode: 0 }]);
-		expect(result).toContain("⚠️ EMPTY OUTPUT");
+		expect(result).toContain("[!] EMPTY OUTPUT");
 	});
 
 	it("marks skipped tasks distinctly from failures", () => {


### PR DESCRIPTION
## Summary

Add plain-text ASCII fallbacks for all emoji icons across oh-pi packages. When enabled, emoji like 🐜 ✅ ❌ 🚀 are replaced with ASCII equivalents (`[ant]` `[ok]` `[ERR]` `[>>]`) — for terminals or fonts that don't render Unicode emoji correctly.

Fixes #24

## Three ways to enable

| Method | Usage | Persistent? |
|--------|-------|-------------|
| **Environment variable** | `OH_PI_PLAIN_ICONS=1` | Shell profile |
| **CLI flag** | `pi --plain-icons` | Per session |
| **settings.json** | `{ "plainIcons": true }` | ✅ Global (`~/.pi/agent/settings.json`) or project-local (`.pi/settings.json`) |

Priority: env var → CLI flag → settings.json.

## Changes

- **New `packages/core/src/icons.ts`** — icon registry with 40+ named icons, each with emoji and ASCII variants, controlled by `OH_PI_PLAIN_ICONS` env var
- **`ant-colony/ui.ts`** — dual-mode `EMOJI_STATUS_ICONS` / `PLAIN_STATUS_ICONS` maps; new `antIcon()`, `checkMark()`, `crossMark()`, `boltIcon()` helpers
- **`ant-colony/index.ts`** — all 30+ inline emoji replaced with helper calls
- **`extensions/*`** — removed inline emoji from `bg-process`, `btw`, `git-guard`, `safe-guard`, `scheduler`, `usage-tracker`
- **`compact-header.ts`** — bootstraps plain-icons setting: reads `plainIcons` from settings.json, registers `--plain-icons` CLI flag, bridges to env var
- **`subagents/*`** — replaced emoji in `chain-clarify`, `chain-execution`, `formatters`, `render`, `settings`, etc.
- **`plan/task-agents.ts`** and **`spec/extension/status.ts`** — replaced emoji status markers
- **`core/registry.ts`** — EXTENSIONS labels now use dynamic `icon()` getters
- **`README.md`** — new Configuration → Plain Icons section documenting all three methods
- **Tests** — comprehensive tests for icon mode switching; updated existing tests for new output

## Files changed

34 files, +720 / -138