### PR TITLE
refactor: add shared core agent path utilities

### DIFF
--- a/.changeset/add-core-agent-path-utilities.md
+++ b/.changeset/add-core-agent-path-utilities.md
@@ -1,0 +1,5 @@
+---
+default: patch
+---
+
+add shared pi agent-dir and mirrored storage path utilities to `@ifi/oh-pi-core` for consistent config and storage path resolution.

--- a/packages/core/src/agent-paths.test.ts
+++ b/packages/core/src/agent-paths.test.ts
@@ -1,0 +1,58 @@
+import path from "node:path";
+import { describe, expect, it } from "vitest";
+import {
+	expandHomeDir,
+	getExtensionConfigPath,
+	getMirroredWorkspacePathSegments,
+	getSharedStoragePath,
+	resolvePiAgentDir,
+} from "./agent-paths.js";
+
+describe("agent path utilities", () => {
+	it("uses the default ~/.pi/agent path when no override is set", () => {
+		expect(resolvePiAgentDir({ env: {}, homeDir: "/mock-home" })).toBe(path.join("/mock-home", ".pi", "agent"));
+	});
+
+	it("honors PI_CODING_AGENT_DIR overrides", () => {
+		expect(resolvePiAgentDir({ env: { PI_CODING_AGENT_DIR: "/tmp/custom-agent" }, homeDir: "/mock-home" })).toBe(
+			"/tmp/custom-agent",
+		);
+	});
+
+	it("expands ~ in PI_CODING_AGENT_DIR overrides", () => {
+		expect(resolvePiAgentDir({ env: { PI_CODING_AGENT_DIR: "~/agent-data" }, homeDir: "/mock-home" })).toBe(
+			path.join("/mock-home", "agent-data"),
+		);
+	});
+
+	it("builds extension config paths under the resolved agent dir", () => {
+		expect(getExtensionConfigPath("scheduler", "config.json", { env: {}, homeDir: "/mock-home" })).toBe(
+			path.join("/mock-home", ".pi", "agent", "extensions", "scheduler", "config.json"),
+		);
+	});
+
+	it("mirrors workspace paths for shared storage", () => {
+		expect(getMirroredWorkspacePathSegments("/Users/test/work/repo")).toEqual([
+			"root",
+			"Users",
+			"test",
+			"work",
+			"repo",
+		]);
+	});
+
+	it("builds shared storage paths inside the resolved agent dir", () => {
+		expect(
+			getSharedStoragePath("scheduler", "/Users/test/work/repo", ["scheduler.json"], {
+				env: {},
+				homeDir: "/mock-home",
+			}),
+		).toBe(
+			path.join("/mock-home", ".pi", "agent", "scheduler", "root", "Users", "test", "work", "repo", "scheduler.json"),
+		);
+	});
+
+	it("expands home directory shortcuts directly", () => {
+		expect(expandHomeDir("~/nested/path", { homeDir: "/mock-home" })).toBe(path.join("/mock-home", "nested", "path"));
+	});
+});

--- a/packages/core/src/agent-paths.ts
+++ b/packages/core/src/agent-paths.ts
@@ -1,0 +1,65 @@
+import { homedir } from "node:os";
+import path from "node:path";
+
+export interface AgentPathOptions {
+	env?: NodeJS.ProcessEnv;
+	homeDir?: string;
+}
+
+function defaultHomeDir(options?: AgentPathOptions): string {
+	return options?.homeDir ?? homedir();
+}
+
+export function expandHomeDir(inputPath: string, options?: AgentPathOptions): string {
+	const homeDir = defaultHomeDir(options);
+	if (inputPath === "~") {
+		return homeDir;
+	}
+	if (inputPath.startsWith("~/") || inputPath.startsWith(`~${path.sep}`)) {
+		return path.join(homeDir, inputPath.slice(2));
+	}
+	return inputPath;
+}
+
+export function resolvePiAgentDir(options?: AgentPathOptions): string {
+	const envPath = options?.env?.PI_CODING_AGENT_DIR?.trim();
+	if (envPath) {
+		return path.resolve(expandHomeDir(envPath, options));
+	}
+	return path.join(defaultHomeDir(options), ".pi", "agent");
+}
+
+export function getExtensionConfigPath(
+	extensionName: string,
+	fileName = "config.json",
+	options?: AgentPathOptions,
+): string {
+	return path.join(resolvePiAgentDir(options), "extensions", extensionName, fileName);
+}
+
+export function getMirroredWorkspacePathSegments(cwd: string): string[] {
+	const resolved = path.resolve(cwd);
+	const parsed = path.parse(resolved);
+	const relativeSegments = resolved.slice(parsed.root.length).split(path.sep).filter(Boolean);
+	const rootSegment = parsed.root
+		? parsed.root
+				.replaceAll(/[^a-zA-Z0-9]+/g, "-")
+				.replaceAll(/^-+|-+$/g, "")
+				.toLowerCase() || "root"
+		: "root";
+	return [rootSegment, ...relativeSegments];
+}
+
+export function getSharedStoragePath(
+	namespace: string,
+	cwd: string,
+	relativeSegments: string[] = [],
+	options?: AgentPathOptions,
+): string {
+	return path.join(
+		resolvePiAgentDir(options),
+		namespace,
+		...getMirroredWorkspacePathSegments(cwd),
+		...relativeSegments,
+	);
+}

--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -1,3 +1,11 @@
+export type { AgentPathOptions } from "./agent-paths.js";
+export {
+	expandHomeDir,
+	getExtensionConfigPath,
+	getMirroredWorkspacePathSegments,
+	getSharedStoragePath,
+	resolvePiAgentDir,
+} from "./agent-paths.js";
 export { getLocale, selectLanguage, setLocale, t } from "./i18n.js";
 export type { IconMode, IconName } from "./icons.js";
 export { icon, isPlainIcons, setPlainIcons } from "./icons.js";


### PR DESCRIPTION
Closes #34

## Summary
- add shared pi agent-dir utilities to @ifi/oh-pi-core
- support PI_CODING_AGENT_DIR overrides and mirrored workspace storage path generation
- add tests for default, overridden, and shared-storage path resolution

## Testing
- pnpm exec vitest run packages/core/src/agent-paths.test.ts packages/core/src/registry.test.ts packages/core/src/i18n.test.ts packages/core/src/icons.test.ts
- pnpm --filter @ifi/oh-pi-core build
- pnpm lint
