### PR TITLE
feat(footer): show clickable PR link in custom footer

### DIFF
--- a/.changeset/show-pr-link-in-footer.md
+++ b/.changeset/show-pr-link-in-footer.md
@@ -1,0 +1,5 @@
+---
+default: minor
+---
+
+show the current PR as a clickable hyperlink in the custom footer when a PR is open for the current branch.

--- a/packages/extensions/extensions/custom-footer.test.ts
+++ b/packages/extensions/extensions/custom-footer.test.ts
@@ -6,7 +6,7 @@ vi.mock("@mariozechner/pi-tui", () => ({
 	truncateToWidth: (text: string, width: number) => text.slice(0, width),
 }));
 
-import customFooter, { collectFooterUsageTotals, fmt, formatElapsed } from "./custom-footer";
+import customFooter, { collectFooterUsageTotals, fmt, formatElapsed, hyperlink } from "./custom-footer";
 import { resetSafeModeStateForTests, setSafeModeState } from "./runtime-mode";
 
 function makeAssistantMessage(overrides: Partial<{ input: number; output: number; cost: number }> = {}) {
@@ -35,6 +35,7 @@ function createMockPi() {
 		getThinkingLevel() {
 			return "medium";
 		},
+		exec: vi.fn().mockResolvedValue({ stdout: "", exitCode: 1 }),
 		_handlers: handlers,
 		async _emit(event: string, ...args: any[]) {
 			for (const handler of handlers.get(event) ?? []) {
@@ -49,6 +50,13 @@ afterEach(() => {
 });
 
 describe("custom-footer helpers", () => {
+	it("generates OSC 8 hyperlinks", () => {
+		const link = hyperlink("https://github.com/ifiokjr/oh-pi/pull/42", "PR #42");
+		expect(link).toContain("\x1b]8;;https://github.com/ifiokjr/oh-pi/pull/42\x07");
+		expect(link).toContain("PR #42");
+		expect(link).toContain("\x1b]8;;\x07");
+	});
+
 	it("formats elapsed time compactly", () => {
 		expect(formatElapsed(42_000)).toBe("42s");
 		expect(formatElapsed(3 * 60_000 + 12_000)).toBe("3m12s");
@@ -187,5 +195,73 @@ describe("custom-footer extension", () => {
 
 		setSafeModeState(true, { source: "manual", reason: "test" });
 		expect(component.render(200)).toEqual([]);
+	});
+
+	it("shows a clickable PR link in the footer when a PR is open", async () => {
+		const pi = createMockPi();
+		pi.exec = vi.fn().mockResolvedValue({
+			stdout: JSON.stringify({ number: 77, url: "https://github.com/ifiokjr/oh-pi/pull/77" }),
+			exitCode: 0,
+		});
+		customFooter(pi as any);
+
+		let footerFactory: any;
+		const ctx = {
+			model: { id: "claude-sonnet", provider: "anthropic" },
+			getContextUsage: () => ({ percent: 12 }),
+			sessionManager: { getBranch: () => [] },
+			ui: {
+				setFooter(factory: any) {
+					footerFactory = factory;
+				},
+			},
+		};
+
+		await pi._emit("session_start", {}, ctx);
+
+		// The PR probe fires inside the setFooter factory, so instantiate the component first
+		const component = footerFactory(
+			{ requestRender: vi.fn() },
+			{ fg: (_color: string, text: string) => text },
+			{ onBranchChange: () => () => undefined, getGitBranch: () => "feat/footer-pr-link" },
+		);
+
+		// Wait for the async PR probe to resolve
+		await vi.waitFor(() => expect(pi.exec).toHaveBeenCalled());
+		await new Promise((resolve) => setTimeout(resolve, 10));
+
+		const rendered = component.render(300)[0];
+		expect(rendered).toContain("PR #77");
+		expect(rendered).toContain("https://github.com/ifiokjr/oh-pi/pull/77");
+	});
+
+	it("does not show PR link when no PR is open", async () => {
+		const pi = createMockPi();
+		pi.exec = vi.fn().mockResolvedValue({ stdout: "", exitCode: 1 });
+		customFooter(pi as any);
+
+		let footerFactory: any;
+		const ctx = {
+			model: { id: "claude-sonnet", provider: "anthropic" },
+			getContextUsage: () => ({ percent: 12 }),
+			sessionManager: { getBranch: () => [] },
+			ui: {
+				setFooter(factory: any) {
+					footerFactory = factory;
+				},
+			},
+		};
+
+		await pi._emit("session_start", {}, ctx);
+		await new Promise((resolve) => setTimeout(resolve, 0));
+
+		const component = footerFactory(
+			{ requestRender: vi.fn() },
+			{ fg: (_color: string, text: string) => text },
+			{ onBranchChange: () => () => undefined, getGitBranch: () => "main" },
+		);
+
+		const rendered = component.render(300)[0];
+		expect(rendered).not.toContain("PR #");
 	});
 });

--- a/packages/extensions/extensions/custom-footer.ts
+++ b/packages/extensions/extensions/custom-footer.ts
@@ -17,6 +17,18 @@ import type { ExtensionAPI, ExtensionContext } from "@mariozechner/pi-coding-age
 import { truncateToWidth } from "@mariozechner/pi-tui";
 import { getSafeModeState, subscribeSafeMode } from "./runtime-mode";
 
+/** OSC 8 hyperlink: renders `text` as a clickable terminal link to `url`. */
+export function hyperlink(url: string, text: string): string {
+	return `\x1b]8;;${url}\x07${text}\x1b]8;;\x07`;
+}
+
+export type PrInfo = {
+	number: number;
+	url: string;
+};
+
+const PR_PROBE_COOLDOWN_MS = 60_000;
+
 export type FooterUsageTotals = {
 	input: number;
 	output: number;
@@ -68,9 +80,56 @@ export default function (pi: ExtensionAPI) {
 	let sessionStart = Date.now();
 	/** Cached assistant usage totals to avoid rescanning the full session on every render. */
 	let usageTotals: FooterUsageTotals = { input: 0, output: 0, cost: 0 };
+	/** Cached PR info for the current branch. */
+	let cachedPr: PrInfo | null = null;
+	/** Branch name when the PR was last probed. */
+	let prProbedForBranch: string | null = null;
+	/** Last time a PR probe was attempted. */
+	let lastPrProbeAt = 0;
+	/** Whether a PR probe is in flight. */
+	let prProbeInFlight = false;
 
 	const syncUsageTotals = (ctx: Pick<ExtensionContext, "sessionManager">) => {
 		usageTotals = collectFooterUsageTotals(ctx);
+	};
+
+	const probePr = (branch: string | null) => {
+		if (!branch || prProbeInFlight) {
+			return;
+		}
+		const now = Date.now();
+		if (branch === prProbedForBranch && now - lastPrProbeAt < PR_PROBE_COOLDOWN_MS) {
+			return;
+		}
+		if (branch !== prProbedForBranch) {
+			cachedPr = null;
+		}
+		prProbeInFlight = true;
+		prProbedForBranch = branch;
+		lastPrProbeAt = now;
+		pi.exec("gh", ["pr", "view", "--json", "number,url", "--jq", "{number,url}"], { timeout: 8000 })
+			.then(({ stdout, exitCode }) => {
+				if (exitCode !== 0 || !stdout.trim()) {
+					cachedPr = null;
+					return;
+				}
+				try {
+					const parsed = JSON.parse(stdout.trim()) as { number?: number; url?: string };
+					if (parsed.number && parsed.url) {
+						cachedPr = { number: parsed.number, url: parsed.url };
+					} else {
+						cachedPr = null;
+					}
+				} catch {
+					cachedPr = null;
+				}
+			})
+			.catch(() => {
+				cachedPr = null;
+			})
+			.finally(() => {
+				prProbeInFlight = false;
+			});
 	};
 
 	pi.on("session_start", async (_event, ctx) => {
@@ -78,9 +137,13 @@ export default function (pi: ExtensionAPI) {
 		syncUsageTotals(ctx);
 
 		ctx.ui.setFooter((tui, theme, footerData) => {
-			const unsub = footerData.onBranchChange(() => tui.requestRender());
+			const unsub = footerData.onBranchChange(() => {
+				probePr(footerData.getGitBranch());
+				tui.requestRender();
+			});
 			const unsubSafeMode = subscribeSafeMode(() => tui.requestRender());
 			const timer = setInterval(() => tui.requestRender(), 30000);
+			probePr(footerData.getGitBranch());
 
 			return {
 				dispose() {
@@ -113,7 +176,13 @@ export default function (pi: ExtensionAPI) {
 					const cwdStr = theme.fg("muted", `⌂ ${short}`);
 
 					const branch = footerData.getGitBranch();
-					const branchStr = branch ? theme.fg("accent", `⎇ ${branch}`) : "";
+					let branchStr = branch ? theme.fg("accent", `⎇ ${branch}`) : "";
+					if (cachedPr) {
+						const prLabel = theme.fg("success", `PR #${cachedPr.number}`);
+						branchStr = branchStr
+							? `${branchStr} ${hyperlink(cachedPr.url, prLabel)}`
+							: hyperlink(cachedPr.url, prLabel);
+					}
 
 					const thinking = pi.getThinkingLevel();
 					const thinkColor =

--- a/packages/skills/skills/git-workflow/SKILL.md
+++ b/packages/skills/skills/git-workflow/SKILL.md
@@ -45,6 +45,18 @@ chore(scope): maintenance tasks
 2. Generate PR title and description
 3. Suggest reviewers based on changed files (`git log --format='%an' -- <files>`)
 
+### PR link in summaries
+
+When a PR has been opened, **always include the full GitHub PR URL** in any summary or status
+update you provide. This makes it easy for the user to click through to the PR directly.
+
+Example summary format:
+```
+PR: https://github.com/owner/repo/pull/42
+```
+
+Use `gh pr view --json url --jq .url` to retrieve the URL if you do not already have it.
+
 ### Non-interactive safety for agent-run Git/GitHub commands
 
 When **the agent** runs `git` or `gh`, avoid opening an interactive editor or prompt.


### PR DESCRIPTION
## Summary

### Footer PR link
- detect the current branch's open PR via `gh pr view --json number,url`
- show `PR #N` as a clickable OSC 8 hyperlink next to the branch name in the footer
- probe is fire-and-forget with a 60s cooldown; re-probes on branch change
- gracefully degrades when `gh` is unavailable or no PR is open

### Git-workflow skill
- add guidance to always include the full GitHub PR URL when providing summaries after opening a PR

## Tests
- hyperlink OSC 8 generation
- PR info appears in footer render when a PR is open
- no PR info in footer when no PR is open
- existing footer tests updated with `exec` mock

## Validation
- `pnpm exec vitest run packages/extensions/extensions/custom-footer.test.ts packages/extensions/extensions/smoke.test.ts`
- `pnpm lint`
