### PR TITLE
feat(footer): add /status overlay command

### DIFF
--- a/.changeset/add-status-overlay-command.md
+++ b/.changeset/add-status-overlay-command.md
@@ -1,0 +1,5 @@
+---
+default: minor
+---
+
+add `/status` command that opens an overlay showing model, session, context window, workspace, git branch, PR link, extension statuses, and safe-mode state.

--- a/packages/extensions/extensions/custom-footer.test.ts
+++ b/packages/extensions/extensions/custom-footer.test.ts
@@ -24,6 +24,7 @@ function makeAssistantMessage(overrides: Partial<{ input: number; output: number
 
 function createMockPi() {
 	const handlers = new Map<string, ((...args: any[]) => any)[]>();
+	const commands = new Map<string, any>();
 
 	return {
 		on(event: string, handler: (...args: any[]) => any) {
@@ -32,11 +33,15 @@ function createMockPi() {
 			}
 			handlers.get(event)?.push(handler);
 		},
+		registerCommand(name: string, opts: any) {
+			commands.set(name, opts);
+		},
 		getThinkingLevel() {
 			return "medium";
 		},
 		exec: vi.fn().mockResolvedValue({ stdout: "", exitCode: 1 }),
 		_handlers: handlers,
+		_commands: commands,
 		async _emit(event: string, ...args: any[]) {
 			for (const handler of handlers.get(event) ?? []) {
 				await handler(...args);
@@ -263,5 +268,70 @@ describe("custom-footer extension", () => {
 
 		const rendered = component.render(300)[0];
 		expect(rendered).not.toContain("PR #");
+	});
+
+	it("registers a /status command", () => {
+		const pi = createMockPi();
+		customFooter(pi as any);
+		expect(pi._commands.has("status")).toBe(true);
+	});
+
+	it("/status overlay shows model, session, tokens, context, branch, and extension statuses", async () => {
+		const pi = createMockPi();
+		customFooter(pi as any);
+
+		let customFactory: any;
+		const ctx = {
+			model: { id: "claude-sonnet-4-20250514", provider: "anthropic" },
+			getContextUsage: () => ({ tokens: 45000, contextWindow: 200000, percent: 22.5 }),
+			sessionManager: {
+				getBranch: () => [{ type: "message", message: makeAssistantMessage({ input: 1200, output: 800, cost: 0.03 }) }],
+			},
+			ui: {
+				setFooter(factory: any) {
+					factory(
+						{ requestRender: vi.fn() },
+						{ fg: (_c: string, t: string) => t },
+						{
+							onBranchChange: () => () => undefined,
+							getGitBranch: () => "feat/test-branch",
+							getExtensionStatuses: () =>
+								new Map([
+									["pi-scheduler", "2 active \u2022 next 10:30"],
+									["watchdog", "cpu 12% \u00b7 rss 380MB"],
+								]),
+							getAvailableProviderCount: () => 3,
+						},
+					);
+				},
+				custom: vi.fn().mockImplementation(async (factory: any) => {
+					customFactory = factory;
+				}),
+			},
+		};
+
+		await pi._emit("session_start", {}, ctx);
+		await pi._commands.get("status").handler("", ctx);
+
+		expect(customFactory).toBeDefined();
+		const component = customFactory(
+			{ requestRender: vi.fn() },
+			{ fg: (_color: string, text: string) => text },
+			{},
+			() => {},
+		);
+		const rendered = component.render(200).join("\n");
+
+		expect(rendered).toContain("claude-sonnet-4-20250514");
+		expect(rendered).toContain("anthropic");
+		expect(rendered).toContain("medium");
+		expect(rendered).toContain("$0.03");
+		expect(rendered).toContain("1.2k");
+		expect(rendered).toContain("23% used");
+		expect(rendered).toContain("feat/test-branch");
+		expect(rendered).toContain("pi-scheduler");
+		expect(rendered).toContain("2 active");
+		expect(rendered).toContain("watchdog");
+		expect(rendered).toContain("cpu 12%");
 	});
 });

--- a/packages/extensions/extensions/custom-footer.ts
+++ b/packages/extensions/extensions/custom-footer.ts
@@ -13,7 +13,7 @@
  */
 
 import type { AssistantMessage } from "@mariozechner/pi-ai";
-import type { ExtensionAPI, ExtensionContext } from "@mariozechner/pi-coding-agent";
+import type { ExtensionAPI, ExtensionContext, ReadonlyFooterDataProvider } from "@mariozechner/pi-coding-agent";
 import { truncateToWidth } from "@mariozechner/pi-tui";
 import { getSafeModeState, subscribeSafeMode } from "./runtime-mode";
 
@@ -81,6 +81,8 @@ export default function (pi: ExtensionAPI) {
 	/** Cached assistant usage totals to avoid rescanning the full session on every render. */
 	let usageTotals: FooterUsageTotals = { input: 0, output: 0, cost: 0 };
 	/** Cached PR info for the current branch. */
+	let activeFooterData: ReadonlyFooterDataProvider | null = null;
+	let activeCtx: ExtensionContext | null = null;
 	let cachedPr: PrInfo | null = null;
 	/** Branch name when the PR was last probed. */
 	let prProbedForBranch: string | null = null;
@@ -135,8 +137,10 @@ export default function (pi: ExtensionAPI) {
 	pi.on("session_start", async (_event, ctx) => {
 		sessionStart = Date.now();
 		syncUsageTotals(ctx);
+		activeCtx = ctx;
 
 		ctx.ui.setFooter((tui, theme, footerData) => {
+			activeFooterData = footerData;
 			const unsub = footerData.onBranchChange(() => {
 				probePr(footerData.getGitBranch());
 				tui.requestRender();
@@ -222,5 +226,119 @@ export default function (pi: ExtensionAPI) {
 		if (event.message.role === "assistant") {
 			accumulateAssistantUsage(usageTotals, event.message as AssistantMessage);
 		}
+	});
+
+	// ─── /status overlay ─────────────────────────────────────────────────
+
+	// biome-ignore lint/complexity/noExcessiveCognitiveComplexity: Status overlay assembles many optional sections.
+	function buildStatusLines(theme: { fg: (color: string, text: string) => string }): string[] {
+		const lines: string[] = [];
+		const sep = theme.fg("dim", " │ ");
+		const divider = theme.fg("dim", "─".repeat(60));
+
+		lines.push(theme.fg("accent", "╭─ Status ───────────────────────────────────────────────────╮"));
+		lines.push("");
+
+		// ── Model ──
+		const thinking = pi.getThinkingLevel();
+		const thinkLabel = thinking === "none" ? "off" : thinking;
+		const modelId = activeCtx?.model?.id || "no-model";
+		const provider = (activeCtx?.model as { provider?: string })?.provider || "unknown";
+		lines.push(`  ${theme.fg("accent", "Model")}${sep}${theme.fg("accent", modelId)}`);
+		lines.push(`  ${theme.fg("accent", "Provider")}${sep}${provider}`);
+		lines.push(`  ${theme.fg("accent", "Thinking")}${sep}${thinkLabel}`);
+		lines.push("");
+
+		// ── Session ──
+		lines.push(`  ${divider}`);
+		const elapsed = formatElapsed(Date.now() - sessionStart);
+		lines.push(
+			`  ${theme.fg("accent", "Session")}${sep}${elapsed}${sep}${theme.fg("warning", `$${usageTotals.cost.toFixed(2)}`)}`,
+		);
+		lines.push(
+			`  ${theme.fg("accent", "Tokens")}${sep}${theme.fg("success", fmt(usageTotals.input))} in${sep}${theme.fg("warning", fmt(usageTotals.output))} out${sep}${theme.fg("dim", fmt(usageTotals.input + usageTotals.output))} total`,
+		);
+
+		// ── Context window ──
+		const usage = activeCtx?.getContextUsage?.();
+		if (usage) {
+			const pct = usage.percent ?? 0;
+			const pctColor = pct > 75 ? "error" : pct > 50 ? "warning" : "success";
+			const tokens = usage.tokens == null ? "?" : fmt(usage.tokens);
+			lines.push(
+				`  ${theme.fg("accent", "Context")}${sep}${theme.fg(pctColor, `${pct.toFixed(0)}% used`)}${sep}${tokens} / ${fmt(usage.contextWindow)} tokens`,
+			);
+		}
+		lines.push("");
+
+		// ── Workspace ──
+		lines.push(`  ${divider}`);
+		lines.push(`  ${theme.fg("accent", "Directory")}${sep}${process.cwd()}`);
+
+		const branch = activeFooterData?.getGitBranch?.();
+		if (branch) {
+			lines.push(`  ${theme.fg("accent", "Branch")}${sep}${theme.fg("accent", branch)}`);
+		}
+
+		if (cachedPr) {
+			const prLink = hyperlink(cachedPr.url, `#${cachedPr.number}`);
+			lines.push(
+				`  ${theme.fg("accent", "Pull Request")}${sep}${theme.fg("success", prLink)}${sep}${theme.fg("dim", cachedPr.url)}`,
+			);
+		}
+		lines.push("");
+
+		// ── Extension statuses ──
+		const statuses = activeFooterData?.getExtensionStatuses?.();
+		if (statuses && statuses.size > 0) {
+			lines.push(`  ${divider}`);
+			lines.push(`  ${theme.fg("accent", "Extension Statuses")}`);
+			lines.push("");
+			for (const [key, value] of statuses) {
+				lines.push(`  ${theme.fg("dim", key.padEnd(24))}${value}`);
+			}
+			lines.push("");
+		}
+
+		// ── Safe mode ──
+		const safeMode = getSafeModeState();
+		if (safeMode.enabled) {
+			lines.push(`  ${divider}`);
+			const source = safeMode.auto ? "watchdog" : (safeMode.source ?? "manual");
+			lines.push(
+				`  ${theme.fg("warning", "⚠ Safe mode ON")}${sep}source: ${source}${safeMode.reason ? `${sep}${safeMode.reason}` : ""}`,
+			);
+			lines.push("");
+		}
+
+		lines.push(theme.fg("accent", "╰────────────────────────────────────────────────────────────╯"));
+		lines.push(theme.fg("dim", "  Press q/Esc/Space to close"));
+
+		return lines;
+	}
+
+	pi.registerCommand("status", {
+		description: "Show a full status overview: model, session, context, workspace, PR, and extension statuses",
+		async handler(_args, ctx) {
+			activeCtx = ctx;
+			await ctx.ui.custom(
+				(_tui, theme, _keybindings, done) => {
+					const lines = buildStatusLines(theme);
+					return {
+						render(width: number) {
+							return lines.map((line) => truncateToWidth(line, width));
+						},
+						handleInput(data: string) {
+							if (data === "q" || data === "\x1b" || data === "\r" || data === " ") {
+								done(undefined);
+							}
+						},
+						// biome-ignore lint/suspicious/noEmptyBlockStatements: required by Component interface
+						dispose() {},
+					};
+				},
+				{ overlay: true },
+			);
+		},
 	});
 }


### PR DESCRIPTION
## Summary

Adds a `/status` command that opens a full-screen overlay showing everything the footer shows and more, in a human-readable format.

### What the overlay shows

```
╭─ Status ───────────────────────────────────────────────────╮

  Model │ claude-sonnet-4-20250514
  Provider │ anthropic
  Thinking │ medium

  ────────────────────────────────────────────────────────────
  Session │ 3m12s │ $0.42
  Tokens │ 12.3k in │ 8.1k out │ 20.4k total
  Context │ 23% used │ 45.0k / 200.0k tokens

  ────────────────────────────────────────────────────────────
  Directory │ /Users/you/projects/oh-pi
  Branch │ feat/my-branch

  ────────────────────────────────────────────────────────────
  Extension Statuses

  pi-scheduler            2 active • next 10:30
  watchdog                cpu 12% · rss 380MB

╰────────────────────────────────────────────────────────────╯
  Press q/Esc/Space to close
```

### Sections
- **Model** — name, provider, thinking level
- **Session** — elapsed time, accumulated cost
- **Tokens** — input/output/total
- **Context** — window usage % and token counts
- **Workspace** — full directory path and git branch
- **Extension Statuses** — all `setStatus()` entries (scheduler, watchdog, safe-mode, etc.)
- **Safe mode** — shown when enabled, with source and reason

### Tests
- registers `/status` command
- overlay renders model, session, tokens, context, branch, and extension statuses

## Validation
- `pnpm exec vitest run packages/extensions/extensions/custom-footer.test.ts packages/extensions/extensions/smoke.test.ts`
- `pnpm lint`
