### PR TITLE
chore: add package readmes for published packages

### DIFF
--- a/.changeset/add-package-readmes.md
+++ b/.changeset/add-package-readmes.md
@@ -1,0 +1,5 @@
+---
+default: patch
+---
+
+add missing package-level READMEs for published packages so npm and pi.dev package pages have package-specific documentation.

--- a/packages/agents/README.md
+++ b/packages/agents/README.md
@@ -1,0 +1,40 @@
+# @ifi/oh-pi-agents
+
+AGENTS.md templates for pi.
+
+This package contains reusable agent profile templates such as:
+- `general-developer`
+- `fullstack-developer`
+- `security-researcher`
+- `data-ai-engineer`
+- `colony-operator`
+
+## What this package is for
+
+`@ifi/oh-pi-agents` is a content package used by the oh-pi configurator and installer. It helps seed
+`AGENTS.md`-style instructions for pi projects and user setups.
+
+## Install
+
+Most users should install the full bundle instead:
+
+```bash
+npx @ifi/oh-pi
+```
+
+This package is typically consumed by `@ifi/oh-pi-cli` and is not usually installed directly.
+
+## Contents
+
+Templates live under:
+
+```text
+agents/
+```
+
+Each file is a markdown template intended to be copied into a pi environment or project workflow.
+
+## Related packages
+
+- `@ifi/oh-pi` — full installer bundle
+- `@ifi/oh-pi-cli` — interactive configurator

--- a/packages/cli/README.md
+++ b/packages/cli/README.md
@@ -1,0 +1,46 @@
+# @ifi/oh-pi-cli
+
+Interactive TUI configurator for `pi-coding-agent`.
+
+## What it does
+
+`@ifi/oh-pi-cli` powers the interactive `oh-pi` setup experience. It helps configure:
+- providers and auth
+- models
+- extensions
+- prompts
+- skills
+- themes
+- agent templates
+- installer presets
+
+## Usage
+
+Run the CLI with:
+
+```bash
+npx @ifi/oh-pi-cli
+```
+
+Most users will want the meta-installer instead:
+
+```bash
+npx @ifi/oh-pi
+```
+
+## Package role
+
+This is a compiled Node.js CLI package. It is part of the oh-pi monorepo and depends on the other
+workspace packages for content and installation targets.
+
+## Development
+
+```bash
+pnpm --filter @ifi/oh-pi-cli build
+pnpm --filter @ifi/oh-pi-cli typecheck
+```
+
+## Related packages
+
+- `@ifi/oh-pi` — one-command installer
+- `@ifi/oh-pi-core` — shared registries and types

--- a/packages/core/README.md
+++ b/packages/core/README.md
@@ -1,0 +1,30 @@
+# @ifi/oh-pi-core
+
+Shared types, registries, icons, and i18n helpers for oh-pi packages.
+
+## What this package is for
+
+`@ifi/oh-pi-core` is an internal library used by other packages in this monorepo. It provides
+common building blocks for the CLI and other compiled packages.
+
+## Typical consumers
+
+- `@ifi/oh-pi-cli`
+- other first-party oh-pi packages that need shared registries or presentation helpers
+
+## Install
+
+This package is primarily intended for internal monorepo use rather than direct end-user
+installation.
+
+## Development
+
+```bash
+pnpm --filter @ifi/oh-pi-core build
+pnpm --filter @ifi/oh-pi-core typecheck
+```
+
+## Exports
+
+The package publishes compiled output from `dist/` and exposes its public API through the package
+root export.

--- a/packages/extensions/README.md
+++ b/packages/extensions/README.md
@@ -1,0 +1,46 @@
+# @ifi/oh-pi-extensions
+
+Core first-party extensions for pi.
+
+## Included extensions
+
+This package includes extensions such as:
+- safe-guard
+- git-guard
+- auto-session-name
+- custom-footer
+- compact-header
+- auto-update
+- bg-process
+- usage-tracker
+- scheduler
+- btw / qq
+
+## Install
+
+```bash
+pi install npm:@ifi/oh-pi-extensions
+```
+
+Or install the full bundle:
+
+```bash
+npx @ifi/oh-pi
+```
+
+## What it provides
+
+These extensions add commands, tools, UI widgets, safety checks, background process handling,
+usage monitoring, and scheduling features to pi.
+
+## Package layout
+
+```text
+extensions/
+```
+
+Pi loads the raw TypeScript extensions from this directory.
+
+## Notes
+
+This package ships raw `.ts` extensions for pi to load directly.

--- a/packages/prompts/README.md
+++ b/packages/prompts/README.md
@@ -1,0 +1,42 @@
+# @ifi/oh-pi-prompts
+
+Prompt templates for pi.
+
+## Included prompts
+
+This package contains reusable prompt templates such as:
+- review
+- fix
+- explain
+- refactor
+- test
+- commit
+- document
+- optimize
+- security
+- pr
+
+## Install
+
+```bash
+pi install npm:@ifi/oh-pi-prompts
+```
+
+Or install the full bundle:
+
+```bash
+npx @ifi/oh-pi
+```
+
+## Package layout
+
+```text
+prompts/
+```
+
+Templates are markdown files intended to be discovered and loaded by pi.
+
+## Use case
+
+Use this package when you want a ready-made library of prompt shortcuts and reusable task framing
+for common development workflows.

--- a/packages/skills/README.md
+++ b/packages/skills/README.md
@@ -1,0 +1,39 @@
+# @ifi/oh-pi-skills
+
+On-demand skill packs for pi.
+
+## What this package includes
+
+This package bundles reusable skills for common workflows, including areas like:
+- web search and fetch
+- debugging
+- git workflow help
+- architecture review
+- frontend design
+- skill authoring
+- planning and refactor support
+
+## Install
+
+```bash
+pi install npm:@ifi/oh-pi-skills
+```
+
+Or install the full bundle:
+
+```bash
+npx @ifi/oh-pi
+```
+
+## Package layout
+
+```text
+skills/
+```
+
+Each skill lives in its own directory and is designed to be discovered and loaded by pi on demand.
+
+## Use case
+
+Install this package when you want first-party reusable workflow guidance available directly inside
+pi conversations.

--- a/packages/themes/README.md
+++ b/packages/themes/README.md
@@ -1,0 +1,38 @@
+# @ifi/oh-pi-themes
+
+Color themes for pi.
+
+## Included themes
+
+This package contains first-party themes such as:
+- Catppuccin Mocha
+- Cyberpunk
+- Gruvbox Dark
+- Nord
+- Oh P Dark
+- Tokyo Night
+
+## Install
+
+```bash
+pi install npm:@ifi/oh-pi-themes
+```
+
+Or install the full bundle:
+
+```bash
+npx @ifi/oh-pi
+```
+
+## Package layout
+
+```text
+themes/
+```
+
+Themes are shipped as JSON files for pi to discover and load.
+
+## Use case
+
+Use this package to add a curated theme pack to your pi setup without installing the full oh-pi
+bundle.

--- a/packages/web-client/README.md
+++ b/packages/web-client/README.md
@@ -1,0 +1,31 @@
+# @ifi/pi-web-client
+
+Platform-agnostic TypeScript client for remote pi sessions.
+
+## What it does
+
+`@ifi/pi-web-client` is a lightweight client library for connecting to pi remote session servers.
+It is designed to work in:
+- browsers
+- Node.js
+- React Native
+- other TypeScript runtimes with WebSocket support
+
+## Install
+
+```bash
+pnpm add @ifi/pi-web-client
+```
+
+## Use case
+
+Use this package when you want to build your own web or mobile UI for a remote pi instance.
+
+## API surface
+
+The package exposes a small client-facing API from its compiled `dist/` output.
+
+## Related packages
+
+- `@ifi/pi-web-server` — embeddable remote server
+- `@ifi/pi-web-remote` — pi extension that starts remote sharing from inside pi

--- a/packages/web-remote/README.md
+++ b/packages/web-remote/README.md
@@ -1,0 +1,35 @@
+# @ifi/pi-web-remote
+
+Pi extension that adds the `/remote` command for sharing sessions via a web UI.
+
+## What it does
+
+This package registers a `/remote` command that can:
+- start remote access for the current pi session
+- expose a connection URL or tunnel-backed URL
+- show connection status
+- stop remote sharing
+
+## Install
+
+```bash
+pi install npm:@ifi/pi-web-remote
+```
+
+## Usage
+
+Inside pi:
+
+```text
+/remote
+/remote stop
+```
+
+## Related packages
+
+- `@ifi/pi-web-server` — the server implementation used by this extension
+- `@ifi/pi-web-client` — client library for custom remote UIs
+
+## Notes
+
+This package ships raw TypeScript for pi to load directly as an extension.

--- a/packages/web-server/README.md
+++ b/packages/web-server/README.md
@@ -1,0 +1,30 @@
+# @ifi/pi-web-server
+
+Embeddable HTTP + WebSocket server for remote pi session management.
+
+## What it does
+
+`@ifi/pi-web-server` provides the server-side building blocks for exposing a pi session over HTTP
+and WebSocket transports.
+
+It includes support for:
+- token-based access
+- LAN/tunnel-aware connection flows
+- remote session transport primitives
+- embedding in first-party or custom tooling
+
+## Install
+
+```bash
+pnpm add @ifi/pi-web-server
+```
+
+## Use case
+
+Use this package if you want to embed remote pi access into your own app or service, or if you are
+building on top of the oh-pi remote workflow.
+
+## Related packages
+
+- `@ifi/pi-web-client` — remote client library
+- `@ifi/pi-web-remote` — pi extension that exposes the feature as `/remote`


### PR DESCRIPTION
Closes #30

## Summary
- add missing package-level READMEs for published packages that declared them in package manifests
- tailor each README to the package role (library, extension, content package, or CLI)
- add a changeset for the package quality improvement

## Testing
- pnpm lint
- verify package READMEs exist for all targeted packages
- verify README.md appears in pnpm pack --dry-run output for each targeted package
