### PR TITLE
feat: add experimental Ollama Cloud provider

### DIFF
--- a/.changeset/add-ollama-cloud-provider.md
+++ b/.changeset/add-ollama-cloud-provider.md
@@ -1,0 +1,6 @@
+---
+default: minor
+---
+
+- Add the experimental `@ifi/pi-provider-ollama-cloud` package so pi can log in to Ollama Cloud via `/login ollama-cloud`, discover the current cloud model catalog, and expose those models in `/model`.
+- Document the new opt-in provider package and include it in release/package verification metadata.

--- a/README.md
+++ b/README.md
@@ -47,13 +47,15 @@ This is a monorepo. Install everything at once with `npx @ifi/oh-pi`, or pick in
 | [`@ifi/pi-shared-qna`](./packages/shared-qna)             | Shared Q&A TUI helpers                      | (library, not installed directly)           |
 | [`@ifi/pi-spec`](./packages/spec)                         | Native spec-driven workflow with `/spec`    | `pi install npm:@ifi/pi-spec`               |
 | [`@ifi/pi-provider-cursor`](./packages/cursor)            | Experimental Cursor OAuth provider          | `pi install npm:@ifi/pi-provider-cursor`    |
+| [`@ifi/pi-provider-ollama-cloud`](./packages/ollama)      | Experimental Ollama Cloud provider          | `pi install npm:@ifi/pi-provider-ollama-cloud` |
 | [`@ifi/oh-pi-themes`](./packages/themes)                  | 6 color themes                              | `pi install npm:@ifi/oh-pi-themes`          |
 | [`@ifi/oh-pi-prompts`](./packages/prompts)                | 10 prompt templates                         | `pi install npm:@ifi/oh-pi-prompts`         |
 | [`@ifi/oh-pi-skills`](./packages/skills)                  | 12 skill packs                              | `pi install npm:@ifi/oh-pi-skills`          |
 | [`@ifi/oh-pi-agents`](./packages/agents)                  | 5 AGENTS.md templates                       | (used by CLI only)                          |
 
-`@ifi/pi-provider-cursor` stays opt-in for now and is **not** installed by `npx @ifi/oh-pi`. It
-uses unofficial Cursor endpoints and is intentionally shipped as a separate experimental package.
+`@ifi/pi-provider-cursor` and `@ifi/pi-provider-ollama-cloud` stay opt-in for now and are **not**
+installed by `npx @ifi/oh-pi`. They are intentionally shipped as separate experimental provider
+packages.
 
 ### Native `/spec` Workflow
 
@@ -560,6 +562,7 @@ oh-pi/
 │   ├── plan/                   Planning mode extension (raw .ts)
 │   ├── spec/                   Native spec-driven workflow package (raw .ts)
 │   ├── cursor/                 Experimental Cursor OAuth provider package (raw .ts)
+│   ├── ollama/                 Experimental Ollama Cloud provider package (raw .ts)
 │   ├── themes/                 6 JSON theme files
 │   ├── prompts/                10 markdown prompt templates
 │   ├── skills/                 12 skill directories

--- a/docs/agent-rules/engineering.md
+++ b/docs/agent-rules/engineering.md
@@ -73,6 +73,7 @@ packages/
   plan/                   → @ifi/pi-plan (raw .ts planning mode extension)
   spec/                   → @ifi/pi-spec (raw .ts spec-driven workflow package)
   cursor/                 → @ifi/pi-provider-cursor (raw .ts experimental Cursor provider package)
+  ollama/                 → @ifi/pi-provider-ollama-cloud (raw .ts experimental Ollama Cloud provider package)
   oh-pi/                  → @ifi/oh-pi (installer CLI: `npx @ifi/oh-pi`)
 ```
 

--- a/docs/agent-rules/packaging-and-release.md
+++ b/docs/agent-rules/packaging-and-release.md
@@ -55,6 +55,7 @@ pi install npm:@ifi/pi-extension-subagents
 pi install npm:@ifi/pi-plan
 pi install npm:@ifi/pi-spec
 pi install npm:@ifi/pi-provider-cursor
+pi install npm:@ifi/pi-provider-ollama-cloud
 ```
 
 Do not use `bundledDependencies` in `@ifi/oh-pi`.

--- a/knope.toml
+++ b/knope.toml
@@ -19,6 +19,8 @@ versioned_files = [
   "packages/shared-qna/package.json",
   "packages/plan/package.json",
   "packages/spec/package.json",
+  "packages/cursor/package.json",
+  "packages/ollama/package.json",
   "packages/oh-pi/package.json",
   "packages/web-server/package.json",
   "packages/web-remote/package.json",

--- a/package.json
+++ b/package.json
@@ -48,7 +48,8 @@
 			"brace-expansion@^2.0.2": "2.0.3",
 			"brace-expansion@^5.0.2": "5.0.5",
 			"yaml": "2.8.3",
-			"picomatch": "4.0.4"
+			"picomatch": "4.0.4",
+			"vite": "7.3.2"
 		}
 	}
 }

--- a/packages/extensions/extensions/package-manifest.test.ts
+++ b/packages/extensions/extensions/package-manifest.test.ts
@@ -24,6 +24,7 @@ describe("pi package extension entrypoints", () => {
 			"packages/spec/package.json",
 			"packages/ant-colony/package.json",
 			"packages/cursor/package.json",
+			"packages/ollama/package.json",
 		];
 
 		for (const packagePath of extensionPackages) {

--- a/packages/ollama/README.md
+++ b/packages/ollama/README.md
@@ -1,0 +1,52 @@
+# @ifi/pi-provider-ollama-cloud
+
+Experimental Ollama Cloud provider for pi.
+
+## What it does
+
+- Registers an `ollama-cloud` provider via `pi.registerProvider(...)`
+- Adds `/login ollama-cloud` support using an Ollama API key flow
+- Discovers the current Ollama Cloud model catalog and stores it with the login credential
+- Exposes discovered models in `/model` as `ollama-cloud/<model-id>`
+- Adds `/ollama-cloud refresh-models` to refresh the catalog on demand
+
+## Install
+
+```bash
+pi install npm:@ifi/pi-provider-ollama-cloud
+```
+
+This package is intentionally separate from `@ifi/oh-pi` for now.
+
+## Use
+
+1. Install the package
+2. Run `/login ollama-cloud`
+3. Create an API key on Ollama when pi opens the keys page
+4. Paste the key back into pi
+5. Open `/model` and select an `ollama-cloud/...` model
+6. Optionally run `/ollama-cloud refresh-models` later to refresh the catalog
+
+## Commands
+
+- `/ollama-cloud status` — show auth and catalog status
+- `/ollama-cloud refresh-models` — rediscover available Ollama Cloud models and refresh the provider registry
+
+## Notes
+
+- This integration is **cloud-only** for now. It does not configure local Ollama models.
+- pi uses Ollama's documented API-key flow for third-party cloud access.
+- Model discovery is stored alongside the login credential so `/login ollama-cloud` can refresh the model list immediately.
+- Costs are currently left at zero because Ollama Cloud subscription billing is not exposed as stable per-token pricing in the docs yet.
+
+## Test hooks
+
+These environment variables exist mainly for tests and local debugging:
+
+- `PI_OLLAMA_CLOUD_API_URL`
+- `PI_OLLAMA_CLOUD_MODELS_URL`
+- `PI_OLLAMA_CLOUD_SHOW_URL`
+- `PI_OLLAMA_CLOUD_KEYS_URL`
+- `PI_OLLAMA_CLOUD_ORIGIN`
+
+Legacy `OLLAMA_CLOUD_*` env names are also accepted for compatibility with local debugging.

--- a/packages/ollama/auth.ts
+++ b/packages/ollama/auth.ts
@@ -1,0 +1,86 @@
+import type { OAuthCredentials, OAuthLoginCallbacks, OAuthProviderInterface } from "@mariozechner/pi-ai";
+import {
+	OLLAMA_CLOUD_API,
+	OLLAMA_CLOUD_API_KEY_ENV,
+	OLLAMA_CLOUD_AUTH_DOCS_URL,
+	OLLAMA_CLOUD_PROVIDER,
+	getOllamaCloudRuntimeConfig,
+} from "./config.js";
+import { enrichOllamaCloudCredentials, getCredentialModels, type OllamaCloudCredentials } from "./models.js";
+
+const STATIC_CREDENTIAL_TTL_MS = 365 * 24 * 60 * 60 * 1000;
+
+export async function loginOllamaCloud(callbacks: OAuthLoginCallbacks): Promise<OllamaCloudCredentials> {
+	const config = getOllamaCloudRuntimeConfig();
+	callbacks.onAuth({
+		url: config.keysUrl,
+		instructions:
+			"Create an Ollama API key, then paste it back into pi. Ollama documents API keys for third-party cloud access; pi uses that flow for Ollama Cloud login.",
+	});
+	callbacks.onProgress?.("Waiting for Ollama Cloud API key...");
+	const envApiKey = getEnvApiKey();
+	const promptMessage = envApiKey
+		? `Paste your Ollama API key (leave blank to use ${OLLAMA_CLOUD_API_KEY_ENV} from the environment):`
+		: `Paste your Ollama API key (see ${OLLAMA_CLOUD_AUTH_DOCS_URL}):`;
+	const input = (await callbacks.onPrompt({ message: promptMessage })).trim();
+	const apiKey = input || envApiKey;
+	if (!apiKey) {
+		throw new Error(`No Ollama API key provided. Set ${OLLAMA_CLOUD_API_KEY_ENV} or paste a key from ${config.keysUrl}.`);
+	}
+	callbacks.onProgress?.("Validating Ollama Cloud API key and discovering models...");
+	return enrichOllamaCloudCredentials(createStaticCredential(apiKey), { signal: callbacks.signal });
+}
+
+export async function refreshOllamaCloudCredential(
+	credentials: OAuthCredentials,
+	options: { preserveModels?: boolean } = {},
+): Promise<OllamaCloudCredentials> {
+	return enrichOllamaCloudCredentials(createStaticCredential(credentials.access), {
+		previous: options.preserveModels === false ? undefined : (credentials as OllamaCloudCredentials),
+	});
+}
+
+export async function refreshOllamaCloudCredentialModels(credentials: OllamaCloudCredentials): Promise<OllamaCloudCredentials> {
+	return enrichOllamaCloudCredentials(createStaticCredential(credentials.access), { previous: credentials });
+}
+
+export function createOllamaCloudOAuthProvider(): Omit<OAuthProviderInterface, "id"> {
+	return {
+		name: "Ollama Cloud",
+		async login(callbacks) {
+			return loginOllamaCloud(callbacks);
+		},
+		async refreshToken(credentials) {
+			return refreshOllamaCloudCredential(credentials);
+		},
+		getApiKey(credentials) {
+			return credentials.access;
+		},
+		modifyModels(models, credentials) {
+			const config = getOllamaCloudRuntimeConfig();
+			const current = getCredentialModels(credentials as OllamaCloudCredentials);
+			return [
+				...models.filter((model) => model.provider !== OLLAMA_CLOUD_PROVIDER),
+				...current.map((model) => ({
+					...model,
+					provider: OLLAMA_CLOUD_PROVIDER,
+					api: OLLAMA_CLOUD_API,
+					baseUrl: config.apiUrl,
+				})),
+			];
+		},
+	};
+}
+
+function createStaticCredential(apiKey: string): OAuthCredentials {
+	return {
+		refresh: apiKey,
+		access: apiKey,
+		expires: Date.now() + STATIC_CREDENTIAL_TTL_MS,
+	};
+}
+
+function getEnvApiKey(): string | undefined {
+	const value = process.env[OLLAMA_CLOUD_API_KEY_ENV];
+	return typeof value === "string" && value.trim().length > 0 ? value.trim() : undefined;
+}

--- a/packages/ollama/config.ts
+++ b/packages/ollama/config.ts
@@ -1,0 +1,59 @@
+const DEFAULT_OLLAMA_CLOUD_ORIGIN = "https://ollama.com";
+const DEFAULT_OLLAMA_CLOUD_API_PATH = "/v1";
+const DEFAULT_OLLAMA_CLOUD_KEYS_PATH = "/settings/keys";
+const DEFAULT_OLLAMA_CLOUD_SHOW_PATH = "/api/show";
+const DEFAULT_OLLAMA_CLOUD_MODELS_PATH = "/models";
+
+function getEnv(name: string): string | undefined {
+	const value = process.env[name];
+	return typeof value === "string" && value.trim().length > 0 ? value.trim() : undefined;
+}
+
+function stripTrailingSlash(value: string): string {
+	return value.replace(/\/+$/, "");
+}
+
+function normalizeApiUrl(value: string): string {
+	return stripTrailingSlash(value);
+}
+
+function deriveOriginFromApiUrl(apiUrl: string): string {
+	try {
+		const url = new URL(apiUrl);
+		url.pathname = "";
+		url.search = "";
+		url.hash = "";
+		return stripTrailingSlash(url.toString());
+	} catch {
+		return DEFAULT_OLLAMA_CLOUD_ORIGIN;
+	}
+}
+
+export function getOllamaCloudRuntimeConfig(): {
+	origin: string;
+	apiUrl: string;
+	keysUrl: string;
+	showUrl: string;
+	modelsUrl: string;
+} {
+	const configuredApiUrl = getEnv("PI_OLLAMA_CLOUD_API_URL") ?? getEnv("OLLAMA_CLOUD_API_URL");
+	const apiUrl = normalizeApiUrl(configuredApiUrl ?? `${DEFAULT_OLLAMA_CLOUD_ORIGIN}${DEFAULT_OLLAMA_CLOUD_API_PATH}`);
+	const origin =
+		stripTrailingSlash(getEnv("PI_OLLAMA_CLOUD_ORIGIN") ?? getEnv("OLLAMA_CLOUD_ORIGIN") ?? deriveOriginFromApiUrl(apiUrl));
+	const keysUrl = stripTrailingSlash(
+		getEnv("PI_OLLAMA_CLOUD_KEYS_URL") ?? getEnv("OLLAMA_CLOUD_KEYS_URL") ?? `${origin}${DEFAULT_OLLAMA_CLOUD_KEYS_PATH}`,
+	);
+	const showUrl = stripTrailingSlash(
+		getEnv("PI_OLLAMA_CLOUD_SHOW_URL") ?? getEnv("OLLAMA_CLOUD_SHOW_URL") ?? `${origin}${DEFAULT_OLLAMA_CLOUD_SHOW_PATH}`,
+	);
+	const modelsUrl = stripTrailingSlash(
+		getEnv("PI_OLLAMA_CLOUD_MODELS_URL") ?? getEnv("OLLAMA_CLOUD_MODELS_URL") ?? `${apiUrl}${DEFAULT_OLLAMA_CLOUD_MODELS_PATH}`,
+	);
+	return { origin, apiUrl, keysUrl, showUrl, modelsUrl };
+}
+
+export const OLLAMA_CLOUD_PROVIDER = "ollama-cloud";
+export const OLLAMA_CLOUD_API = "openai-completions" as const;
+export const OLLAMA_CLOUD_API_KEY_ENV = "OLLAMA_API_KEY";
+export const OLLAMA_CLOUD_AUTH_DOCS_URL = "https://docs.ollama.com/api/authentication";
+export const OLLAMA_CLOUD_LIST_DOCS_URL = "https://docs.ollama.com/api/tags";

--- a/packages/ollama/index.ts
+++ b/packages/ollama/index.ts
@@ -1,0 +1,76 @@
+import type { ExtensionAPI } from "@mariozechner/pi-coding-agent";
+import {
+	createOllamaCloudOAuthProvider,
+	refreshOllamaCloudCredential,
+	refreshOllamaCloudCredentialModels,
+} from "./auth.js";
+import { OLLAMA_CLOUD_API, OLLAMA_CLOUD_PROVIDER, getOllamaCloudRuntimeConfig } from "./config.js";
+import { getCredentialModels, getFallbackOllamaCloudModels, toProviderModels, type OllamaCloudCredentials } from "./models.js";
+
+function registerOllamaCloudProvider(pi: ExtensionAPI): void {
+	pi.registerProvider(OLLAMA_CLOUD_PROVIDER, {
+		api: OLLAMA_CLOUD_API,
+		apiKey: "OLLAMA_API_KEY",
+		baseUrl: getOllamaCloudRuntimeConfig().apiUrl,
+		oauth: createOllamaCloudOAuthProvider(),
+		models: toProviderModels(getFallbackOllamaCloudModels()),
+	});
+}
+
+function registerOllamaCloudCommand(pi: ExtensionAPI): void {
+	pi.registerCommand("ollama-cloud", {
+		description: "Inspect or refresh the Ollama Cloud provider: /ollama-cloud [status|refresh-models]",
+		async handler(args, ctx) {
+			const action = args.trim().toLowerCase() || "status";
+			const authStorage = ctx.modelRegistry.authStorage;
+			const credential = authStorage.get(OLLAMA_CLOUD_PROVIDER);
+			const envConfigured = Boolean(process.env.OLLAMA_API_KEY?.trim());
+
+			if (action === "refresh-models") {
+				if (!credential || credential.type !== "oauth") {
+					ctx.ui.notify(
+						envConfigured
+							? "OLLAMA_API_KEY is set in the environment, but there is no persisted Ollama Cloud login to refresh. Run /login ollama-cloud to store a reusable credential."
+							: "Not logged in to Ollama Cloud. Run /login ollama-cloud first.",
+						"warning",
+					);
+					return;
+				}
+
+				const refreshed = credential.expires <= Date.now()
+					? await refreshOllamaCloudCredential(credential)
+					: await refreshOllamaCloudCredentialModels(credential as OllamaCloudCredentials);
+				authStorage.set(OLLAMA_CLOUD_PROVIDER, { type: "oauth", ...refreshed });
+				ctx.modelRegistry.refresh();
+				ctx.ui.notify(`Refreshed Ollama Cloud models (${getCredentialModels(refreshed).length} available).`, "info");
+				return;
+			}
+
+			const models = credential && credential.type === "oauth" ? getCredentialModels(credential as OllamaCloudCredentials) : [];
+			const authSource = credential?.type === "oauth" ? "stored via /login" : envConfigured ? "environment only" : "not configured";
+			ctx.ui.notify(
+				[
+					`Ollama Cloud auth: ${authSource}`,
+					`Discovered models: ${models.length}`,
+					`Base URL: ${getOllamaCloudRuntimeConfig().apiUrl}`,
+				].join("\n"),
+				"info",
+			);
+		},
+	});
+}
+
+export { createOllamaCloudOAuthProvider, loginOllamaCloud, refreshOllamaCloudCredential } from "./auth.js";
+export {
+	discoverOllamaCloudModels,
+	getCredentialModels,
+	getFallbackOllamaCloudModels,
+	toOllamaCloudModel,
+	type OllamaCloudCredentials,
+	type OllamaCloudProviderModel,
+} from "./models.js";
+
+export default function ollamaCloudProviderExtension(pi: ExtensionAPI): void {
+	registerOllamaCloudProvider(pi);
+	registerOllamaCloudCommand(pi);
+}

--- a/packages/ollama/models.ts
+++ b/packages/ollama/models.ts
@@ -1,0 +1,304 @@
+import type { OAuthCredentials, Model, Api } from "@mariozechner/pi-ai";
+import { getOllamaCloudRuntimeConfig } from "./config.js";
+
+export type OllamaCloudProviderModel = {
+	id: string;
+	name: string;
+	reasoning: boolean;
+	input: ("text" | "image")[];
+	cost: {
+		input: number;
+		output: number;
+		cacheRead: number;
+		cacheWrite: number;
+	};
+	contextWindow: number;
+	maxTokens: number;
+	compat?: Model<Api>["compat"];
+};
+
+export type OllamaCloudCredentials = OAuthCredentials & {
+	models?: OllamaCloudProviderModel[];
+	lastModelRefresh?: number;
+};
+
+type OllamaCloudListedModel = {
+	id?: string;
+	object?: string;
+};
+
+type OllamaCloudShowResponse = {
+	capabilities?: unknown;
+	model_info?: Record<string, unknown>;
+};
+
+const DEFAULT_CONTEXT_WINDOW = 128_000;
+const DEFAULT_MAX_TOKENS = 16_384;
+const MAX_DISCOVERY_CONCURRENCY = 6;
+
+const OLLAMA_OPENAI_COMPAT: NonNullable<OllamaCloudProviderModel["compat"]> = {
+	supportsDeveloperRole: false,
+	supportsReasoningEffort: true,
+	reasoningEffortMap: {
+		minimal: "low",
+		low: "low",
+		medium: "medium",
+		high: "high",
+		xhigh: "high",
+	},
+	maxTokensField: "max_tokens",
+};
+
+const FALLBACK_OLLAMA_CLOUD_MODELS: OllamaCloudProviderModel[] = [
+	toOllamaCloudModel({ id: "cogito-2.1:671b", reasoning: true, input: ["text"], contextWindow: 163_840, maxTokens: 20_480 }),
+	toOllamaCloudModel({ id: "deepseek-v3.1:671b", reasoning: true, input: ["text"], contextWindow: 163_840, maxTokens: 20_480 }),
+	toOllamaCloudModel({ id: "deepseek-v3.2", reasoning: true, input: ["text"], contextWindow: 163_840, maxTokens: 20_480 }),
+	toOllamaCloudModel({ id: "devstral-2:123b", reasoning: false, input: ["text"], contextWindow: 262_144, maxTokens: 32_768 }),
+	toOllamaCloudModel({ id: "devstral-small-2:24b", reasoning: false, input: ["text", "image"], contextWindow: 262_144, maxTokens: 32_768 }),
+	toOllamaCloudModel({ id: "gemini-3-flash-preview", reasoning: true, input: ["text"], contextWindow: 1_048_576, maxTokens: 65_536 }),
+	toOllamaCloudModel({ id: "gemma3:12b", reasoning: false, input: ["text", "image"], contextWindow: 131_072, maxTokens: 16_384 }),
+	toOllamaCloudModel({ id: "gemma3:27b", reasoning: false, input: ["text", "image"], contextWindow: 131_072, maxTokens: 16_384 }),
+	toOllamaCloudModel({ id: "gemma3:4b", reasoning: false, input: ["text", "image"], contextWindow: 131_072, maxTokens: 16_384 }),
+	toOllamaCloudModel({ id: "gemma4:31b", reasoning: true, input: ["text", "image"], contextWindow: 262_144, maxTokens: 32_768 }),
+	toOllamaCloudModel({ id: "glm-4.6", reasoning: true, input: ["text"], contextWindow: 202_752, maxTokens: 25_344 }),
+	toOllamaCloudModel({ id: "glm-4.7", reasoning: true, input: ["text"], contextWindow: 202_752, maxTokens: 25_344 }),
+	toOllamaCloudModel({ id: "glm-5", reasoning: true, input: ["text"], contextWindow: 202_752, maxTokens: 25_344 }),
+	toOllamaCloudModel({ id: "gpt-oss:120b", reasoning: true, input: ["text"], contextWindow: 131_072, maxTokens: 16_384 }),
+	toOllamaCloudModel({ id: "gpt-oss:20b", reasoning: true, input: ["text"], contextWindow: 131_072, maxTokens: 16_384 }),
+	toOllamaCloudModel({ id: "kimi-k2-thinking", reasoning: true, input: ["text"], contextWindow: 262_144, maxTokens: 32_768 }),
+	toOllamaCloudModel({ id: "kimi-k2.5", reasoning: true, input: ["text", "image"], contextWindow: 262_144, maxTokens: 32_768 }),
+	toOllamaCloudModel({ id: "kimi-k2:1t", reasoning: false, input: ["text"], contextWindow: 262_144, maxTokens: 32_768 }),
+	toOllamaCloudModel({ id: "minimax-m2", reasoning: false, input: ["text"], contextWindow: 204_800, maxTokens: 25_600 }),
+	toOllamaCloudModel({ id: "minimax-m2.1", reasoning: true, input: ["text"], contextWindow: 204_800, maxTokens: 25_600 }),
+	toOllamaCloudModel({ id: "minimax-m2.5", reasoning: true, input: ["text"], contextWindow: 204_800, maxTokens: 25_600 }),
+	toOllamaCloudModel({ id: "minimax-m2.7", reasoning: true, input: ["text"], contextWindow: 204_800, maxTokens: 25_600 }),
+	toOllamaCloudModel({ id: "ministral-3:14b", reasoning: false, input: ["text", "image"], contextWindow: 262_144, maxTokens: 32_768 }),
+	toOllamaCloudModel({ id: "ministral-3:3b", reasoning: false, input: ["text", "image"], contextWindow: 262_144, maxTokens: 32_768 }),
+	toOllamaCloudModel({ id: "ministral-3:8b", reasoning: false, input: ["text", "image"], contextWindow: 262_144, maxTokens: 32_768 }),
+	toOllamaCloudModel({ id: "mistral-large-3:675b", reasoning: false, input: ["text", "image"], contextWindow: 262_144, maxTokens: 32_768 }),
+	toOllamaCloudModel({ id: "nemotron-3-nano:30b", reasoning: true, input: ["text"], contextWindow: 1_048_576, maxTokens: 65_536 }),
+	toOllamaCloudModel({ id: "nemotron-3-super", reasoning: true, input: ["text"], contextWindow: 262_144, maxTokens: 32_768 }),
+	toOllamaCloudModel({ id: "qwen3-coder-next", reasoning: false, input: ["text"], contextWindow: 262_144, maxTokens: 32_768 }),
+	toOllamaCloudModel({ id: "qwen3-coder:480b", reasoning: false, input: ["text"], contextWindow: 262_144, maxTokens: 32_768 }),
+	toOllamaCloudModel({ id: "qwen3-next:80b", reasoning: true, input: ["text"], contextWindow: 262_144, maxTokens: 32_768 }),
+	toOllamaCloudModel({ id: "qwen3-vl:235b", reasoning: true, input: ["text", "image"], contextWindow: 262_144, maxTokens: 32_768 }),
+	toOllamaCloudModel({ id: "qwen3-vl:235b-instruct", reasoning: false, input: ["text", "image"], contextWindow: 262_144, maxTokens: 32_768 }),
+	toOllamaCloudModel({ id: "qwen3.5:397b", reasoning: true, input: ["text", "image"], contextWindow: 262_144, maxTokens: 32_768 }),
+	toOllamaCloudModel({ id: "rnj-1:8b", reasoning: false, input: ["text"], contextWindow: 32_768, maxTokens: 16_384 }),
+];
+
+export function getFallbackOllamaCloudModels(): OllamaCloudProviderModel[] {
+	return FALLBACK_OLLAMA_CLOUD_MODELS.map(cloneModel);
+}
+
+export function getCredentialModels(credentials: OllamaCloudCredentials): OllamaCloudProviderModel[] {
+	const models = Array.isArray(credentials.models) ? credentials.models : [];
+	return models.length > 0 ? sanitizeStoredModels(models) : getFallbackOllamaCloudModels();
+}
+
+export async function discoverOllamaCloudModels(apiKey: string, options: { signal?: AbortSignal } = {}): Promise<OllamaCloudProviderModel[] | null> {
+	const config = getOllamaCloudRuntimeConfig();
+	const listed = await fetchJson<{ data?: OllamaCloudListedModel[] }>(config.modelsUrl, {
+		headers: createDiscoveryHeaders(apiKey),
+		signal: options.signal,
+	});
+	const modelIds = Array.isArray(listed.data)
+		? listed.data
+				.map((entry) => (typeof entry?.id === "string" ? entry.id.trim() : ""))
+				.filter(Boolean)
+				.sort((left, right) => left.localeCompare(right))
+		: [];
+	if (modelIds.length === 0) {
+		return null;
+	}
+
+	const discovered = await mapConcurrent(modelIds, MAX_DISCOVERY_CONCURRENCY, async (id) => {
+		const payload = await fetchJson<OllamaCloudShowResponse>(config.showUrl, {
+			method: "POST",
+			headers: createDiscoveryHeaders(apiKey),
+			body: JSON.stringify({ model: id }),
+			signal: options.signal,
+		});
+		return normalizeDiscoveredModel(id, payload);
+	});
+	const models = discovered.filter((model): model is OllamaCloudProviderModel => model !== null);
+	return models.length > 0 ? models : null;
+}
+
+export async function enrichOllamaCloudCredentials(
+	credentials: OAuthCredentials,
+	options: { previous?: OllamaCloudCredentials; signal?: AbortSignal } = {},
+): Promise<OllamaCloudCredentials> {
+	let models: OllamaCloudProviderModel[] | undefined;
+	try {
+		models = (await discoverOllamaCloudModels(credentials.access, { signal: options.signal })) ?? undefined;
+	} catch {
+		models = undefined;
+	}
+	return {
+		...options.previous,
+		...credentials,
+		models: models ?? options.previous?.models ?? getFallbackOllamaCloudModels(),
+		lastModelRefresh: Date.now(),
+	};
+}
+
+export function toProviderModels(models: OllamaCloudProviderModel[]): OllamaCloudProviderModel[] {
+	return sanitizeStoredModels(models);
+}
+
+export function toOllamaCloudModel(
+	model: Partial<OllamaCloudProviderModel> & Pick<OllamaCloudProviderModel, "id">,
+): OllamaCloudProviderModel {
+	const contextWindow = normalizePositiveInteger(model.contextWindow, DEFAULT_CONTEXT_WINDOW);
+	const maxTokens = normalizePositiveInteger(model.maxTokens, inferMaxTokens(contextWindow));
+	return {
+		id: model.id,
+		name: model.name?.trim() || formatDisplayName(model.id),
+		reasoning: model.reasoning ?? false,
+		input: sanitizeInput(model.input),
+		cost: model.cost ? { ...model.cost } : { input: 0, output: 0, cacheRead: 0, cacheWrite: 0 },
+		contextWindow,
+		maxTokens,
+		compat: { ...OLLAMA_OPENAI_COMPAT, ...(model.compat ?? {}) },
+	};
+}
+
+function sanitizeStoredModels(models: readonly OllamaCloudProviderModel[]): OllamaCloudProviderModel[] {
+	return models.map((model) => toOllamaCloudModel(model));
+}
+
+function cloneModel(model: OllamaCloudProviderModel): OllamaCloudProviderModel {
+	return {
+		...model,
+		input: [...model.input],
+		cost: { ...model.cost },
+		compat: model.compat ? { ...model.compat } : undefined,
+	};
+}
+
+function normalizeDiscoveredModel(id: string, payload: OllamaCloudShowResponse): OllamaCloudProviderModel | null {
+	const capabilities = Array.isArray(payload.capabilities)
+		? payload.capabilities.filter((capability): capability is string => typeof capability === "string")
+		: [];
+	const capabilitySet = new Set(capabilities.map((capability) => capability.toLowerCase()));
+	const contextWindow = extractContextWindow(payload.model_info) ?? findFallbackModel(id)?.contextWindow ?? DEFAULT_CONTEXT_WINDOW;
+	return toOllamaCloudModel({
+		id,
+		reasoning: capabilitySet.has("thinking"),
+		input: capabilitySet.has("vision") ? ["text", "image"] : ["text"],
+		contextWindow,
+		maxTokens: inferMaxTokens(contextWindow),
+	});
+}
+
+function extractContextWindow(modelInfo: Record<string, unknown> | undefined): number | null {
+	if (!modelInfo) {
+		return null;
+	}
+	for (const [key, value] of Object.entries(modelInfo)) {
+		if (!key.endsWith(".context_length")) {
+			continue;
+		}
+		const parsed = typeof value === "number" ? value : Number(value);
+		if (Number.isFinite(parsed) && parsed > 0) {
+			return Math.floor(parsed);
+		}
+	}
+	return null;
+}
+
+function sanitizeInput(input: OllamaCloudProviderModel["input"] | undefined): ("text" | "image")[] {
+	const next = Array.isArray(input) && input.includes("image") ? (["text", "image"] as const) : (["text"] as const);
+	return [...next];
+}
+
+function inferMaxTokens(contextWindow: number): number {
+	if (contextWindow >= 1_000_000) {
+		return 65_536;
+	}
+	if (contextWindow >= 262_144) {
+		return 32_768;
+	}
+	if (contextWindow >= 160_000) {
+		return 20_480;
+	}
+	return DEFAULT_MAX_TOKENS;
+}
+
+function normalizePositiveInteger(value: number | undefined, fallback: number): number {
+	return typeof value === "number" && Number.isFinite(value) && value > 0 ? Math.floor(value) : fallback;
+}
+
+function formatDisplayName(id: string): string {
+	return id
+		.replace(/[-_]/g, " ")
+		.replace(/:/g, " ")
+		.replace(/\bglm\b/gi, "GLM")
+		.replace(/\bgpt\b/gi, "GPT")
+		.replace(/\boss\b/gi, "OSS")
+		.replace(/\bvl\b/gi, "VL")
+		.replace(/\brnj\b/gi, "RNJ")
+		.replace(/\b(\d+)b\b/gi, (_, size: string) => `${size.toUpperCase()}B`)
+		.split(/\s+/)
+		.filter(Boolean)
+		.map((part) => {
+			if (/^[A-Z0-9.]+$/.test(part)) {
+				return part;
+			}
+			return `${part.slice(0, 1).toUpperCase()}${part.slice(1)}`;
+		})
+		.join(" ");
+}
+
+function findFallbackModel(id: string): OllamaCloudProviderModel | undefined {
+	return FALLBACK_OLLAMA_CLOUD_MODELS.find((model) => model.id === id);
+}
+
+function createDiscoveryHeaders(apiKey: string): Record<string, string> {
+	return {
+		Authorization: `Bearer ${apiKey}`,
+		"Content-Type": "application/json",
+	};
+}
+
+async function fetchJson<T>(
+	url: string,
+	options: {
+		method?: string;
+		headers?: Record<string, string>;
+		body?: string;
+		signal?: AbortSignal;
+	} = {},
+): Promise<T> {
+	const response = await fetch(url, {
+		method: options.method ?? (options.body ? "POST" : "GET"),
+		headers: options.headers,
+		body: options.body,
+		signal: options.signal,
+	});
+	if (!response.ok) {
+		const body = await response.text();
+		throw new Error(`Ollama Cloud request failed (${response.status}): ${body || response.statusText}`);
+	}
+	return (await response.json()) as T;
+}
+
+async function mapConcurrent<T, TResult>(
+	items: readonly T[],
+	limit: number,
+	mapper: (item: T) => Promise<TResult>,
+): Promise<TResult[]> {
+	const results = new Array<TResult>(items.length);
+	let nextIndex = 0;
+	const workers = Array.from({ length: Math.min(limit, items.length) }, async () => {
+		while (nextIndex < items.length) {
+			const current = nextIndex++;
+			results[current] = await mapper(items[current]!);
+		}
+	});
+	await Promise.all(workers);
+	return results;
+}
+
+export { OLLAMA_OPENAI_COMPAT };

--- a/packages/ollama/package.json
+++ b/packages/ollama/package.json
@@ -1,0 +1,48 @@
+{
+	"name": "@ifi/pi-provider-ollama-cloud",
+	"version": "0.4.4",
+	"description": "Experimental Ollama Cloud provider for pi with /login support and dynamic model discovery.",
+	"type": "module",
+	"keywords": [
+		"pi-package",
+		"pi",
+		"pi-coding-agent",
+		"ollama",
+		"provider",
+		"cloud",
+		"experimental"
+	],
+	"pi": {
+		"extensions": [
+			"./index.ts"
+		]
+	},
+	"files": [
+		"*.ts",
+		"README.md",
+		"!**/*.test.ts",
+		"!tests/**"
+	],
+	"license": "MIT",
+	"repository": {
+		"type": "git",
+		"url": "git+https://github.com/ifiokjr/oh-pi.git",
+		"directory": "packages/ollama"
+	},
+	"homepage": "https://github.com/ifiokjr/oh-pi/tree/main/packages/ollama",
+	"bugs": {
+		"url": "https://github.com/ifiokjr/oh-pi/issues"
+	},
+	"scripts": {
+		"build": "pnpm run typecheck && pnpm run test:worktree",
+		"typecheck": "tsgo --project ./tsconfig.json --noEmit",
+		"test:worktree": "vitest run --config ./vitest.worktree.config.ts"
+	},
+	"peerDependencies": {
+		"@mariozechner/pi-agent-core": ">=0.56.1",
+		"@mariozechner/pi-ai": ">=0.56.1",
+		"@mariozechner/pi-coding-agent": ">=0.56.1",
+		"@mariozechner/pi-tui": ">=0.56.1",
+		"@sinclair/typebox": "*"
+	}
+}

--- a/packages/ollama/tests/auth.test.ts
+++ b/packages/ollama/tests/auth.test.ts
@@ -1,0 +1,73 @@
+import { afterEach, describe, expect, it, vi } from "vitest";
+import { createOllamaCloudOAuthProvider, loginOllamaCloud, refreshOllamaCloudCredential } from "../auth.js";
+import { createTestOllamaCloudBackend } from "./test-backend.js";
+
+const envSnapshot = { ...process.env };
+
+afterEach(() => {
+	for (const key of Object.keys(process.env)) {
+		if (!(key in envSnapshot)) {
+			delete process.env[key];
+		}
+	}
+	Object.assign(process.env, envSnapshot);
+});
+
+describe("ollama cloud auth", () => {
+	it("opens the keys page and exchanges a pasted API key for a static credential with discovered models", async () => {
+		const backend = await createTestOllamaCloudBackend();
+		backend.setModels([{ id: "gpt-oss:120b", capabilities: ["completion", "tools", "thinking"], contextWindow: 131072 }]);
+		process.env.PI_OLLAMA_CLOUD_API_URL = backend.apiUrl;
+		process.env.PI_OLLAMA_CLOUD_MODELS_URL = `${backend.apiUrl}/models`;
+		process.env.PI_OLLAMA_CLOUD_SHOW_URL = `${backend.apiUrl.replace(/\/v1$/, "")}/api/show`;
+		process.env.PI_OLLAMA_CLOUD_KEYS_URL = backend.keysUrl;
+
+		let openedUrl = "";
+		const credential = await loginOllamaCloud({
+			onAuth(params) {
+				openedUrl = params.url;
+			},
+			onPrompt: vi.fn(async () => "test-key"),
+		});
+
+		expect(openedUrl).toBe(backend.keysUrl);
+		expect(credential.access).toBe("test-key");
+		expect(credential.models?.[0]?.id).toBe("gpt-oss:120b");
+		await backend.close();
+	});
+
+	it("refreshes credentials and preserves discovered models when discovery fails", async () => {
+		const backend = await createTestOllamaCloudBackend();
+		backend.setRejectAuth(true);
+		process.env.PI_OLLAMA_CLOUD_API_URL = backend.apiUrl;
+		process.env.PI_OLLAMA_CLOUD_MODELS_URL = `${backend.apiUrl}/models`;
+		process.env.PI_OLLAMA_CLOUD_SHOW_URL = `${backend.apiUrl.replace(/\/v1$/, "")}/api/show`;
+
+		const refreshed = await refreshOllamaCloudCredential({
+			refresh: "test-key",
+			access: "test-key",
+			expires: Date.now() - 1000,
+			models: [{ id: "qwen3-next:80b", name: "Qwen3 Next 80B", reasoning: true, input: ["text"], cost: { input: 0, output: 0, cacheRead: 0, cacheWrite: 0 }, contextWindow: 262144, maxTokens: 32768 }],
+		} as never);
+
+		expect(refreshed.models?.[0]?.id).toBe("qwen3-next:80b");
+		await backend.close();
+	});
+
+	it("modifies provider models from credential-discovered models", () => {
+		const provider = createOllamaCloudOAuthProvider();
+		const modified = provider.modifyModels?.(
+			[
+				{ id: "placeholder", name: "Placeholder", api: "openai-completions", provider: "ollama-cloud", baseUrl: "https://example.com/v1", reasoning: false, input: ["text"], cost: { input: 0, output: 0, cacheRead: 0, cacheWrite: 0 }, contextWindow: 1, maxTokens: 1 },
+			],
+			{
+				refresh: "r",
+				access: "a",
+				expires: Date.now() + 1000,
+				models: [{ id: "gpt-oss:120b", name: "GPT OSS 120B", reasoning: true, input: ["text"], cost: { input: 0, output: 0, cacheRead: 0, cacheWrite: 0 }, contextWindow: 131072, maxTokens: 16384 }],
+			} as never,
+		);
+
+		expect(modified?.map((model) => model.id)).toEqual(["gpt-oss:120b"]);
+	});
+});

--- a/packages/ollama/tests/models.test.ts
+++ b/packages/ollama/tests/models.test.ts
@@ -1,0 +1,63 @@
+import { afterEach, describe, expect, it } from "vitest";
+import {
+	discoverOllamaCloudModels,
+	getCredentialModels,
+	getFallbackOllamaCloudModels,
+	toOllamaCloudModel,
+} from "../models.js";
+import { createTestOllamaCloudBackend } from "./test-backend.js";
+
+const envSnapshot = { ...process.env };
+
+afterEach(() => {
+	for (const key of Object.keys(process.env)) {
+		if (!(key in envSnapshot)) {
+			delete process.env[key];
+		}
+	}
+	Object.assign(process.env, envSnapshot);
+});
+
+describe("ollama cloud models", () => {
+	it("returns a fallback catalog", () => {
+		const models = getFallbackOllamaCloudModels();
+		expect(models.some((model) => model.id === "gpt-oss:120b")).toBe(true);
+		expect(models.some((model) => model.id === "qwen3-vl:235b")).toBe(true);
+	});
+
+	it("normalizes model defaults", () => {
+		const model = toOllamaCloudModel({ id: "gpt-oss:120b", reasoning: true, input: ["text"] });
+		const compat = model.compat as { supportsDeveloperRole?: boolean; maxTokensField?: string } | undefined;
+		expect(model.name).toContain("GPT");
+		expect(compat?.supportsDeveloperRole).toBe(false);
+		expect(compat?.maxTokensField).toBe("max_tokens");
+	});
+
+	it("discovers models from the cloud API and uses bearer auth", async () => {
+		const backend = await createTestOllamaCloudBackend();
+		backend.setModels([
+			{ id: "gpt-oss:120b", capabilities: ["completion", "tools", "thinking"], contextWindow: 131072 },
+			{ id: "qwen3-vl:235b", capabilities: ["completion", "tools", "thinking", "vision"], contextWindow: 262144 },
+		]);
+		process.env.PI_OLLAMA_CLOUD_API_URL = backend.apiUrl;
+		process.env.PI_OLLAMA_CLOUD_MODELS_URL = `${backend.apiUrl}/models`;
+		process.env.PI_OLLAMA_CLOUD_SHOW_URL = `${backend.apiUrl.replace(/\/v1$/, "")}/api/show`;
+		const models = await discoverOllamaCloudModels("test-key");
+		expect(models?.map((model) => model.id)).toEqual(["gpt-oss:120b", "qwen3-vl:235b"]);
+		expect(models?.[0]?.reasoning).toBe(true);
+		expect(models?.[1]?.input).toEqual(["text", "image"]);
+		expect(backend.getAuthHeaders().every((header) => header === "Bearer test-key")).toBe(true);
+		await backend.close();
+	});
+
+	it("prefers models stored with the login credential", () => {
+		const models = getCredentialModels({
+			refresh: "r",
+			access: "a",
+			expires: Date.now() + 1000,
+			models: [toOllamaCloudModel({ id: "qwen3-next:80b", reasoning: true, input: ["text"], contextWindow: 262144, maxTokens: 32768 })],
+		});
+		expect(models).toHaveLength(1);
+		expect(models[0]?.id).toBe("qwen3-next:80b");
+	});
+});

--- a/packages/ollama/tests/smoke.test.ts
+++ b/packages/ollama/tests/smoke.test.ts
@@ -1,0 +1,13 @@
+import { describe, expect, it } from "vitest";
+import { createExtensionHarness } from "../../../test-utils/extension-runtime-harness.js";
+import ollamaCloudProviderExtension from "../index.js";
+
+describe("ollama cloud provider smoke tests", () => {
+	it("registers the ollama cloud provider and command without crashing", () => {
+		const harness = createExtensionHarness();
+		ollamaCloudProviderExtension(harness.pi as never);
+
+		expect(harness.commands.has("ollama-cloud")).toBe(true);
+		expect(harness.providers.has("ollama-cloud")).toBe(true);
+	});
+});

--- a/packages/ollama/tests/test-backend.ts
+++ b/packages/ollama/tests/test-backend.ts
@@ -1,0 +1,95 @@
+import http from "node:http";
+import type { AddressInfo } from "node:net";
+
+export interface TestOllamaCloudBackend {
+	apiUrl: string;
+	keysUrl: string;
+	setModels(models: Array<{ id: string; capabilities?: string[]; contextWindow?: number }>): void;
+	setRejectAuth(reject: boolean): void;
+	getAuthHeaders(): string[];
+	close(): Promise<void>;
+}
+
+export async function createTestOllamaCloudBackend(): Promise<TestOllamaCloudBackend> {
+	let models: Array<{ id: string; capabilities?: string[]; contextWindow?: number }> = [];
+	let rejectAuth = false;
+	const authHeaders: string[] = [];
+
+	const server = http.createServer((req, res) => {
+		const url = req.url ?? "/";
+		if (url === "/v1/models" && req.method === "GET") {
+			const auth = String(req.headers.authorization ?? "");
+			authHeaders.push(auth);
+			if (rejectAuth) {
+				res.writeHead(401, { "Content-Type": "text/plain" });
+				res.end("unauthorized");
+				return;
+			}
+			res.writeHead(200, { "Content-Type": "application/json" });
+			res.end(JSON.stringify({ data: models.map((model) => ({ id: model.id, object: "model" })) }));
+			return;
+		}
+
+		if (url === "/api/show" && req.method === "POST") {
+			const auth = String(req.headers.authorization ?? "");
+			authHeaders.push(auth);
+			if (rejectAuth) {
+				res.writeHead(401, { "Content-Type": "text/plain" });
+				res.end("unauthorized");
+				return;
+			}
+			let body = "";
+			req.on("data", (chunk) => {
+				body += String(chunk);
+			});
+			req.on("end", () => {
+				const parsed = JSON.parse(body || "{}") as { model?: string };
+				const match = models.find((model) => model.id === parsed.model);
+				if (!match) {
+					res.writeHead(404, { "Content-Type": "text/plain" });
+					res.end("model not found");
+					return;
+				}
+				const family = match.id.split(/[:.-]/)[0] ?? "ollama";
+				res.writeHead(200, { "Content-Type": "application/json" });
+				res.end(
+					JSON.stringify({
+						capabilities: match.capabilities ?? ["completion", "tools"],
+						model_info: { [`${family}.context_length`]: match.contextWindow ?? 131072 },
+					}),
+				);
+			});
+			return;
+		}
+
+		if (url === "/settings/keys") {
+			res.writeHead(200, { "Content-Type": "text/html" });
+			res.end("<html><body>keys</body></html>");
+			return;
+		}
+
+		res.writeHead(404, { "Content-Type": "text/plain" });
+		res.end("not found");
+	});
+
+	await new Promise<void>((resolve) => server.listen(0, "127.0.0.1", resolve));
+	const port = (server.address() as AddressInfo).port;
+	const origin = `http://127.0.0.1:${port}`;
+
+	return {
+		apiUrl: `${origin}/v1`,
+		keysUrl: `${origin}/settings/keys`,
+		setModels(nextModels) {
+			models = nextModels;
+		},
+		setRejectAuth(reject) {
+			rejectAuth = reject;
+		},
+		getAuthHeaders() {
+			return [...authHeaders];
+		},
+		async close() {
+			await new Promise<void>((resolve, reject) => server.close((error) => (error ? reject(error) : resolve())));
+		},
+	};
+}

--- a/packages/ollama/tsconfig.json
+++ b/packages/ollama/tsconfig.json
@@ -1,0 +1,7 @@
+{
+	"extends": "../../tsconfig.base.json",
+	"compilerOptions": {
+		"noEmit": true
+	},
+	"include": ["**/*.ts"]
+}

--- a/packages/ollama/vitest.worktree.config.ts
+++ b/packages/ollama/vitest.worktree.config.ts
@@ -1,0 +1,7 @@
+import { defineConfig } from "vitest/config";
+
+export default defineConfig({
+	test: {
+		include: ["tests/**/*.test.ts"],
+	},
+});

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -14,6 +14,7 @@ overrides:
   brace-expansion@^5.0.2: 5.0.5
   yaml: 2.8.3
   picomatch: 4.0.4
+  vite: 7.3.2
 
 importers:
 
@@ -1309,7 +1310,7 @@ packages:
     resolution: {integrity: sha512-46ryTE9RZO/rfDd7pEqFl7etuyzekzEhUbTW3BvmeO/BcCMEgq59BKhek3dXDWgAj4oMK6OZi+vRr1wPW6qjEQ==}
     peerDependencies:
       msw: ^2.4.9
-      vite: ^5.0.0 || ^6.0.0 || ^7.0.0-0
+      vite: 7.3.2
     peerDependenciesMeta:
       msw:
         optional: true
@@ -2025,8 +2026,8 @@ packages:
     engines: {node: ^18.0.0 || ^20.0.0 || >=22.0.0}
     hasBin: true
 
-  vite@7.3.1:
-    resolution: {integrity: sha512-w+N7Hifpc3gRjZ63vYBXA56dvvRlNWRczTdmCBBa+CotUzAPf5b7YMdMR/8CQoeYE5LX3W4wj6RYTgonm1b9DA==}
+  vite@7.3.2:
+    resolution: {integrity: sha512-Bby3NOsna2jsjfLVOHKes8sGwgl4TT0E6vvpYgnAYDIF/tie7MRaFthmKuHx1NSXjiTueXH3do80FMQgvEktRg==}
     engines: {node: ^20.19.0 || >=22.12.0}
     hasBin: true
     peerDependencies:
@@ -3351,13 +3352,13 @@ snapshots:
       chai: 5.3.3
       tinyrainbow: 2.0.0
 
-  '@vitest/mocker@3.2.4(vite@7.3.1(@types/node@22.19.13)(yaml@2.8.3))':
+  '@vitest/mocker@3.2.4(vite@7.3.2(@types/node@22.19.13)(yaml@2.8.3))':
     dependencies:
       '@vitest/spy': 3.2.4
       estree-walker: 3.0.3
       magic-string: 0.30.21
     optionalDependencies:
-      vite: 7.3.1(@types/node@22.19.13)(yaml@2.8.3)
+      vite: 7.3.2(@types/node@22.19.13)(yaml@2.8.3)
 
   '@vitest/pretty-format@3.2.4':
     dependencies:
@@ -4092,7 +4093,7 @@ snapshots:
       debug: 4.4.3
       es-module-lexer: 1.7.0
       pathe: 2.0.3
-      vite: 7.3.1(@types/node@22.19.13)(yaml@2.8.3)
+      vite: 7.3.2(@types/node@22.19.13)(yaml@2.8.3)
     transitivePeerDependencies:
       - '@types/node'
       - jiti
@@ -4107,7 +4108,7 @@ snapshots:
       - tsx
       - yaml
 
-  vite@7.3.1(@types/node@22.19.13)(yaml@2.8.3):
+  vite@7.3.2(@types/node@22.19.13)(yaml@2.8.3):
     dependencies:
       esbuild: 0.27.3
       fdir: 6.5.0(picomatch@4.0.4)
@@ -4124,7 +4125,7 @@ snapshots:
     dependencies:
       '@types/chai': 5.2.3
       '@vitest/expect': 3.2.4
-      '@vitest/mocker': 3.2.4(vite@7.3.1(@types/node@22.19.13)(yaml@2.8.3))
+      '@vitest/mocker': 3.2.4(vite@7.3.2(@types/node@22.19.13)(yaml@2.8.3))
       '@vitest/pretty-format': 3.2.4
       '@vitest/runner': 3.2.4
       '@vitest/snapshot': 3.2.4
@@ -4142,7 +4143,7 @@ snapshots:
       tinyglobby: 0.2.15
       tinypool: 1.1.1
       tinyrainbow: 2.0.0
-      vite: 7.3.1(@types/node@22.19.13)(yaml@2.8.3)
+      vite: 7.3.2(@types/node@22.19.13)(yaml@2.8.3)
       vite-node: 3.2.4(@types/node@22.19.13)(yaml@2.8.3)
       why-is-node-running: 2.3.0
     optionalDependencies:

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -196,6 +196,24 @@ importers:
         specifier: workspace:*
         version: link:../spec
 
+  packages/ollama:
+    dependencies:
+      '@mariozechner/pi-agent-core':
+        specifier: '>=0.56.1'
+        version: 0.56.1(ws@8.19.0)(zod@3.25.76)
+      '@mariozechner/pi-ai':
+        specifier: '>=0.56.1'
+        version: 0.56.1(ws@8.19.0)(zod@3.25.76)
+      '@mariozechner/pi-coding-agent':
+        specifier: '>=0.56.1'
+        version: 0.56.1(ws@8.19.0)(zod@3.25.76)
+      '@mariozechner/pi-tui':
+        specifier: '>=0.56.1'
+        version: 0.56.1
+      '@sinclair/typebox':
+        specifier: '*'
+        version: 0.34.48
+
   packages/plan:
     dependencies:
       '@ifi/pi-extension-subagents':

--- a/scripts/package-classes.mjs
+++ b/scripts/package-classes.mjs
@@ -18,6 +18,7 @@ export const publishedPackages = [
 	{ name: "@ifi/pi-plan", dir: "packages/plan" },
 	{ name: "@ifi/pi-spec", dir: "packages/spec" },
 	{ name: "@ifi/pi-provider-cursor", dir: "packages/cursor" },
+	{ name: "@ifi/pi-provider-ollama-cloud", dir: "packages/ollama" },
 	{ name: "@ifi/pi-web-remote", dir: "packages/web-remote" },
 	{ name: "@ifi/oh-pi", dir: "packages/oh-pi" },
 ];

--- a/scripts/verify-pi-compat.mjs
+++ b/scripts/verify-pi-compat.mjs
@@ -16,6 +16,7 @@ const SMOKE_TESTS = [
 	"packages/subagents/tests/smoke.test.ts",
 	"packages/spec/tests/smoke.test.ts",
 	"packages/cursor/tests/smoke.test.ts",
+	"packages/ollama/tests/smoke.test.ts",
 ];
 
 function parseArgs(argv) {


### PR DESCRIPTION
## Summary
- add an experimental `@ifi/pi-provider-ollama-cloud` package with `/login ollama-cloud` and dynamic cloud model discovery
- store discovered models on the credential and add `/ollama-cloud status|refresh-models` helpers
- wire the new opt-in provider into repo docs, release metadata, and package verification

## Testing
- pnpm docs:check
- pnpm lint
- pnpm typecheck
- pnpm build
- pnpm test