### PR TITLE
fix(packages): avoid loading helper modules as extensions

### DIFF
--- a/.changeset/fix-package-extension-entrypoints.md
+++ b/.changeset/fix-package-extension-entrypoints.md
@@ -1,0 +1,5 @@
+---
+default: patch
+---
+
+fix pi package extension manifests to list explicit entrypoint files so helper modules are not loaded as standalone extensions.

--- a/packages/ant-colony/package.json
+++ b/packages/ant-colony/package.json
@@ -8,7 +8,7 @@
   ],
   "pi": {
     "extensions": [
-      "./extensions"
+      "./extensions/ant-colony/index.ts"
     ]
   },
   "files": [

--- a/packages/extensions/extensions/package-manifest.test.ts
+++ b/packages/extensions/extensions/package-manifest.test.ts
@@ -1,0 +1,36 @@
+import { readFileSync } from "node:fs";
+import path from "node:path";
+import { fileURLToPath } from "node:url";
+import { describe, expect, it } from "vitest";
+
+type PiPackageManifest = {
+	pi?: {
+		extensions?: string[];
+	};
+};
+
+const extensionsDir = path.dirname(fileURLToPath(import.meta.url));
+
+function readPackageJson(relativePath: string): PiPackageManifest {
+	return JSON.parse(
+		readFileSync(path.resolve(extensionsDir, "..", "..", "..", relativePath), "utf-8"),
+	) as PiPackageManifest;
+}
+
+describe("pi package extension entrypoints", () => {
+	it("lists explicit extension entrypoint files for helper-heavy packages", () => {
+		const extensionPackages = [
+			"packages/extensions/package.json",
+			"packages/spec/package.json",
+			"packages/ant-colony/package.json",
+		];
+
+		for (const packagePath of extensionPackages) {
+			const manifest = readPackageJson(packagePath);
+			const entries = manifest.pi?.extensions ?? [];
+			expect(entries.length).toBeGreaterThan(0);
+			expect(entries.every((entry) => entry.endsWith(".ts"))).toBe(true);
+			expect(entries.every((entry) => !(entry.endsWith("/extensions") || entry.endsWith("/extension")))).toBe(true);
+		}
+	});
+});

--- a/packages/extensions/package.json
+++ b/packages/extensions/package.json
@@ -7,7 +7,17 @@
   ],
   "pi": {
     "extensions": [
-      "./extensions"
+      "./extensions/auto-session-name.ts",
+      "./extensions/auto-update.ts",
+      "./extensions/bg-process.ts",
+      "./extensions/btw.ts",
+      "./extensions/compact-header.ts",
+      "./extensions/custom-footer.ts",
+      "./extensions/git-guard.ts",
+      "./extensions/safe-guard.ts",
+      "./extensions/scheduler.ts",
+      "./extensions/usage-tracker.ts",
+      "./extensions/watchdog.ts"
     ]
   },
   "files": [

--- a/packages/spec/package.json
+++ b/packages/spec/package.json
@@ -14,7 +14,7 @@
   ],
   "pi": {
     "extensions": [
-      "./extension"
+      "./extension/index.ts"
     ]
   },
   "exports": {


### PR DESCRIPTION
## Summary
- replace directory-based `pi.extensions` manifests with explicit extension entrypoint files for helper-heavy packages
- cover `@ifi/oh-pi-extensions`, `@ifi/pi-spec`, and `@ifi/oh-pi-ant-colony`
- add a regression test so these manifests do not drift back to directory entries

## Validation
- `pnpm exec vitest run packages/extensions/extensions/package-manifest.test.ts packages/extensions/extensions/smoke.test.ts packages/spec/tests/smoke.test.ts packages/ant-colony/tests/smoke.test.ts`
- `pnpm lint`
- `pnpm typecheck`
- `pnpm test`
- `pnpm verify:published-packages`
