### PR TITLE
fix(extensions): prevent scheduler startup prompt replay

### DIFF
--- a/.changeset/fix-scheduler-startup-replay.md
+++ b/.changeset/fix-scheduler-startup-replay.md
@@ -1,0 +1,5 @@
+---
+default: patch
+---
+
+fix scheduler startup replay by restoring overdue persisted tasks for manual review instead of auto-running them in a new session

--- a/packages/extensions/extensions/scheduler-registration.ts
+++ b/packages/extensions/extensions/scheduler-registration.ts
@@ -196,7 +196,7 @@ export function registerTools(pi: ExtensionAPI, runtime: SchedulerRuntime) {
 			"Use this tool when the user asks to remind/check back later, revisit something in the future, or monitor PRs, CI, builds, deploys, or background work.",
 			"For recurring tasks use kind='recurring' with duration like 5m or 2h, or provide cron.",
 			"For one-time reminders use kind='once' with duration like 30m or 1h.",
-			"Scheduled tasks run only while pi is active and idle, so phrase reminders and follow-ups accordingly.",
+			"Scheduled tasks run only while pi is active and idle. Persisted overdue tasks are restored for manual review instead of auto-running at startup.",
 		],
 		parameters: SchedulePromptToolParams,
 		execute: async (
@@ -240,8 +240,8 @@ function handleToolList(runtime: SchedulerRuntime): ToolResult {
 			task.kind === "once"
 				? "-"
 				: (task.cronExpression ?? formatDurationShort(task.intervalMs ?? DEFAULT_LOOP_INTERVAL));
-		const state = task.enabled ? "on" : "off";
-		const status = task.lastStatus ?? "pending";
+		const state = task.resumeRequired ? "due" : task.enabled ? "on" : "off";
+		const status = task.resumeRequired ? "resume_required" : (task.lastStatus ?? "pending");
 		const last = task.lastRunAt ? runtime.formatRelativeTime(task.lastRunAt) : "never";
 		return `${task.id}\t${state}\t${task.kind}\t${schedule}\t${runtime.formatRelativeTime(task.nextRunAt)}\t${task.runCount}\t${last}\t${status}\t${task.prompt}`;
 	});
@@ -417,6 +417,7 @@ export function registerEvents(pi: ExtensionAPI, runtime: SchedulerRuntime) {
 	pi.on("session_start", async (event, ctx) => {
 		refreshRuntimeContext(event, ctx);
 		runtime.startScheduler();
+		runtime.notifyResumeRequiredTasks();
 	});
 
 	pi.on("session_switch", refreshRuntimeContext);

--- a/packages/extensions/extensions/scheduler-shared.ts
+++ b/packages/extensions/extensions/scheduler-shared.ts
@@ -28,6 +28,7 @@ export interface ScheduleTask {
 	lastStatus?: TaskStatus;
 	runCount: number;
 	pending: boolean;
+	resumeRequired?: boolean;
 }
 
 export type RecurringSpec =

--- a/packages/extensions/extensions/scheduler.test.ts
+++ b/packages/extensions/extensions/scheduler.test.ts
@@ -1097,6 +1097,34 @@ describe("SchedulerRuntime", () => {
 			expect(ctx._statusMap.get("pi-scheduler")).toContain("1 active");
 		});
 
+		it("shows due count for overdue restored tasks", () => {
+			const now = Date.now();
+			(existsSync as ReturnType<typeof vi.fn>).mockReturnValue(true);
+			(readFileSync as ReturnType<typeof vi.fn>).mockReturnValue(
+				JSON.stringify({
+					version: 1,
+					tasks: [
+						{
+							id: "due12345",
+							prompt: "check build",
+							kind: "once",
+							enabled: true,
+							createdAt: now - 10 * ONE_MINUTE,
+							nextRunAt: now - ONE_MINUTE,
+							jitterMs: 0,
+							runCount: 0,
+							pending: false,
+						},
+					],
+				}),
+			);
+
+			const ctx = createMockCtx();
+			runtime.setRuntimeContext(ctx as any);
+			runtime.updateStatus();
+			expect(ctx._statusMap.get("pi-scheduler")).toContain("1 due");
+		});
+
 		it("shows paused message when all tasks disabled", () => {
 			const ctx = createMockCtx();
 			runtime.setRuntimeContext(ctx as any);
@@ -1174,7 +1202,78 @@ describe("SchedulerRuntime", () => {
 			expect(task).toBeDefined();
 			expect(task!.prompt).toBe("check build");
 			expect(task!.runCount).toBe(3);
+			expect(task!.resumeRequired).toBe(false);
 			expect(readFileSync).toHaveBeenCalledWith(getSchedulerStoragePath(ctx.cwd), "utf-8");
+		});
+
+		it("marks overdue restored tasks as resume-required instead of dispatching them immediately", async () => {
+			const now = Date.now();
+			(existsSync as ReturnType<typeof vi.fn>).mockReturnValue(true);
+			(readFileSync as ReturnType<typeof vi.fn>).mockReturnValue(
+				JSON.stringify({
+					version: 1,
+					tasks: [
+						{
+							id: "overdue1",
+							prompt: "check build",
+							kind: "recurring",
+							enabled: true,
+							createdAt: now - 10 * ONE_MINUTE,
+							nextRunAt: now - ONE_MINUTE,
+							intervalMs: 5 * ONE_MINUTE,
+							expiresAt: now + THREE_DAYS,
+							jitterMs: 0,
+							runCount: 1,
+							pending: false,
+						},
+					],
+				}),
+			);
+
+			const ctx = createMockCtx();
+			runtime.setRuntimeContext(ctx as any);
+
+			const task = runtime.getTask("overdue1");
+			expect(task).toBeDefined();
+			expect(task!.resumeRequired).toBe(true);
+			expect(task!.pending).toBe(false);
+
+			await runtime.tickScheduler();
+			expect(task!.pending).toBe(false);
+			expect(pi._userMessages).toHaveLength(0);
+		});
+
+		it("lets users explicitly resume an overdue restored task by re-enabling it", async () => {
+			const now = Date.now();
+			(existsSync as ReturnType<typeof vi.fn>).mockReturnValue(true);
+			(readFileSync as ReturnType<typeof vi.fn>).mockReturnValue(
+				JSON.stringify({
+					version: 1,
+					tasks: [
+						{
+							id: "overdue2",
+							prompt: "check build",
+							kind: "once",
+							enabled: true,
+							createdAt: now - 10 * ONE_MINUTE,
+							nextRunAt: now - ONE_MINUTE,
+							jitterMs: 0,
+							runCount: 0,
+							pending: false,
+						},
+					],
+				}),
+			);
+
+			const ctx = createMockCtx();
+			runtime.setRuntimeContext(ctx as any);
+
+			expect(runtime.getTask("overdue2")!.resumeRequired).toBe(true);
+			runtime.setTaskEnabled("overdue2", false);
+			runtime.setTaskEnabled("overdue2", true);
+			await runtime.tickScheduler();
+
+			expect(pi._userMessages).toEqual(["check build"]);
 		});
 
 		it("skips expired tasks when loading from disk", () => {
@@ -1926,6 +2025,34 @@ describe("event wiring", () => {
 		const ctx = createMockCtx();
 		pi._emit("session_start", { type: "session_start" }, ctx);
 		// Scheduler is started (no easy way to verify timer, but it should not throw)
+	});
+
+	it("warns about overdue restored tasks on session_start without dispatching them", () => {
+		const now = Date.now();
+		(existsSync as ReturnType<typeof vi.fn>).mockReturnValue(true);
+		(readFileSync as ReturnType<typeof vi.fn>).mockReturnValue(
+			JSON.stringify({
+				version: 1,
+				tasks: [
+					{
+						id: "overdue3",
+						prompt: "check build",
+						kind: "once",
+						enabled: true,
+						createdAt: now - 10 * ONE_MINUTE,
+						nextRunAt: now - ONE_MINUTE,
+						jitterMs: 0,
+						runCount: 0,
+						pending: false,
+					},
+				],
+			}),
+		);
+
+		const ctx = createMockCtx();
+		pi._emit("session_start", { type: "session_start" }, ctx);
+		expect(ctx._notifications.some((n: any) => n.msg.includes("will not run automatically"))).toBe(true);
+		expect(pi._userMessages).toHaveLength(0);
 	});
 
 	it("updates status on session_switch", () => {

--- a/packages/extensions/extensions/scheduler.ts
+++ b/packages/extensions/extensions/scheduler.ts
@@ -10,7 +10,8 @@
  *
  * Tasks run only while pi is active and idle. State is persisted under
  * `~/.pi/agent/scheduler/.../scheduler.json` using a path that mirrors the
- * current workspace path.
+ * current workspace path. Overdue tasks restored from disk are surfaced for
+ * manual review instead of auto-dispatching on session start.
  */
 
 import * as fs from "node:fs";
@@ -35,13 +36,7 @@ import {
 	MAX_TASKS,
 	MIN_RECURRING_INTERVAL,
 	ONE_MINUTE,
-	type ParseResult,
-	type RecurringSpec,
-	type ReminderParseResult,
-	type SchedulePromptAddPlan,
 	type ScheduleTask,
-	type TaskKind,
-	type TaskStatus,
 	THREE_DAYS,
 } from "./scheduler-shared.js";
 
@@ -77,7 +72,7 @@ export type {
 	ScheduleTask,
 	TaskKind,
 	TaskStatus,
-};
+} from "./scheduler-shared.js";
 
 interface SchedulerStore {
 	version: 1;
@@ -136,7 +131,9 @@ export class SchedulerRuntime {
 			return false;
 		}
 		task.enabled = enabled;
-		if (!enabled) {
+		if (enabled) {
+			task.resumeRequired = false;
+		} else {
 			task.pending = false;
 		}
 		this.persistTasks();
@@ -186,13 +183,13 @@ export class SchedulerRuntime {
 
 		const lines = ["Scheduled tasks:", ""];
 		for (const task of list) {
-			const state = task.enabled ? "on" : "off";
+			const state = this.taskStateLabel(task);
 			const mode = this.taskMode(task);
 			const next = `${this.formatRelativeTime(task.nextRunAt)} (${this.formatClock(task.nextRunAt)})`;
 			const last = task.lastRunAt
 				? `${this.formatRelativeTime(task.lastRunAt)} (${this.formatClock(task.lastRunAt)})`
 				: "never";
-			const status = task.lastStatus ?? "pending";
+			const status = this.taskStatusLabel(task);
 			const preview = task.prompt.length > 72 ? `${task.prompt.slice(0, 69)}...` : task.prompt;
 			lines.push(`${task.id}  ${state}  ${mode}  next ${next}`);
 			lines.push(`  runs=${task.runCount}  last=${last}  status=${status}`);
@@ -314,10 +311,18 @@ export class SchedulerRuntime {
 			return;
 		}
 
-		const nextRunAt = Math.min(...enabled.map((t) => t.nextRunAt));
-		const next = new Date(nextRunAt).toLocaleTimeString([], { hour: "2-digit", minute: "2-digit" });
-		const text = `${enabled.length} active • next ${next}`;
-		this.runtimeCtx.ui.setStatus("pi-scheduler", text);
+		const resumeRequired = enabled.filter((task) => task.resumeRequired);
+		const scheduled = enabled.filter((task) => !task.resumeRequired);
+		const parts: string[] = [];
+		if (resumeRequired.length > 0) {
+			parts.push(`${resumeRequired.length} due`);
+		}
+		if (scheduled.length > 0) {
+			const nextRunAt = Math.min(...scheduled.map((task) => task.nextRunAt));
+			const next = new Date(nextRunAt).toLocaleTimeString([], { hour: "2-digit", minute: "2-digit" });
+			parts.push(`${scheduled.length} active • next ${next}`);
+		}
+		this.runtimeCtx.ui.setStatus("pi-scheduler", parts.join(" • ") || "paused");
 	}
 
 	private pruneDispatchHistory(now: number) {
@@ -366,7 +371,7 @@ export class SchedulerRuntime {
 				continue;
 			}
 
-			if (!task.enabled) {
+			if (!task.enabled || task.resumeRequired) {
 				continue;
 			}
 			if (now >= task.nextRunAt) {
@@ -494,6 +499,7 @@ export class SchedulerRuntime {
 			if (action === "Run now") {
 				task.nextRunAt = Date.now();
 				task.pending = true;
+				task.resumeRequired = false;
 				this.persistTasks();
 				this.updateStatus();
 				this.tickScheduler().catch(() => {
@@ -534,6 +540,7 @@ export class SchedulerRuntime {
 				task.jitterMs = this.computeJitterMs(task.id, normalized.durationMs);
 				task.nextRunAt = Date.now() + normalized.durationMs + task.jitterMs;
 				task.pending = false;
+				task.resumeRequired = false;
 				this.persistTasks();
 				ctx.ui.notify(`Updated ${task.id} to every ${formatDurationShort(normalized.durationMs)}.`, "info");
 				if (normalized.note) {
@@ -563,6 +570,7 @@ export class SchedulerRuntime {
 			task.jitterMs = 0;
 			task.nextRunAt = nextRunAt;
 			task.pending = false;
+			task.resumeRequired = false;
 			this.persistTasks();
 			ctx.ui.notify(`Updated ${task.id} to cron ${normalizedCron.expression}.`, "info");
 			if (normalizedCron.note) {
@@ -582,6 +590,7 @@ export class SchedulerRuntime {
 		const normalized = normalizeDuration(parsed);
 		task.nextRunAt = Date.now() + normalized.durationMs;
 		task.pending = false;
+		task.resumeRequired = false;
 		this.persistTasks();
 		ctx.ui.notify(`Updated ${task.id} reminder to ${this.formatRelativeTime(task.nextRunAt)}.`, "info");
 		if (normalized.note) {
@@ -612,6 +621,7 @@ export class SchedulerRuntime {
 		}
 
 		task.pending = false;
+		task.resumeRequired = false;
 		task.lastRunAt = now;
 		task.lastStatus = "success";
 		task.runCount += 1;
@@ -679,7 +689,7 @@ export class SchedulerRuntime {
 	}
 
 	private taskOptionLabel(task: ScheduleTask): string {
-		const state = task.enabled ? "+" : "-";
+		const state = task.resumeRequired ? "!" : task.enabled ? "+" : "-";
 		return `${task.id} • ${state} ${this.taskMode(task)} • ${this.formatRelativeTime(task.nextRunAt)} • ${this.truncateText(task.prompt, 50)}`;
 	}
 
@@ -791,6 +801,7 @@ export class SchedulerRuntime {
 					enabled: task.enabled ?? true,
 					pending: false,
 					runCount: task.runCount ?? 0,
+					resumeRequired: task.resumeRequired ?? false,
 				};
 				if (normalized.kind === "recurring" && normalized.expiresAt && now >= normalized.expiresAt) {
 					mutated = true;
@@ -830,6 +841,10 @@ export class SchedulerRuntime {
 						normalized.nextRunAt = now + fallbackDelay;
 					}
 				}
+				if (normalized.enabled && normalized.nextRunAt <= now) {
+					normalized.resumeRequired = true;
+					mutated = true;
+				}
 
 				this.tasks.set(normalized.id, normalized);
 			}
@@ -840,6 +855,34 @@ export class SchedulerRuntime {
 			this.persistTasks();
 		}
 		this.updateStatus();
+	}
+
+	private taskStateLabel(task: ScheduleTask): string {
+		if (task.resumeRequired) {
+			return "due";
+		}
+		return task.enabled ? "on" : "off";
+	}
+
+	private taskStatusLabel(task: ScheduleTask): string {
+		if (task.resumeRequired) {
+			return "resume_required";
+		}
+		return task.lastStatus ?? "pending";
+	}
+
+	notifyResumeRequiredTasks() {
+		if (!this.runtimeCtx?.hasUI) {
+			return;
+		}
+		const dueTasks = this.getSortedTasks().filter((task) => task.enabled && task.resumeRequired);
+		if (dueTasks.length === 0) {
+			return;
+		}
+		this.runtimeCtx.ui.notify(
+			`Scheduler restored ${dueTasks.length} overdue task${dueTasks.length === 1 ? "" : "s"} from a previous session. They will not run automatically; use /schedule to review, run, reschedule, or disable them.`,
+			"warning",
+		);
 	}
 
 	persistTasks() {


### PR DESCRIPTION
## Summary
- restore overdue persisted scheduler tasks in a resume-required state instead of auto-dispatching them at startup
- surface due tasks in scheduler status/list output and notify on session start
- add regression coverage plus a changeset

## Validation
- pnpm lint
- pnpm test
- pnpm typecheck
- pnpm build