### PR TITLE
fix: improve error reporting and robustness for ant colony and subagent swarms

### DIFF
--- a/.changes/robust-colony.md
+++ b/.changes/robust-colony.md
@@ -1,0 +1,25 @@
+---
+default: patch
+---
+
+Improve error reporting and robustness for ant colony and subagent swarms.
+
+**Ant Colony:**
+- Fix nest lock file crash (`ENOENT`) when colony storage directory is cleaned up mid-run — the lock now recreates the directory instead of crashing
+- Expand error messages from 80–120 chars to 200–500+ chars across queen, spawner, index, and ui
+- Include full stack traces in colony crash reports and task failure records
+- Surface task failures via `emitSignal` so they appear in the TUI instead of being silently swallowed
+- Include validation issues and scout intelligence in plan recovery failure messages
+- Budget-exceeded messages now report how many tasks completed before the limit
+- Failed tasks in `onAntDone` now include error context in the log entry
+- Model resolution errors now include provider and model details
+- Session dispose errors are logged instead of silently swallowed
+
+**Subagent Swarms:**
+- Add fallback error messages for subagent processes that exit non-zero with no stderr
+- Capture `stderr` from `runPiStreaming` and include it in failure output
+- Track `aborted` flag on results when tasks are killed via signal
+- Count JSON parse errors instead of silently swallowing them
+- Extend `detectSubagentError` to run on all results, not just exit-code-0
+- Write failure result files when the runner process crashes, so the parent knows what happened
+- Process spawn errors now capture the error message

--- a/packages/ant-colony/extensions/ant-colony/index.ts
+++ b/packages/ant-colony/extensions/ant-colony/index.ts
@@ -488,9 +488,10 @@ export default function antColonyExtension(pi: ExtensionAPI) {
 				const icon = ant.status === "done" ? checkMark() : crossMark();
 				const progress = m ? `${m.tasksDone}/${m.tasksTotal}` : "";
 				const cost = m ? formatCost(m.totalCost) : "";
+				const errorSuffix = ant.status !== "done" && task.error ? ` — ${task.error.slice(0, 150)}` : "";
 				pushLog(colony, {
 					level: ant.status === "done" ? "info" : "warning",
-					text: `${icon} ${task.title.slice(0, 80)} (${progress}${cost ? `, ${cost}` : ""})`,
+					text: `${icon} ${task.title.slice(0, 120)} (${progress}${cost ? `, ${cost}` : ""})${errorSuffix}`,
 				});
 				pi.sendMessage(
 					{
@@ -613,7 +614,8 @@ export default function antColonyExtension(pi: ExtensionAPI) {
 				});
 			})
 			.catch((e) => {
-				pushLog(colony, { level: "error", text: `CRASHED · ${String(e).slice(0, 120)}` });
+				const crashDetail = e instanceof Error ? `${e.message}\n${e.stack || ""}` : String(e);
+				pushLog(colony, { level: "error", text: `CRASHED · ${crashDetail.slice(0, 500)}` });
 				cleanupWorkspace("crash");
 				colonies.delete(colonyId);
 				if (colonies.size === 0) {

--- a/packages/ant-colony/extensions/ant-colony/nest.ts
+++ b/packages/ant-colony/extensions/ant-colony/nest.ts
@@ -458,14 +458,33 @@ export class Nest {
 	 * the timeout (3s) is reached. Stale locks (>30s old or from dead
 	 * processes) are automatically broken.
 	 */
+	/** Extract the `code` property from a filesystem error, if present. */
+	private fsErrorCode(error: unknown): string | undefined {
+		return typeof error === "object" && error !== null && "code" in error ? String(error.code) : undefined;
+	}
+
+	/** Whether the error is a transient directory-missing error that can be retried. */
+	private isDirectoryMissingError(error: unknown): boolean {
+		return this.fsErrorCode(error) === "ENOENT";
+	}
+
+	// biome-ignore lint/complexity/noExcessiveCognitiveComplexity: Lock acquisition requires spin-wait + stale-lock recovery + directory recovery.
 	private withStateLock<T>(fn: () => T): T {
 		const start = Date.now();
 		while (true) {
 			try {
+				// Ensure the colony storage directory still exists (it may have
+				// been cleaned up mid-run by worktree teardown or another process).
+				fs.mkdirSync(path.dirname(this.lockFile), { recursive: true });
 				fs.writeFileSync(this.lockFile, `${process.pid}:${Date.now()}`, { flag: "wx" });
 				break;
 			} catch (error) {
 				if (!this.isLockContentionError(error)) {
+					// ENOENT can occur if the directory was removed between
+					// mkdirSync and writeFileSync — retry instead of crashing.
+					if (this.isDirectoryMissingError(error) && Date.now() - start < STATE_LOCK_WAIT_MS) {
+						continue;
+					}
 					throw new Error(
 						`[Nest] failed to acquire state lock at ${this.lockFile}: ${error instanceof Error ? error.message : String(error)}`,
 					);

--- a/packages/ant-colony/extensions/ant-colony/queen.ts
+++ b/packages/ant-colony/extensions/ant-colony/queen.ts
@@ -679,13 +679,17 @@ async function runAntWave(opts: WaveOptions): Promise<"ok" | "budget"> {
 						antId: "queen",
 						antCaste: caste,
 						taskId: task.id,
-						content: `Failed: ${task.title} — ${String(e).slice(0, 100)}`,
+						content: `Failed: ${task.title} — ${String(e).slice(0, 300)}`,
 						files: task.files,
 						strength: warnStrength,
 						createdAt: Date.now(),
 					});
 				}
-				nest.updateTaskStatus(task.id, "failed", undefined, String(e));
+				// Preserve full error with stack trace for debugging
+				const fullError = e instanceof Error ? `${e.message}\n${e.stack || ""}` : String(e);
+				nest.updateTaskStatus(task.id, "failed", undefined, fullError.slice(0, 2000));
+				// Surface the failure so it's not silent
+				emitSignal("working", `Task failed: ${task.title.slice(0, 60)} — ${errStr.slice(0, 120)}`);
 
 				// Bio 6: Corpse cleanup — error pattern tracking + diagnostic task
 				const pattern = classifyError(errStr);
@@ -694,7 +698,7 @@ async function runAntWave(opts: WaveOptions): Promise<"ok" | "budget"> {
 				for (const f of task.files) {
 					entry.files.add(f);
 				}
-				entry.errors.push(errStr.slice(0, 200));
+				entry.errors.push(errStr.slice(0, 500));
 				errorPatterns.set(pattern, entry);
 
 				if (entry.count >= 2 && entry.files.size > 0) {
@@ -971,10 +975,14 @@ export async function runColony(opts: QueenOptions): Promise<ColonyState> {
 		}
 
 		if (!plan.ok) {
+			const intel = collectScoutIntelligence(nest, 2000);
+			const issueDetail = plan.issues.join(", ");
+			const warningDetail = plan.warnings.length > 0 ? ` | warnings: ${plan.warnings.join(", ")}` : "";
+			const failureContext = `No valid execution plan after ${recoveryRound} recovery rounds. Issues: ${issueDetail}${warningDetail}. Scout intel (${intel.length} chars): ${intel.slice(0, 300)}`;
 			nest.updateState({ status: "failed", finishedAt: Date.now() });
 			const finalState = nest.getState();
 			callbacks.onComplete?.(finalState);
-			emitSignal("failed", `No valid execution plan: ${plan.issues.slice(0, 3).join(", ")}`);
+			emitSignal("failed", failureContext.slice(0, 500));
 			return finalState;
 		}
 
@@ -1027,7 +1035,10 @@ export async function runColony(opts: QueenOptions): Promise<ColonyState> {
 			const result = await runAntWave({ ...waveBase, caste: "worker" });
 			if (result === "budget") {
 				nest.updateState({ status: "budget_exceeded", finishedAt: Date.now() });
-				emitSignal("budget_exceeded", "Budget exhausted");
+				emitSignal(
+					"budget_exceeded",
+					`Budget exhausted: ${updateMetrics(nest).tasksDone}/${updateMetrics(nest).tasksTotal} tasks completed before limit`,
+				);
 				const budgetState = nest.getState();
 				callbacks.onComplete?.(budgetState);
 				return budgetState;
@@ -1061,7 +1072,10 @@ export async function runColony(opts: QueenOptions): Promise<ColonyState> {
 					const result = await runAntWave({ ...waveBase, caste: "worker" });
 					if (result === "budget") {
 						nest.updateState({ status: "budget_exceeded", finishedAt: Date.now() });
-						emitSignal("budget_exceeded", "Budget exhausted");
+						emitSignal(
+							"budget_exceeded",
+							`Budget exhausted: ${updateMetrics(nest).tasksDone}/${updateMetrics(nest).tasksTotal} tasks completed before limit`,
+						);
 						const budgetState = nest.getState();
 						callbacks.onComplete?.(budgetState);
 						return budgetState;
@@ -1109,10 +1123,12 @@ export async function runColony(opts: QueenOptions): Promise<ColonyState> {
 		emitSignal("done", `${finalMetrics.tasksDone}/${finalMetrics.tasksTotal} tasks done`);
 		return finalState;
 	} catch (e) {
+		const fullError = e instanceof Error ? `${e.message}\n${e.stack || ""}` : String(e);
 		nest.updateState({ status: "failed", finishedAt: Date.now() });
 		const failState = nest.getState();
 		callbacks.onComplete?.(failState);
-		emitSignal("failed", String(e).slice(0, 100));
+		const m = failState.metrics;
+		emitSignal("failed", `Colony crashed (${m.tasksDone}/${m.tasksTotal} done): ${fullError.slice(0, 500)}`);
 		return failState;
 	} finally {
 		if (ownsUsageLimitsTracker) {
@@ -1190,7 +1206,10 @@ export async function resumeColony(opts: QueenOptions): Promise<ColonyState> {
 			const result = await runAntWave({ ...waveBase, caste: "worker" });
 			if (result === "budget") {
 				nest.updateState({ status: "budget_exceeded", finishedAt: Date.now() });
-				emitSignal("budget_exceeded", "Budget exhausted");
+				emitSignal(
+					"budget_exceeded",
+					`Budget exhausted: ${updateMetrics(nest).tasksDone}/${updateMetrics(nest).tasksTotal} tasks completed before limit`,
+				);
 				const s = nest.getState();
 				callbacks.onComplete?.(s);
 				return s;
@@ -1228,10 +1247,12 @@ export async function resumeColony(opts: QueenOptions): Promise<ColonyState> {
 		emitSignal("done", `Resumed: ${finalMetrics.tasksDone}/${finalMetrics.tasksTotal} tasks done`);
 		return finalState;
 	} catch (e) {
+		const fullError = e instanceof Error ? `${e.message}\n${e.stack || ""}` : String(e);
 		nest.updateState({ status: "failed", finishedAt: Date.now() });
 		const failState = nest.getState();
 		callbacks.onComplete?.(failState);
-		emitSignal("failed", String(e).slice(0, 100));
+		const m = failState.metrics;
+		emitSignal("failed", `Colony crashed (${m.tasksDone}/${m.tasksTotal} done): ${fullError.slice(0, 500)}`);
 		return failState;
 	} finally {
 		if (ownsUsageLimitsTracker) {

--- a/packages/ant-colony/extensions/ant-colony/spawner.ts
+++ b/packages/ant-colony/extensions/ant-colony/spawner.ts
@@ -324,7 +324,11 @@ export async function spawnAnt(
 	const registry = modelRegistry ?? new ModelRegistry(auth);
 	const model = resolveModel(antConfig.model, registry);
 	if (!model) {
-		throw new Error(`Model not found: ${antConfig.model}`);
+		const identity = modelIdentity(antConfig.model);
+		throw new Error(
+			`Model not found: ${antConfig.model} (provider: ${identity.provider}, model: ${identity.model}). ` +
+				"Ensure the model is configured in your provider settings or pass a valid model override.",
+		);
 	}
 	const configuredIdentity = modelIdentity(antConfig.model);
 
@@ -497,14 +501,21 @@ export async function spawnAnt(
 			nest.dropPheromone(p);
 		}
 
-		nest.updateTaskStatus(task.id, "failed", accumulatedText, errStr);
+		// Preserve full error with stack trace for post-mortem debugging
+		const fullError = e instanceof Error ? `${e.message}\n${e.stack || ""}` : errStr;
+		const errorWithPartialOutput = accumulatedText
+			? `${fullError.slice(0, 1500)}\n\n--- Partial output before failure ---\n${accumulatedText.slice(-500)}`
+			: fullError.slice(0, 2000);
+		nest.updateTaskStatus(task.id, "failed", accumulatedText, errorWithPartialOutput);
 
 		return { ant, output: accumulatedText, newTasks, pheromones, rateLimited: false };
 	} finally {
 		try {
 			session?.dispose();
-		} catch {
-			/* ignore dispose errors */
+		} catch (disposeErr) {
+			// Log dispose errors instead of swallowing them silently.
+			// These can indicate resource leaks (unclosed streams, handles).
+			console.error(`[ant:${antId}] session dispose error: ${String(disposeErr).slice(0, 200)}`);
 		}
 	}
 }

--- a/packages/ant-colony/extensions/ant-colony/ui.ts
+++ b/packages/ant-colony/extensions/ant-colony/ui.ts
@@ -185,6 +185,6 @@ export function buildReport(state: ColonyState): string {
 		...state.tasks.filter((t) => t.status === "done").map((t) => `- ${checkMark()} **${t.title}**`),
 		...state.tasks
 			.filter((t) => t.status === "failed")
-			.map((t) => `- ${crossMark()} **${t.title}** — ${t.error?.slice(0, 80) || "unknown"}`),
+			.map((t) => `- ${crossMark()} **${t.title}** — ${t.error?.slice(0, 200) || "unknown"}`),
 	].join("\n");
 }

--- a/packages/ant-colony/tests/nest.test.ts
+++ b/packages/ant-colony/tests/nest.test.ts
@@ -202,9 +202,11 @@ describe("withStateLock spin", () => {
 		expect(nest.getStateLight().status).toBe("reviewing");
 	});
 
-	it("surfaces non-contention lock errors immediately", () => {
+	it("recovers from directory removal by recreating it", () => {
 		fs.rmSync(nest.dir, { recursive: true, force: true });
 
-		expect(() => nest.updateState({ status: "reviewing" })).toThrow(/failed to acquire state lock/i);
+		// The lock should recover by recreating the directory (robustness fix)
+		expect(() => nest.updateState({ status: "reviewing" })).not.toThrow();
+		expect(fs.existsSync(nest.dir)).toBe(true);
 	});
 });

--- a/packages/subagents/execution.ts
+++ b/packages/subagents/execution.ts
@@ -327,7 +327,10 @@ export async function runSync(
 					}
 					scheduleUpdate();
 				}
-			} catch {}
+			} catch {
+				// Count unparseable lines — corrupted output shouldn't be silently lost
+				result.parseErrors = (result.parseErrors ?? 0) + 1;
+			}
 		};
 
 		let stderrBuf = "";
@@ -354,17 +357,31 @@ export async function runSync(
 			if (code !== 0 && stderrBuf.trim() && !result.error) {
 				result.error = stderrBuf.trim();
 			}
+			// Provide a fallback error for non-zero exits with no error details
+			if (code !== 0 && !result.error) {
+				result.error = `Subagent process exited with code ${code} (no stderr output captured)`;
+			}
 			resolve(code ?? 0);
 		});
-		proc.on("error", () => resolve(1));
+		proc.on("error", (err) => {
+			result.error = result.error || `Subagent process error: ${err.message}`;
+			resolve(1);
+		});
 
 		if (signal) {
 			const kill = () => {
 				proc.kill("SIGTERM");
 				setTimeout(() => !proc.killed && proc.kill("SIGKILL"), 3000);
 			};
-			if (signal.aborted) kill();
-			else signal.addEventListener("abort", kill, { once: true });
+			if (signal.aborted) {
+				kill();
+				result.aborted = true;
+			} else {
+				signal.addEventListener("abort", () => {
+					result.aborted = true;
+					kill();
+				}, { once: true });
+			}
 		}
 	});
 
@@ -377,7 +394,8 @@ export async function runSync(
 	if (tmpDir) fs.rmSync(tmpDir, { recursive: true, force: true });
 	result.exitCode = exitCode;
 
-	if (exitCode === 0 && !result.error) {
+	// Check for internal errors even when exit code is 0 (or non-zero without error details)
+	if (!result.error || exitCode === 0) {
 		const errInfo = detectSubagentError(result.messages);
 		if (errInfo.hasError) {
 			result.exitCode = errInfo.exitCode ?? 1;

--- a/packages/subagents/subagent-runner.ts
+++ b/packages/subagents/subagent-runner.ts
@@ -103,13 +103,14 @@ function runPiStreaming(
 	outputFile: string,
 	env?: Record<string, string | undefined>,
 	piPackageRoot?: string,
-): Promise<{ stdout: string; exitCode: number | null }> {
+): Promise<{ stdout: string; stderr: string; exitCode: number | null }> {
 	return new Promise((resolve) => {
 		const outputStream = fs.createWriteStream(outputFile, { flags: "w" });
 		const spawnEnv = { ...process.env, ...(env ?? {}), ...getSubagentDepthEnv() };
 		const spawnSpec = getPiSpawnCommand(args, piPackageRoot ? { piPackageRoot } : undefined);
 		const child = spawn(spawnSpec.command, spawnSpec.args, { cwd, stdio: ["ignore", "pipe", "pipe"], env: spawnEnv });
 		let stdout = "";
+		let stderr = "";
 
 		child.stdout.on("data", (chunk: Buffer) => {
 			const text = chunk.toString();
@@ -118,17 +119,19 @@ function runPiStreaming(
 		});
 
 		child.stderr.on("data", (chunk: Buffer) => {
-			outputStream.write(chunk.toString());
+			const text = chunk.toString();
+			stderr += text;
+			outputStream.write(text);
 		});
 
 		child.on("close", (exitCode) => {
 			outputStream.end();
-			resolve({ stdout, exitCode });
+			resolve({ stdout, stderr, exitCode });
 		});
 
-		child.on("error", () => {
+		child.on("error", (err) => {
 			outputStream.end();
-			resolve({ stdout, exitCode: 1 });
+			resolve({ stdout, stderr: stderr || `Process spawn error: ${err.message}`, exitCode: 1 });
 		});
 	});
 }
@@ -393,6 +396,11 @@ async function runSingleStep(
 				"utf-8",
 			);
 		}
+	}
+
+	// Include stderr in output when process fails without stdout
+	if (result.exitCode !== 0 && !outputForSummary && result.stderr) {
+		outputForSummary = `[!] Process failed (exit ${result.exitCode}):\n${result.stderr.slice(0, 1000)}`;
 	}
 
 	return { agent: step.agent, output: outputForSummary, exitCode: result.exitCode, artifactPaths };
@@ -839,6 +847,31 @@ async function runSubagent(config: SubagentRunConfig): Promise<void> {
 	}
 }
 
+/** Write a failure result file so the parent process knows what happened. */
+function writeFailureResult(resultPath: string | undefined, id: string, error: unknown): void {
+	if (!resultPath) return;
+	try {
+		const errMsg = error instanceof Error ? `${error.message}\n${error.stack || ""}` : String(error);
+		fs.mkdirSync(path.dirname(resultPath), { recursive: true });
+		fs.writeFileSync(
+			resultPath,
+			JSON.stringify({
+				id,
+				agent: "unknown",
+				success: false,
+				summary: `Runner crashed: ${errMsg.slice(0, 1000)}`,
+				results: [],
+				exitCode: 1,
+				timestamp: Date.now(),
+				error: errMsg.slice(0, 2000),
+			}),
+		);
+	} catch {
+		// Last resort — at least log it
+		console.error(`Failed to write failure result to ${resultPath}`);
+	}
+}
+
 const configArg = process.argv[2];
 if (configArg) {
 	try {
@@ -849,6 +882,7 @@ if (configArg) {
 		} catch {}
 		runSubagent(config).catch((runErr) => {
 			console.error("Subagent runner error:", runErr);
+			writeFailureResult(config.resultPath, config.id, runErr);
 			process.exit(1);
 		});
 	} catch (err) {
@@ -866,6 +900,7 @@ if (configArg) {
 			const config = JSON.parse(input) as SubagentRunConfig;
 			runSubagent(config).catch((runErr) => {
 				console.error("Subagent runner error:", runErr);
+				writeFailureResult(config.resultPath, config.id, runErr);
 				process.exit(1);
 			});
 		} catch (err) {

--- a/packages/subagents/types.ts
+++ b/packages/subagents/types.ts
@@ -88,6 +88,10 @@ export interface SingleResult {
 	usage: Usage;
 	model?: string;
 	error?: string;
+	/** Whether the subagent was aborted via signal (vs failed naturally). */
+	aborted?: boolean;
+	/** Number of unparseable JSONL lines received from the subprocess. */
+	parseErrors?: number;
 	sessionFile?: string;
 	skills?: string[];
 	skillsWarning?: string;


### PR DESCRIPTION
## Problem

When colonies or subagent swarms encounter errors during large workloads, they often fail silently — no error context is surfaced to the user. The user sees a failed colony with no explanation of *what* went wrong or *why*.

Additionally, the colony itself crashes with `ENOENT` on `state.lock` when the storage directory is cleaned up mid-run (observed twice during this PR's own development).

## Root Causes

1. **Error message truncation** — errors were sliced to 80–120 chars throughout queen.ts, spawner.ts, index.ts, and ui.ts, losing stack traces and diagnostic detail
2. **Silent error swallowing** — task failures in `runAntWave` updated the nest but never called `emitSignal`, so failures were invisible in the TUI
3. **Nest lock fragility** — `withStateLock` threw on `ENOENT` instead of retrying after recreating the directory
4. **Subagent process failures** — non-zero exit codes with empty stderr produced no error message; runner crashes wrote nothing to the result file

## Changes

### Ant Colony (`packages/ant-colony/`)

| File | Fix |
|------|-----|
| **nest.ts** | Lock acquisition now `mkdirSync` before `writeFileSync` and retries on `ENOENT` instead of crashing |
| **queen.ts** | Error signals expanded to 500 chars with stack traces; task failures now emit signals; plan validation failures include scout intel; budget-exceeded shows tasks completed |
| **spawner.ts** | Full error+stack preserved in task failure records; partial output included; model resolution errors include provider/model details; dispose errors logged |
| **index.ts** | Crash log expanded from 120→500 chars with stack; `onAntDone` includes error context for failed tasks |
| **ui.ts** | `buildReport()` error truncation expanded from 80→200 chars |

### Subagent Swarms (`packages/subagents/`)

| File | Fix |
|------|-----|
| **execution.ts** | Fallback error for empty-stderr exits; parse error counter; `aborted` flag; `detectSubagentError` runs on all results; spawn error captures message |
| **subagent-runner.ts** | `runPiStreaming` captures stderr; failure output includes stderr; `writeFailureResult` writes crash info to result file; spawn errors include message |
| **types.ts** | Added `aborted?` and `parseErrors?` to `SingleResult` |

### Tests

- Updated nest lock test: directory removal now triggers recovery (recreate) instead of crash

## Verification

- All 819 tests pass
- Lint clean
- Typecheck clean