### PR TITLE
fix(spec): gate specs/ dir fallback on non-git repos only

### DIFF
--- a/packages/spec/extension/index.ts
+++ b/packages/spec/extension/index.ts
@@ -79,10 +79,19 @@ async function resolveActiveFeatureName(
 	ctx: ExtensionCommandContext,
 	repoRoot: string,
 	currentBranch: string,
+	hasGit = true,
 ): Promise<string | undefined> {
 	const featureFromBranch = resolveFeatureFromBranch(repoRoot, currentBranch);
 	if (featureFromBranch) {
 		return featureFromBranch;
+	}
+
+	// When git is available, the current branch is the source of truth for the
+	// active feature — matching upstream spec-kit behavior.  The specs/ directory
+	// scan is only a fallback for non-git repositories where branch detection is
+	// unavailable.
+	if (hasGit) {
+		return undefined;
 	}
 
 	const features = listFeatureDirs(repoRoot);
@@ -103,8 +112,9 @@ async function resolveFeaturePaths(
 	ctx: ExtensionCommandContext,
 	repoRoot: string,
 	currentBranch: string,
+	hasGit = true,
 ): Promise<WorkflowPaths | undefined> {
-	const featureName = await resolveActiveFeatureName(ctx, repoRoot, currentBranch);
+	const featureName = await resolveActiveFeatureName(ctx, repoRoot, currentBranch, hasGit);
 	if (!featureName) {
 		ctx.ui.notify("No active feature found. Run /spec specify <feature description> first.", "warning");
 		return undefined;
@@ -178,8 +188,9 @@ async function handleStatus(
 	ctx: ExtensionCommandContext,
 	repoRoot: string,
 	currentBranch: string,
+	hasGit: boolean,
 ): Promise<void> {
-	const activeFeature = await resolveActiveFeatureName(ctx, repoRoot, currentBranch);
+	const activeFeature = await resolveActiveFeatureName(ctx, repoRoot, currentBranch, hasGit);
 	sendReport(
 		pi,
 		formatWorkflowStatus(
@@ -198,8 +209,9 @@ async function handleNext(
 	ctx: ExtensionCommandContext,
 	repoRoot: string,
 	currentBranch: string,
+	hasGit: boolean,
 ): Promise<void> {
-	const activeFeature = await resolveActiveFeatureName(ctx, repoRoot, currentBranch);
+	const activeFeature = await resolveActiveFeatureName(ctx, repoRoot, currentBranch, hasGit);
 	const status = buildWorkflowStatus({
 		repoRoot,
 		currentBranch,
@@ -287,8 +299,8 @@ async function handleWorkflowStep(
 
 	const featurePaths =
 		step === "constitution"
-			? buildWorkflowPaths(env.repoRoot, await resolveActiveFeatureName(ctx, env.repoRoot, env.currentBranch))
-			: await resolveFeaturePaths(ctx, env.repoRoot, env.currentBranch);
+			? buildWorkflowPaths(env.repoRoot, await resolveActiveFeatureName(ctx, env.repoRoot, env.currentBranch, env.hasGit))
+			: await resolveFeaturePaths(ctx, env.repoRoot, env.currentBranch, env.hasGit);
 	ensureWorkflowScaffold(featurePaths ?? env.basePaths);
 	if (!featurePaths) {
 		return;
@@ -347,11 +359,11 @@ export default function specExtension(pi: ExtensionAPI) {
 				return;
 			}
 			if (subcommand === "status") {
-				await handleStatus(pi, ctx, env.repoRoot, env.currentBranch);
+				await handleStatus(pi, ctx, env.repoRoot, env.currentBranch, env.hasGit);
 				return;
 			}
 			if (subcommand === "next") {
-				await handleNext(pi, ctx, env.repoRoot, env.currentBranch);
+				await handleNext(pi, ctx, env.repoRoot, env.currentBranch, env.hasGit);
 				return;
 			}
 			if (!isWorkflowStep(subcommand)) {


### PR DESCRIPTION
## Summary

Aligns active feature resolution with upstream spec-kit behavior. When git is available, the current branch name is the sole source of truth for the active feature. The `specs/` directory scan fallback now only fires for non-git repositories.

## Problem

`resolveActiveFeatureName()` unconditionally fell back to scanning `specs/` dirs when branch matching failed. This caused completed features (whose branches were merged and deleted) to appear as "active" indefinitely in `/spec status`.

On `main` with a single `specs/001-*` directory, it was always auto-selected — even though the feature was long finished.

## Root cause

Upstream spec-kit's `get_current_branch()` in `scripts/bash/common.sh` only scans `specs/` directories when `has_git` is false (non-git repos). When git is available, it returns the actual branch name, and if that branch has no `###-` prefix, `find_feature_dir_by_prefix` finds no match — resulting in no active feature.

The pi-spec extension removed this `has_git` gate during the port, unconditionally falling back to `specs/` dir scanning.

## Fix

Added a `hasGit` parameter to `resolveActiveFeatureName()` and `resolveFeaturePaths()`. When `hasGit` is true and the current branch does not match a feature prefix, the function returns `undefined` immediately — matching spec-kit's behavior. The `specs/` directory scan remains available for non-git repos.

All existing tests pass. Typecheck clean.

Fixes #73