### PR TITLE
docs(skills): add non-interactive git workflow guidance

### DIFF
--- a/.changeset/docs-noninteractive-git-agent-guidance.md
+++ b/.changeset/docs-noninteractive-git-agent-guidance.md
@@ -1,0 +1,5 @@
+---
+default: patch
+---
+
+document non-interactive git and GitHub CLI guidance for agent-run workflows

--- a/docs/agent-rules/git-and-pr-workflow.md
+++ b/docs/agent-rules/git-and-pr-workflow.md
@@ -32,6 +32,29 @@ Use these types:
 
 - Only use squash merging.
 
+## Non-interactive Git/GitHub commands for agents
+
+When the agent runs `git` or `gh`, prefer non-interactive invocations so an editor like Helix or Vim does not block the run.
+
+- Do not assume `git rebase --continue` supports `--no-edit` — it does not.
+- When continuing a rebase, use:
+  ```bash
+  GIT_EDITOR=true git rebase --continue
+  ```
+  or:
+  ```bash
+  git -c core.editor=true rebase --continue
+  ```
+- Always provide commit/tag/PR text explicitly on the command line when possible:
+  - `git commit -m "..."`
+  - `git tag -a vX.Y.Z -m "..."`
+  - `gh pr create --title "..." --body "..."`
+- Use `git merge --no-edit` when reusing the generated merge message.
+- Run GitHub CLI commands with prompts disabled unless the user explicitly wants an interactive flow:
+  ```bash
+  GH_PROMPT_DISABLED=1 gh ...
+  ```
+
 ## PR checks
 
 - When you create or manage a PR, monitor failing or pending checks until they pass.

--- a/packages/skills/skills/git-workflow/SKILL.md
+++ b/packages/skills/skills/git-workflow/SKILL.md
@@ -45,6 +45,33 @@ chore(scope): maintenance tasks
 2. Generate PR title and description
 3. Suggest reviewers based on changed files (`git log --format='%an' -- <files>`)
 
+### Non-interactive safety for agent-run Git/GitHub commands
+
+When **the agent** runs `git` or `gh`, avoid opening an interactive editor or prompt.
+
+- For `git rebase --continue`, do **not** rely on `--no-edit` — `git rebase --continue` does not support it.
+  Use one of these instead:
+  ```bash
+  GIT_EDITOR=true git rebase --continue
+  # or
+  git -c core.editor=true rebase --continue
+  ```
+- For commits, always pass the message on the command line:
+  ```bash
+  git commit -m "fix(scope): message"
+  ```
+- For merges that should reuse the existing message, use:
+  ```bash
+  git merge --no-edit
+  ```
+- For any other git command that could open an editor, set `GIT_EDITOR=true` for that invocation.
+- For GitHub CLI commands, disable terminal prompts and provide all required fields explicitly:
+  ```bash
+  GH_PROMPT_DISABLED=1 gh pr create --title "..." --body "..."
+  GH_PROMPT_DISABLED=1 gh pr merge --squash --delete-branch
+  ```
+- Only allow interactive editors/prompts when the user explicitly asks the agent to leave them enabled.
+
 ### Conflict Resolution
 
 1. `git diff --name-only --diff-filter=U` — Find conflicted files
@@ -55,3 +82,9 @@ chore(scope): maintenance tasks
 ### Interactive Rebase
 
 Guide through `git rebase -i` for cleaning up history before PR.
+
+If the agent is resolving conflicts during a rebase, continue with a non-interactive command such as:
+
+```bash
+GIT_EDITOR=true git rebase --continue
+```


### PR DESCRIPTION
## Summary
- document non-interactive git command patterns for agent-run workflows
- clarify that `git rebase --continue` should use `GIT_EDITOR=true` rather than `--no-edit`
- add matching guidance for GitHub CLI prompt suppression

## Validation
- changeset added
- rebased onto `main`