### PR TITLE
refactor: centralize pi tui fallback loading

### DIFF
--- a/.changeset/centralize-pi-tui-bun-fallback-loading.md
+++ b/.changeset/centralize-pi-tui-bun-fallback-loading.md
@@ -1,0 +1,5 @@
+---
+default: patch
+---
+
+centralize pi-tui fallback resolution behind a shared loader used by shared-qna and plan runtime modules.

--- a/packages/plan/request-user-input.ts
+++ b/packages/plan/request-user-input.ts
@@ -1,9 +1,6 @@
-import { createRequire } from "node:module";
-import os from "node:os";
-import path from "node:path";
 import type { AgentToolResult } from "@mariozechner/pi-agent-core";
 import type { ExtensionAPI, ExtensionContext } from "@mariozechner/pi-coding-agent";
-import { QnATuiComponent, type QnAResponse, type QnAResult } from "@ifi/pi-shared-qna";
+import { QnATuiComponent, requirePiTuiModule, type QnAResponse, type QnAResult } from "@ifi/pi-shared-qna";
 import type {
 	NormalizedRequestUserInputQuestion,
 	PlanModeState,
@@ -14,22 +11,8 @@ import type {
 } from "./types";
 import { findDuplicateId } from "./utils";
 
-const require = createRequire(import.meta.url);
-
-function requirePiTui() {
-	try {
-		return require("@mariozechner/pi-tui");
-	} catch (error) {
-		const code = (error as { code?: string }).code;
-		if (code !== "MODULE_NOT_FOUND") {
-			throw error;
-		}
-		return require(path.join(os.homedir(), ".bun", "install", "global", "node_modules", "@mariozechner", "pi-tui"));
-	}
-}
-
 function createText(text: string) {
-	const { Text } = requirePiTui() as {
+	const { Text } = requirePiTuiModule() as {
 		Text: new (text: string, x: number, y: number) => unknown;
 	};
 	return new Text(text, 0, 0);

--- a/packages/plan/state.ts
+++ b/packages/plan/state.ts
@@ -1,27 +1,11 @@
-import { createRequire } from "node:module";
-import os from "node:os";
-import path from "node:path";
 import type { ExtensionAPI, ExtensionContext } from "@mariozechner/pi-coding-agent";
+import { requirePiTuiModule } from "@ifi/pi-shared-qna";
 import { resolveActivePlanFilePath } from "./plan-files";
 import type { PlanModeState } from "./types";
 import { createInactivePlanModeState, isPlanModeState } from "./utils";
 
-const require = createRequire(import.meta.url);
-
-function requirePiTui() {
-	try {
-		return require("@mariozechner/pi-tui");
-	} catch (error) {
-		const code = (error as { code?: string }).code;
-		if (code !== "MODULE_NOT_FOUND") {
-			throw error;
-		}
-		return require(path.join(os.homedir(), ".bun", "install", "global", "node_modules", "@mariozechner", "pi-tui"));
-	}
-}
-
 function getPiTui() {
-	return requirePiTui() as {
+	return requirePiTuiModule() as {
 		truncateToWidth: (text: string, width: number) => string;
 		wrapTextWithAnsi: (text: string, width: number) => string[];
 	};

--- a/packages/plan/task-agents.ts
+++ b/packages/plan/task-agents.ts
@@ -1,9 +1,7 @@
 import { randomBytes } from "node:crypto";
-import { createRequire } from "node:module";
-import os from "node:os";
-import path from "node:path";
 import type { AgentToolResult } from "@mariozechner/pi-agent-core";
 import type { ExtensionAPI } from "@mariozechner/pi-coding-agent";
+import { requirePiTuiModule } from "@ifi/pi-shared-qna";
 import { runSync } from "@ifi/pi-extension-subagents/execution.ts";
 import { getFinalOutput } from "@ifi/pi-extension-subagents/utils.ts";
 import type {
@@ -50,22 +48,8 @@ type RunTaskAgentTaskOptions = {
 	index: number;
 };
 
-const require = createRequire(import.meta.url);
-
-function requirePiTui() {
-	try {
-		return require("@mariozechner/pi-tui");
-	} catch (error) {
-		const code = (error as { code?: string }).code;
-		if (code !== "MODULE_NOT_FOUND") {
-			throw error;
-		}
-		return require(path.join(os.homedir(), ".bun", "install", "global", "node_modules", "@mariozechner", "pi-tui"));
-	}
-}
-
 function createRenderText(text: string) {
-	const { Text } = requirePiTui() as {
+	const { Text } = requirePiTuiModule() as {
 		Text: new (text: string, x: number, y: number) => unknown;
 	};
 	return new Text(text, 0, 0);

--- a/packages/shared-qna/index.ts
+++ b/packages/shared-qna/index.ts
@@ -1,1 +1,2 @@
+export * from "./pi-tui-loader.js";
 export * from "./qna-tui.js";

--- a/packages/shared-qna/package.json
+++ b/packages/shared-qna/package.json
@@ -13,6 +13,7 @@
   ],
   "exports": {
     ".": "./index.ts",
+    "./pi-tui-loader": "./pi-tui-loader.ts",
     "./package.json": "./package.json"
   },
   "files": [

--- a/packages/shared-qna/pi-tui-loader.ts
+++ b/packages/shared-qna/pi-tui-loader.ts
@@ -1,0 +1,52 @@
+import { createRequire } from "node:module";
+import os from "node:os";
+import path from "node:path";
+
+export type PiTuiRequire = (specifier: string) => unknown;
+
+export interface PiTuiLoaderOptions {
+	homeDir?: string;
+	bunInstallDir?: string | undefined;
+	requireFn?: PiTuiRequire;
+}
+
+export function getPiTuiFallbackPaths(options: Omit<PiTuiLoaderOptions, "requireFn"> = {}): string[] {
+	const homeDir = options.homeDir ?? os.homedir();
+	const roots = new Set<string>();
+	if (options.bunInstallDir) {
+		roots.add(options.bunInstallDir);
+	}
+	roots.add(path.join(homeDir, ".bun"));
+	return [...roots].map((root) =>
+		path.join(root, "install", "global", "node_modules", "@mariozechner", "pi-tui"),
+	);
+}
+
+export function requirePiTuiModule(options: PiTuiLoaderOptions = {}): unknown {
+	const requireFn = options.requireFn ?? createRequire(import.meta.url);
+	try {
+		return requireFn("@mariozechner/pi-tui");
+	} catch (error) {
+		const code = (error as { code?: string }).code;
+		if (code !== "MODULE_NOT_FOUND") {
+			throw error;
+		}
+
+		const fallbackPaths = getPiTuiFallbackPaths(options);
+		for (const fallbackPath of fallbackPaths) {
+			try {
+				return requireFn(fallbackPath);
+			} catch (fallbackError) {
+				const fallbackCode = (fallbackError as { code?: string }).code;
+				if (fallbackCode !== "MODULE_NOT_FOUND") {
+					throw fallbackError;
+				}
+			}
+		}
+
+		throw new Error(
+			`Unable to load @mariozechner/pi-tui. Checked the local dependency and Bun global fallbacks: ${fallbackPaths.join(", ")}`,
+			{ cause: error },
+		);
+	}
+}

--- a/packages/shared-qna/qna-tui.ts
+++ b/packages/shared-qna/qna-tui.ts
@@ -1,20 +1,4 @@
-import { createRequire } from "node:module";
-import os from "node:os";
-import path from "node:path";
-
-const require = createRequire(import.meta.url);
-
-function requirePiTui() {
-	try {
-		return require("@mariozechner/pi-tui");
-	} catch (error) {
-		const code = (error as { code?: string }).code;
-		if (code !== "MODULE_NOT_FOUND") {
-			throw error;
-		}
-		return require(path.join(os.homedir(), ".bun", "install", "global", "node_modules", "@mariozechner", "pi-tui"));
-	}
-}
+import { requirePiTuiModule } from "./pi-tui-loader.js";
 
 type Component = {
 	handleInput: (data: string) => void;
@@ -35,7 +19,7 @@ type EditorTheme = {
 };
 
 function getPiTui() {
-	return requirePiTui() as {
+	return requirePiTuiModule() as {
 		Editor: new (tui: TUI, theme: EditorTheme) => {
 			disableSubmit?: boolean;
 			onChange?: () => void;

--- a/packages/shared-qna/tests/pi-tui-loader.test.ts
+++ b/packages/shared-qna/tests/pi-tui-loader.test.ts
@@ -1,0 +1,75 @@
+import { describe, expect, it } from "vitest";
+import { getPiTuiFallbackPaths, requirePiTuiModule } from "../pi-tui-loader.js";
+
+describe("getPiTuiFallbackPaths", () => {
+	it("includes BUN_INSTALL and the default home fallback without duplicates", () => {
+		const paths = getPiTuiFallbackPaths({
+			homeDir: "/Users/tester",
+			bunInstallDir: "/custom-bun",
+		});
+		expect(paths).toEqual([
+			"/custom-bun/install/global/node_modules/@mariozechner/pi-tui",
+			"/Users/tester/.bun/install/global/node_modules/@mariozechner/pi-tui",
+		]);
+	});
+
+	it("deduplicates the default bun root when BUN_INSTALL matches it", () => {
+		const paths = getPiTuiFallbackPaths({
+			homeDir: "/Users/tester",
+			bunInstallDir: "/Users/tester/.bun",
+		});
+		expect(paths).toEqual(["/Users/tester/.bun/install/global/node_modules/@mariozechner/pi-tui"]);
+	});
+});
+
+describe("requirePiTuiModule", () => {
+	it("uses the regular package resolution path first", () => {
+		const calls: string[] = [];
+		const resolved = requirePiTuiModule({
+			requireFn(specifier) {
+				calls.push(specifier);
+				return { source: specifier };
+			},
+		});
+		expect(resolved).toEqual({ source: "@mariozechner/pi-tui" });
+		expect(calls).toEqual(["@mariozechner/pi-tui"]);
+	});
+
+	it("falls back to Bun global paths on module-not-found", () => {
+		const calls: string[] = [];
+		const resolved = requirePiTuiModule({
+			homeDir: "/Users/tester",
+			bunInstallDir: "/custom-bun",
+			requireFn(specifier) {
+				calls.push(specifier);
+				if (specifier === "@mariozechner/pi-tui") {
+					const error = new Error("missing");
+					(error as Error & { code?: string }).code = "MODULE_NOT_FOUND";
+					throw error;
+				}
+				if (specifier.includes("/custom-bun/")) {
+					return { source: specifier };
+				}
+				const error = new Error("missing");
+				(error as Error & { code?: string }).code = "MODULE_NOT_FOUND";
+				throw error;
+			},
+		});
+		expect(resolved).toEqual({ source: "/custom-bun/install/global/node_modules/@mariozechner/pi-tui" });
+		expect(calls[0]).toBe("@mariozechner/pi-tui");
+		expect(calls[1]).toBe("/custom-bun/install/global/node_modules/@mariozechner/pi-tui");
+	});
+
+	it("throws a helpful error when no location resolves", () => {
+		expect(() =>
+			requirePiTuiModule({
+				homeDir: "/Users/tester",
+				requireFn() {
+					const error = new Error("missing");
+					(error as Error & { code?: string }).code = "MODULE_NOT_FOUND";
+					throw error;
+				},
+			}),
+		).toThrow(/Unable to load @mariozechner\/pi-tui/);
+	});
+});


### PR DESCRIPTION
Closes #51

## Summary
- centralize pi-tui Bun/global fallback resolution in a shared loader
- reuse the shared loader from shared-qna and plan runtime modules instead of duplicating fallback logic
- add focused tests for fallback path resolution and module loading behavior

## Testing
- pnpm exec vitest run packages/shared-qna/tests/*.test.ts packages/plan/tests/*.test.ts packages/extensions/extensions/smoke.test.ts packages/spec/tests/smoke.test.ts
- pnpm lint
- pnpm typecheck
- pnpm --filter @ifi/oh-pi-core build && pnpm test
