### PR TITLE
fix(extensions): suppress watchdog and scheduler notification spam

### DIFF
--- a/.changeset/suppress-watchdog-scheduler-notification-spam.md
+++ b/.changeset/suppress-watchdog-scheduler-notification-spam.md
@@ -1,0 +1,5 @@
+---
+default: patch
+---
+
+suppress repeated watchdog and scheduler notifications by capping toast alerts at 2 per session and persisting ongoing warnings in the status bar instead.

--- a/packages/extensions/extensions/scheduler.test.ts
+++ b/packages/extensions/extensions/scheduler.test.ts
@@ -2123,7 +2123,9 @@ describe("event wiring", () => {
 		const ctx = createMockCtx();
 		pi._emit("session_start", { type: "session_start" }, ctx);
 		await Promise.resolve();
-		expect(ctx._notifications.some((n: any) => n.msg.includes("will not run automatically"))).toBe(true);
+		expect(ctx._notifications.some((n: any) => n.msg.includes("stale task") && n.msg.includes("need review"))).toBe(
+			true,
+		);
 		expect(pi._userMessages).toHaveLength(0);
 	});
 

--- a/packages/extensions/extensions/scheduler.ts
+++ b/packages/extensions/extensions/scheduler.ts
@@ -416,6 +416,11 @@ export class SchedulerRuntime {
 		if (!this.runtimeCtx?.hasUI) {
 			return;
 		}
+		// Clear the stale-task status hint when no tasks need review.
+		const staleCount = Array.from(this.tasks.values()).filter((t) => t.enabled && t.resumeRequired).length;
+		if (staleCount === 0) {
+			this.runtimeCtx.ui.setStatus("pi-scheduler-stale", undefined);
+		}
 		if (this.tasks.size === 0) {
 			this.runtimeCtx.ui.setStatus("pi-scheduler", undefined);
 			return;
@@ -1372,9 +1377,15 @@ export class SchedulerRuntime {
 		const details = Array.from(counts.entries())
 			.map(([reason, count]) => `${count} ${this.resumeReasonLabel(reason)}`)
 			.join(", ");
+		const count = dueTasks.length;
 		this.runtimeCtx.ui.notify(
-			`Scheduler restored ${dueTasks.length} task${dueTasks.length === 1 ? "" : "s"} requiring review (${details}). They will not run automatically; use /schedule to review, adopt, reschedule, disable, or delete them.`,
+			`Scheduler: ${count} stale task${count === 1 ? "" : "s"} need review (${details}). Use /schedule to manage them.`,
 			"warning",
+		);
+		// Persist a compact hint in the status bar so users see it without repeated notifications.
+		this.runtimeCtx.ui.setStatus(
+			"pi-scheduler-stale",
+			`⚠ ${count} stale task${count === 1 ? "" : "s"} — /schedule to review`,
 		);
 	}
 

--- a/packages/extensions/extensions/watchdog.ts
+++ b/packages/extensions/extensions/watchdog.ts
@@ -16,6 +16,7 @@ const DEFAULT_SAMPLE_INTERVAL_MS = 5_000;
 const MIN_SAMPLE_INTERVAL_MS = 1_000;
 const MAX_SAMPLE_INTERVAL_MS = 60_000;
 const ALERT_COOLDOWN_MS = 45_000;
+const ALERT_NOTIFICATION_LIMIT = 2;
 const AUTO_SAFE_MODE_AFTER_CONSECUTIVE_ALERTS = 2;
 const HISTOGRAM_RESOLUTION_MS = 20;
 const SAMPLE_HISTORY_LIMIT = 60;
@@ -356,6 +357,8 @@ export default function watchdogExtension(pi: ExtensionAPI) {
 	let latestSample: WatchdogSample | null = null;
 	let lastAlertAt = 0;
 	let consecutiveAlerts = 0;
+	let alertNotificationCount = 0;
+	let latestAlertMessage: string | null = null;
 	let enabled = config.enabled !== false;
 	let timer: ReturnType<typeof setInterval> | null = null;
 	let lastCpuUsage = process.cpuUsage();
@@ -412,11 +415,24 @@ export default function watchdogExtension(pi: ExtensionAPI) {
 
 		consecutiveAlerts += 1;
 		pushBounded(alertHistory, alert, ALERT_HISTORY_LIMIT);
-		setAlertStatus(`watchdog: ${alert.reasons.join(", ")}`);
+		latestAlertMessage = `watchdog: ${alert.reasons.join(", ")}`;
+		setAlertStatus(latestAlertMessage);
 
-		if (activeCtx?.hasUI && now - lastAlertAt >= ALERT_COOLDOWN_MS) {
+		if (
+			activeCtx?.hasUI &&
+			now - lastAlertAt >= ALERT_COOLDOWN_MS &&
+			alertNotificationCount < ALERT_NOTIFICATION_LIMIT
+		) {
 			lastAlertAt = now;
-			activeCtx.ui.notify(formatWatchdogAlert(alert), levelForAlert(alert));
+			alertNotificationCount += 1;
+			if (alertNotificationCount >= ALERT_NOTIFICATION_LIMIT) {
+				activeCtx.ui.notify(
+					`${formatWatchdogAlert(alert)} Further alerts suppressed — check status bar or /watchdog overlay.`,
+					levelForAlert(alert),
+				);
+			} else {
+				activeCtx.ui.notify(formatWatchdogAlert(alert), levelForAlert(alert));
+			}
 		}
 
 		if (
@@ -466,6 +482,8 @@ export default function watchdogExtension(pi: ExtensionAPI) {
 		resetCounters();
 		latestSample = null;
 		lastAlertAt = 0;
+		alertNotificationCount = 0;
+		latestAlertMessage = null;
 		sampleHistory.length = 0;
 		alertHistory.length = 0;
 		setAlertStatus(undefined);


### PR DESCRIPTION
## Summary
- cap watchdog toast notifications at 2 per session; after the limit, alerts are only shown in the status bar
- the second (final) watchdog notification tells the user further alerts are suppressed
- scheduler stale-task warning now also persists a compact hint in the status bar (`⚠ N stale tasks — /schedule to review`) that auto-clears when all tasks are adopted/deleted
- shorten the scheduler stale-task notification text

## Validation
- `pnpm exec vitest run packages/extensions/extensions/watchdog.test.ts packages/extensions/extensions/scheduler.test.ts packages/extensions/extensions/smoke.test.ts`
- `pnpm lint`
