### PR TITLE
fix(build): run all workspace package builds

### DIFF
--- a/.changeset/build-all-workspace-packages-and-guard-extension-manifests.md
+++ b/.changeset/build-all-workspace-packages-and-guard-extension-manifests.md
@@ -1,0 +1,5 @@
+---
+default: patch
+---
+
+fix workspace builds to run every package build script, repair the spec worktree build config, and verify published extension entrypoints are explicit files.

--- a/README.md
+++ b/README.md
@@ -468,7 +468,7 @@ See [CONTRIBUTING.md](./CONTRIBUTING.md) for contributor workflow, changeset req
 ### Commands
 
 ```bash
-pnpm build          # Build core + cli (tsc)
+pnpm build          # Build every workspace package that exposes a build script
 pnpm typecheck      # Type check with tsgo (fast)
 pnpm test           # Run all tests
 pnpm lint           # Biome lint + format check

--- a/docs/agent-rules/engineering.md
+++ b/docs/agent-rules/engineering.md
@@ -17,7 +17,7 @@
 - `pnpm format` — format the repo
 - `pnpm test` — run the full test suite
 - `pnpm typecheck` — run repo type-checking with `tsgo`
-- `pnpm build` — build compiled packages
+- `pnpm build` — run every workspace package build script
 - `pnpm security:check` — run dependency allowlist and audit checks
 
 ## Testing conventions

--- a/package.json
+++ b/package.json
@@ -2,8 +2,8 @@
 	"private": true,
 	"packageManager": "pnpm@10.30.2",
 	"scripts": {
-		"build": "pnpm -r --filter @ifi/oh-pi-core --filter @ifi/oh-pi-cli --filter @ifi/pi-web-client --filter @ifi/pi-web-server run build",
-		"build:fast": "pnpm -r --filter @ifi/oh-pi-core --filter @ifi/oh-pi-cli --filter @ifi/pi-web-client --filter @ifi/pi-web-server run build:fast",
+		"build": "pnpm -r run build",
+		"build:fast": "pnpm -r run build:fast",
 		"typecheck": "pnpm --filter @ifi/oh-pi-core build && pnpm -r --filter @ifi/oh-pi-ant-colony --filter @ifi/oh-pi-core --filter @ifi/oh-pi-cli --filter @ifi/pi-spec --filter @ifi/pi-web-client --filter @ifi/pi-web-server run typecheck",
 		"verify:completion": "pnpm exec vitest run packages/ant-colony/tests/commands.test.ts",
 		"security:allowlist": "node ./scripts/security/check-dependency-allowlist.mjs",

--- a/packages/spec/vitest.worktree.config.ts
+++ b/packages/spec/vitest.worktree.config.ts
@@ -2,6 +2,6 @@ import { defineConfig } from "vitest/config";
 
 export default defineConfig({
 	test: {
-		include: ["packages/spec/tests/**/*.test.ts"],
+		include: ["tests/**/*.test.ts"],
 	},
 });

--- a/scripts/verify-published-packages.mjs
+++ b/scripts/verify-published-packages.mjs
@@ -1,9 +1,53 @@
 import { execFileSync } from "node:child_process";
+import fs from "node:fs";
+import os from "node:os";
+import path from "node:path";
 import { publishedPackages } from "./package-classes.mjs";
 
-for (const pkg of publishedPackages) {
-	console.log(`Packing ${pkg.name}...`);
-	execFileSync("pnpm", ["pack", "--dry-run"], { cwd: pkg.dir, stdio: "ignore" });
+function normalizePackageEntry(entry) {
+	return entry.replace(/^\.\//, "");
+}
+
+function verifyExtensionEntrypoints(pkg, manifest, packedFiles) {
+	const extensionEntries = manifest.pi?.extensions ?? [];
+	const packedPaths = new Set(packedFiles.map((file) => file.path));
+
+	for (const entry of extensionEntries) {
+		const normalizedEntry = normalizePackageEntry(entry);
+		const absoluteEntry = path.resolve(pkg.dir, normalizedEntry);
+		if (!fs.existsSync(absoluteEntry)) {
+			throw new Error(`${pkg.name}: pi.extensions entry does not exist: ${entry}`);
+		}
+		const stat = fs.statSync(absoluteEntry);
+		if (!stat.isFile()) {
+			throw new Error(`${pkg.name}: pi.extensions entries must reference explicit files, not directories: ${entry}`);
+		}
+		if (!packedPaths.has(normalizedEntry)) {
+			throw new Error(`${pkg.name}: packed tarball is missing declared pi.extensions entry: ${entry}`);
+		}
+		const source = fs.readFileSync(absoluteEntry, "utf8");
+		if (!/export\s+default\b/.test(source)) {
+			throw new Error(`${pkg.name}: declared extension entrypoint is missing a default export: ${entry}`);
+		}
+	}
+}
+
+const packRoot = fs.mkdtempSync(path.join(os.tmpdir(), "oh-pi-pack-"));
+
+try {
+	for (const pkg of publishedPackages) {
+		console.log(`Packing ${pkg.name}...`);
+		const output = execFileSync("pnpm", ["pack", "--json", "--pack-destination", packRoot], {
+			cwd: pkg.dir,
+			encoding: "utf8",
+		});
+		const parsedOutput = JSON.parse(output);
+		const packResult = Array.isArray(parsedOutput) ? parsedOutput[0] : parsedOutput;
+		const manifest = JSON.parse(fs.readFileSync(path.join(pkg.dir, "package.json"), "utf8"));
+		verifyExtensionEntrypoints(pkg, manifest, packResult.files ?? []);
+	}
+} finally {
+	fs.rmSync(packRoot, { recursive: true, force: true });
 }
 
 console.log("All published packages pack successfully.");


### PR DESCRIPTION
## Summary
- make `pnpm build` and publish validation run every workspace package build script
- fix the spec worktree Vitest config so `pnpm -r run build` succeeds from the package directory
- strengthen published package verification by checking packed `pi.extensions` entries resolve to explicit files with default exports

## Validation
- `pnpm build`
- `pnpm verify:published-packages`
- `pnpm lint`
- `pnpm typecheck`
- `pnpm test`
