### PR TITLE
build: exclude compiled test artifacts from tarballs

### DIFF
--- a/.changeset/exclude-compiled-test-artifacts.md
+++ b/.changeset/exclude-compiled-test-artifacts.md
@@ -1,0 +1,5 @@
+---
+default: patch
+---
+
+exclude compiled test artifacts from published tarballs for compiled packages and add a CI guard to catch regressions.

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -286,3 +286,6 @@ jobs:
           test -f packages/core/dist/index.js || (echo "core dist/index.js missing" && exit 1)
           test -f packages/cli/dist/index.js || (echo "cli dist/index.js missing" && exit 1)
           test -f packages/cli/dist/bin/oh-pi.js || (echo "cli dist/bin/oh-pi.js missing" && exit 1)
+
+      - name: Verify compiled tarballs exclude test artifacts
+        run: pnpm verify:compiled-tarballs

--- a/package.json
+++ b/package.json
@@ -11,6 +11,7 @@
 		"security:audit:dev": "pnpm audit -D --audit-level=high",
 		"security:check": "pnpm security:allowlist && pnpm security:audit:prod && pnpm security:audit:dev",
 		"test": "vitest run",
+		"verify:compiled-tarballs": "node ./scripts/verify-compiled-tarballs.mjs",
 		"lint": "biome check --error-on-warnings .",
 		"lint:fix": "biome check --fix .",
 		"format": "biome format --write .",

--- a/packages/cli/tsconfig.json
+++ b/packages/cli/tsconfig.json
@@ -4,5 +4,6 @@
 		"outDir": "dist",
 		"rootDir": "src"
 	},
-	"include": ["src"]
+	"include": ["src"],
+	"exclude": ["src/**/*.test.ts"]
 }

--- a/packages/core/tsconfig.json
+++ b/packages/core/tsconfig.json
@@ -4,5 +4,6 @@
 		"outDir": "dist",
 		"rootDir": "src"
 	},
-	"include": ["src"]
+	"include": ["src"],
+	"exclude": ["src/**/*.test.ts"]
 }

--- a/scripts/verify-compiled-tarballs.mjs
+++ b/scripts/verify-compiled-tarballs.mjs
@@ -1,0 +1,25 @@
+import { execFileSync } from "node:child_process";
+
+const compiledPackages = [
+	{ name: "@ifi/oh-pi-core", dir: "packages/core" },
+	{ name: "@ifi/oh-pi-cli", dir: "packages/cli" },
+	{ name: "@ifi/pi-web-client", dir: "packages/web-client" },
+	{ name: "@ifi/pi-web-server", dir: "packages/web-server" },
+];
+
+for (const pkg of compiledPackages) {
+	console.log(`Verifying tarball for ${pkg.name}...`);
+	execFileSync("pnpm", ["run", "build"], { cwd: pkg.dir, stdio: "ignore" });
+	const output = execFileSync("pnpm", ["pack", "--dry-run"], { cwd: pkg.dir, encoding: "utf8" });
+
+	const leakedTestArtifact = output
+		.split(/\r?\n/)
+		.map((line) => line.trim())
+		.find((line) => /(^|\s)dist\/.*\.test\.(?:js|d\.ts|d\.ts\.map|js\.map)$/.test(line));
+
+	if (leakedTestArtifact) {
+		throw new Error(`${pkg.name} tarball contains compiled test artifact: ${leakedTestArtifact}`);
+	}
+}
+
+console.log("Compiled package tarballs do not contain test artifacts.");


### PR DESCRIPTION
Closes #32

## Summary
- exclude `*.test.ts` files from compiled output in core and cli
- add a tarball verification script that rebuilds compiled packages and fails if test artifacts leak into dist tarballs
- run the tarball verification in CI build validation

## Testing
- pnpm verify:compiled-tarballs
- pnpm lint
