### PR TITLE
fix(scheduler): isolate scheduled tasks by instance

### DIFF
--- a/.changeset/fix-scheduler-instance-ownership.md
+++ b/.changeset/fix-scheduler-instance-ownership.md
@@ -1,0 +1,5 @@
+---
+default: patch
+---
+
+prevent scheduled prompts from being auto-run in newly opened pi instances for the same workspace by adding instance ownership, workspace-scoped opt-in tasks, scheduler leasing, takeover prompts, and explicit adopt/release/clear-foreign controls.

--- a/packages/extensions/extensions/scheduler-registration.ts
+++ b/packages/extensions/extensions/scheduler-registration.ts
@@ -7,7 +7,7 @@ import {
 	parseRemindScheduleArgs,
 	validateSchedulePromptAddInput,
 } from "./scheduler-parsing.js";
-import { DEFAULT_LOOP_INTERVAL, MAX_TASKS, type TaskKind } from "./scheduler-shared.js";
+import { DEFAULT_LOOP_INTERVAL, MAX_TASKS, type ScheduleScope, type TaskKind } from "./scheduler-shared.js";
 
 const SchedulePromptToolParams = Type.Object({
 	action: Type.Union(
@@ -18,6 +18,9 @@ const SchedulePromptToolParams = Type.Object({
 			Type.Literal("clear"),
 			Type.Literal("enable"),
 			Type.Literal("disable"),
+			Type.Literal("adopt"),
+			Type.Literal("release"),
+			Type.Literal("clear_foreign"),
 		],
 		{ description: "Action to perform" },
 	),
@@ -35,19 +38,37 @@ const SchedulePromptToolParams = Type.Object({
 				"Cron expression for recurring tasks. Accepts 5-field (minute hour dom month dow) or 6-field (sec minute hour dom month dow).",
 		}),
 	),
-	id: Type.Optional(Type.String({ description: "Task id for delete/enable/disable action" })),
+	scope: Type.Optional(
+		Type.Union([Type.Literal("instance"), Type.Literal("workspace")], {
+			description: "Task ownership scope. Use workspace for monitors that should survive instance changes.",
+		}),
+	),
+	id: Type.Optional(Type.String({ description: "Task id for delete/enable/disable/adopt/release action" })),
 });
 
 type ToolResult = { content: { type: "text"; text: string }[]; details: Record<string, unknown> };
 
+function parseScopeFlag(input: string): { scope: ScheduleScope | undefined; rest: string } {
+	const trimmed = input.trim();
+	if (trimmed.startsWith("--workspace ") || trimmed === "--workspace") {
+		return { scope: "workspace", rest: trimmed.slice("--workspace".length).trim() };
+	}
+	if (trimmed.startsWith("--instance ") || trimmed === "--instance") {
+		return { scope: "instance", rest: trimmed.slice("--instance".length).trim() };
+	}
+	return { scope: undefined, rest: trimmed };
+}
+
 export function registerCommands(pi: ExtensionAPI, runtime: SchedulerRuntime) {
 	pi.registerCommand("loop", {
-		description: "Schedule recurring prompt: /loop 5m <prompt>, /loop <prompt> every 2h, or /loop cron <expr> <prompt>",
+		description:
+			"Schedule recurring prompt: /loop 5m <prompt>, /loop --workspace 5m <prompt>, or /loop cron <expr> <prompt>",
 		handler: async (args, ctx) => {
-			const parsed = parseLoopScheduleArgs(args);
+			const scoped = parseScopeFlag(args);
+			const parsed = parseLoopScheduleArgs(scoped.rest);
 			if (!parsed) {
 				ctx.ui.notify(
-					"Usage: /loop 5m check build OR /loop cron '*/5 * * * *' check build (minimum cron cadence is 1m)",
+					"Usage: /loop 5m check build OR /loop --workspace 5m check build OR /loop cron '*/5 * * * *' check build (minimum cron cadence is 1m)",
 					"warning",
 				);
 				return;
@@ -59,21 +80,28 @@ export function registerCommands(pi: ExtensionAPI, runtime: SchedulerRuntime) {
 			}
 
 			if (parsed.recurring.mode === "cron") {
-				const task = runtime.addRecurringCronTask(parsed.prompt, parsed.recurring.cronExpression);
+				const task = runtime.addRecurringCronTask(parsed.prompt, parsed.recurring.cronExpression, {
+					scope: scoped.scope,
+				});
 				if (!task) {
 					ctx.ui.notify("Invalid cron schedule. Cron tasks must run no more often than once per minute.", "error");
 					return;
 				}
-				ctx.ui.notify(`Scheduled cron ${task.cronExpression} (id: ${task.id}). Expires in 3 days.`, "info");
+				ctx.ui.notify(
+					`Scheduled cron ${task.cronExpression} (id: ${task.id}). Expires in 3 days. Scope: ${task.scope ?? "instance"}.`,
+					"info",
+				);
 				if (parsed.recurring.note) {
 					ctx.ui.notify(parsed.recurring.note, "info");
 				}
 				return;
 			}
 
-			const task = runtime.addRecurringIntervalTask(parsed.prompt, parsed.recurring.durationMs);
+			const task = runtime.addRecurringIntervalTask(parsed.prompt, parsed.recurring.durationMs, {
+				scope: scoped.scope,
+			});
 			ctx.ui.notify(
-				`Scheduled every ${formatDurationShort(parsed.recurring.durationMs)} (id: ${task.id}). Expires in 3 days.`,
+				`Scheduled every ${formatDurationShort(parsed.recurring.durationMs)} (id: ${task.id}). Expires in 3 days. Scope: ${task.scope ?? "instance"}.`,
 				"info",
 			);
 			if (parsed.recurring.note) {
@@ -83,9 +111,10 @@ export function registerCommands(pi: ExtensionAPI, runtime: SchedulerRuntime) {
 	});
 
 	pi.registerCommand("remind", {
-		description: "Schedule one-time reminder: /remind in 45m <prompt>",
+		description: "Schedule one-time reminder: /remind in 45m <prompt> or /remind --workspace in 45m <prompt>",
 		handler: async (args, ctx) => {
-			const parsed = parseRemindScheduleArgs(args);
+			const scoped = parseScopeFlag(args);
+			const parsed = parseRemindScheduleArgs(scoped.rest);
 			if (!parsed) {
 				ctx.ui.notify("Usage: /remind in 45m check deployment", "warning");
 				return;
@@ -96,8 +125,11 @@ export function registerCommands(pi: ExtensionAPI, runtime: SchedulerRuntime) {
 				return;
 			}
 
-			const task = runtime.addOneShotTask(parsed.prompt, parsed.durationMs);
-			ctx.ui.notify(`Reminder set for ${runtime.formatRelativeTime(task.nextRunAt)} (id: ${task.id}).`, "info");
+			const task = runtime.addOneShotTask(parsed.prompt, parsed.durationMs, { scope: scoped.scope });
+			ctx.ui.notify(
+				`Reminder set for ${runtime.formatRelativeTime(task.nextRunAt)} (id: ${task.id}, scope: ${task.scope ?? "instance"}).`,
+				"info",
+			);
 			if (parsed.note) {
 				ctx.ui.notify(parsed.note, "info");
 			}
@@ -106,7 +138,7 @@ export function registerCommands(pi: ExtensionAPI, runtime: SchedulerRuntime) {
 
 	pi.registerCommand("schedule", {
 		description:
-			"Manage scheduled reminders and future check-ins. No args opens TUI manager. Also: list | enable <id> | disable <id> | delete <id> | clear",
+			"Manage scheduled reminders and future check-ins. No args opens TUI manager. Also: list | enable <id> | disable <id> | delete <id> | clear | adopt <id|all> | release <id|all> | clear-foreign",
 		// biome-ignore lint/complexity/noExcessiveCognitiveComplexity: Command router with multiple subcommands.
 		handler: async (args, ctx) => {
 			const trimmed = args.trim();
@@ -115,7 +147,7 @@ export function registerCommands(pi: ExtensionAPI, runtime: SchedulerRuntime) {
 				return;
 			}
 
-			const [rawAction, rawArg] = trimmed.split(/\s+/, 2);
+			const [rawAction, rawArg, rawExtra] = trimmed.split(/\s+/, 3);
 			const action = rawAction.toLowerCase();
 
 			if (action === "list") {
@@ -162,7 +194,56 @@ export function registerCommands(pi: ExtensionAPI, runtime: SchedulerRuntime) {
 				return;
 			}
 
-			ctx.ui.notify("Usage: /schedule [tui|list|enable <id>|disable <id>|delete <id>|clear]", "warning");
+			if (action === "adopt") {
+				const target = rawArg?.trim() || "all";
+				const result = runtime.adoptTasks(target);
+				if (result.error) {
+					ctx.ui.notify(result.error, "warning");
+					return;
+				}
+				ctx.ui.notify(`Adopted ${result.count} scheduled task${result.count === 1 ? "" : "s"}.`, "info");
+				return;
+			}
+
+			if (action === "release") {
+				const target = rawArg?.trim() || "all";
+				const result = runtime.releaseTasks(target);
+				if (result.error) {
+					ctx.ui.notify(result.error, "warning");
+					return;
+				}
+				ctx.ui.notify(`Released ${result.count} scheduled task${result.count === 1 ? "" : "s"}.`, "info");
+				return;
+			}
+
+			if (action === "clear-foreign") {
+				const result = runtime.clearForeignTasks();
+				ctx.ui.notify(`Cleared ${result.count} foreign scheduled task${result.count === 1 ? "" : "s"}.`, "info");
+				return;
+			}
+
+			if (action === "scope") {
+				ctx.ui.notify(
+					"Change scope by recreating with --workspace/--instance or by adopting and re-scheduling. /schedule scope is not supported yet.",
+					"info",
+				);
+				return;
+			}
+
+			if (action === "adopt" || action === "release") {
+				ctx.ui.notify(`Usage: /schedule ${action} <id|all>`, "warning");
+				return;
+			}
+
+			if (rawExtra) {
+				ctx.ui.notify("Too many arguments for /schedule.", "warning");
+				return;
+			}
+
+			ctx.ui.notify(
+				"Usage: /schedule [tui|list|enable <id>|disable <id>|delete <id>|clear|adopt <id|all>|release <id|all>|clear-foreign]",
+				"warning",
+			);
 		},
 	});
 
@@ -189,19 +270,28 @@ export function registerTools(pi: ExtensionAPI, runtime: SchedulerRuntime) {
 		name: "schedule_prompt",
 		label: "Schedule Prompt",
 		description:
-			"Create/list/enable/disable/delete scheduled prompts. Use this when the user asks for reminders, to check back later, or to follow up on PRs, CI, builds, deployments, or any recurring check. add requires prompt; once tasks require duration; recurring supports interval (duration) or cron expression (cron).",
+			"Create/list/enable/disable/delete/adopt/release/clear scheduled prompts. Use this when the user asks for reminders, to check back later, or to follow up on PRs, CI, builds, deployments, or any recurring check. add requires prompt; once tasks require duration; recurring supports interval (duration) or cron expression (cron).",
 		promptSnippet:
-			"Create/list/enable/disable/delete scheduled prompts for one-time reminders, future follow-ups, and recurring PR/CI/build/deployment checks. Supports intervals/cron and one-time reminders while this pi session remains active.",
+			"Create/list/enable/disable/delete/adopt/release/clear scheduled prompts for one-time reminders, future follow-ups, and recurring PR/CI/build/deployment checks. Supports intervals/cron and one-time reminders while this pi instance remains active unless scope='workspace' is used.",
 		promptGuidelines: [
 			"Use this tool when the user asks to remind/check back later, revisit something in the future, or monitor PRs, CI, builds, deploys, or background work.",
 			"For recurring tasks use kind='recurring' with duration like 5m or 2h, or provide cron.",
 			"For one-time reminders use kind='once' with duration like 30m or 1h.",
-			"Scheduled tasks run only while pi is active and idle. Persisted overdue tasks are restored for manual review instead of auto-running at startup.",
+			"Default scope is instance. Use scope='workspace' only for monitors that should be adoptable across pi instances in the same workspace.",
+			"Scheduled tasks run only while pi is active and idle. Persisted overdue or foreign-owned tasks are restored for manual review instead of auto-running at startup.",
 		],
 		parameters: SchedulePromptToolParams,
 		execute: async (
 			_toolCallId,
-			params: { action: string; kind?: TaskKind; prompt?: string; duration?: string; cron?: string; id?: string },
+			params: {
+				action: string;
+				kind?: TaskKind;
+				prompt?: string;
+				duration?: string;
+				cron?: string;
+				scope?: ScheduleScope;
+				id?: string;
+			},
 		): Promise<{ content: { type: "text"; text: string }[]; details: Record<string, unknown> }> => {
 			const { action } = params;
 
@@ -216,6 +306,15 @@ export function registerTools(pi: ExtensionAPI, runtime: SchedulerRuntime) {
 			}
 			if (action === "enable" || action === "disable") {
 				return handleToolToggle(params, runtime);
+			}
+			if (action === "adopt") {
+				return handleToolAdopt(params, runtime);
+			}
+			if (action === "release") {
+				return handleToolRelease(params, runtime);
+			}
+			if (action === "clear_foreign") {
+				return handleToolClearForeign(runtime);
 			}
 			if (action === "add") {
 				return handleToolAdd(params, runtime);
@@ -240,16 +339,16 @@ function handleToolList(runtime: SchedulerRuntime): ToolResult {
 			task.kind === "once"
 				? "-"
 				: (task.cronExpression ?? formatDurationShort(task.intervalMs ?? DEFAULT_LOOP_INTERVAL));
-		const state = task.resumeRequired ? "due" : task.enabled ? "on" : "off";
+		const state = task.resumeRequired ? `due:${task.resumeReason ?? "unknown"}` : task.enabled ? "on" : "off";
 		const status = task.resumeRequired ? "resume_required" : (task.lastStatus ?? "pending");
 		const last = task.lastRunAt ? runtime.formatRelativeTime(task.lastRunAt) : "never";
-		return `${task.id}\t${state}\t${task.kind}\t${schedule}\t${runtime.formatRelativeTime(task.nextRunAt)}\t${task.runCount}\t${last}\t${status}\t${task.prompt}`;
+		return `${task.id}\t${state}\t${task.kind}\t${task.scope ?? "instance"}\t${schedule}\t${runtime.formatRelativeTime(task.nextRunAt)}\t${task.runCount}\t${last}\t${status}\t${task.prompt}`;
 	});
 	return {
 		content: [
 			{
 				type: "text",
-				text: `Scheduled tasks (id\tstate\tkind\tschedule\tnext\truns\tlast\tstatus\tprompt):\n${lines.join("\n")}`,
+				text: `Scheduled tasks (id\tstate\tkind\tscope\tschedule\tnext\truns\tlast\tstatus\tprompt):\n${lines.join("\n")}`,
 			},
 		],
 		details: { action: "list", tasks: list },
@@ -308,6 +407,46 @@ function handleToolToggle(params: { action: string; id?: string }, runtime: Sche
 	};
 }
 
+function handleToolAdopt(params: { id?: string }, runtime: SchedulerRuntime): ToolResult {
+	const target = params.id?.trim() || "all";
+	const result = runtime.adoptTasks(target);
+	if (result.error) {
+		return {
+			content: [{ type: "text", text: `Error: ${result.error}` }],
+			details: { action: "adopt", error: result.error },
+		};
+	}
+	return {
+		content: [{ type: "text", text: `Adopted ${result.count} scheduled task${result.count === 1 ? "" : "s"}.` }],
+		details: { action: "adopt", target, adopted: result.count },
+	};
+}
+
+function handleToolRelease(params: { id?: string }, runtime: SchedulerRuntime): ToolResult {
+	const target = params.id?.trim() || "all";
+	const result = runtime.releaseTasks(target);
+	if (result.error) {
+		return {
+			content: [{ type: "text", text: `Error: ${result.error}` }],
+			details: { action: "release", error: result.error },
+		};
+	}
+	return {
+		content: [{ type: "text", text: `Released ${result.count} scheduled task${result.count === 1 ? "" : "s"}.` }],
+		details: { action: "release", target, released: result.count },
+	};
+}
+
+function handleToolClearForeign(runtime: SchedulerRuntime): ToolResult {
+	const result = runtime.clearForeignTasks();
+	return {
+		content: [
+			{ type: "text", text: `Cleared ${result.count} foreign scheduled task${result.count === 1 ? "" : "s"}.` },
+		],
+		details: { action: "clear_foreign", cleared: result.count },
+	};
+}
+
 function validationErrorMessage(error: string): string {
 	switch (error) {
 		case "missing_duration":
@@ -326,7 +465,7 @@ function validationErrorMessage(error: string): string {
 }
 
 function handleToolAdd(
-	params: { kind?: TaskKind; prompt?: string; duration?: string; cron?: string },
+	params: { kind?: TaskKind; prompt?: string; duration?: string; cron?: string; scope?: ScheduleScope },
 	runtime: SchedulerRuntime,
 ): ToolResult {
 	const prompt = params.prompt?.trim();
@@ -357,12 +496,12 @@ function handleToolAdd(
 	}
 
 	if (validated.plan.kind === "once") {
-		const task = runtime.addOneShotTask(prompt, validated.plan.durationMs);
+		const task = runtime.addOneShotTask(prompt, validated.plan.durationMs, { scope: params.scope });
 		return {
 			content: [
 				{
 					type: "text",
-					text: `Reminder scheduled (id: ${task.id}) for ${runtime.formatRelativeTime(task.nextRunAt)}.${
+					text: `Reminder scheduled (id: ${task.id}) for ${runtime.formatRelativeTime(task.nextRunAt)} as ${task.scope ?? "instance"}-scoped.${
 						validated.plan.note ? ` ${validated.plan.note}` : ""
 					}`,
 				},
@@ -372,7 +511,7 @@ function handleToolAdd(
 	}
 
 	if (validated.plan.mode === "cron") {
-		const task = runtime.addRecurringCronTask(prompt, validated.plan.cronExpression);
+		const task = runtime.addRecurringCronTask(prompt, validated.plan.cronExpression, { scope: params.scope });
 		if (!task) {
 			return {
 				content: [
@@ -385,7 +524,7 @@ function handleToolAdd(
 			content: [
 				{
 					type: "text",
-					text: `Recurring cron task scheduled (id: ${task.id}) with '${task.cronExpression}'. Expires in 3 days.${
+					text: `Recurring cron task scheduled (id: ${task.id}) with '${task.cronExpression}' as ${task.scope ?? "instance"}-scoped. Expires in 3 days.${
 						validated.plan.note ? ` ${validated.plan.note}` : ""
 					}`,
 				},
@@ -394,12 +533,12 @@ function handleToolAdd(
 		};
 	}
 
-	const task = runtime.addRecurringIntervalTask(prompt, validated.plan.durationMs);
+	const task = runtime.addRecurringIntervalTask(prompt, validated.plan.durationMs, { scope: params.scope });
 	return {
 		content: [
 			{
 				type: "text",
-				text: `Recurring task scheduled (id: ${task.id}) every ${formatDurationShort(validated.plan.durationMs)}. Expires in 3 days.${
+				text: `Recurring task scheduled (id: ${task.id}) every ${formatDurationShort(validated.plan.durationMs)} as ${task.scope ?? "instance"}-scoped. Expires in 3 days.${
 					validated.plan.note ? ` ${validated.plan.note}` : ""
 				}`,
 			},
@@ -416,6 +555,7 @@ export function registerEvents(pi: ExtensionAPI, runtime: SchedulerRuntime) {
 
 	pi.on("session_start", async (event, ctx) => {
 		refreshRuntimeContext(event, ctx);
+		await runtime.handleStartupOwnership(ctx);
 		runtime.startScheduler();
 		runtime.notifyResumeRequiredTasks();
 	});

--- a/packages/extensions/extensions/scheduler-shared.ts
+++ b/packages/extensions/extensions/scheduler-shared.ts
@@ -9,14 +9,19 @@ export const DEFAULT_LOOP_INTERVAL = 10 * ONE_MINUTE;
 export const MIN_RECURRING_INTERVAL = ONE_MINUTE;
 export const DISPATCH_RATE_LIMIT_WINDOW_MS = ONE_MINUTE;
 export const MAX_DISPATCHES_PER_WINDOW = 6;
+export const SCHEDULER_LEASE_HEARTBEAT_MS = 1_000;
+export const SCHEDULER_LEASE_STALE_AFTER_MS = 10_000;
 
 export type TaskKind = "recurring" | "once";
 export type TaskStatus = "pending" | "success" | "error";
+export type ScheduleScope = "instance" | "workspace";
+export type ResumeReason = "overdue" | "foreign_owner" | "stale_owner" | "legacy_unowned" | "released";
 
 export interface ScheduleTask {
 	id: string;
 	prompt: string;
 	kind: TaskKind;
+	scope?: ScheduleScope;
 	enabled: boolean;
 	createdAt: number;
 	nextRunAt: number;
@@ -29,6 +34,18 @@ export interface ScheduleTask {
 	runCount: number;
 	pending: boolean;
 	resumeRequired?: boolean;
+	resumeReason?: ResumeReason;
+	ownerInstanceId?: string;
+	ownerSessionId?: string | null;
+}
+
+export interface SchedulerLease {
+	version: 1;
+	instanceId: string;
+	sessionId: string | null;
+	pid: number;
+	cwd: string;
+	heartbeatAt: number;
 }
 
 export type RecurringSpec =
@@ -66,6 +83,12 @@ export function getSchedulerStoragePath(cwd: string): string {
 				.toLowerCase() || "root"
 		: "root";
 	return path.join(getSchedulerStorageRoot(), rootSegment, ...relativeSegments, "scheduler.json");
+}
+
+export function getSchedulerLeasePath(cwd: string): string {
+	const storagePath = getSchedulerStoragePath(cwd);
+	const parentDir = path.dirname(storagePath);
+	return path.join(parentDir, "scheduler.lease.json");
 }
 
 export function getLegacySchedulerStoragePath(cwd: string): string {

--- a/packages/extensions/extensions/scheduler.test.ts
+++ b/packages/extensions/extensions/scheduler.test.ts
@@ -99,6 +99,9 @@ function createMockCtx(overrides: Record<string, any> = {}) {
 		hasUI: overrides.hasUI ?? true,
 		isIdle: overrides.isIdle ?? (() => true),
 		hasPendingMessages: overrides.hasPendingMessages ?? (() => false),
+		sessionManager: overrides.sessionManager ?? {
+			getSessionFile: () => "/mock-home/.pi/agent/sessions/test-session.jsonl",
+		},
 		ui: {
 			notify(msg: string, type: string) {
 				notifications.push({ msg, type });
@@ -138,6 +141,7 @@ import schedulerExtension, {
 	DISPATCH_RATE_LIMIT_WINDOW_MS,
 	FIFTEEN_MINUTES,
 	formatDurationShort,
+	getSchedulerLeasePath,
 	getSchedulerStoragePath,
 	MAX_DISPATCHES_PER_WINDOW,
 	MAX_TASKS,
@@ -603,6 +607,14 @@ describe("getSchedulerStoragePath", () => {
 	});
 });
 
+describe("getSchedulerLeasePath", () => {
+	it("stores the scheduler lease alongside the shared scheduler state", () => {
+		expect(getSchedulerLeasePath("/mock-project")).toBe(
+			"/mock-home/.pi/agent/scheduler/root/mock-project/scheduler.lease.json",
+		);
+	});
+});
+
 describe("SchedulerRuntime", () => {
 	let pi: ReturnType<typeof createMockPi>;
 	let runtime: SchedulerRuntime;
@@ -721,6 +733,27 @@ describe("SchedulerRuntime", () => {
 			stored.pending = true;
 			runtime.setTaskEnabled(task.id, false);
 			expect(runtime.getTask(task.id)!.pending).toBe(false);
+		});
+	});
+
+	describe("ownership and scope", () => {
+		it("defaults new reminders to instance scope and current ownership", () => {
+			const task = runtime.addOneShotTask("remind", 5 * ONE_MINUTE);
+			expect(task.scope).toBe("instance");
+			expect(task.ownerInstanceId).toBe(runtime.currentInstanceId);
+		});
+
+		it("adopts and releases tasks explicitly", () => {
+			const task = runtime.addRecurringIntervalTask("check build", 5 * ONE_MINUTE);
+
+			const released = runtime.releaseTasks(task.id);
+			expect(released.count).toBe(1);
+			expect(runtime.getTask(task.id)?.resumeReason).toBe("released");
+
+			const adopted = runtime.adoptTasks(task.id);
+			expect(adopted.count).toBe(1);
+			expect(runtime.getTask(task.id)?.ownerInstanceId).toBe(runtime.currentInstanceId);
+			expect(runtime.getTask(task.id)?.resumeRequired).toBe(false);
 		});
 	});
 
@@ -1189,6 +1222,9 @@ describe("SchedulerRuntime", () => {
 							jitterMs: 0,
 							runCount: 3,
 							pending: false,
+							scope: "instance",
+							ownerInstanceId: runtime.currentInstanceId,
+							ownerSessionId: null,
 						},
 					],
 				}),
@@ -1225,6 +1261,7 @@ describe("SchedulerRuntime", () => {
 							jitterMs: 0,
 							runCount: 1,
 							pending: false,
+							scope: "workspace",
 						},
 					],
 				}),
@@ -1260,6 +1297,7 @@ describe("SchedulerRuntime", () => {
 							jitterMs: 0,
 							runCount: 0,
 							pending: false,
+							scope: "workspace",
 						},
 					],
 				}),
@@ -1568,6 +1606,11 @@ describe("command handlers", () => {
 		it("creates task with default 10m interval", async () => {
 			await pi._commands.get("loop").handler("check build status", ctx);
 			expect(ctx._notifications.some((n: any) => n.msg.includes("Scheduled every 10m"))).toBe(true);
+		});
+
+		it("creates workspace-scoped loop tasks with an explicit flag", async () => {
+			await pi._commands.get("loop").handler("--workspace 5m check build", ctx);
+			expect(ctx._notifications.some((n: any) => n.msg.includes("Scope: workspace"))).toBe(true);
 		});
 
 		it("shows warning on empty args", async () => {
@@ -1987,6 +2030,31 @@ describe("schedule_prompt tool", () => {
 		});
 	});
 
+	describe("ownership actions", () => {
+		it("supports workspace-scoped tasks via the tool API", async () => {
+			const result = await tool.execute("id", {
+				action: "add",
+				prompt: "watch CI",
+				kind: "recurring",
+				duration: "5m",
+				scope: "workspace",
+			});
+			expect(result.content[0].text).toContain("workspace-scoped");
+			expect(result.details.task.scope).toBe("workspace");
+		});
+
+		it("adopts and releases tasks through the tool API", async () => {
+			const addResult = await tool.execute("id", { action: "add", prompt: "check", duration: "5m" });
+			const taskId = addResult.details.task.id;
+
+			const releaseResult = await tool.execute("id", { action: "release", id: taskId });
+			expect(releaseResult.content[0].text).toContain("Released 1 scheduled task");
+
+			const adoptResult = await tool.execute("id", { action: "adopt", id: taskId });
+			expect(adoptResult.content[0].text).toContain("Adopted 1 scheduled task");
+		});
+	});
+
 	describe("action: unsupported", () => {
 		it("returns error for unknown action", async () => {
 			const result = await tool.execute("id", { action: "banana" });
@@ -2027,7 +2095,7 @@ describe("event wiring", () => {
 		// Scheduler is started (no easy way to verify timer, but it should not throw)
 	});
 
-	it("warns about overdue restored tasks on session_start without dispatching them", () => {
+	it("warns about overdue restored tasks on session_start without dispatching them", async () => {
 		const now = Date.now();
 		(existsSync as ReturnType<typeof vi.fn>).mockReturnValue(true);
 		(readFileSync as ReturnType<typeof vi.fn>).mockReturnValue(
@@ -2044,6 +2112,7 @@ describe("event wiring", () => {
 						jitterMs: 0,
 						runCount: 0,
 						pending: false,
+						scope: "workspace",
 					},
 				],
 			}),
@@ -2051,7 +2120,55 @@ describe("event wiring", () => {
 
 		const ctx = createMockCtx();
 		pi._emit("session_start", { type: "session_start" }, ctx);
+		await Promise.resolve();
 		expect(ctx._notifications.some((n: any) => n.msg.includes("will not run automatically"))).toBe(true);
+		expect(pi._userMessages).toHaveLength(0);
+	});
+
+	it("prompts before a new instance adopts tasks owned by another live instance", async () => {
+		const now = Date.now();
+		(existsSync as ReturnType<typeof vi.fn>).mockImplementation(
+			(file: string) => file.endsWith("scheduler.json") || file.endsWith("scheduler.lease.json"),
+		);
+		(readFileSync as ReturnType<typeof vi.fn>).mockImplementation((file: string) => {
+			if (file.endsWith("scheduler.lease.json")) {
+				return JSON.stringify({
+					version: 1,
+					instanceId: "foreign-instance",
+					sessionId: "/mock-home/.pi/agent/sessions/foreign.jsonl",
+					pid: 123,
+					cwd: "/mock-project",
+					heartbeatAt: now,
+				});
+			}
+			return JSON.stringify({
+				version: 1,
+				tasks: [
+					{
+						id: "foreign1",
+						prompt: "check build",
+						kind: "once",
+						enabled: true,
+						createdAt: now - ONE_MINUTE,
+						nextRunAt: now + ONE_MINUTE,
+						jitterMs: 0,
+						runCount: 0,
+						pending: false,
+						scope: "instance",
+						ownerInstanceId: "foreign-instance",
+						ownerSessionId: "/mock-home/.pi/agent/sessions/foreign.jsonl",
+					},
+				],
+			});
+		});
+
+		const ctx = createMockCtx({ select: vi.fn().mockResolvedValue("Leave tasks in the other instance") });
+		pi._emit("session_start", { type: "session_start" }, ctx);
+		await Promise.resolve();
+		await Promise.resolve();
+
+		expect(ctx.ui.select).toHaveBeenCalled();
+		expect(ctx._notifications.some((n: any) => n.msg.includes("observe scheduler tasks"))).toBe(true);
 		expect(pi._userMessages).toHaveLength(0);
 	});
 

--- a/packages/extensions/extensions/scheduler.ts
+++ b/packages/extensions/extensions/scheduler.ts
@@ -14,6 +14,7 @@
  * manual review instead of auto-dispatching on session start.
  */
 
+import { randomUUID } from "node:crypto";
 import * as fs from "node:fs";
 import * as path from "node:path";
 import type { ExtensionAPI, ExtensionContext } from "@mariozechner/pi-coding-agent";
@@ -30,12 +31,18 @@ import {
 	DISPATCH_RATE_LIMIT_WINDOW_MS,
 	FIFTEEN_MINUTES,
 	getLegacySchedulerStoragePath,
+	getSchedulerLeasePath,
 	getSchedulerStoragePath,
 	getSchedulerStorageRoot,
 	MAX_DISPATCHES_PER_WINDOW,
 	MAX_TASKS,
 	MIN_RECURRING_INTERVAL,
 	ONE_MINUTE,
+	type ResumeReason,
+	SCHEDULER_LEASE_HEARTBEAT_MS,
+	SCHEDULER_LEASE_STALE_AFTER_MS,
+	type SchedulerLease,
+	type ScheduleScope,
 	type ScheduleTask,
 	THREE_DAYS,
 } from "./scheduler-shared.js";
@@ -51,33 +58,46 @@ export {
 	parseRemindScheduleArgs,
 	validateSchedulePromptAddInput,
 } from "./scheduler-parsing.js";
+export type {
+	ParseResult,
+	RecurringSpec,
+	ReminderParseResult,
+	ResumeReason,
+	SchedulePromptAddPlan,
+	SchedulerLease,
+	ScheduleScope,
+	ScheduleTask,
+	TaskKind,
+	TaskStatus,
+} from "./scheduler-shared.js";
 export {
 	DEFAULT_LOOP_INTERVAL,
 	DISPATCH_RATE_LIMIT_WINDOW_MS,
 	FIFTEEN_MINUTES,
 	getLegacySchedulerStoragePath,
+	getSchedulerLeasePath,
 	getSchedulerStoragePath,
 	getSchedulerStorageRoot,
 	MAX_DISPATCHES_PER_WINDOW,
 	MAX_TASKS,
 	MIN_RECURRING_INTERVAL,
 	ONE_MINUTE,
+	SCHEDULER_LEASE_HEARTBEAT_MS,
+	SCHEDULER_LEASE_STALE_AFTER_MS,
 	THREE_DAYS,
 };
-export type {
-	ParseResult,
-	RecurringSpec,
-	ReminderParseResult,
-	SchedulePromptAddPlan,
-	ScheduleTask,
-	TaskKind,
-	TaskStatus,
-} from "./scheduler-shared.js";
 
 interface SchedulerStore {
 	version: 1;
 	tasks: ScheduleTask[];
 }
+
+type SchedulerDispatchMode = "auto" | "observer";
+
+type TaskMutationResult = {
+	count: number;
+	error?: string;
+};
 
 // ── Runtime ─────────────────────────────────────────────────────────────────
 
@@ -87,8 +107,13 @@ export class SchedulerRuntime {
 	private runtimeCtx: ExtensionContext | undefined;
 	private dispatching = false;
 	private storagePath: string | undefined;
+	private leasePath: string | undefined;
 	private readonly dispatchTimestamps: number[] = [];
 	private lastRateLimitNoticeAt = 0;
+	private readonly instanceId = randomUUID().slice(0, 12);
+	private sessionId: string | null = null;
+	private dispatchMode: SchedulerDispatchMode = "auto";
+	private startupOwnershipHandled = false;
 
 	constructor(private readonly pi: ExtensionAPI) {}
 
@@ -96,18 +121,31 @@ export class SchedulerRuntime {
 		return this.tasks.size;
 	}
 
+	get currentInstanceId(): string {
+		return this.instanceId;
+	}
+
 	setRuntimeContext(ctx: ExtensionContext | undefined) {
 		this.runtimeCtx = ctx;
+		this.sessionId = this.getSessionId(ctx);
 		if (!ctx?.cwd) {
 			return;
 		}
 
 		const nextStorePath = getSchedulerStoragePath(ctx.cwd);
-		if (nextStorePath !== this.storagePath) {
+		const nextLeasePath = getSchedulerLeasePath(ctx.cwd);
+		if (nextStorePath !== this.storagePath || nextLeasePath !== this.leasePath) {
+			this.releaseLeaseIfOwned();
 			this.storagePath = nextStorePath;
+			this.leasePath = nextLeasePath;
+			this.dispatchMode = "auto";
+			this.startupOwnershipHandled = false;
 			this.migrateLegacyStore(ctx.cwd);
 			this.loadTasksFromDisk();
+			return;
 		}
+
+		this.reconcileTaskOwnership();
 	}
 
 	clearStatus(ctx?: ExtensionContext) {
@@ -131,11 +169,14 @@ export class SchedulerRuntime {
 			return false;
 		}
 		task.enabled = enabled;
-		if (enabled) {
-			task.resumeRequired = false;
-		} else {
+		if (!enabled) {
 			task.pending = false;
 		}
+		if (enabled && task.resumeReason === "overdue") {
+			task.resumeRequired = false;
+			task.resumeReason = undefined;
+		}
+		this.reconcileTaskOwnership();
 		this.persistTasks();
 		this.updateStatus();
 		return true;
@@ -156,6 +197,70 @@ export class SchedulerRuntime {
 		this.persistTasks();
 		this.updateStatus();
 		return count;
+	}
+
+	adoptTasks(target = "all"): TaskMutationResult {
+		const matching = this.resolveTaskTargets(target, (task) => task.ownerInstanceId !== this.instanceId);
+		if (matching.error) {
+			return { count: 0, error: matching.error };
+		}
+		for (const task of matching.tasks) {
+			this.assignOwner(task, task.scope ?? "instance");
+		}
+		this.reconcileTaskOwnership();
+		this.persistTasks();
+		this.updateStatus();
+		return { count: matching.tasks.length };
+	}
+
+	releaseTasks(target = "all"): TaskMutationResult {
+		const matching = this.resolveTaskTargets(target, (task) => task.ownerInstanceId === this.instanceId);
+		if (matching.error) {
+			return { count: 0, error: matching.error };
+		}
+		for (const task of matching.tasks) {
+			task.ownerInstanceId = undefined;
+			task.ownerSessionId = undefined;
+			task.pending = false;
+			task.resumeRequired = true;
+			task.resumeReason = "released";
+		}
+		this.reconcileTaskOwnership();
+		this.persistTasks();
+		this.updateStatus();
+		return { count: matching.tasks.length };
+	}
+
+	clearForeignTasks(): TaskMutationResult {
+		let count = 0;
+		for (const task of Array.from(this.tasks.values())) {
+			if (task.ownerInstanceId && task.ownerInstanceId !== this.instanceId) {
+				this.tasks.delete(task.id);
+				count += 1;
+			}
+		}
+		if (count > 0) {
+			this.persistTasks();
+			this.updateStatus();
+		}
+		return { count };
+	}
+
+	disableForeignTasks(): TaskMutationResult {
+		let count = 0;
+		for (const task of this.tasks.values()) {
+			if (task.ownerInstanceId && task.ownerInstanceId !== this.instanceId) {
+				task.enabled = false;
+				task.pending = false;
+				count += 1;
+			}
+		}
+		if (count > 0) {
+			this.reconcileTaskOwnership();
+			this.persistTasks();
+			this.updateStatus();
+		}
+		return { count };
 	}
 
 	formatRelativeTime(timestamp: number): string {
@@ -192,13 +297,13 @@ export class SchedulerRuntime {
 			const status = this.taskStatusLabel(task);
 			const preview = task.prompt.length > 72 ? `${task.prompt.slice(0, 69)}...` : task.prompt;
 			lines.push(`${task.id}  ${state}  ${mode}  next ${next}`);
-			lines.push(`  runs=${task.runCount}  last=${last}  status=${status}`);
+			lines.push(`  owner=${this.taskOwnerLabel(task)}  runs=${task.runCount}  last=${last}  status=${status}`);
 			lines.push(`  ${preview}`);
 		}
 		return lines.join("\n");
 	}
 
-	addRecurringIntervalTask(prompt: string, intervalMs: number): ScheduleTask {
+	addRecurringIntervalTask(prompt: string, intervalMs: number, options: { scope?: ScheduleScope } = {}): ScheduleTask {
 		const id = this.createId();
 		const createdAt = Date.now();
 		const safeIntervalMs = Number.isFinite(intervalMs)
@@ -210,6 +315,7 @@ export class SchedulerRuntime {
 			id,
 			prompt,
 			kind: "recurring",
+			scope: options.scope ?? "instance",
 			enabled: true,
 			createdAt,
 			nextRunAt,
@@ -219,13 +325,18 @@ export class SchedulerRuntime {
 			runCount: 0,
 			pending: false,
 		};
+		this.assignOwner(task, task.scope ?? "instance");
 		this.tasks.set(id, task);
 		this.persistTasks();
 		this.updateStatus();
 		return task;
 	}
 
-	addRecurringCronTask(prompt: string, cronExpression: string): ScheduleTask | undefined {
+	addRecurringCronTask(
+		prompt: string,
+		cronExpression: string,
+		options: { scope?: ScheduleScope } = {},
+	): ScheduleTask | undefined {
 		const normalizedCron = normalizeCronExpression(cronExpression);
 		if (!normalizedCron) {
 			return undefined;
@@ -242,6 +353,7 @@ export class SchedulerRuntime {
 			id,
 			prompt,
 			kind: "recurring",
+			scope: options.scope ?? "instance",
 			enabled: true,
 			createdAt,
 			nextRunAt,
@@ -251,19 +363,21 @@ export class SchedulerRuntime {
 			runCount: 0,
 			pending: false,
 		};
+		this.assignOwner(task, task.scope ?? "instance");
 		this.tasks.set(id, task);
 		this.persistTasks();
 		this.updateStatus();
 		return task;
 	}
 
-	addOneShotTask(prompt: string, delayMs: number): ScheduleTask {
+	addOneShotTask(prompt: string, delayMs: number, options: { scope?: ScheduleScope } = {}): ScheduleTask {
 		const id = this.createId();
 		const createdAt = Date.now();
 		const task: ScheduleTask = {
 			id,
 			prompt,
 			kind: "once",
+			scope: options.scope ?? "instance",
 			enabled: true,
 			createdAt,
 			nextRunAt: createdAt + delayMs,
@@ -271,6 +385,7 @@ export class SchedulerRuntime {
 			runCount: 0,
 			pending: false,
 		};
+		this.assignOwner(task, task.scope ?? "instance");
 		this.tasks.set(id, task);
 		this.persistTasks();
 		this.updateStatus();
@@ -285,15 +400,16 @@ export class SchedulerRuntime {
 			this.tickScheduler().catch(() => {
 				// Best-effort scheduler tick; errors are non-fatal.
 			});
-		}, 1000);
+		}, SCHEDULER_LEASE_HEARTBEAT_MS);
+		this.schedulerTimer.unref?.();
 	}
 
 	stopScheduler() {
-		if (!this.schedulerTimer) {
-			return;
+		if (this.schedulerTimer) {
+			clearInterval(this.schedulerTimer);
+			this.schedulerTimer = undefined;
 		}
-		clearInterval(this.schedulerTimer);
-		this.schedulerTimer = undefined;
+		this.releaseLeaseIfOwned();
 	}
 
 	updateStatus() {
@@ -313,7 +429,11 @@ export class SchedulerRuntime {
 
 		const resumeRequired = enabled.filter((task) => task.resumeRequired);
 		const scheduled = enabled.filter((task) => !task.resumeRequired);
+		const leaseStatus = this.getLeaseStatus();
 		const parts: string[] = [];
+		if (leaseStatus.activeForeign && this.dispatchMode === "observer") {
+			parts.push("observing other instance");
+		}
 		if (resumeRequired.length > 0) {
 			parts.push(`${resumeRequired.length} due`);
 		}
@@ -362,7 +482,7 @@ export class SchedulerRuntime {
 		}
 
 		const now = Date.now();
-		let mutated = false;
+		let mutated = this.reconcileTaskOwnership();
 
 		for (const task of Array.from(this.tasks.values())) {
 			if (task.kind === "recurring" && task.expiresAt && now >= task.expiresAt) {
@@ -395,8 +515,14 @@ export class SchedulerRuntime {
 			return;
 		}
 
+		const leaseStatus = this.ensureDispatchLease(now);
+		if (!leaseStatus.canDispatch) {
+			this.updateStatus();
+			return;
+		}
+
 		const nextTask = Array.from(this.tasks.values())
-			.filter((task) => task.enabled && task.pending)
+			.filter((task) => task.enabled && task.pending && this.canCurrentInstanceDispatchTask(task))
 			.sort((a, b) => a.nextRunAt - b.nextRunAt)[0];
 
 		if (!nextTask) {
@@ -409,6 +535,60 @@ export class SchedulerRuntime {
 		} finally {
 			this.dispatching = false;
 		}
+	}
+
+	async handleStartupOwnership(ctx: ExtensionContext): Promise<void> {
+		if (this.startupOwnershipHandled) {
+			return;
+		}
+		this.startupOwnershipHandled = true;
+		const leaseStatus = this.getLeaseStatus();
+		if (!leaseStatus.activeForeign) {
+			this.dispatchMode = "auto";
+			return;
+		}
+
+		this.dispatchMode = "observer";
+		if (!ctx.hasUI) {
+			return;
+		}
+
+		const foreignTaskCount = this.getForeignTaskCount();
+		const option = await ctx.ui.select("Another pi instance is managing scheduled tasks for this workspace.", [
+			"Leave tasks in the other instance",
+			"Review tasks",
+			`Take over scheduler and adopt foreign tasks${foreignTaskCount > 0 ? ` (${foreignTaskCount})` : ""}`,
+			`Disable foreign tasks${foreignTaskCount > 0 ? ` (${foreignTaskCount})` : ""}`,
+			`Clear foreign tasks${foreignTaskCount > 0 ? ` (${foreignTaskCount})` : ""}`,
+		]);
+
+		switch (option) {
+			case "Review tasks":
+				await this.openTaskManager(ctx);
+				break;
+			case `Take over scheduler and adopt foreign tasks${foreignTaskCount > 0 ? ` (${foreignTaskCount})` : ""}`: {
+				const adopted = this.takeOverScheduler(true);
+				ctx.ui.notify(
+					`Scheduler ownership moved to this instance.${adopted > 0 ? ` Adopted ${adopted} task${adopted === 1 ? "" : "s"}.` : ""}`,
+					"warning",
+				);
+				break;
+			}
+			case `Disable foreign tasks${foreignTaskCount > 0 ? ` (${foreignTaskCount})` : ""}`: {
+				const result = this.disableForeignTasks();
+				ctx.ui.notify(`Disabled ${result.count} foreign task${result.count === 1 ? "" : "s"}.`, "warning");
+				break;
+			}
+			case `Clear foreign tasks${foreignTaskCount > 0 ? ` (${foreignTaskCount})` : ""}`: {
+				const result = this.clearForeignTasks();
+				ctx.ui.notify(`Cleared ${result.count} foreign task${result.count === 1 ? "" : "s"}.`, "warning");
+				break;
+			}
+			default:
+				ctx.ui.notify("This instance will observe scheduler tasks without dispatching them.", "info");
+		}
+
+		this.updateStatus();
 	}
 
 	async openTaskManager(ctx: ExtensionContext): Promise<void> {
@@ -464,6 +644,8 @@ export class SchedulerRuntime {
 				task.kind === "recurring" ? "⏱ Change schedule" : "⏱ Change reminder delay",
 				task.enabled ? "Disable" : "Enable",
 				"Run now",
+				"Adopt",
+				"Release",
 				"🗑 Delete",
 				"↩ Back",
 				"✕ Close",
@@ -484,6 +666,26 @@ export class SchedulerRuntime {
 				continue;
 			}
 
+			if (action === "Adopt") {
+				const result = this.adoptTasks(task.id);
+				if (result.error) {
+					ctx.ui.notify(result.error, "warning");
+				} else {
+					ctx.ui.notify(`Adopted ${task.id}.`, "info");
+				}
+				continue;
+			}
+
+			if (action === "Release") {
+				const result = this.releaseTasks(task.id);
+				if (result.error) {
+					ctx.ui.notify(result.error, "warning");
+				} else {
+					ctx.ui.notify(`Released ${task.id}.`, "info");
+				}
+				continue;
+			}
+
 			if (action === "🗑 Delete") {
 				const ok = await ctx.ui.confirm("Delete scheduled task?", `${task.id}: ${task.prompt}`);
 				if (!ok) {
@@ -500,6 +702,8 @@ export class SchedulerRuntime {
 				task.nextRunAt = Date.now();
 				task.pending = true;
 				task.resumeRequired = false;
+				task.resumeReason = undefined;
+				this.reconcileTaskOwnership();
 				this.persistTasks();
 				this.updateStatus();
 				this.tickScheduler().catch(() => {
@@ -541,6 +745,8 @@ export class SchedulerRuntime {
 				task.nextRunAt = Date.now() + normalized.durationMs + task.jitterMs;
 				task.pending = false;
 				task.resumeRequired = false;
+				task.resumeReason = undefined;
+				this.reconcileTaskOwnership();
 				this.persistTasks();
 				ctx.ui.notify(`Updated ${task.id} to every ${formatDurationShort(normalized.durationMs)}.`, "info");
 				if (normalized.note) {
@@ -571,6 +777,8 @@ export class SchedulerRuntime {
 			task.nextRunAt = nextRunAt;
 			task.pending = false;
 			task.resumeRequired = false;
+			task.resumeReason = undefined;
+			this.reconcileTaskOwnership();
 			this.persistTasks();
 			ctx.ui.notify(`Updated ${task.id} to cron ${normalizedCron.expression}.`, "info");
 			if (normalizedCron.note) {
@@ -580,7 +788,6 @@ export class SchedulerRuntime {
 			return;
 		}
 
-		// One-shot task: update delay
 		const parsed = parseDuration(raw);
 		if (!parsed) {
 			ctx.ui.notify("Invalid duration. Try values like 5m, 2h, or 1 day.", "warning");
@@ -591,6 +798,8 @@ export class SchedulerRuntime {
 		task.nextRunAt = Date.now() + normalized.durationMs;
 		task.pending = false;
 		task.resumeRequired = false;
+		task.resumeReason = undefined;
+		this.reconcileTaskOwnership();
 		this.persistTasks();
 		ctx.ui.notify(`Updated ${task.id} reminder to ${this.formatRelativeTime(task.nextRunAt)}.`, "info");
 		if (normalized.note) {
@@ -600,7 +809,7 @@ export class SchedulerRuntime {
 	}
 
 	dispatchTask(task: ScheduleTask) {
-		if (!task.enabled) {
+		if (!(task.enabled && this.canCurrentInstanceDispatchTask(task))) {
 			return;
 		}
 		const now = Date.now();
@@ -622,6 +831,7 @@ export class SchedulerRuntime {
 
 		task.pending = false;
 		task.resumeRequired = false;
+		task.resumeReason = undefined;
 		task.lastRunAt = now;
 		task.lastStatus = "success";
 		task.runCount += 1;
@@ -689,8 +899,8 @@ export class SchedulerRuntime {
 	}
 
 	private taskOptionLabel(task: ScheduleTask): string {
-		const state = task.resumeRequired ? "!" : task.enabled ? "+" : "-";
-		return `${task.id} • ${state} ${this.taskMode(task)} • ${this.formatRelativeTime(task.nextRunAt)} • ${this.truncateText(task.prompt, 50)}`;
+		const state = task.resumeRequired ? `! ${task.resumeReason ?? "review"}` : task.enabled ? "+" : "-";
+		return `${task.id} • ${state} [${task.scope ?? "instance"}] ${this.taskMode(task)} • ${this.formatRelativeTime(task.nextRunAt)} • ${this.truncateText(task.prompt, 50)}`;
 	}
 
 	private truncateText(value: string, max = 64): string {
@@ -721,6 +931,244 @@ export class SchedulerRuntime {
 		return this.hashString(taskId) % (maxJitter + 1);
 	}
 
+	private getSessionId(ctx: ExtensionContext | undefined): string | null {
+		try {
+			return ctx?.sessionManager?.getSessionFile?.() ?? null;
+		} catch {
+			return null;
+		}
+	}
+
+	private assignOwner(task: ScheduleTask, scope: ScheduleScope) {
+		task.scope = scope;
+		task.ownerInstanceId = this.instanceId;
+		task.ownerSessionId = this.sessionId;
+		task.resumeRequired = false;
+		task.resumeReason = undefined;
+	}
+
+	private resolveTaskTargets(
+		target: string,
+		predicate?: (task: ScheduleTask) => boolean,
+	): { tasks: ScheduleTask[]; error?: undefined } | { tasks: ScheduleTask[]; error: string } {
+		if (target === "all") {
+			const tasks = this.getSortedTasks().filter((task) => predicate?.(task) ?? true);
+			return { tasks };
+		}
+		const task = this.tasks.get(target);
+		if (!task) {
+			return { tasks: [], error: `Task not found: ${target}` };
+		}
+		if (predicate && !predicate(task)) {
+			return { tasks: [], error: `Task ${target} is not eligible for that operation.` };
+		}
+		return { tasks: [task] };
+	}
+
+	private getForeignTaskCount(): number {
+		return Array.from(this.tasks.values()).filter(
+			(task) => task.ownerInstanceId && task.ownerInstanceId !== this.instanceId,
+		).length;
+	}
+
+	private readLease(): SchedulerLease | undefined {
+		if (!this.leasePath) {
+			return undefined;
+		}
+		try {
+			if (!fs.existsSync(this.leasePath)) {
+				return undefined;
+			}
+			const raw = fs.readFileSync(this.leasePath, "utf-8");
+			const parsed = JSON.parse(raw) as SchedulerLease;
+			if (!(parsed?.instanceId && Number.isFinite(parsed?.heartbeatAt))) {
+				return undefined;
+			}
+			return parsed;
+		} catch {
+			return undefined;
+		}
+	}
+
+	private isLeaseFresh(lease: SchedulerLease | undefined, now = Date.now()): boolean {
+		if (!lease) {
+			return false;
+		}
+		return now - lease.heartbeatAt < SCHEDULER_LEASE_STALE_AFTER_MS;
+	}
+
+	private getLeaseStatus(now = Date.now()): {
+		lease?: SchedulerLease;
+		ownedByCurrent: boolean;
+		activeForeign: boolean;
+	} {
+		const lease = this.readLease();
+		const ownedByCurrent = Boolean(lease && lease.instanceId === this.instanceId && this.isLeaseFresh(lease, now));
+		const activeForeign = Boolean(lease && lease.instanceId !== this.instanceId && this.isLeaseFresh(lease, now));
+		return { lease, ownedByCurrent, activeForeign };
+	}
+
+	private writeLease(now = Date.now(), force = false): boolean {
+		if (!(this.leasePath && this.runtimeCtx?.cwd)) {
+			return false;
+		}
+		try {
+			const current = this.readLease();
+			if (!force && current && current.instanceId !== this.instanceId && this.isLeaseFresh(current, now)) {
+				return false;
+			}
+			const lease: SchedulerLease = {
+				version: 1,
+				instanceId: this.instanceId,
+				sessionId: this.sessionId,
+				pid: process.pid,
+				cwd: this.runtimeCtx.cwd,
+				heartbeatAt: now,
+			};
+			fs.mkdirSync(path.dirname(this.leasePath), { recursive: true });
+			const tempPath = `${this.leasePath}.tmp`;
+			fs.writeFileSync(tempPath, JSON.stringify(lease, null, 2), "utf-8");
+			fs.renameSync(tempPath, this.leasePath);
+			const confirmed = this.readLease();
+			return confirmed ? confirmed.instanceId === this.instanceId : true;
+		} catch {
+			return false;
+		}
+	}
+
+	private releaseLeaseIfOwned() {
+		if (!this.leasePath) {
+			return;
+		}
+		try {
+			const lease = this.readLease();
+			if (lease?.instanceId !== this.instanceId) {
+				return;
+			}
+			fs.rmSync(this.leasePath, { force: true });
+		} catch {
+			// Best-effort cleanup.
+		}
+	}
+
+	private ensureDispatchLease(now = Date.now()): { canDispatch: boolean } {
+		if (this.dispatchMode === "observer") {
+			return { canDispatch: false };
+		}
+		const status = this.getLeaseStatus(now);
+		if (status.ownedByCurrent) {
+			return { canDispatch: this.writeLease(now, true) };
+		}
+		if (status.activeForeign) {
+			return { canDispatch: false };
+		}
+		return { canDispatch: this.writeLease(now) };
+	}
+
+	private takeOverScheduler(adoptForeignTasks: boolean): number {
+		this.dispatchMode = "auto";
+		this.writeLease(Date.now(), true);
+		if (!adoptForeignTasks) {
+			return 0;
+		}
+		let count = 0;
+		for (const task of this.tasks.values()) {
+			if (task.ownerInstanceId && task.ownerInstanceId !== this.instanceId) {
+				this.assignOwner(task, task.scope ?? "instance");
+				count += 1;
+			}
+		}
+		this.reconcileTaskOwnership();
+		this.persistTasks();
+		this.updateStatus();
+		return count;
+	}
+
+	private canCurrentInstanceDispatchTask(task: ScheduleTask): boolean {
+		if (!(task.enabled && !task.resumeRequired)) {
+			return false;
+		}
+		if ((task.scope ?? "instance") === "workspace") {
+			return true;
+		}
+		return task.ownerInstanceId === this.instanceId;
+	}
+
+	private normalizeTaskScope(task: ScheduleTask): boolean {
+		if (task.scope) {
+			return false;
+		}
+		task.scope = task.kind === "once" ? "instance" : "workspace";
+		return true;
+	}
+
+	private getTaskRestriction(
+		task: ScheduleTask,
+		leaseStatus: ReturnType<SchedulerRuntime["getLeaseStatus"]>,
+		legacyTask: boolean,
+	): ResumeReason | null {
+		if (legacyTask) {
+			return "legacy_unowned";
+		}
+		if ((task.scope ?? "instance") !== "instance") {
+			return null;
+		}
+		if (!task.ownerInstanceId) {
+			return task.resumeReason === "released" ? "released" : "legacy_unowned";
+		}
+		if (task.ownerInstanceId === this.instanceId) {
+			return null;
+		}
+		return leaseStatus.activeForeign && leaseStatus.lease?.instanceId === task.ownerInstanceId
+			? "foreign_owner"
+			: "stale_owner";
+	}
+
+	private markTaskForReview(task: ScheduleTask, reason: ResumeReason): boolean {
+		if (task.resumeRequired && task.resumeReason === reason && !task.pending) {
+			return false;
+		}
+		task.resumeRequired = true;
+		task.resumeReason = reason;
+		task.pending = false;
+		return true;
+	}
+
+	private clearTaskReviewState(task: ScheduleTask): boolean {
+		if (!(task.resumeRequired || task.resumeReason)) {
+			return false;
+		}
+		task.resumeRequired = false;
+		task.resumeReason = undefined;
+		return true;
+	}
+
+	private reconcileTaskOwnership(): boolean {
+		const leaseStatus = this.getLeaseStatus(Date.now());
+		let mutated = false;
+
+		for (const task of this.tasks.values()) {
+			const legacyTask = task.scope === undefined && task.ownerInstanceId === undefined;
+			mutated = this.normalizeTaskScope(task) || mutated;
+
+			const restriction = this.getTaskRestriction(task, leaseStatus, legacyTask);
+			if (restriction) {
+				mutated = this.markTaskForReview(task, restriction) || mutated;
+				continue;
+			}
+
+			if (task.resumeReason === "overdue") {
+				continue;
+			}
+
+			if (task.resumeRequired || task.resumeReason) {
+				mutated = this.clearTaskReviewState(task) || mutated;
+			}
+		}
+
+		return mutated;
+	}
+
 	private migrateLegacyStore(cwd: string) {
 		if (!this.storagePath) {
 			return;
@@ -749,6 +1197,7 @@ export class SchedulerRuntime {
 		} catch {
 			// Best-effort cleanup.
 		}
+		this.releaseLeaseIfOwned();
 
 		const schedulerRoot = getSchedulerStorageRoot();
 		let currentDir = path.dirname(this.storagePath);
@@ -798,10 +1247,12 @@ export class SchedulerRuntime {
 
 				const normalized: ScheduleTask = {
 					...task,
+					scope: task.scope,
 					enabled: task.enabled ?? true,
 					pending: false,
 					runCount: task.runCount ?? 0,
 					resumeRequired: task.resumeRequired ?? false,
+					resumeReason: task.resumeReason,
 				};
 				if (normalized.kind === "recurring" && normalized.expiresAt && now >= normalized.expiresAt) {
 					mutated = true;
@@ -843,6 +1294,7 @@ export class SchedulerRuntime {
 				}
 				if (normalized.enabled && normalized.nextRunAt <= now) {
 					normalized.resumeRequired = true;
+					normalized.resumeReason = "overdue";
 					mutated = true;
 				}
 
@@ -851,6 +1303,7 @@ export class SchedulerRuntime {
 		} catch {
 			// Ignore corrupted store and continue with empty in-memory state.
 		}
+		mutated = this.reconcileTaskOwnership() || mutated;
 		if (mutated) {
 			this.persistTasks();
 		}
@@ -859,16 +1312,26 @@ export class SchedulerRuntime {
 
 	private taskStateLabel(task: ScheduleTask): string {
 		if (task.resumeRequired) {
-			return "due";
+			return `review:${task.resumeReason ?? "unknown"}`;
 		}
 		return task.enabled ? "on" : "off";
 	}
 
 	private taskStatusLabel(task: ScheduleTask): string {
 		if (task.resumeRequired) {
-			return "resume_required";
+			return `resume_required (${task.resumeReason ?? "unknown"})`;
 		}
 		return task.lastStatus ?? "pending";
+	}
+
+	private taskOwnerLabel(task: ScheduleTask): string {
+		if (task.ownerInstanceId === this.instanceId) {
+			return `this:${this.instanceId}`;
+		}
+		if (task.ownerInstanceId) {
+			return `${task.ownerInstanceId}${task.ownerSessionId ? ` (${task.ownerSessionId})` : ""}`;
+		}
+		return "unowned";
 	}
 
 	notifyResumeRequiredTasks() {
@@ -879,10 +1342,33 @@ export class SchedulerRuntime {
 		if (dueTasks.length === 0) {
 			return;
 		}
+		const counts = new Map<ResumeReason, number>();
+		for (const task of dueTasks) {
+			const reason = task.resumeReason ?? "overdue";
+			counts.set(reason, (counts.get(reason) ?? 0) + 1);
+		}
+		const details = Array.from(counts.entries())
+			.map(([reason, count]) => `${count} ${this.resumeReasonLabel(reason)}`)
+			.join(", ");
 		this.runtimeCtx.ui.notify(
-			`Scheduler restored ${dueTasks.length} overdue task${dueTasks.length === 1 ? "" : "s"} from a previous session. They will not run automatically; use /schedule to review, run, reschedule, or disable them.`,
+			`Scheduler restored ${dueTasks.length} task${dueTasks.length === 1 ? "" : "s"} requiring review (${details}). They will not run automatically; use /schedule to review, adopt, reschedule, disable, or delete them.`,
 			"warning",
 		);
+	}
+
+	private resumeReasonLabel(reason: ResumeReason): string {
+		switch (reason) {
+			case "foreign_owner":
+				return "owned by another live instance";
+			case "stale_owner":
+				return "owned by a stale instance";
+			case "legacy_unowned":
+				return "legacy unowned task";
+			case "released":
+				return "released task";
+			default:
+				return "overdue task";
+		}
 	}
 
 	persistTasks() {


### PR DESCRIPTION
## Summary
- add scheduler task ownership, workspace-scoped opt-in tasks, and a per-workspace dispatcher lease
- prevent newly opened pi instances from auto-running tasks created by another live instance in the same folder
- prompt on startup when another live instance owns the workspace scheduler, with takeover/disable/clear options
- add adopt/release/clear-foreign controls plus tests for ownership, lease handling, and workspace-scope flows

## Details
- default task scope is now `instance`
- `--workspace` and tool `scope: "workspace"` opt into cross-instance monitoring flows
- foreign instance-owned tasks are restored in review mode instead of auto-running
- only the lease holder dispatches workspace tasks

## Validation
- `pnpm build`
- `pnpm test`
- `pnpm lint`
- `pnpm typecheck`
