### PR TITLE
refactor: migrate agent dir resolution to shared resolvers

### DIFF
--- a/.changeset/migrate-agent-dir-path-resolution.md
+++ b/.changeset/migrate-agent-dir-path-resolution.md
@@ -1,0 +1,5 @@
+---
+default: patch
+---
+
+migrate hardcoded pi agent-dir paths in CLI and extensions to shared resolver utilities so custom `PI_CODING_AGENT_DIR` setups behave consistently.

--- a/packages/ant-colony/extensions/ant-colony/storage.ts
+++ b/packages/ant-colony/extensions/ant-colony/storage.ts
@@ -1,6 +1,7 @@
 import * as fs from "node:fs";
-import { homedir } from "node:os";
 import * as path from "node:path";
+import { expandHomeDir } from "@ifi/oh-pi-core";
+import { getAgentDir } from "@mariozechner/pi-coding-agent";
 
 export type ColonyStorageMode = "shared" | "project";
 
@@ -16,8 +17,8 @@ interface AntColonyConfig {
 
 const STORAGE_MODE_ENV_FLAG = "PI_ANT_COLONY_STORAGE_MODE";
 const STORAGE_ROOT_ENV_FLAG = "PI_ANT_COLONY_STORAGE_ROOT";
-const DEFAULT_SHARED_ROOT = path.join(homedir(), ".pi", "agent", "ant-colony");
-const CONFIG_PATH = path.join(homedir(), ".pi", "agent", "extensions", "ant-colony", "config.json");
+const DEFAULT_SHARED_ROOT = path.join(getAgentDir(), "ant-colony");
+const CONFIG_PATH = path.join(getAgentDir(), "extensions", "ant-colony", "config.json");
 
 function parseStorageMode(value: unknown): ColonyStorageMode | undefined {
 	if (value !== "shared" && value !== "project") {
@@ -27,7 +28,7 @@ function parseStorageMode(value: unknown): ColonyStorageMode | undefined {
 }
 
 function expandTilde(value: string): string {
-	return value.startsWith("~/") ? path.join(homedir(), value.slice(2)) : value;
+	return expandHomeDir(value);
 }
 
 export function loadAntColonyConfig(): AntColonyConfig {

--- a/packages/ant-colony/package.json
+++ b/packages/ant-colony/package.json
@@ -2,6 +2,7 @@
   "name": "@ifi/oh-pi-ant-colony",
   "version": "0.3.6",
   "description": "Autonomous multi-agent swarm extension for pi — adaptive concurrency, pheromone communication.",
+  "type": "module",
   "keywords": [
     "pi-package"
   ],
@@ -16,6 +17,9 @@
     "!**/*.test.ts"
   ],
   "license": "MIT",
+  "dependencies": {
+    "@ifi/oh-pi-core": "workspace:*"
+  },
   "scripts": {
     "build": "pnpm run typecheck:worktree && pnpm run test:worktree",
     "typecheck": "pnpm run typecheck:worktree",

--- a/packages/ant-colony/tests/queen.test.ts
+++ b/packages/ant-colony/tests/queen.test.ts
@@ -17,6 +17,7 @@ vi.mock("@mariozechner/pi-coding-agent", () => ({
 	SessionManager: { inMemory: vi.fn() },
 	SettingsManager: { inMemory: vi.fn() },
 	createExtensionRuntime: vi.fn(),
+	getAgentDir: () => "/mock-home/.pi/agent",
 }));
 vi.mock("@mariozechner/pi-ai", () => ({ getModel: vi.fn() }));
 

--- a/packages/ant-colony/tests/spawner.test.ts
+++ b/packages/ant-colony/tests/spawner.test.ts
@@ -14,6 +14,7 @@ vi.mock("@mariozechner/pi-coding-agent", () => ({
 	SessionManager: { inMemory: vi.fn() },
 	SettingsManager: { inMemory: vi.fn() },
 	createExtensionRuntime: vi.fn(),
+	getAgentDir: () => "/mock-home/.pi/agent",
 }));
 vi.mock("@mariozechner/pi-ai", () => ({ getModel: vi.fn() }));
 

--- a/packages/cli/src/tui/confirm-apply.ts
+++ b/packages/cli/src/tui/confirm-apply.ts
@@ -1,6 +1,5 @@
 import * as p from "@clack/prompts";
-import type { OhPConfig } from "@ifi/oh-pi-core";
-import { t } from "@ifi/oh-pi-core";
+import { type OhPConfig, resolvePiAgentDir, t } from "@ifi/oh-pi-core";
 import chalk from "chalk";
 import type { EnvInfo } from "../utils/detect.js";
 import { applyConfig, backupConfig, installPi } from "../utils/install.js";
@@ -125,7 +124,7 @@ export async function confirmApply(config: OhPConfig, env: EnvInfo) {
 
 	// ═══ Result ═══
 	const tree = [
-		`${chalk.gray("~/.pi/agent/")}`,
+		`${chalk.gray(`${resolvePiAgentDir()}/`)}`,
 		`${chalk.gray("├── ")}auth.json ${chalk.dim("")}`,
 		`${chalk.gray("├── ")}settings.json`,
 		...(config.keybindings !== "default" ? [`${chalk.gray("├── ")}keybindings.json`] : []),

--- a/packages/cli/src/utils/detect.ts
+++ b/packages/cli/src/utils/detect.ts
@@ -1,7 +1,7 @@
 import { execSync } from "node:child_process";
 import { existsSync, readdirSync, readFileSync, statSync } from "node:fs";
-import { homedir } from "node:os";
 import { join } from "node:path";
+import { resolvePiAgentDir } from "@ifi/oh-pi-core";
 
 export interface EnvInfo {
 	piInstalled: boolean;
@@ -112,7 +112,7 @@ function detectProviders(agentDir: string): string[] {
  * @returns Environment info object {@link EnvInfo}
  */
 export async function detectEnv(): Promise<EnvInfo> {
-	const agentDir = join(homedir(), ".pi", "agent");
+	const agentDir = resolvePiAgentDir();
 
 	// Detect pi version and scan config in parallel
 	const [versionResult, existingFiles] = await Promise.all([

--- a/packages/cli/src/utils/install.ts
+++ b/packages/cli/src/utils/install.ts
@@ -1,8 +1,7 @@
 import { execSync } from "node:child_process";
 import { copyFileSync, existsSync, mkdirSync, readdirSync, rmSync, statSync } from "node:fs";
-import { homedir } from "node:os";
-import { join } from "node:path";
-import type { OhPConfig } from "@ifi/oh-pi-core";
+import { basename, dirname, join } from "node:path";
+import { type OhPConfig, resolvePiAgentDir } from "@ifi/oh-pi-core";
 import {
 	writeAgents,
 	writeExtensions,
@@ -84,10 +83,10 @@ function copyDir(src: string, dest: string) {
 }
 
 /**
- * Apply an OhPConfig by generating and writing all config files to ~/.pi/agent/.
+ * Apply an OhPConfig by generating and writing all config files to pi's resolved agent dir.
  */
 export function applyConfig(config: OhPConfig) {
-	const agentDir = join(homedir(), ".pi", "agent");
+	const agentDir = resolvePiAgentDir();
 	ensureDir(agentDir);
 	if ((config.providerStrategy ?? "replace") === "replace") {
 		cleanupManagedConfig(agentDir);
@@ -124,16 +123,16 @@ export function installPi() {
 }
 
 /**
- * Back up ~/.pi/agent/ to ~/.pi/agent.bak-{timestamp}/.
+ * Back up the resolved pi agent dir to a sibling `.bak-{timestamp}` directory.
  * @returns Backup directory path, or empty string if source doesn't exist.
  */
 export function backupConfig(): string {
-	const agentDir = join(homedir(), ".pi", "agent");
+	const agentDir = resolvePiAgentDir();
 	if (!existsSync(agentDir)) {
 		return "";
 	}
 	const ts = new Date().toISOString().replace(/[:.]/g, "-").slice(0, 19);
-	const backupDir = join(homedir(), ".pi", `agent.bak-${ts}`);
+	const backupDir = join(dirname(agentDir), `${basename(agentDir)}.bak-${ts}`);
 	copyDir(agentDir, backupDir);
 	return backupDir;
 }

--- a/packages/extensions/extensions/auto-update.test.ts
+++ b/packages/extensions/extensions/auto-update.test.ts
@@ -1,6 +1,8 @@
 import { describe, expect, it, vi } from "vitest";
 
-vi.mock("@mariozechner/pi-coding-agent", () => ({}));
+vi.mock("@mariozechner/pi-coding-agent", () => ({
+	getAgentDir: () => "/mock-home/.pi/agent",
+}));
 
 import { isNewer } from "./auto-update";
 

--- a/packages/extensions/extensions/auto-update.ts
+++ b/packages/extensions/extensions/auto-update.ts
@@ -7,16 +7,15 @@
  */
 import { execSync } from "node:child_process";
 import { existsSync, readFileSync, writeFileSync } from "node:fs";
-import { homedir } from "node:os";
 import { dirname, join } from "node:path";
 import { fileURLToPath } from "node:url";
-import type { ExtensionAPI } from "@mariozechner/pi-coding-agent";
+import { type ExtensionAPI, getAgentDir } from "@mariozechner/pi-coding-agent";
 
 /** Minimum interval between version checks (24 hours). */
 const CHECK_INTERVAL = 24 * 60 * 60 * 1000;
 
 /** Stamp file path — stores the timestamp of the last version check. */
-const STAMP_FILE = join(homedir(), ".pi", "agent", ".update-check");
+const STAMP_FILE = join(getAgentDir(), ".update-check");
 
 /** Read the last-check timestamp from the stamp file. Returns 0 if missing or unreadable. */
 function readStamp(): number {

--- a/packages/extensions/extensions/scheduler.test.ts
+++ b/packages/extensions/extensions/scheduler.test.ts
@@ -31,7 +31,9 @@ vi.mock("node:os", async (importOriginal) => {
 	return { ...actual, homedir: () => "/mock-home" };
 });
 
-vi.mock("@mariozechner/pi-coding-agent", () => ({}));
+vi.mock("@mariozechner/pi-coding-agent", () => ({
+	getAgentDir: () => "/mock-home/.pi/agent",
+}));
 vi.mock("@mariozechner/pi-ai", () => ({}));
 
 vi.mock("@sinclair/typebox", () => ({

--- a/packages/extensions/extensions/scheduler.ts
+++ b/packages/extensions/extensions/scheduler.ts
@@ -14,9 +14,8 @@
  */
 
 import * as fs from "node:fs";
-import { homedir } from "node:os";
 import * as path from "node:path";
-import type { ExtensionAPI, ExtensionContext } from "@mariozechner/pi-coding-agent";
+import { type ExtensionAPI, type ExtensionContext, getAgentDir } from "@mariozechner/pi-coding-agent";
 import { Type } from "@sinclair/typebox";
 import { Cron } from "croner";
 
@@ -79,7 +78,7 @@ interface SchedulerStore {
 }
 
 function getSchedulerStorageRoot(): string {
-	return path.join(homedir(), ".pi", "agent", "scheduler");
+	return path.join(getAgentDir(), "scheduler");
 }
 
 export function getSchedulerStoragePath(cwd: string): string {

--- a/packages/extensions/extensions/usage-tracker.test.ts
+++ b/packages/extensions/extensions/usage-tracker.test.ts
@@ -28,6 +28,7 @@ vi.mock("node:os", async (importOriginal) => {
 
 vi.mock("@mariozechner/pi-coding-agent", () => ({
 	CustomEditor: class {},
+	getAgentDir: () => "/mock-home/.pi/agent",
 }));
 
 vi.mock("@mariozechner/pi-ai", () => ({}));

--- a/packages/extensions/extensions/usage-tracker.ts
+++ b/packages/extensions/extensions/usage-tracker.ts
@@ -20,10 +20,9 @@
  */
 
 import { existsSync, mkdirSync, readFileSync, writeFileSync } from "node:fs";
-import { homedir } from "node:os";
 import { dirname, join } from "node:path";
 import type { AssistantMessage } from "@mariozechner/pi-ai";
-import type { ExtensionAPI, ExtensionContext } from "@mariozechner/pi-coding-agent";
+import { type ExtensionAPI, type ExtensionContext, getAgentDir } from "@mariozechner/pi-coding-agent";
 import { Type } from "@sinclair/typebox";
 
 // ─── Types ──────────────────────────────────────────────────────────────────
@@ -439,7 +438,7 @@ async function getOAuthModule(): Promise<typeof import("@mariozechner/pi-ai/oaut
 
 /** Path to pi's auth storage file. */
 function getAuthPath(): string {
-	return join(homedir(), ".pi", "agent", "auth.json");
+	return join(getAgentDir(), "auth.json");
 }
 
 /** Read pi's auth config from ~/.pi/agent/auth.json. */
@@ -1163,7 +1162,7 @@ function providerDisplayName(provider: ProviderKey): string {
  * already configured, and writes back. This is a one-time idempotent operation.
  */
 function ensureCtrlUUnbound(): void {
-	const keybindingsPath = join(homedir(), ".pi", "agent", "keybindings.json");
+	const keybindingsPath = join(getAgentDir(), "keybindings.json");
 	try {
 		let config: Record<string, unknown> = {};
 		if (existsSync(keybindingsPath)) {
@@ -1203,7 +1202,7 @@ function ensureCtrlUUnbound(): void {
 }
 
 function getUsageHistoryPath(): string {
-	return join(homedir(), ".pi", "agent", "usage-tracker-history.json");
+	return join(getAgentDir(), "usage-tracker-history.json");
 }
 
 export default function usageTracker(pi: ExtensionAPI) {

--- a/packages/plan/prompts.ts
+++ b/packages/plan/prompts.ts
@@ -1,7 +1,7 @@
 import { readFile } from "node:fs/promises";
-import os from "node:os";
 import path from "node:path";
 import { fileURLToPath } from "node:url";
+import { getAgentDir } from "@mariozechner/pi-coding-agent";
 
 const PLAN_MODE_PROMPT_FILENAME = "PLAN.prompt.md";
 
@@ -27,7 +27,7 @@ export async function loadPlanModePrompt(options?: {
 	agentDirPath?: string;
 	bundledPromptPath?: string;
 }): Promise<string> {
-	const agentDirPath = options?.agentDirPath ?? path.join(os.homedir(), ".pi", "agent");
+	const agentDirPath = options?.agentDirPath ?? getAgentDir();
 	const bundledPromptPath = options?.bundledPromptPath ?? getBundledPromptPath();
 	const overridePromptPath = path.join(agentDirPath, PLAN_MODE_PROMPT_FILENAME);
 

--- a/packages/subagents/agents.ts
+++ b/packages/subagents/agents.ts
@@ -9,6 +9,7 @@ import { fileURLToPath } from "node:url";
 import { KNOWN_FIELDS } from "./agent-serializer.js";
 import { mergeAgentsForScope } from "./agent-selection.js";
 import { parseChain } from "./chain-serializer.js";
+import { getUserAgentsDir } from "./paths.js";
 import { findNearestProjectAgentsDir } from "./project-agents-storage.js";
 
 export type AgentScope = "user" | "project" | "both";
@@ -227,7 +228,7 @@ function loadChainsFromDir(dir: string, source: AgentSource): ChainConfig[] {
 const BUILTIN_AGENTS_DIR = path.join(path.dirname(fileURLToPath(import.meta.url)), "agents");
 
 export function discoverAgents(cwd: string, scope: AgentScope): AgentDiscoveryResult {
-	const userDir = path.join(os.homedir(), ".pi", "agent", "agents");
+	const userDir = getUserAgentsDir();
 	const projectAgentsDir = findNearestProjectAgentsDir(cwd);
 
 	const builtinAgents = loadAgentsFromDir(BUILTIN_AGENTS_DIR, "builtin");
@@ -246,7 +247,7 @@ export function discoverAgentsAll(cwd: string): {
 	userDir: string;
 	projectDir: string;
 } {
-	const userDir = path.join(os.homedir(), ".pi", "agent", "agents");
+	const userDir = getUserAgentsDir();
 	const projectDir = findNearestProjectAgentsDir(cwd);
 
 	const builtin = loadAgentsFromDir(BUILTIN_AGENTS_DIR, "builtin");

--- a/packages/subagents/artifacts.ts
+++ b/packages/subagents/artifacts.ts
@@ -1,6 +1,6 @@
 import * as fs from "node:fs";
-import * as os from "node:os";
 import * as path from "node:path";
+import { getSessionsBaseDir } from "./paths.js";
 import type { ArtifactPaths } from "./types.js";
 
 const TEMP_ARTIFACTS_DIR = path.join(os.tmpdir(), "pi-subagent-artifacts");
@@ -73,7 +73,7 @@ export function cleanupOldArtifacts(dir: string, maxAgeDays: number): void {
 export function cleanupAllArtifactDirs(maxAgeDays: number): void {
 	cleanupOldArtifacts(TEMP_ARTIFACTS_DIR, maxAgeDays);
 
-	const sessionsBase = path.join(os.homedir(), ".pi", "agent", "sessions");
+	const sessionsBase = getSessionsBaseDir();
 	if (!fs.existsSync(sessionsBase)) return;
 
 	let dirs: string[];

--- a/packages/subagents/chain-clarify.ts
+++ b/packages/subagents/chain-clarify.ts
@@ -9,9 +9,9 @@ import type { Theme } from "@mariozechner/pi-coding-agent";
 import type { Component, TUI } from "@mariozechner/pi-tui";
 import { matchesKey, visibleWidth, truncateToWidth } from "@mariozechner/pi-tui";
 import * as fs from "node:fs";
-import * as os from "node:os";
 import * as path from "node:path";
 import type { AgentConfig, ChainConfig, ChainStepConfig } from "./agents.js";
+import { getUserAgentsDir } from "./paths.js";
 import type { ResolvedStepBehavior } from "./settings.js";
 import type { TextEditorState } from "./text-editor.js";
 import {
@@ -339,7 +339,7 @@ export class ChainClarifyComponent implements Component {
 				return;
 			}
 			try {
-				const dir = path.join(os.homedir(), ".pi", "agent", "agents");
+				const dir = getUserAgentsDir();
 				fs.mkdirSync(dir, { recursive: true });
 				const filePath = path.join(dir, `${name}.chain.md`);
 				const config = this.buildChainConfig(name);

--- a/packages/subagents/index.ts
+++ b/packages/subagents/index.ts
@@ -61,6 +61,7 @@ import { finalizeSingleOutput, injectSingleOutputInstruction, resolveSingleOutpu
 import { AgentManagerComponent, type ManagerResult } from "./agent-manager.js";
 import { recordRun } from "./run-history.js";
 import { handleManagementAction } from "./agent-management.js";
+import { getSubagentConfigPath } from "./paths.js";
 
 // ExtensionConfig is now imported from ./types.js
 
@@ -81,7 +82,7 @@ function getSubagentSessionRoot(parentSessionFile: string | null): string {
 }
 
 function loadConfig(): ExtensionConfig {
-	const configPath = path.join(os.homedir(), ".pi", "agent", "extensions", "subagent", "config.json");
+	const configPath = getSubagentConfigPath();
 	try {
 		if (fs.existsSync(configPath)) {
 			return JSON.parse(fs.readFileSync(configPath, "utf-8")) as ExtensionConfig;

--- a/packages/subagents/package.json
+++ b/packages/subagents/package.json
@@ -31,6 +31,9 @@
     "!test/**"
   ],
   "license": "MIT",
+  "dependencies": {
+    "@ifi/oh-pi-core": "workspace:*"
+  },
   "repository": {
     "type": "git",
     "url": "git+https://github.com/ifiokjr/oh-pi.git",

--- a/packages/subagents/paths.ts
+++ b/packages/subagents/paths.ts
@@ -1,0 +1,22 @@
+import path from "node:path";
+import { getAgentDir } from "@mariozechner/pi-coding-agent";
+
+export function resolveAgentDir(): string {
+	return getAgentDir();
+}
+
+export function getSubagentConfigPath(): string {
+	return path.join(resolveAgentDir(), "extensions", "subagent", "config.json");
+}
+
+export function getUserAgentsDir(): string {
+	return path.join(resolveAgentDir(), "agents");
+}
+
+export function getSessionsBaseDir(): string {
+	return path.join(resolveAgentDir(), "sessions");
+}
+
+export function getRunHistoryPath(): string {
+	return path.join(resolveAgentDir(), "run-history.jsonl");
+}

--- a/packages/subagents/project-agents-storage.ts
+++ b/packages/subagents/project-agents-storage.ts
@@ -1,6 +1,11 @@
 import * as fs from "node:fs";
-import * as os from "node:os";
 import * as path from "node:path";
+import {
+	expandHomeDir,
+	getExtensionConfigPath,
+	getMirroredWorkspacePathSegments,
+	resolvePiAgentDir,
+} from "@ifi/oh-pi-core";
 
 export type ProjectAgentStorageMode = "shared" | "project";
 
@@ -16,8 +21,8 @@ interface SubagentStorageConfig {
 
 const STORAGE_MODE_ENV_FLAG = "PI_SUBAGENT_PROJECT_AGENTS_MODE";
 const STORAGE_ROOT_ENV_FLAG = "PI_SUBAGENT_PROJECT_AGENTS_ROOT";
-const CONFIG_PATH = path.join(os.homedir(), ".pi", "agent", "extensions", "subagent", "config.json");
-const DEFAULT_SHARED_ROOT = path.join(os.homedir(), ".pi", "agent", "subagents", "project-agents");
+const CONFIG_PATH = getExtensionConfigPath("subagent");
+const DEFAULT_SHARED_ROOT = path.join(resolvePiAgentDir(), "subagents", "project-agents");
 
 function parseStorageMode(value: unknown): ProjectAgentStorageMode | undefined {
 	if (value !== "shared" && value !== "project") {
@@ -27,7 +32,7 @@ function parseStorageMode(value: unknown): ProjectAgentStorageMode | undefined {
 }
 
 function expandTilde(value: string): string {
-	return value.startsWith("~/") ? path.join(os.homedir(), value.slice(2)) : value;
+	return expandHomeDir(value);
 }
 
 function loadStorageConfig(): SubagentStorageConfig {
@@ -61,18 +66,6 @@ export function resolveProjectAgentStorageOptions(
 	return { mode, sharedRoot };
 }
 
-function getMirroredWorkspacePath(cwd: string): string {
-	const resolved = path.resolve(cwd);
-	const parsed = path.parse(resolved);
-	const relativeSegments = resolved.slice(parsed.root.length).split(path.sep).filter(Boolean);
-	const rootSegment = parsed.root
-		? parsed.root
-				.replaceAll(/[^a-zA-Z0-9]+/g, "-")
-				.replaceAll(/^-+|-+$/g, "")
-				.toLowerCase() || "root"
-		: "root";
-	return path.join(rootSegment, ...relativeSegments);
-}
 
 function isDirectory(p: string): boolean {
 	try {
@@ -102,7 +95,7 @@ export function getLegacyProjectAgentsDir(cwd: string): string {
 
 export function getSharedProjectAgentsDir(cwd: string, options?: ProjectAgentStorageOptions): string {
 	const resolved = resolveProjectAgentStorageOptions(options);
-	return path.join(resolved.sharedRoot, getMirroredWorkspacePath(cwd), "agents");
+	return path.join(resolved.sharedRoot, ...getMirroredWorkspacePathSegments(cwd), "agents");
 }
 
 function cleanupLegacyPiDir(cwd: string): void {

--- a/packages/subagents/run-history.ts
+++ b/packages/subagents/run-history.ts
@@ -1,6 +1,6 @@
 import * as fs from "node:fs";
-import * as os from "node:os";
 import * as path from "node:path";
+import { getRunHistoryPath } from "./paths.js";
 
 export interface RunEntry {
 	agent: string;
@@ -11,7 +11,7 @@ export interface RunEntry {
 	exit?: number;
 }
 
-const HISTORY_PATH = path.join(os.homedir(), ".pi", "agent", "run-history.jsonl");
+const HISTORY_PATH = getRunHistoryPath();
 const ROTATE_READ_THRESHOLD = 1200;
 const ROTATE_KEEP = 1000;
 

--- a/packages/subagents/skills.ts
+++ b/packages/subagents/skills.ts
@@ -4,9 +4,10 @@
 
 import { execSync } from "node:child_process";
 import * as fs from "node:fs";
-import * as os from "node:os";
 import * as path from "node:path";
+import { expandHomeDir } from "@ifi/oh-pi-core";
 import { loadSkills, type Skill } from "@mariozechner/pi-coding-agent";
+import { resolveAgentDir } from "./paths.js";
 
 export type SkillSource =
 	| "project"
@@ -46,7 +47,7 @@ let loadSkillsCache: { cwd: string; skills: CachedSkillEntry[]; timestamp: numbe
 const LOAD_SKILLS_CACHE_TTL_MS = 5000;
 
 const CONFIG_DIR = ".pi";
-const AGENT_DIR = path.join(os.homedir(), ".pi", "agent");
+const AGENT_DIR = resolveAgentDir();
 
 const SOURCE_PRIORITY: Record<SkillSource, number> = {
 	project: 700,
@@ -167,7 +168,7 @@ function collectSettingsSkillPaths(cwd: string): string[] {
 				if (typeof entry !== "string") continue;
 				let resolved = entry;
 				if (resolved.startsWith("~/")) {
-					resolved = path.join(os.homedir(), resolved.slice(2));
+					resolved = expandHomeDir(resolved);
 				} else if (!path.isAbsolute(resolved)) {
 					resolved = path.resolve(base, resolved);
 				}

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -36,6 +36,9 @@ importers:
 
   packages/ant-colony:
     dependencies:
+      '@ifi/oh-pi-core':
+        specifier: workspace:*
+        version: link:../core
       '@mariozechner/pi-agent-core':
         specifier: '*'
         version: 0.56.1(ws@8.19.0)(zod@3.25.76)
@@ -208,6 +211,9 @@ importers:
 
   packages/subagents:
     dependencies:
+      '@ifi/oh-pi-core':
+        specifier: workspace:*
+        version: link:../core
       '@mariozechner/pi-agent-core':
         specifier: '*'
         version: 0.56.1(ws@8.19.0)(zod@3.25.76)


### PR DESCRIPTION
Closes #35

## Summary
- replace hardcoded `~/.pi/agent` path construction in the CLI, extensions, plan prompt loading, ant-colony storage, and subagents helpers
- use resolver-based paths so `PI_CODING_AGENT_DIR` is honored consistently across runtime state, config, and helper flows
- add/update affected tests and package dependencies where shared path helpers are now used

## Testing
- pnpm typecheck
- pnpm test
- pnpm lint
