### PR TITLE
fix(extensions): persist provider usage windows

### DIFF
--- a/.changeset/persist-provider-rate-limit-cache.md
+++ b/.changeset/persist-provider-rate-limit-cache.md
@@ -1,0 +1,5 @@
+---
+default: patch
+---
+
+persist provider rate limit data so usage widgets and dashboards can keep showing the last known subscription windows when live provider probes are temporarily rate-limited.

--- a/packages/extensions/extensions/usage-tracker.test.ts
+++ b/packages/extensions/extensions/usage-tracker.test.ts
@@ -57,6 +57,7 @@ vi.stubGlobal("fetch", mockFetch);
 // ─── Auth helpers ───────────────────────────────────────────────────────────
 
 const AUTH_JSON_PATH = "/mock-home/.pi/agent/auth.json";
+const RATE_LIMIT_CACHE_PATH = "/mock-home/.pi/agent/usage-tracker-rate-limits.json";
 
 function makeAuthJson(overrides: Record<string, any> = {}) {
 	return JSON.stringify({
@@ -84,6 +85,32 @@ function makeAuthJson(overrides: Record<string, any> = {}) {
 			email: "test@example.com",
 		},
 		...overrides,
+	});
+}
+
+function makeRateLimitCacheJson(overrides: Record<string, any> = {}) {
+	return JSON.stringify({
+		version: 1,
+		providers: {
+			anthropic: {
+				provider: "anthropic",
+				windows: [
+					{
+						label: "7-day Sonnet",
+						percentLeft: 72,
+						resetDescription: "in 6d",
+						windowMinutes: 10_080,
+					},
+				],
+				credits: null,
+				account: null,
+				plan: "OAuth",
+				note: null,
+				probedAt: Date.now() - 60_000,
+				error: null,
+			},
+			...overrides,
+		},
 	});
 }
 
@@ -696,6 +723,37 @@ describe("usage-tracker extension", () => {
 			expect(text).toContain("60% left");
 		});
 
+		it("restores cached Anthropic windows across restarts when the live probe is rate-limited", async () => {
+			(existsSync as ReturnType<typeof vi.fn>).mockImplementation((path: string) => {
+				if (String(path) === AUTH_JSON_PATH || String(path) === RATE_LIMIT_CACHE_PATH) {
+					return true;
+				}
+				return false;
+			});
+			(readFileSync as ReturnType<typeof vi.fn>).mockImplementation((path: string) => {
+				if (String(path) === AUTH_JSON_PATH) {
+					return makeAuthJson();
+				}
+				if (String(path) === RATE_LIMIT_CACHE_PATH) {
+					return makeRateLimitCacheJson();
+				}
+				return "{}";
+			});
+			mockFetch.mockResolvedValue(makeFetchResponse({ status: 429, ok: false, headers: { "retry-after": "120" } }));
+
+			usageTracker(pi as any);
+			pi._emit("session_start", { type: "session_start" }, ctx);
+
+			const tool = pi._tools.get("usage_report");
+			const result = await runWithTimers(() => tool.execute("id", { format: "detailed" }, undefined, undefined, ctx));
+			const text = result.content[0].text;
+
+			expect(text).toContain("Anthropic Rate Limits:");
+			expect(text).toContain("7-day Sonnet");
+			expect(text).toContain("72% left");
+			expect(text).toContain("Showing last known window values");
+		});
+
 		it("shows OpenAI windows from the ChatGPT usage endpoint", async () => {
 			ctx.model = { id: "gpt-4o" } as any;
 			mockFetch.mockImplementation((url: string) => {
@@ -905,6 +963,42 @@ describe("usage-tracker extension", () => {
 			const rendered = component?.render(200).join("\n") ?? "";
 			expect(rendered).toContain("$");
 			expect(rendered).toContain("30d:");
+		});
+
+		it("shows cached Anthropic windows in the widget when live probing is rate-limited", () => {
+			(existsSync as ReturnType<typeof vi.fn>).mockImplementation((path: string) => {
+				if (String(path) === AUTH_JSON_PATH || String(path) === RATE_LIMIT_CACHE_PATH) {
+					return true;
+				}
+				return false;
+			});
+			(readFileSync as ReturnType<typeof vi.fn>).mockImplementation((path: string) => {
+				if (String(path) === AUTH_JSON_PATH) {
+					return makeAuthJson();
+				}
+				if (String(path) === RATE_LIMIT_CACHE_PATH) {
+					return makeRateLimitCacheJson();
+				}
+				return "{}";
+			});
+			mockFetch.mockResolvedValue(makeFetchResponse({ status: 429, ok: false, headers: { "retry-after": "120" } }));
+
+			usageTracker(pi as any);
+			pi._emit("session_start", { type: "session_start" }, ctx);
+
+			const widgetFactory = ctx._widgets.get("usage-tracker") as
+				| ((
+						tui: { requestRender: () => void },
+						theme: { fg: (_color: string, text: string) => string },
+				  ) => {
+						render: (width: number) => string[];
+				  })
+				| undefined;
+			expect(widgetFactory).toBeDefined();
+			const component = widgetFactory?.({ requestRender: vi.fn() }, { fg: (_color: string, text: string) => text });
+			const rendered = component?.render(200).join("\n") ?? "";
+			expect(rendered).toContain("Anthropic");
+			expect(rendered).toContain("72%");
 		});
 
 		it("truncates widget output to terminal width", () => {

--- a/packages/extensions/extensions/usage-tracker.ts
+++ b/packages/extensions/extensions/usage-tracker.ts
@@ -116,6 +116,10 @@ function getUsageHistoryPath(): string {
 	return join(getAgentDir(), "usage-tracker-history.json");
 }
 
+function getRateLimitCachePath(): string {
+	return join(getAgentDir(), "usage-tracker-rate-limits.json");
+}
+
 export default function usageTracker(pi: ExtensionAPI) {
 	// Unbind ctrl+u from deleteToLineStart so our shortcut wins cleanly
 	ensureCtrlUUnbound();
@@ -144,6 +148,8 @@ export default function usageTracker(pi: ExtensionAPI) {
 	const usageHistoryPath = getUsageHistoryPath();
 	/** Rolling history points (cost + timestamp), persisted on disk. */
 	const rollingHistory: HistoricalCostPoint[] = [];
+	/** Persistent cache of last known provider rate limits. */
+	const rateLimitCachePath = getRateLimitCachePath();
 
 	function pruneRollingHistory(now = Date.now()): void {
 		const cutoff = now - ROLLING_COST_WINDOW_MS;
@@ -209,7 +215,94 @@ export default function usageTracker(pi: ExtensionAPI) {
 		}
 	}
 
+	function normalizeProviderRateLimits(value: unknown): ProviderRateLimits | null {
+		if (!value || typeof value !== "object") {
+			return null;
+		}
+		const candidate = value as Partial<ProviderRateLimits> & { windows?: unknown };
+		if (!(candidate.provider === "anthropic" || candidate.provider === "openai" || candidate.provider === "google")) {
+			return null;
+		}
+		const windows = Array.isArray(candidate.windows)
+			? candidate.windows
+					.map((window) => {
+						if (!window || typeof window !== "object") {
+							return null;
+						}
+						const item = window as {
+							label?: unknown;
+							percentLeft?: unknown;
+							resetDescription?: unknown;
+							windowMinutes?: unknown;
+						};
+						if (typeof item.label !== "string") {
+							return null;
+						}
+						const percentLeft = Number(item.percentLeft);
+						if (!Number.isFinite(percentLeft)) {
+							return null;
+						}
+						const windowMinutes = item.windowMinutes == null ? null : Number(item.windowMinutes);
+						return {
+							label: item.label,
+							percentLeft: clampPercent(percentLeft),
+							resetDescription: typeof item.resetDescription === "string" ? item.resetDescription : null,
+							windowMinutes: Number.isFinite(windowMinutes) ? windowMinutes : null,
+						};
+					})
+					.filter((window): window is NonNullable<typeof window> => window !== null)
+			: [];
+		const probedAt = Number(candidate.probedAt);
+		return {
+			provider: candidate.provider,
+			windows,
+			credits: typeof candidate.credits === "number" && Number.isFinite(candidate.credits) ? candidate.credits : null,
+			account: typeof candidate.account === "string" ? candidate.account : null,
+			plan: typeof candidate.plan === "string" ? candidate.plan : null,
+			note: typeof candidate.note === "string" ? candidate.note : null,
+			probedAt: Number.isFinite(probedAt) ? probedAt : Date.now(),
+			error: typeof candidate.error === "string" ? candidate.error : null,
+		};
+	}
+
+	function loadRateLimitCache(): void {
+		try {
+			if (!existsSync(rateLimitCachePath)) {
+				return;
+			}
+			const raw = JSON.parse(readFileSync(rateLimitCachePath, "utf-8")) as { providers?: unknown };
+			if (!raw.providers || typeof raw.providers !== "object") {
+				return;
+			}
+			for (const value of Object.values(raw.providers)) {
+				const providerRateLimits = normalizeProviderRateLimits(value);
+				if (!providerRateLimits) {
+					continue;
+				}
+				rateLimits.set(providerRateLimits.provider, providerRateLimits);
+			}
+		} catch {
+			// Non-critical. The next live probe will repopulate provider data.
+		}
+	}
+
+	function saveRateLimitCache(): void {
+		try {
+			const dir = dirname(rateLimitCachePath);
+			if (!existsSync(dir)) {
+				mkdirSync(dir, { recursive: true });
+			}
+			const providers = Object.fromEntries(
+				Array.from(rateLimits.entries()).map(([provider, value]) => [provider, value]),
+			);
+			writeFileSync(rateLimitCachePath, `${JSON.stringify({ version: 1, providers }, null, 2)}\n`, "utf-8");
+		} catch {
+			// Non-critical. We can still rely on in-memory provider data.
+		}
+	}
+
 	loadRollingHistory();
+	loadRateLimitCache();
 
 	// ─── Data collection ──────────────────────────────────────────────────
 
@@ -478,6 +571,7 @@ export default function usageTracker(pi: ExtensionAPI) {
 					probedAt: now,
 					error: null,
 				});
+				saveRateLimitCache();
 				lastProbeTime.set(provider, now);
 				return;
 			}
@@ -495,6 +589,7 @@ export default function usageTracker(pi: ExtensionAPI) {
 					probedAt: now,
 					error: `${providerDisplayName(provider)} token refresh failed \u2014 re-authenticate with pi login.`,
 				});
+				saveRateLimitCache();
 				lastProbeTime.set(provider, now);
 				return;
 			}
@@ -521,6 +616,7 @@ export default function usageTracker(pi: ExtensionAPI) {
 			}
 
 			rateLimits.set(provider, limits);
+			saveRateLimitCache();
 			lastProbeTime.set(provider, Date.now());
 		} catch {
 			// Probe failed — keep stale data if any


### PR DESCRIPTION
## Summary
- persist last known provider rate limit data to disk
- restore cached windows on startup so the usage footer and `ctrl+u` dashboard keep showing prior subscription windows when live provider probes are temporarily rate-limited
- cover cached Anthropic recovery in both dashboard and widget tests

## Validation
- `pnpm exec vitest run packages/extensions/extensions/usage-tracker.test.ts packages/extensions/extensions/smoke.test.ts`
- `pnpm lint`
