### PR TITLE
chore: add package repository metadata

### DIFF
--- a/.changeset/add-package-repository-metadata.md
+++ b/.changeset/add-package-repository-metadata.md
@@ -1,0 +1,5 @@
+---
+default: patch
+---
+
+add repository, homepage, and bugs metadata to published package manifests so npm package pages link back to the correct monorepo locations.

--- a/packages/agents/package.json
+++ b/packages/agents/package.json
@@ -14,5 +14,14 @@
     "agents-md",
     "agent-templates",
     "prompts"
-  ]
+  ],
+  "repository": {
+    "type": "git",
+    "url": "git+https://github.com/ifiokjr/oh-pi.git",
+    "directory": "packages/agents"
+  },
+  "homepage": "https://github.com/ifiokjr/oh-pi/tree/main/packages/agents",
+  "bugs": {
+    "url": "https://github.com/ifiokjr/oh-pi/issues"
+  }
 }

--- a/packages/ant-colony/package.json
+++ b/packages/ant-colony/package.json
@@ -28,5 +28,14 @@
     "@mariozechner/pi-coding-agent": "*",
     "@mariozechner/pi-tui": "*",
     "@sinclair/typebox": "*"
+  },
+  "repository": {
+    "type": "git",
+    "url": "git+https://github.com/ifiokjr/oh-pi.git",
+    "directory": "packages/ant-colony"
+  },
+  "homepage": "https://github.com/ifiokjr/oh-pi/tree/main/packages/ant-colony",
+  "bugs": {
+    "url": "https://github.com/ifiokjr/oh-pi/issues"
   }
 }

--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -46,5 +46,14 @@
     "tui",
     "configuration",
     "installer"
-  ]
+  ],
+  "repository": {
+    "type": "git",
+    "url": "git+https://github.com/ifiokjr/oh-pi.git",
+    "directory": "packages/cli"
+  },
+  "homepage": "https://github.com/ifiokjr/oh-pi/tree/main/packages/cli",
+  "bugs": {
+    "url": "https://github.com/ifiokjr/oh-pi/issues"
+  }
 }

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -37,5 +37,14 @@
     "types",
     "registry",
     "i18n"
-  ]
+  ],
+  "repository": {
+    "type": "git",
+    "url": "git+https://github.com/ifiokjr/oh-pi.git",
+    "directory": "packages/core"
+  },
+  "homepage": "https://github.com/ifiokjr/oh-pi/tree/main/packages/core",
+  "bugs": {
+    "url": "https://github.com/ifiokjr/oh-pi/issues"
+  }
 }

--- a/packages/extensions/package.json
+++ b/packages/extensions/package.json
@@ -25,5 +25,14 @@
     "@mariozechner/pi-coding-agent": "*",
     "@mariozechner/pi-tui": "*",
     "@sinclair/typebox": "*"
+  },
+  "repository": {
+    "type": "git",
+    "url": "git+https://github.com/ifiokjr/oh-pi.git",
+    "directory": "packages/extensions"
+  },
+  "homepage": "https://github.com/ifiokjr/oh-pi/tree/main/packages/extensions",
+  "bugs": {
+    "url": "https://github.com/ifiokjr/oh-pi/issues"
   }
 }

--- a/packages/oh-pi/package.json
+++ b/packages/oh-pi/package.json
@@ -27,5 +27,14 @@
     "@ifi/oh-pi-prompts": "workspace:*",
     "@ifi/oh-pi-skills": "workspace:*",
     "@ifi/oh-pi-agents": "workspace:*"
+  },
+  "repository": {
+    "type": "git",
+    "url": "git+https://github.com/ifiokjr/oh-pi.git",
+    "directory": "packages/oh-pi"
+  },
+  "homepage": "https://github.com/ifiokjr/oh-pi/tree/main/packages/oh-pi",
+  "bugs": {
+    "url": "https://github.com/ifiokjr/oh-pi/issues"
   }
 }

--- a/packages/prompts/package.json
+++ b/packages/prompts/package.json
@@ -14,5 +14,14 @@
     "prompts",
     "README.md"
   ],
-  "license": "MIT"
+  "license": "MIT",
+  "repository": {
+    "type": "git",
+    "url": "git+https://github.com/ifiokjr/oh-pi.git",
+    "directory": "packages/prompts"
+  },
+  "homepage": "https://github.com/ifiokjr/oh-pi/tree/main/packages/prompts",
+  "bugs": {
+    "url": "https://github.com/ifiokjr/oh-pi/issues"
+  }
 }

--- a/packages/skills/package.json
+++ b/packages/skills/package.json
@@ -14,5 +14,14 @@
     "skills",
     "README.md"
   ],
-  "license": "MIT"
+  "license": "MIT",
+  "repository": {
+    "type": "git",
+    "url": "git+https://github.com/ifiokjr/oh-pi.git",
+    "directory": "packages/skills"
+  },
+  "homepage": "https://github.com/ifiokjr/oh-pi/tree/main/packages/skills",
+  "bugs": {
+    "url": "https://github.com/ifiokjr/oh-pi/issues"
+  }
 }

--- a/packages/themes/package.json
+++ b/packages/themes/package.json
@@ -14,5 +14,14 @@
     "themes",
     "README.md"
   ],
-  "license": "MIT"
+  "license": "MIT",
+  "repository": {
+    "type": "git",
+    "url": "git+https://github.com/ifiokjr/oh-pi.git",
+    "directory": "packages/themes"
+  },
+  "homepage": "https://github.com/ifiokjr/oh-pi/tree/main/packages/themes",
+  "bugs": {
+    "url": "https://github.com/ifiokjr/oh-pi/issues"
+  }
 }

--- a/packages/web-client/package.json
+++ b/packages/web-client/package.json
@@ -33,5 +33,14 @@
     "client",
     "websocket",
     "typescript"
-  ]
+  ],
+  "repository": {
+    "type": "git",
+    "url": "git+https://github.com/ifiokjr/oh-pi.git",
+    "directory": "packages/web-client"
+  },
+  "homepage": "https://github.com/ifiokjr/oh-pi/tree/main/packages/web-client",
+  "bugs": {
+    "url": "https://github.com/ifiokjr/oh-pi/issues"
+  }
 }

--- a/packages/web-remote/package.json
+++ b/packages/web-remote/package.json
@@ -29,5 +29,14 @@
   "peerDependencies": {
     "@mariozechner/pi-coding-agent": "*",
     "@sinclair/typebox": "*"
+  },
+  "repository": {
+    "type": "git",
+    "url": "git+https://github.com/ifiokjr/oh-pi.git",
+    "directory": "packages/web-remote"
+  },
+  "homepage": "https://github.com/ifiokjr/oh-pi/tree/main/packages/web-remote",
+  "bugs": {
+    "url": "https://github.com/ifiokjr/oh-pi/issues"
   }
 }

--- a/packages/web-server/package.json
+++ b/packages/web-server/package.json
@@ -47,5 +47,14 @@
     "server",
     "websocket",
     "http"
-  ]
+  ],
+  "repository": {
+    "type": "git",
+    "url": "git+https://github.com/ifiokjr/oh-pi.git",
+    "directory": "packages/web-server"
+  },
+  "homepage": "https://github.com/ifiokjr/oh-pi/tree/main/packages/web-server",
+  "bugs": {
+    "url": "https://github.com/ifiokjr/oh-pi/issues"
+  }
 }


### PR DESCRIPTION
Closes #31

## Summary
- add repository, homepage, and bugs metadata to published package manifests that were missing them
- point package metadata at the correct monorepo directories on GitHub
- add a changeset for the package metadata improvement

## Testing
- pnpm lint
- validate all package manifests include repository, homepage, and bugs fields
