### PR TITLE
ci: add pi runtime compatibility matrix

### DIFF
--- a/.changeset/add-pi-compatibility-ci-matrix.md
+++ b/.changeset/add-pi-compatibility-ci-matrix.md
@@ -1,0 +1,5 @@
+---
+default: patch
+---
+
+add a small CI compatibility matrix that smoke-tests oh-pi extensions against the minimum supported pi baseline and a current upstream runtime.

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -260,10 +260,33 @@ jobs:
       - name: Run tests
         run: pnpm test
 
+  compat:
+    name: Compatibility (pi ${{ matrix.label }})
+    runs-on: ubuntu-latest
+    strategy:
+      matrix:
+        include:
+          - label: min-0.56.1
+            version: 0.56.1
+          - label: current-0.64.0
+            version: 0.64.0
+    steps:
+      - uses: actions/checkout@v6.0.2
+
+      - uses: pnpm/action-setup@v4.4.0
+
+      - uses: actions/setup-node@v6.3.0
+        with:
+          node-version: 22
+          cache: pnpm
+
+      - name: Verify compatibility smoke suite
+        run: pnpm verify:pi-compat -- --version ${{ matrix.version }}
+
   build:
     name: Build
     runs-on: ubuntu-latest
-    needs: [commit-lint, changeset, security, lint, typecheck, test]
+    needs: [commit-lint, changeset, security, lint, typecheck, test, compat]
     # Run build even if changeset was skipped (release commits)
     if: "!failure() && !cancelled()"
     steps:

--- a/README.md
+++ b/README.md
@@ -83,6 +83,7 @@ Policy:
 - compatibility with older pi builds is best-effort unless explicitly documented otherwise
 - peer dependency ranges on pi-facing packages express the minimum supported baseline more clearly
 - higher-risk runtime integrations should gain smoke coverage before broadening compatibility claims
+- CI smoke-checks both the minimum supported baseline (`0.56.1`) and a pinned current upstream runtime (`0.64.0`)
 
 ---
 

--- a/package.json
+++ b/package.json
@@ -13,6 +13,7 @@
 		"test": "vitest run",
 		"verify:compiled-tarballs": "node ./scripts/verify-compiled-tarballs.mjs",
 		"verify:published-packages": "node ./scripts/verify-published-packages.mjs",
+		"verify:pi-compat": "node ./scripts/verify-pi-compat.mjs",
 		"lint": "biome check --error-on-warnings .",
 		"lint:fix": "biome check --fix .",
 		"format": "biome format --write .",
@@ -23,7 +24,11 @@
 		"@types/node": "^22.0.0",
 		"@typescript/native-preview": "7.0.0-dev.20260305.1",
 		"typescript": "^5.7.0",
-		"vitest": "^3.0.0"
+		"vitest": "^3.0.0",
+		"@mariozechner/pi-agent-core": "0.56.1",
+		"@mariozechner/pi-ai": "0.56.1",
+		"@mariozechner/pi-coding-agent": "0.56.1",
+		"@mariozechner/pi-tui": "0.56.1"
 	},
 	"engines": {
 		"node": ">=20.0.0"

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -19,6 +19,18 @@ importers:
       '@biomejs/biome':
         specifier: ^2.4.6
         version: 2.4.6
+      '@mariozechner/pi-agent-core':
+        specifier: 0.56.1
+        version: 0.56.1(ws@8.19.0)(zod@3.25.76)
+      '@mariozechner/pi-ai':
+        specifier: 0.56.1
+        version: 0.56.1(ws@8.19.0)(zod@3.25.76)
+      '@mariozechner/pi-coding-agent':
+        specifier: 0.56.1
+        version: 0.56.1(ws@8.19.0)(zod@3.25.76)
+      '@mariozechner/pi-tui':
+        specifier: 0.56.1
+        version: 0.56.1
       '@types/node':
         specifier: ^22.0.0
         version: 22.19.13

--- a/scripts/verify-pi-compat.mjs
+++ b/scripts/verify-pi-compat.mjs
@@ -1,0 +1,104 @@
+#!/usr/bin/env node
+import { execFileSync } from "node:child_process";
+import { existsSync, readFileSync, writeFileSync } from "node:fs";
+
+const MIN_VERSION = "0.56.1";
+const CURRENT_VERSION = "0.64.0";
+const PI_PACKAGES = [
+	"@mariozechner/pi-agent-core",
+	"@mariozechner/pi-ai",
+	"@mariozechner/pi-coding-agent",
+	"@mariozechner/pi-tui",
+];
+const SMOKE_TESTS = [
+	"packages/extensions/extensions/smoke.test.ts",
+	"packages/ant-colony/tests/smoke.test.ts",
+	"packages/subagents/tests/smoke.test.ts",
+	"packages/spec/tests/smoke.test.ts",
+];
+
+function parseArgs(argv) {
+	const parsed = { version: process.env.PI_COMPAT_VERSION, restore: false };
+	for (let i = 0; i < argv.length; i++) {
+		const arg = argv[i];
+		if ((arg === "--version" || arg === "-v") && argv[i + 1]) {
+			parsed.version = argv[++i];
+			continue;
+		}
+		if (arg === "--restore") {
+			parsed.restore = true;
+		}
+	}
+	if (!parsed.version) {
+		throw new Error("Missing pi compatibility version. Use --version <semver> or set PI_COMPAT_VERSION.");
+	}
+	return parsed;
+}
+
+function run(command, args, options = {}) {
+	console.log(`\n> ${command} ${args.join(" ")}`);
+	execFileSync(command, args, {
+		stdio: "inherit",
+		env: process.env,
+		...options,
+	});
+}
+
+function patchRootManifest(version) {
+	const manifestPath = "package.json";
+	const pkg = JSON.parse(readFileSync(manifestPath, "utf8"));
+	pkg.devDependencies ??= {};
+	for (const dependency of PI_PACKAGES) {
+		pkg.devDependencies[dependency] = version;
+	}
+	writeFileSync(manifestPath, `${JSON.stringify(pkg, null, "\t")}\n`);
+}
+
+function readInstalledVersions() {
+	for (const dependency of PI_PACKAGES) {
+		const packageJsonPath = `node_modules/${dependency}/package.json`;
+		if (!existsSync(packageJsonPath)) {
+			console.log(`${dependency}: missing`);
+			continue;
+		}
+		const pkg = JSON.parse(readFileSync(packageJsonPath, "utf8"));
+		console.log(`${dependency}: ${pkg.version}`);
+	}
+}
+
+function restoreFiles(snapshot) {
+	for (const [file, contents] of Object.entries(snapshot)) {
+		if (contents === null) {
+			continue;
+		}
+		writeFileSync(file, contents);
+	}
+}
+
+const { version, restore } = parseArgs(process.argv.slice(2));
+const snapshot = {
+	"package.json": readFileSync("package.json", "utf8"),
+	"pnpm-lock.yaml": existsSync("pnpm-lock.yaml") ? readFileSync("pnpm-lock.yaml", "utf8") : null,
+};
+
+console.log(`Verifying pi compatibility against ${version}`);
+if (version === MIN_VERSION) {
+	console.log("Mode: minimum supported baseline");
+} else if (version === CURRENT_VERSION) {
+	console.log("Mode: current pinned upstream runtime");
+}
+
+try {
+	patchRootManifest(version);
+	run("pnpm", ["install", "--no-frozen-lockfile"]);
+	console.log("\nInstalled pi package versions:");
+	readInstalledVersions();
+	run("pnpm", ["--filter", "@ifi/oh-pi-core", "build"]);
+	run("pnpm", ["exec", "vitest", "run", ...SMOKE_TESTS]);
+} finally {
+	if (restore) {
+		console.log("\nRestoring package.json and pnpm-lock.yaml...");
+		restoreFiles(snapshot);
+		run("pnpm", ["install", "--frozen-lockfile"]);
+	}
+}


### PR DESCRIPTION
Closes #50

## Summary
- add a compatibility CI job that smoke-tests oh-pi against pi 0.56.1 and 0.64.0
- add a reusable `verify-pi-compat` script to install pinned upstream pi packages and run the extension smoke suite
- document the baseline/current runtime smoke coverage in the root README

## Testing
- pnpm verify:pi-compat -- --version 0.56.1 --restore
- pnpm verify:pi-compat -- --version 0.64.0 --restore
- pnpm --filter @ifi/oh-pi-core build && pnpm test
- pnpm lint
- pnpm typecheck
