### PR TITLE
feat(scheduler): add clear-all review shortcut

### DIFF
--- a/.changeset/add-clear-all-shortcut-to-scheduler-review.md
+++ b/.changeset/add-clear-all-shortcut-to-scheduler-review.md
@@ -1,0 +1,5 @@
+---
+default: patch
+---
+
+add a clear-all shortcut to the scheduler review UI so scheduled tasks can be removed directly from the task list.

--- a/packages/extensions/extensions/scheduler.test.ts
+++ b/packages/extensions/extensions/scheduler.test.ts
@@ -2308,11 +2308,30 @@ describe("edge cases", () => {
 		expect(select).toHaveBeenNthCalledWith(
 			1,
 			"Scheduled tasks for /mock-project/apps/api (select one)",
-			expect.arrayContaining([expect.stringContaining("every 5m"), "+ Close"]),
+			expect.arrayContaining([expect.stringContaining("every 5m"), "🗑 Clear all", "+ Close"]),
 		);
 		const actionTitle = select.mock.calls[1][0];
 		expect(actionTitle).toContain("Workspace: /mock-project/apps/api");
 		expect(actionTitle).toContain(`Prompt: ${prompt}`);
+	});
+
+	it("can clear all tasks directly from the task manager list", async () => {
+		await pi._commands.get("loop").handler("5m check api health", ctx);
+		await pi._commands.get("loop").handler("10m check worker backlog", ctx);
+		const select = vi.fn().mockResolvedValueOnce("🗑 Clear all");
+		const confirm = vi.fn().mockResolvedValueOnce(true);
+		const taskCtx = createMockCtx({ cwd: "/mock-project/apps/api", select, confirm });
+
+		await pi._commands.get("schedule").handler("", taskCtx);
+
+		expect(confirm).toHaveBeenCalledWith(
+			"Clear all scheduled tasks?",
+			"Delete 2 scheduled tasks for /mock-project/apps/api?",
+		);
+		expect(taskCtx._notifications.some((n: any) => n.msg.includes("Cleared 2 scheduled tasks."))).toBe(true);
+		expect(pi._messages.some((m: any) => m.content.includes("No scheduled tasks"))).toBe(false);
+		await pi._commands.get("schedule").handler("list", ctx);
+		expect(pi._messages.some((m: any) => m.content.includes("No scheduled tasks"))).toBe(true);
 	});
 
 	it("creates and then deletes a task via different commands", async () => {

--- a/packages/extensions/extensions/scheduler.ts
+++ b/packages/extensions/extensions/scheduler.ts
@@ -609,10 +609,24 @@ export class SchedulerRuntime {
 			}
 
 			const options = list.map((task) => this.taskOptionLabel(task));
+			options.push("🗑 Clear all");
 			options.push("+ Close");
 
 			const selected = await ctx.ui.select(`Scheduled tasks for ${this.getWorkspaceLabel(ctx)} (select one)`, options);
 			if (!selected || selected === "+ Close") {
+				return;
+			}
+			if (selected === "🗑 Clear all") {
+				const count = list.length;
+				const ok = await ctx.ui.confirm(
+					"Clear all scheduled tasks?",
+					`Delete ${count} scheduled task${count === 1 ? "" : "s"} for ${this.getWorkspaceLabel(ctx)}?`,
+				);
+				if (!ok) {
+					continue;
+				}
+				this.clearTasks();
+				ctx.ui.notify(`Cleared ${count} scheduled task${count === 1 ? "" : "s"}.`, "info");
 				return;
 			}
 


### PR DESCRIPTION
## Summary
- add a `🗑 Clear all` shortcut directly in the scheduler review task list
- confirm before deleting all scheduled tasks for the current workspace
- cover the shortcut with scheduler regression tests

## Validation
- `pnpm exec vitest run packages/extensions/extensions/scheduler.test.ts packages/extensions/extensions/smoke.test.ts`
- `pnpm lint`
