### PR TITLE
fix(oh-pi): support Windows by using shell mode for execFileSync

### DIFF
--- a/.changeset/fix-windows-findpi-shell.md
+++ b/.changeset/fix-windows-findpi-shell.md
@@ -1,0 +1,5 @@
+---
+default: patch
+---
+
+fix `findPi()` on Windows by trying `pi.cmd` first and passing `shell: true` to `execFileSync` so the npm CMD shim is resolved correctly.

--- a/package.json
+++ b/package.json
@@ -23,15 +23,15 @@
 		"check": "biome ci --error-on-warnings ."
 	},
 	"devDependencies": {
-		"@biomejs/biome": "^2.4.6",
-		"@types/node": "^22.0.0",
-		"@typescript/native-preview": "7.0.0-dev.20260305.1",
-		"typescript": "^5.7.0",
-		"vitest": "^3.0.0",
+		"@biomejs/biome": "^2.4.10",
 		"@mariozechner/pi-agent-core": "0.56.1",
 		"@mariozechner/pi-ai": "0.56.1",
 		"@mariozechner/pi-coding-agent": "0.56.1",
-		"@mariozechner/pi-tui": "0.56.1"
+		"@mariozechner/pi-tui": "0.56.1",
+		"@types/node": "^22.0.0",
+		"@typescript/native-preview": "7.0.0-dev.20260305.1",
+		"typescript": "^5.7.0",
+		"vitest": "^3.0.0"
 	},
 	"engines": {
 		"node": ">=20.0.0"

--- a/packages/ant-colony/extensions/ant-colony/budget-planner.ts
+++ b/packages/ant-colony/extensions/ant-colony/budget-planner.ts
@@ -328,7 +328,7 @@ export function planBudget(
 	const severity = classifySeverity(lowestRateLimitPct, costSpent, maxCost);
 
 	// Remaining budget for allocation
-	const remainingBudget = maxCost != null ? Math.max(0, maxCost - costSpent) : Number.POSITIVE_INFINITY;
+	const remainingBudget = maxCost == null ? Number.POSITIVE_INFINITY : Math.max(0, maxCost - costSpent);
 
 	// Recommended max concurrency (min of severity cap and hardware cap)
 	const recommendedMaxConcurrency = Math.min(CONCURRENCY_CAPS[severity], concurrency.max);

--- a/packages/cli/src/tui/confirm-apply.ts
+++ b/packages/cli/src/tui/confirm-apply.ts
@@ -127,7 +127,7 @@ export async function confirmApply(config: OhPConfig, env: EnvInfo) {
 		`${chalk.gray(`${resolvePiAgentDir()}/`)}`,
 		`${chalk.gray("├── ")}auth.json ${chalk.dim("")}`,
 		`${chalk.gray("├── ")}settings.json`,
-		...(config.keybindings !== "default" ? [`${chalk.gray("├── ")}keybindings.json`] : []),
+		...(config.keybindings === "default" ? [] : [`${chalk.gray("├── ")}keybindings.json`]),
 		`${chalk.gray("├── ")}AGENTS.md ${chalk.dim(config.agents)}`,
 		...(config.extensions.length > 0
 			? [`${chalk.gray("├── ")}extensions/ ${chalk.dim(`${config.extensions.length} items`)}`]

--- a/packages/extensions/extensions/bg-process.ts
+++ b/packages/extensions/extensions/bg-process.ts
@@ -157,7 +157,7 @@ export default function (pi: ExtensionAPI) {
 					clearTimeout(timer);
 
 					const output = (stdout + stderr).trim();
-					const exitInfo = code !== 0 ? `\n[Exit code: ${code}]` : "";
+					const exitInfo = code === 0 ? "" : `\n[Exit code: ${code}]`;
 					resolve({ content: [{ type: "text", text: output + exitInfo }], details: {} });
 				});
 

--- a/packages/extensions/extensions/usage-tracker-providers.ts
+++ b/packages/extensions/extensions/usage-tracker-providers.ts
@@ -463,7 +463,7 @@ function maybeAddOpenAIWhamWindow(
 	const labelSuffix = roundedWindowSeconds ? windowLabelFromSeconds(roundedWindowSeconds) : windowLabel;
 	const resetFromDuration = countdownFromSeconds(typed.reset_after_seconds);
 	const resetAtSeconds = parseFiniteNumber(typed.reset_at);
-	const resetFromTimestamp = resetAtSeconds !== null ? countdownFromSeconds(resetAtSeconds - Date.now() / 1000) : null;
+	const resetFromTimestamp = resetAtSeconds === null ? null : countdownFromSeconds(resetAtSeconds - Date.now() / 1000);
 
 	upsertWindow(result.windows, {
 		label: `${groupLabel} (${labelSuffix})`,

--- a/packages/oh-pi/bin/oh-pi.mjs
+++ b/packages/oh-pi/bin/oh-pi.mjs
@@ -11,6 +11,9 @@
  */
 
 import { execFileSync } from "node:child_process";
+import process from "node:process";
+
+const IS_WINDOWS = process.platform === "win32";
 
 const PACKAGES = [
 	"@ifi/oh-pi-extensions",
@@ -76,21 +79,27 @@ ${PACKAGES.map((p) => `  • ${p}`).join("\n")}
 }
 
 function findPi() {
-	try {
-		execFileSync("pi", ["--version"], { stdio: "ignore" });
-		return "pi";
-	} catch {
-		console.error("Error: 'pi' command not found. Install pi-coding-agent first:");
-		console.error("  npm install -g @mariozechner/pi-coding-agent");
-		process.exit(1);
+	const candidates = IS_WINDOWS ? ["pi.cmd", "pi"] : ["pi"];
+
+	for (const cmd of candidates) {
+		try {
+			execFileSync(cmd, ["--version"], { stdio: "ignore", shell: IS_WINDOWS });
+			return cmd;
+		} catch {
+			// try next candidate
+		}
 	}
+
+	console.error("Error: 'pi' command not found. Install pi-coding-agent first:");
+	console.error("  npm install -g @mariozechner/pi-coding-agent");
+	process.exit(1);
 }
 
 function run(pi, command, args, { label }) {
 	const display = [pi, command, ...args].join(" ");
 	process.stdout.write(`  ${label} ... `);
 	try {
-		execFileSync(pi, [command, ...args], { stdio: "pipe", timeout: 60_000 });
+		execFileSync(pi, [command, ...args], { stdio: "pipe", timeout: 60_000, shell: IS_WINDOWS });
 		console.log("✓");
 	} catch (error) {
 		const stderr = error.stderr?.toString().trim();

--- a/packages/spec/extension/index.ts
+++ b/packages/spec/extension/index.ts
@@ -299,7 +299,10 @@ async function handleWorkflowStep(
 
 	const featurePaths =
 		step === "constitution"
-			? buildWorkflowPaths(env.repoRoot, await resolveActiveFeatureName(ctx, env.repoRoot, env.currentBranch, env.hasGit))
+			? buildWorkflowPaths(
+					env.repoRoot,
+					await resolveActiveFeatureName(ctx, env.repoRoot, env.currentBranch, env.hasGit),
+				)
 			: await resolveFeaturePaths(ctx, env.repoRoot, env.currentBranch, env.hasGit);
 	ensureWorkflowScaffold(featurePaths ?? env.basePaths);
 	if (!featurePaths) {

--- a/packages/web-remote/index.ts
+++ b/packages/web-remote/index.ts
@@ -113,6 +113,6 @@ function updateStatus(
 	server: PiWebServer,
 ): void {
 	const count = server.connectedClients;
-	const text = `🌐 Remote: ${count} client${count !== 1 ? "s" : ""}`;
+	const text = `🌐 Remote: ${count} client${count === 1 ? "" : "s"}`;
 	ctx.ui.setStatus("remote", text);
 }

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -20,8 +20,8 @@ importers:
   .:
     devDependencies:
       '@biomejs/biome':
-        specifier: ^2.4.6
-        version: 2.4.6
+        specifier: ^2.4.10
+        version: 2.4.10
       '@mariozechner/pi-agent-core':
         specifier: 0.56.1
         version: 0.56.1(ws@8.19.0)(zod@3.25.76)
@@ -428,59 +428,59 @@ packages:
     resolution: {integrity: sha512-05WQkdpL9COIMz4LjTxGpPNCdlpyimKppYNoJ5Di5EUObifl8t4tuLuUBBZEpoLYOmfvIWrsp9fCl0HoPRVTdA==}
     engines: {node: '>=6.9.0'}
 
-  '@biomejs/biome@2.4.6':
-    resolution: {integrity: sha512-QnHe81PMslpy3mnpL8DnO2M4S4ZnYPkjlGCLWBZT/3R9M6b5daArWMMtEfP52/n174RKnwRIf3oT8+wc9ihSfQ==}
+  '@biomejs/biome@2.4.10':
+    resolution: {integrity: sha512-xxA3AphFQ1geij4JTHXv4EeSTda1IFn22ye9LdyVPoJU19fNVl0uzfEuhsfQ4Yue/0FaLs2/ccVi4UDiE7R30w==}
     engines: {node: '>=14.21.3'}
     hasBin: true
 
-  '@biomejs/cli-darwin-arm64@2.4.6':
-    resolution: {integrity: sha512-NW18GSyxr+8sJIqgoGwVp5Zqm4SALH4b4gftIA0n62PTuBs6G2tHlwNAOj0Vq0KKSs7Sf88VjjmHh0O36EnzrQ==}
+  '@biomejs/cli-darwin-arm64@2.4.10':
+    resolution: {integrity: sha512-vuzzI1cWqDVzOMIkYyHbKqp+AkQq4K7k+UCXWpkYcY/HDn1UxdsbsfgtVpa40shem8Kax4TLDLlx8kMAecgqiw==}
     engines: {node: '>=14.21.3'}
     cpu: [arm64]
     os: [darwin]
 
-  '@biomejs/cli-darwin-x64@2.4.6':
-    resolution: {integrity: sha512-4uiE/9tuI7cnjtY9b07RgS7gGyYOAfIAGeVJWEfeCnAarOAS7qVmuRyX6d7JTKw28/mt+rUzMasYeZ+0R/U1Mw==}
+  '@biomejs/cli-darwin-x64@2.4.10':
+    resolution: {integrity: sha512-14fzASRo+BPotwp7nWULy2W5xeUyFnTaq1V13Etrrxkrih+ez/2QfgFm5Ehtf5vSjtgx/IJycMMpn5kPd5ZNaA==}
     engines: {node: '>=14.21.3'}
     cpu: [x64]
     os: [darwin]
 
-  '@biomejs/cli-linux-arm64-musl@2.4.6':
-    resolution: {integrity: sha512-F/JdB7eN22txiTqHM5KhIVt0jVkzZwVYrdTR1O3Y4auBOQcXxHK4dxULf4z43QyZI5tsnQJrRBHZy7wwtL+B3A==}
+  '@biomejs/cli-linux-arm64-musl@2.4.10':
+    resolution: {integrity: sha512-WrJY6UuiSD/Dh+nwK2qOTu8kdMDlLV3dLMmychIghHPAysWFq1/DGC1pVZx8POE3ZkzKR3PUUnVrtZfMfaJjyQ==}
     engines: {node: '>=14.21.3'}
     cpu: [arm64]
     os: [linux]
     libc: [musl]
 
-  '@biomejs/cli-linux-arm64@2.4.6':
-    resolution: {integrity: sha512-kMLaI7OF5GN1Q8Doymjro1P8rVEoy7BKQALNz6fiR8IC1WKduoNyteBtJlHT7ASIL0Cx2jR6VUOBIbcB1B8pew==}
+  '@biomejs/cli-linux-arm64@2.4.10':
+    resolution: {integrity: sha512-7MH1CMW5uuxQ/s7FLST63qF8B3Hgu2HRdZ7tA1X1+mk+St4JOuIrqdhIBnnyqeyWJNI+Bww7Es5QZ0wIc1Cmkw==}
     engines: {node: '>=14.21.3'}
     cpu: [arm64]
     os: [linux]
     libc: [glibc]
 
-  '@biomejs/cli-linux-x64-musl@2.4.6':
-    resolution: {integrity: sha512-C9s98IPDu7DYarjlZNuzJKTjVHN03RUnmHV5htvqsx6vEUXCDSJ59DNwjKVD5XYoSS4N+BYhq3RTBAL8X6svEg==}
+  '@biomejs/cli-linux-x64-musl@2.4.10':
+    resolution: {integrity: sha512-kDTi3pI6PBN6CiczsWYOyP2zk0IJI08EWEQyDMQWW221rPaaEz6FvjLhnU07KMzLv8q3qSuoB93ua6inSQ55Tw==}
     engines: {node: '>=14.21.3'}
     cpu: [x64]
     os: [linux]
     libc: [musl]
 
-  '@biomejs/cli-linux-x64@2.4.6':
-    resolution: {integrity: sha512-oHXmUFEoH8Lql1xfc3QkFLiC1hGR7qedv5eKNlC185or+o4/4HiaU7vYODAH3peRCfsuLr1g6v2fK9dFFOYdyw==}
+  '@biomejs/cli-linux-x64@2.4.10':
+    resolution: {integrity: sha512-tZLvEEi2u9Xu1zAqRjTcpIDGVtldigVvzug2fTuPG0ME/g8/mXpRPcNgLB22bGn6FvLJpHHnqLnwliOu8xjYrg==}
     engines: {node: '>=14.21.3'}
     cpu: [x64]
     os: [linux]
     libc: [glibc]
 
-  '@biomejs/cli-win32-arm64@2.4.6':
-    resolution: {integrity: sha512-xzThn87Pf3YrOGTEODFGONmqXpTwUNxovQb72iaUOdcw8sBSY3+3WD8Hm9IhMYLnPi0n32s3L3NWU6+eSjfqFg==}
+  '@biomejs/cli-win32-arm64@2.4.10':
+    resolution: {integrity: sha512-umwQU6qPzH+ISTf/eHyJ/QoQnJs3V9Vpjz2OjZXe9MVBZ7prgGafMy7yYeRGnlmDAn87AKTF3Q6weLoMGpeqdQ==}
     engines: {node: '>=14.21.3'}
     cpu: [arm64]
     os: [win32]
 
-  '@biomejs/cli-win32-x64@2.4.6':
-    resolution: {integrity: sha512-7++XhnsPlr1HDbor5amovPjOH6vsrFOCdp93iKXhFn6bcMUI6soodj3WWKfgEO6JosKU1W5n3uky3WW9RlRjTg==}
+  '@biomejs/cli-win32-x64@2.4.10':
+    resolution: {integrity: sha512-aW/JU5GuyH4uxMrNYpoC2kjaHlyJGLgIa3XkhPEZI0uKhZhJZU8BuEyJmvgzSPQNGozBwWjC972RaNdcJ9KyJg==}
     engines: {node: '>=14.21.3'}
     cpu: [x64]
     os: [win32]
@@ -2453,39 +2453,39 @@ snapshots:
 
   '@babel/runtime@7.28.6': {}
 
-  '@biomejs/biome@2.4.6':
+  '@biomejs/biome@2.4.10':
     optionalDependencies:
-      '@biomejs/cli-darwin-arm64': 2.4.6
-      '@biomejs/cli-darwin-x64': 2.4.6
-      '@biomejs/cli-linux-arm64': 2.4.6
-      '@biomejs/cli-linux-arm64-musl': 2.4.6
-      '@biomejs/cli-linux-x64': 2.4.6
-      '@biomejs/cli-linux-x64-musl': 2.4.6
-      '@biomejs/cli-win32-arm64': 2.4.6
-      '@biomejs/cli-win32-x64': 2.4.6
+      '@biomejs/cli-darwin-arm64': 2.4.10
+      '@biomejs/cli-darwin-x64': 2.4.10
+      '@biomejs/cli-linux-arm64': 2.4.10
+      '@biomejs/cli-linux-arm64-musl': 2.4.10
+      '@biomejs/cli-linux-x64': 2.4.10
+      '@biomejs/cli-linux-x64-musl': 2.4.10
+      '@biomejs/cli-win32-arm64': 2.4.10
+      '@biomejs/cli-win32-x64': 2.4.10
 
-  '@biomejs/cli-darwin-arm64@2.4.6':
+  '@biomejs/cli-darwin-arm64@2.4.10':
     optional: true
 
-  '@biomejs/cli-darwin-x64@2.4.6':
+  '@biomejs/cli-darwin-x64@2.4.10':
     optional: true
 
-  '@biomejs/cli-linux-arm64-musl@2.4.6':
+  '@biomejs/cli-linux-arm64-musl@2.4.10':
     optional: true
 
-  '@biomejs/cli-linux-arm64@2.4.6':
+  '@biomejs/cli-linux-arm64@2.4.10':
     optional: true
 
-  '@biomejs/cli-linux-x64-musl@2.4.6':
+  '@biomejs/cli-linux-x64-musl@2.4.10':
     optional: true
 
-  '@biomejs/cli-linux-x64@2.4.6':
+  '@biomejs/cli-linux-x64@2.4.10':
     optional: true
 
-  '@biomejs/cli-win32-arm64@2.4.6':
+  '@biomejs/cli-win32-arm64@2.4.10':
     optional: true
 
-  '@biomejs/cli-win32-x64@2.4.6':
+  '@biomejs/cli-win32-x64@2.4.10':
     optional: true
 
   '@borewit/text-codec@0.2.1': {}


### PR DESCRIPTION
## Summary

Fix `findPi()` failing on Windows with `'pi' command not found` despite pi being installed.

## Problem

On Windows, `execFileSync('pi', ...)` without `shell: true` resolves to the POSIX shell script shim created by npm instead of `pi.cmd`, causing `ENOENT`. Additionally, the `PATH` inside `npx` child processes may not include the global npm bin directory.

## Changes

- Add `IS_WINDOWS` constant (`process.platform === 'win32'`)
- Try `pi.cmd` before `pi` on Windows in `findPi()`
- Pass `shell: IS_WINDOWS` to all `execFileSync` calls (both `findPi()` and `run()`)
- Import `process` explicitly from `node:process`

## Testing

- On macOS/Linux: `IS_WINDOWS` is `false`, behavior is unchanged (no shell, resolves `pi` directly)
- On Windows: tries `pi.cmd` first with `shell: true`, falling back to `pi`

Fixes #71