### PR TITLE
docs(skills): clarify non-interactive git editor guards

### DIFF
--- a/.changeset/fix-git-workflow-editor-vars.md
+++ b/.changeset/fix-git-workflow-editor-vars.md
@@ -1,0 +1,5 @@
+---
+default: patch
+---
+
+- Clarify the git-workflow skill to disable both `GIT_EDITOR` and `GIT_SEQUENCE_EDITOR` (plus `core.editor`/`sequence.editor` overrides) so agent-run Git commands avoid interactive editors in rebase and merge flows.

--- a/packages/skills/skills/git-workflow/SKILL.md
+++ b/packages/skills/skills/git-workflow/SKILL.md
@@ -47,10 +47,10 @@ chore(scope): maintenance tasks
 
 ### PR link in summaries
 
-When a PR has been opened, **always include the full GitHub PR URL** in any summary or status
-update you provide. This makes it easy for the user to click through to the PR directly.
+When a PR has been opened, **always include the full GitHub PR URL** in any summary or status update you provide. This makes it easy for the user to click through to the PR directly.
 
 Example summary format:
+
 ```
 PR: https://github.com/owner/repo/pull/42
 ```
@@ -61,13 +61,17 @@ Use `gh pr view --json url --jq .url` to retrieve the URL if you do not already 
 
 When **the agent** runs `git` or `gh`, avoid opening an interactive editor or prompt.
 
-- For `git rebase --continue`, do **not** rely on `--no-edit` — `git rebase --continue` does not support it.
-  Use one of these instead:
-  ```bash
-  GIT_EDITOR=true git rebase --continue
-  # or
-  git -c core.editor=true rebase --continue
-  ```
+A lot of Git entrypoints use different editor config keys, so avoid surprises by disabling both:
+
+- `core.editor` / `GIT_EDITOR` (commit, merge, tag message editing)
+- `sequence.editor` / `GIT_SEQUENCE_EDITOR` (interactive rebase todo-list editing)
+
+Use this pattern for non-interactive flows:
+
+```bash
+GIT_EDITOR=true GIT_SEQUENCE_EDITOR=true git -c core.editor=true -c sequence.editor=true rebase --continue
+```
+
 - For commits, always pass the message on the command line:
   ```bash
   git commit -m "fix(scope): message"
@@ -76,7 +80,7 @@ When **the agent** runs `git` or `gh`, avoid opening an interactive editor or pr
   ```bash
   git merge --no-edit
   ```
-- For any other git command that could open an editor, set `GIT_EDITOR=true` for that invocation.
+- For any other git command that could open an editor, set `GIT_EDITOR=true` and `GIT_SEQUENCE_EDITOR=true` (plus `-c core.editor=true -c sequence.editor=true`) for that invocation.
 - For GitHub CLI commands, disable terminal prompts and provide all required fields explicitly:
   ```bash
   GH_PROMPT_DISABLED=1 gh pr create --title "..." --body "..."
@@ -98,5 +102,5 @@ Guide through `git rebase -i` for cleaning up history before PR.
 If the agent is resolving conflicts during a rebase, continue with a non-interactive command such as:
 
 ```bash
-GIT_EDITOR=true git rebase --continue
+GIT_EDITOR=true GIT_SEQUENCE_EDITOR=true git -c core.editor=true -c sequence.editor=true rebase --continue
 ```


### PR DESCRIPTION
## Summary

- Update `packages/skills/skills/git-workflow/SKILL.md` to explicitly disable both `GIT_EDITOR` and `GIT_SEQUENCE_EDITOR` (plus `core.editor`/`sequence.editor` overrides) for non-interactive agent Git commands.
- This addresses occasional interactive editor prompts from rebase/merge flows despite `GIT_EDITOR=true` being set.
- Added changeset `.changeset/fix-git-workflow-editor-vars.md` (patch).

## Validation

- `pnpm docs:check`
- `pnpm lint`
- `pnpm typecheck`
- `pnpm build`
- `pnpm test`
