### PR TITLE
feat(scheduler): show workspace and prompt in review UI

### DIFF
--- a/.changeset/show-workspace-and-full-prompt-in-schedule-review.md
+++ b/.changeset/show-workspace-and-full-prompt-in-schedule-review.md
@@ -1,0 +1,5 @@
+---
+default: patch
+---
+
+improve the scheduler review UI by showing the workspace in task listings and the full automated prompt when a scheduled task is selected.

--- a/packages/extensions/extensions/scheduler.test.ts
+++ b/packages/extensions/extensions/scheduler.test.ts
@@ -847,10 +847,12 @@ describe("SchedulerRuntime", () => {
 			expect(runtime.formatTaskList()).toBe("No scheduled tasks.");
 		});
 
-		it("includes task details in list", () => {
+		it("includes task details and workspace in list", () => {
+			const ctx = createMockCtx({ cwd: "/mock-project/apps/api" });
+			runtime.setRuntimeContext(ctx as any);
 			runtime.addRecurringIntervalTask("check build", 5 * ONE_MINUTE);
 			const list = runtime.formatTaskList();
-			expect(list).toContain("Scheduled tasks:");
+			expect(list).toContain("Scheduled tasks for /mock-project/apps/api:");
 			expect(list).toContain("check build");
 			expect(list).toContain("every 5m");
 			expect(list).toContain("runs=0");
@@ -2290,6 +2292,27 @@ describe("edge cases", () => {
 	it("handles /schedule with no args (TUI manager)", async () => {
 		await pi._commands.get("schedule").handler("", ctx);
 		expect(ctx._notifications.some((n: any) => n.msg.includes("No scheduled tasks"))).toBe(true);
+	});
+
+	it("shows workspace in the task manager and full prompt after selecting a task", async () => {
+		const prompt = "check the full deployment pipeline and report every failing stage";
+		await pi._commands.get("loop").handler(`5m ${prompt}`, ctx);
+		const select = vi
+			.fn()
+			.mockImplementationOnce(async (_title: string, options: string[]) => options[0])
+			.mockResolvedValueOnce("↩ Back");
+		const taskCtx = createMockCtx({ cwd: "/mock-project/apps/api", select });
+
+		await pi._commands.get("schedule").handler("", taskCtx);
+
+		expect(select).toHaveBeenNthCalledWith(
+			1,
+			"Scheduled tasks for /mock-project/apps/api (select one)",
+			expect.arrayContaining([expect.stringContaining("every 5m"), "+ Close"]),
+		);
+		const actionTitle = select.mock.calls[1][0];
+		expect(actionTitle).toContain("Workspace: /mock-project/apps/api");
+		expect(actionTitle).toContain(`Prompt: ${prompt}`);
 	});
 
 	it("creates and then deletes a task via different commands", async () => {

--- a/packages/extensions/extensions/scheduler.ts
+++ b/packages/extensions/extensions/scheduler.ts
@@ -286,7 +286,7 @@ export class SchedulerRuntime {
 			return "No scheduled tasks.";
 		}
 
-		const lines = ["Scheduled tasks:", ""];
+		const lines = [`Scheduled tasks for ${this.getWorkspaceLabel()}:`, ""];
 		for (const task of list) {
 			const state = this.taskStateLabel(task);
 			const mode = this.taskMode(task);
@@ -611,7 +611,7 @@ export class SchedulerRuntime {
 			const options = list.map((task) => this.taskOptionLabel(task));
 			options.push("+ Close");
 
-			const selected = await ctx.ui.select("Scheduled tasks (select one)", options);
+			const selected = await ctx.ui.select(`Scheduled tasks for ${this.getWorkspaceLabel(ctx)} (select one)`, options);
 			if (!selected || selected === "+ Close") {
 				return;
 			}
@@ -639,7 +639,11 @@ export class SchedulerRuntime {
 				return false;
 			}
 
-			const title = `${task.id} • ${this.taskMode(task)} • next ${this.formatRelativeTime(task.nextRunAt)} (${this.formatClock(task.nextRunAt)})`;
+			const title = [
+				`${task.id} • ${this.taskMode(task)} • next ${this.formatRelativeTime(task.nextRunAt)} (${this.formatClock(task.nextRunAt)})`,
+				`Workspace: ${this.getWorkspaceLabel(ctx)}`,
+				`Prompt: ${task.prompt}`,
+			].join("\n");
 			const options = [
 				task.kind === "recurring" ? "⏱ Change schedule" : "⏱ Change reminder delay",
 				task.enabled ? "Disable" : "Enable",
@@ -901,6 +905,10 @@ export class SchedulerRuntime {
 	private taskOptionLabel(task: ScheduleTask): string {
 		const state = task.resumeRequired ? `! ${task.resumeReason ?? "review"}` : task.enabled ? "+" : "-";
 		return `${task.id} • ${state} [${task.scope ?? "instance"}] ${this.taskMode(task)} • ${this.formatRelativeTime(task.nextRunAt)} • ${this.truncateText(task.prompt, 50)}`;
+	}
+
+	private getWorkspaceLabel(ctx?: ExtensionContext): string {
+		return ctx?.cwd ?? this.runtimeCtx?.cwd ?? "(unknown workspace)";
 	}
 
 	private truncateText(value: string, max = 64): string {


### PR DESCRIPTION
## Summary
- show the current workspace path in scheduler review listings
- show the full automated prompt after selecting a scheduled task in the review UI
- cover the new behavior with scheduler regression tests

## Validation
- `pnpm exec vitest run packages/extensions/extensions/scheduler.test.ts packages/extensions/extensions/smoke.test.ts`
- `pnpm lint`
