### PR TITLE
feat: unify Ollama local and cloud provider

### DIFF
--- a/.changeset/add-ollama-cloud-provider.md
+++ b/.changeset/add-ollama-cloud-provider.md
@@ -2,5 +2,6 @@
 default: minor
 ---
 
-- Add the experimental `@ifi/pi-provider-ollama-cloud` package so pi can log in to Ollama Cloud via `/login ollama-cloud`, discover the current cloud model catalog, and expose those models in `/model`.
-- Document the new opt-in provider package and include it in release/package verification metadata.
+- Add the experimental `@ifi/pi-provider-ollama` package so pi can discover local Ollama models, log in to Ollama Cloud via `/login ollama-cloud`, and expose both local and cloud models in `/model`.
+- Add unified `/ollama` commands for refreshing local + cloud model catalogs and inspecting discovered model metadata.
+- Extend usage tracking with best-effort Ollama local/cloud status so `/usage` and `usage_report` include Ollama session visibility and any rate-limit headers Ollama exposes.

--- a/README.md
+++ b/README.md
@@ -47,13 +47,13 @@ This is a monorepo. Install everything at once with `npx @ifi/oh-pi`, or pick in
 | [`@ifi/pi-shared-qna`](./packages/shared-qna)             | Shared Q&A TUI helpers                      | (library, not installed directly)           |
 | [`@ifi/pi-spec`](./packages/spec)                         | Native spec-driven workflow with `/spec`    | `pi install npm:@ifi/pi-spec`               |
 | [`@ifi/pi-provider-cursor`](./packages/cursor)            | Experimental Cursor OAuth provider          | `pi install npm:@ifi/pi-provider-cursor`    |
-| [`@ifi/pi-provider-ollama-cloud`](./packages/ollama)      | Experimental Ollama Cloud provider          | `pi install npm:@ifi/pi-provider-ollama-cloud` |
+| [`@ifi/pi-provider-ollama`](./packages/ollama)            | Experimental Ollama local + cloud provider  | `pi install npm:@ifi/pi-provider-ollama`    |
 | [`@ifi/oh-pi-themes`](./packages/themes)                  | 6 color themes                              | `pi install npm:@ifi/oh-pi-themes`          |
 | [`@ifi/oh-pi-prompts`](./packages/prompts)                | 10 prompt templates                         | `pi install npm:@ifi/oh-pi-prompts`         |
 | [`@ifi/oh-pi-skills`](./packages/skills)                  | 12 skill packs                              | `pi install npm:@ifi/oh-pi-skills`          |
 | [`@ifi/oh-pi-agents`](./packages/agents)                  | 5 AGENTS.md templates                       | (used by CLI only)                          |
 
-`@ifi/pi-provider-cursor` and `@ifi/pi-provider-ollama-cloud` stay opt-in for now and are **not**
+`@ifi/pi-provider-cursor` and `@ifi/pi-provider-ollama` stay opt-in for now and are **not**
 installed by `npx @ifi/oh-pi`. They are intentionally shipped as separate experimental provider
 packages.
 
@@ -562,7 +562,7 @@ oh-pi/
 │   ├── plan/                   Planning mode extension (raw .ts)
 │   ├── spec/                   Native spec-driven workflow package (raw .ts)
 │   ├── cursor/                 Experimental Cursor OAuth provider package (raw .ts)
-│   ├── ollama/                 Experimental Ollama Cloud provider package (raw .ts)
+│   ├── ollama/                 Experimental Ollama local + cloud provider package (raw .ts)
 │   ├── themes/                 6 JSON theme files
 │   ├── prompts/                10 markdown prompt templates
 │   ├── skills/                 12 skill directories

--- a/docs/agent-rules/engineering.md
+++ b/docs/agent-rules/engineering.md
@@ -73,7 +73,7 @@ packages/
   plan/                   → @ifi/pi-plan (raw .ts planning mode extension)
   spec/                   → @ifi/pi-spec (raw .ts spec-driven workflow package)
   cursor/                 → @ifi/pi-provider-cursor (raw .ts experimental Cursor provider package)
-  ollama/                 → @ifi/pi-provider-ollama-cloud (raw .ts experimental Ollama Cloud provider package)
+  ollama/                 → @ifi/pi-provider-ollama (raw .ts experimental Ollama local + cloud provider package)
   oh-pi/                  → @ifi/oh-pi (installer CLI: `npx @ifi/oh-pi`)
 ```
 

--- a/docs/agent-rules/packaging-and-release.md
+++ b/docs/agent-rules/packaging-and-release.md
@@ -55,7 +55,7 @@ pi install npm:@ifi/pi-extension-subagents
 pi install npm:@ifi/pi-plan
 pi install npm:@ifi/pi-spec
 pi install npm:@ifi/pi-provider-cursor
-pi install npm:@ifi/pi-provider-ollama-cloud
+pi install npm:@ifi/pi-provider-ollama
 ```
 
 Do not use `bundledDependencies` in `@ifi/oh-pi`.

--- a/packages/extensions/extensions/usage-tracker-providers.ts
+++ b/packages/extensions/extensions/usage-tracker-providers.ts
@@ -17,6 +17,7 @@ export const AUTH_KEY_TO_PROVIDER: Record<string, ProviderKey> = {
 	"openai-codex": "openai",
 	"google-antigravity": "google",
 	"google-gemini-cli": "google",
+	"ollama-cloud": "ollama",
 };
 
 /** Provider API base URLs used by direct usage/rate-limit probes. */
@@ -24,6 +25,7 @@ const PROVIDER_API_BASE: Record<ProviderKey, string> = {
 	anthropic: "https://api.anthropic.com",
 	openai: "https://chatgpt.com/backend-api",
 	google: "https://cloudcode-pa.googleapis.com",
+	ollama: "https://ollama.com",
 };
 
 /**
@@ -146,6 +148,11 @@ export async function ensureFreshToken(
 ): Promise<{ token: string; entry: PiAuthEntry } | null> {
 	if (Date.now() < entry.expires && entry.access) {
 		return { token: entry.access, entry };
+	}
+
+	if (authKey === "ollama-cloud") {
+		const token = entry.access || entry.refresh;
+		return token ? { token, entry: { ...entry, access: token, refresh: entry.refresh || token } } : null;
 	}
 
 	// Token expired — try refreshing via pi's OAuth module
@@ -737,6 +744,128 @@ export async function probeGoogleDirect(token: string, authEntry?: PiAuthEntry):
 	return result;
 }
 
+function getEnv(name: string): string | null {
+	const value = process.env[name];
+	return typeof value === "string" && value.trim().length > 0 ? value.trim() : null;
+}
+
+function stripTrailingSlash(value: string): string {
+	return value.replace(/\/+$/, "");
+}
+
+function normalizeOllamaApiUrl(value: string, fallbackOrigin: string): string {
+	try {
+		const url = new URL(value);
+		if (url.pathname === "" || url.pathname === "/") {
+			url.pathname = "/v1";
+		}
+		url.search = "";
+		url.hash = "";
+		return stripTrailingSlash(url.toString());
+	} catch {
+		return `${stripTrailingSlash(fallbackOrigin)}/v1`;
+	}
+}
+
+function deriveOllamaOrigin(apiUrl: string, fallbackOrigin: string): string {
+	try {
+		const url = new URL(apiUrl);
+		url.pathname = "";
+		url.search = "";
+		url.hash = "";
+		return stripTrailingSlash(url.toString());
+	} catch {
+		return stripTrailingSlash(fallbackOrigin);
+	}
+}
+
+function maybeAddGenericRateLimitWindow(
+	result: ProviderRateLimits,
+	headers: Headers | { get: (key: string) => string | null },
+): void {
+	const limit = parseFiniteNumber(headers.get("x-ratelimit-limit") ?? headers.get("ratelimit-limit"));
+	const remaining = parseFiniteNumber(headers.get("x-ratelimit-remaining") ?? headers.get("ratelimit-remaining"));
+	const reset = headers.get("x-ratelimit-reset") ?? headers.get("ratelimit-reset");
+	if (limit === null || remaining === null || limit <= 0) {
+		return;
+	}
+	upsertWindow(result.windows, {
+		label: `Requests (${fmtTokens(Math.round(limit))}/win)`,
+		percentLeft: clampPercent((remaining / limit) * 100),
+		resetDescription: reset ? resetCountdown(reset) : null,
+		windowMinutes: null,
+	});
+}
+
+export async function probeOllamaDirect(token: string | null): Promise<ProviderRateLimits> {
+	const result: ProviderRateLimits = {
+		provider: "ollama",
+		windows: [],
+		credits: null,
+		account: null,
+		plan: token ? "API key" : null,
+		note: null,
+		probedAt: Date.now(),
+		error: null,
+	};
+
+	const localBase = normalizeOllamaApiUrl(getEnv("OLLAMA_HOST") ?? "http://127.0.0.1:11434", "http://127.0.0.1:11434");
+	const cloudBase = normalizeOllamaApiUrl(
+		getEnv("OLLAMA_HOST_CLOUD") ?? PROVIDER_API_BASE.ollama,
+		PROVIDER_API_BASE.ollama,
+	);
+	const localOrigin = deriveOllamaOrigin(localBase, "http://127.0.0.1:11434");
+
+	let localNote: string;
+	try {
+		const response = await fetch(`${localBase}/models`, {
+			method: "GET",
+			signal: AbortSignal.timeout(PROBE_TIMEOUT_MS),
+		});
+		if (response.ok) {
+			const payload = (await response.json()) as { data?: Array<{ id?: string }> };
+			localNote = `Local daemon reachable at ${localOrigin} (${payload.data?.length ?? 0} model(s)).`;
+		} else {
+			localNote = `Local daemon unavailable at ${localOrigin} (${response.status}).`;
+		}
+	} catch {
+		localNote = `Local daemon unavailable at ${localOrigin}.`;
+	}
+
+	let cloudNote: string;
+	if (token) {
+		try {
+			const response = await fetch(`${cloudBase}/models`, {
+				method: "GET",
+				headers: { authorization: `Bearer ${token}` },
+				signal: AbortSignal.timeout(PROBE_TIMEOUT_MS),
+			});
+			if (response.status === 401) {
+				cloudNote = "Cloud auth was rejected — run /login ollama-cloud again.";
+			} else if (response.ok) {
+				const payload = (await response.json()) as { data?: Array<{ id?: string }> };
+				maybeAddGenericRateLimitWindow(result, response.headers);
+				cloudNote = `Cloud auth configured (${payload.data?.length ?? 0} model(s)).`;
+			} else {
+				cloudNote = `Cloud API returned ${response.status}.`;
+			}
+		} catch {
+			cloudNote = "Cloud API unavailable.";
+		}
+	} else {
+		cloudNote = "Cloud auth not configured.";
+	}
+
+	result.note = `${localNote} ${cloudNote}`;
+	if (result.windows.length === 0) {
+		result.note = appendNote(
+			result.note,
+			"Ollama does not currently expose a documented quota endpoint to pi, so remaining account limits are unavailable.",
+		);
+	}
+	return result;
+}
+
 export function hasProviderDisplayData(rl: ProviderRateLimits): boolean {
 	return rl.windows.length > 0 || rl.credits !== null || Boolean(rl.account || rl.plan || rl.note || rl.error);
 }
@@ -761,5 +890,7 @@ export function providerDisplayName(provider: ProviderKey): string {
 			return "OpenAI";
 		case "google":
 			return "Google";
+		case "ollama":
+			return "Ollama";
 	}
 }

--- a/packages/extensions/extensions/usage-tracker-shared.ts
+++ b/packages/extensions/extensions/usage-tracker-shared.ts
@@ -59,7 +59,7 @@ export interface WindowPace {
 	willLastToReset: boolean;
 }
 
-export type ProviderKey = "anthropic" | "openai" | "google";
+export type ProviderKey = "anthropic" | "openai" | "google" | "ollama";
 
 export interface ProviderRateLimits {
 	provider: ProviderKey;

--- a/packages/extensions/extensions/usage-tracker.test.ts
+++ b/packages/extensions/extensions/usage-tracker.test.ts
@@ -211,7 +211,7 @@ function createMockCtx(entries: any[] = []) {
 	return {
 		sessionManager: { getBranch: () => entries },
 		getContextUsage: () => ({ tokens: 45000, contextWindow: 200000, percent: 22.5 }),
-		model: { id: "claude-sonnet-4-20250514" },
+		model: { id: "claude-sonnet-4-20250514", provider: "anthropic" },
 		ui: {
 			setWidget(key: string, content: any) {
 				if (content === undefined) {
@@ -628,6 +628,73 @@ describe("usage-tracker extension", () => {
 			expect(text).toContain("1 turns");
 			expect(text).toContain("in /");
 			expect(text).toContain("30d:");
+		});
+
+		it("shows best-effort Ollama status for local models", async () => {
+			mockFetch.mockImplementation((url: string) => {
+				if (url.includes("127.0.0.1:11434/v1/models")) {
+					return Promise.resolve(makeFetchResponse({ body: { data: [{ id: "gemma3:4b" }] } }));
+				}
+				return Promise.resolve(makeFetchResponse());
+			});
+
+			const ollamaCtx = createMockCtx();
+			ollamaCtx.model = { id: "gemma3:4b", provider: "ollama" };
+
+			usageTracker(pi as any);
+			pi._emit("session_start", { type: "session_start" }, ollamaCtx);
+			pi._emit(
+				"turn_end",
+				{
+					type: "turn_end",
+					turnIndex: 0,
+					message: makeAssistantMessage({ model: "gemma3:4b", provider: "ollama", api: "openai-completions" }),
+					toolResults: [],
+				},
+				ollamaCtx,
+			);
+
+			const tool = pi._tools.get("usage_report");
+			const result = await runWithTimers(() =>
+				tool.execute("id", { format: "detailed" }, undefined, undefined, ollamaCtx),
+			);
+			const text = result.content[0].text;
+			expect(text).toContain("Ollama Rate Limits:");
+			expect(text).toContain("Local daemon reachable");
+			expect(text).toContain("remaining account limits are unavailable");
+		});
+
+		it("shows Ollama cloud rate headers when available", async () => {
+			process.env.OLLAMA_API_KEY = "test-key";
+			mockFetch.mockImplementation((url: string) => {
+				if (url.includes("127.0.0.1:11434/v1/models")) {
+					return Promise.resolve(makeFetchResponse({ status: 503, ok: false }));
+				}
+				if (url.includes("ollama.com/v1/models")) {
+					return Promise.resolve(
+						makeFetchResponse({
+							headers: { "x-ratelimit-limit": "100", "x-ratelimit-remaining": "75", "x-ratelimit-reset": "60s" },
+							body: { data: [{ id: "gpt-oss:20b" }] },
+						}),
+					);
+				}
+				return Promise.resolve(makeFetchResponse());
+			});
+
+			const ollamaCtx = createMockCtx();
+			ollamaCtx.model = { id: "gpt-oss:20b", provider: "ollama-cloud" };
+
+			usageTracker(pi as any);
+			pi._emit("session_start", { type: "session_start" }, ollamaCtx);
+
+			const tool = pi._tools.get("usage_report");
+			const result = await runWithTimers(() =>
+				tool.execute("id", { format: "detailed" }, undefined, undefined, ollamaCtx),
+			);
+			const text = result.content[0].text;
+			expect(text).toContain("Ollama Rate Limits:");
+			expect(text).toContain("75% left");
+			expect(text).toContain("Cloud auth configured (1 model(s)).");
 		});
 
 		it("shows rate limit windows from Anthropic OAuth usage endpoint", async () => {

--- a/packages/extensions/extensions/usage-tracker.ts
+++ b/packages/extensions/extensions/usage-tracker.ts
@@ -55,6 +55,7 @@ import {
 	hasProviderDisplayData,
 	probeAnthropicDirect,
 	probeGoogleDirect,
+	probeOllamaDirect,
 	probeOpenAIDirect,
 	providerDisplayName,
 	readPiAuth,
@@ -241,7 +242,14 @@ export default function usageTracker(pi: ExtensionAPI) {
 			return null;
 		}
 		const candidate = value as Partial<ProviderRateLimits> & { windows?: unknown };
-		if (!(candidate.provider === "anthropic" || candidate.provider === "openai" || candidate.provider === "google")) {
+		if (
+			!(
+				candidate.provider === "anthropic" ||
+				candidate.provider === "openai" ||
+				candidate.provider === "google" ||
+				candidate.provider === "ollama"
+			)
+		) {
 			return null;
 		}
 		const windows = Array.isArray(candidate.windows)
@@ -569,6 +577,21 @@ export default function usageTracker(pi: ExtensionAPI) {
 		probeInFlight.add(provider);
 		try {
 			const auth = readPiAuth();
+			if (provider === "ollama") {
+				const ollamaEntry = auth["ollama-cloud"];
+				const envToken = process.env.OLLAMA_API_KEY?.trim() || null;
+				const fresh = envToken
+					? { token: envToken, entry: ollamaEntry }
+					: ollamaEntry?.access
+						? await ensureFreshToken("ollama-cloud", ollamaEntry, auth)
+						: null;
+				const limits = await probeOllamaDirect(fresh?.token ?? null);
+				rateLimits.set(provider, limits);
+				saveRateLimitCache();
+				lastProbeTime.set(provider, Date.now());
+				return;
+			}
+
 			let authKey: string | null = null;
 			let authEntry: PiAuthEntry | undefined;
 
@@ -588,7 +611,7 @@ export default function usageTracker(pi: ExtensionAPI) {
 					credits: null,
 					account: null,
 					plan: null,
-					note: `No pi auth configured for ${providerDisplayName(provider)} \u2014 run pi login.`,
+					note: `No pi auth configured for ${providerDisplayName(provider)} — run pi login.`,
 					probedAt: now,
 					error: null,
 				});
@@ -608,7 +631,7 @@ export default function usageTracker(pi: ExtensionAPI) {
 					plan: null,
 					note: null,
 					probedAt: now,
-					error: `${providerDisplayName(provider)} token refresh failed \u2014 re-authenticate with pi login.`,
+					error: `${providerDisplayName(provider)} token refresh failed — re-authenticate with pi login.`,
 				});
 				saveRateLimitCache();
 				lastProbeTime.set(provider, now);
@@ -625,6 +648,9 @@ export default function usageTracker(pi: ExtensionAPI) {
 					break;
 				case "google":
 					limits = await probeGoogleDirect(fresh.token, fresh.entry);
+					break;
+				case "ollama":
+					limits = await probeOllamaDirect(fresh.token);
 					break;
 			}
 
@@ -656,7 +682,14 @@ export default function usageTracker(pi: ExtensionAPI) {
 			return;
 		}
 		const id = model.id.toLowerCase();
-		// Detect provider from model ID
+		const provider =
+			typeof (model as { provider?: unknown }).provider === "string"
+				? String((model as { provider?: unknown }).provider).toLowerCase()
+				: "";
+		// Detect provider from model ID / provider id
+		if (provider === "ollama" || provider === "ollama-cloud") {
+			probeProvider("ollama", force);
+		}
 		if (id.includes("claude") || id.includes("sonnet") || id.includes("opus") || id.includes("haiku")) {
 			probeProvider("anthropic", force);
 		}
@@ -681,6 +714,21 @@ export default function usageTracker(pi: ExtensionAPI) {
 				seen.add(provider);
 				probeProvider(provider, force);
 			}
+		}
+		const activeProvider =
+			activeCtx?.model && typeof (activeCtx.model as { provider?: unknown }).provider === "string"
+				? String((activeCtx.model as { provider?: unknown }).provider).toLowerCase()
+				: "";
+		const shouldProbeOllama =
+			Boolean(
+				process.env.OLLAMA_API_KEY?.trim() || process.env.OLLAMA_HOST?.trim() || process.env.OLLAMA_HOST_CLOUD?.trim(),
+			) ||
+			activeProvider === "ollama" ||
+			activeProvider === "ollama-cloud" ||
+			[...models.values()].some((model) => model.provider === "ollama" || model.provider === "ollama-cloud");
+		if (shouldProbeOllama && !seen.has("ollama")) {
+			seen.add("ollama");
+			probeProvider("ollama", force);
 		}
 	}
 
@@ -1245,7 +1293,7 @@ export default function usageTracker(pi: ExtensionAPI) {
 		name: "usage_report",
 		label: "Usage Report",
 		description:
-			"Generate a rate limit status and token usage report. Shows provider rate limits (Anthropic, OpenAI, Google) using pi-managed auth, plus per-model costs. Use when the user asks about spending, rate limits, quotas, or remaining usage.",
+			"Generate a rate limit status and token usage report. Shows provider rate limits (Anthropic, OpenAI, Google) and best-effort Ollama status, plus per-model costs. Use when the user asks about spending, rate limits, quotas, or remaining usage.",
 		promptSnippet: "Show provider rate limits (% remaining, reset time) and session usage/cost report.",
 		parameters: Type.Object({
 			format: Type.Optional(

--- a/packages/ollama/README.md
+++ b/packages/ollama/README.md
@@ -10,7 +10,7 @@ Experimental Ollama provider package for pi with both local and cloud support.
 - Discovers the current Ollama Cloud model catalog and stores it with the login credential
 - Exposes local models in `/model` as `ollama/<model-id>`
 - Exposes cloud models in `/model` as `ollama-cloud/<model-id>`
-- Adds `/ollama status|refresh-models|info` for a unified local + cloud workflow
+- Adds `/ollama status|refresh-models|models|info` for a unified local + cloud workflow
 
 ## Install
 
@@ -42,7 +42,8 @@ This package is intentionally separate from `@ifi/oh-pi` for now.
 
 - `/ollama status` — show local daemon status and cloud auth/catalog status
 - `/ollama refresh-models` — refresh both local and cloud Ollama models
-- `/ollama info <model>` — show known metadata for a local or cloud Ollama model
+- `/ollama models` — list local and cloud Ollama models with source/capability badges for easier selection
+- `/ollama info <model>` — show detailed metadata for a local or cloud Ollama model
 - `/ollama-cloud status` — backward-compatible cloud-only status alias
 - `/ollama-cloud refresh-models` — backward-compatible cloud-only refresh alias
 

--- a/packages/ollama/README.md
+++ b/packages/ollama/README.md
@@ -1,52 +1,79 @@
-# @ifi/pi-provider-ollama-cloud
+# @ifi/pi-provider-ollama
 
-Experimental Ollama Cloud provider for pi.
+Experimental Ollama provider package for pi with both local and cloud support.
 
 ## What it does
 
-- Registers an `ollama-cloud` provider via `pi.registerProvider(...)`
+- Registers a local `ollama` provider via `pi.registerProvider(...)`
+- Auto-discovers installed local Ollama models from the running daemon
 - Adds `/login ollama-cloud` support using an Ollama API key flow
 - Discovers the current Ollama Cloud model catalog and stores it with the login credential
-- Exposes discovered models in `/model` as `ollama-cloud/<model-id>`
-- Adds `/ollama-cloud refresh-models` to refresh the catalog on demand
+- Exposes local models in `/model` as `ollama/<model-id>`
+- Exposes cloud models in `/model` as `ollama-cloud/<model-id>`
+- Adds `/ollama status|refresh-models|info` for a unified local + cloud workflow
 
 ## Install
 
 ```bash
-pi install npm:@ifi/pi-provider-ollama-cloud
+pi install npm:@ifi/pi-provider-ollama
 ```
 
 This package is intentionally separate from `@ifi/oh-pi` for now.
 
 ## Use
 
+### Local Ollama
+
+1. Install the package
+2. Start Ollama locally
+3. Open `/model` and select an `ollama/...` model
+4. Run `/ollama refresh-models` whenever you pull or remove local models
+
+### Ollama Cloud
+
 1. Install the package
 2. Run `/login ollama-cloud`
 3. Create an API key on Ollama when pi opens the keys page
 4. Paste the key back into pi
 5. Open `/model` and select an `ollama-cloud/...` model
-6. Optionally run `/ollama-cloud refresh-models` later to refresh the catalog
+6. Optionally run `/ollama refresh-models` later to refresh both local and cloud catalogs
 
 ## Commands
 
-- `/ollama-cloud status` — show auth and catalog status
-- `/ollama-cloud refresh-models` — rediscover available Ollama Cloud models and refresh the provider registry
+- `/ollama status` — show local daemon status and cloud auth/catalog status
+- `/ollama refresh-models` — refresh both local and cloud Ollama models
+- `/ollama info <model>` — show known metadata for a local or cloud Ollama model
+- `/ollama-cloud status` — backward-compatible cloud-only status alias
+- `/ollama-cloud refresh-models` — backward-compatible cloud-only refresh alias
 
 ## Notes
 
-- This integration is **cloud-only** for now. It does not configure local Ollama models.
-- pi uses Ollama's documented API-key flow for third-party cloud access.
-- Model discovery is stored alongside the login credential so `/login ollama-cloud` can refresh the model list immediately.
-- Costs are currently left at zero because Ollama Cloud subscription billing is not exposed as stable per-token pricing in the docs yet.
+- Local Ollama uses the daemon's OpenAI-compatible `/v1` API plus `/api/show` metadata.
+- Cloud Ollama uses Ollama's documented API-key flow for third-party access.
+- Local model discovery is dynamic and installation-specific, so there is no static local fallback catalog.
+- Cloud model discovery falls back to a bundled cloud catalog when live discovery is unavailable.
+- Costs are currently left at zero because Ollama does not expose stable per-token pricing for local or cloud use in a way that pi can rely on here.
 
 ## Test hooks
 
 These environment variables exist mainly for tests and local debugging:
+
+### Local
+
+- `PI_OLLAMA_LOCAL_API_URL`
+- `PI_OLLAMA_LOCAL_MODELS_URL`
+- `PI_OLLAMA_LOCAL_SHOW_URL`
+- `PI_OLLAMA_LOCAL_ORIGIN`
+- `OLLAMA_HOST`
+
+### Cloud
 
 - `PI_OLLAMA_CLOUD_API_URL`
 - `PI_OLLAMA_CLOUD_MODELS_URL`
 - `PI_OLLAMA_CLOUD_SHOW_URL`
 - `PI_OLLAMA_CLOUD_KEYS_URL`
 - `PI_OLLAMA_CLOUD_ORIGIN`
+- `OLLAMA_HOST_CLOUD`
+- `OLLAMA_API_KEY`
 
-Legacy `OLLAMA_CLOUD_*` env names are also accepted for compatibility with local debugging.
+Legacy `OLLAMA_CLOUD_*` env names are also accepted for cloud compatibility with earlier iterations of this package.

--- a/packages/ollama/auth.ts
+++ b/packages/ollama/auth.ts
@@ -1,6 +1,6 @@
 import type { OAuthCredentials, OAuthLoginCallbacks, OAuthProviderInterface } from "@mariozechner/pi-ai";
 import {
-	OLLAMA_CLOUD_API,
+	OLLAMA_API,
 	OLLAMA_CLOUD_API_KEY_ENV,
 	OLLAMA_CLOUD_AUTH_DOCS_URL,
 	OLLAMA_CLOUD_PROVIDER,
@@ -64,7 +64,7 @@ export function createOllamaCloudOAuthProvider(): Omit<OAuthProviderInterface, "
 				...current.map((model) => ({
 					...model,
 					provider: OLLAMA_CLOUD_PROVIDER,
-					api: OLLAMA_CLOUD_API,
+					api: OLLAMA_API,
 					baseUrl: config.apiUrl,
 				})),
 			];

--- a/packages/ollama/config.ts
+++ b/packages/ollama/config.ts
@@ -1,23 +1,54 @@
+const DEFAULT_OLLAMA_LOCAL_ORIGIN = "http://127.0.0.1:11434";
 const DEFAULT_OLLAMA_CLOUD_ORIGIN = "https://ollama.com";
-const DEFAULT_OLLAMA_CLOUD_API_PATH = "/v1";
-const DEFAULT_OLLAMA_CLOUD_KEYS_PATH = "/settings/keys";
-const DEFAULT_OLLAMA_CLOUD_SHOW_PATH = "/api/show";
-const DEFAULT_OLLAMA_CLOUD_MODELS_PATH = "/models";
+const DEFAULT_OLLAMA_API_PATH = "/v1";
+const DEFAULT_OLLAMA_KEYS_PATH = "/settings/keys";
+const DEFAULT_OLLAMA_SHOW_PATH = "/api/show";
+const DEFAULT_OLLAMA_MODELS_PATH = "/models";
 
-function getEnv(name: string): string | undefined {
-	const value = process.env[name];
-	return typeof value === "string" && value.trim().length > 0 ? value.trim() : undefined;
+export interface OllamaRuntimeConfig {
+	origin: string;
+	apiUrl: string;
+	showUrl: string;
+	modelsUrl: string;
+}
+
+export interface OllamaCloudRuntimeConfig extends OllamaRuntimeConfig {
+	keysUrl: string;
+}
+
+function getEnv(...names: string[]): string | undefined {
+	for (const name of names) {
+		const value = process.env[name];
+		if (typeof value === "string" && value.trim().length > 0) {
+			return value.trim();
+		}
+	}
+	return undefined;
 }
 
 function stripTrailingSlash(value: string): string {
 	return value.replace(/\/+$/, "");
 }
 
-function normalizeApiUrl(value: string): string {
-	return stripTrailingSlash(value);
+function appendPath(base: string, path: string): string {
+	return `${stripTrailingSlash(base)}${path}`;
 }
 
-function deriveOriginFromApiUrl(apiUrl: string): string {
+function normalizeApiUrl(value: string, fallbackOrigin: string): string {
+	try {
+		const url = new URL(value);
+		if (url.pathname === "" || url.pathname === "/") {
+			url.pathname = DEFAULT_OLLAMA_API_PATH;
+		}
+		url.search = "";
+		url.hash = "";
+		return stripTrailingSlash(url.toString());
+	} catch {
+		return appendPath(fallbackOrigin, DEFAULT_OLLAMA_API_PATH);
+	}
+}
+
+function deriveOriginFromApiUrl(apiUrl: string, fallbackOrigin: string): string {
 	try {
 		const url = new URL(apiUrl);
 		url.pathname = "";
@@ -25,35 +56,46 @@ function deriveOriginFromApiUrl(apiUrl: string): string {
 		url.hash = "";
 		return stripTrailingSlash(url.toString());
 	} catch {
-		return DEFAULT_OLLAMA_CLOUD_ORIGIN;
+		return fallbackOrigin;
 	}
 }
 
-export function getOllamaCloudRuntimeConfig(): {
-	origin: string;
-	apiUrl: string;
-	keysUrl: string;
-	showUrl: string;
-	modelsUrl: string;
-} {
-	const configuredApiUrl = getEnv("PI_OLLAMA_CLOUD_API_URL") ?? getEnv("OLLAMA_CLOUD_API_URL");
-	const apiUrl = normalizeApiUrl(configuredApiUrl ?? `${DEFAULT_OLLAMA_CLOUD_ORIGIN}${DEFAULT_OLLAMA_CLOUD_API_PATH}`);
-	const origin =
-		stripTrailingSlash(getEnv("PI_OLLAMA_CLOUD_ORIGIN") ?? getEnv("OLLAMA_CLOUD_ORIGIN") ?? deriveOriginFromApiUrl(apiUrl));
-	const keysUrl = stripTrailingSlash(
-		getEnv("PI_OLLAMA_CLOUD_KEYS_URL") ?? getEnv("OLLAMA_CLOUD_KEYS_URL") ?? `${origin}${DEFAULT_OLLAMA_CLOUD_KEYS_PATH}`,
-	);
+export function getOllamaLocalRuntimeConfig(): OllamaRuntimeConfig {
+	const explicitApiUrl = getEnv("PI_OLLAMA_LOCAL_API_URL", "OLLAMA_LOCAL_API_URL");
+	const explicitOrigin = getEnv("PI_OLLAMA_LOCAL_ORIGIN", "OLLAMA_LOCAL_ORIGIN", "OLLAMA_HOST");
+	const origin = stripTrailingSlash(explicitOrigin ?? DEFAULT_OLLAMA_LOCAL_ORIGIN);
+	const apiUrl = normalizeApiUrl(explicitApiUrl ?? origin, DEFAULT_OLLAMA_LOCAL_ORIGIN);
+	const resolvedOrigin = deriveOriginFromApiUrl(apiUrl, DEFAULT_OLLAMA_LOCAL_ORIGIN);
 	const showUrl = stripTrailingSlash(
-		getEnv("PI_OLLAMA_CLOUD_SHOW_URL") ?? getEnv("OLLAMA_CLOUD_SHOW_URL") ?? `${origin}${DEFAULT_OLLAMA_CLOUD_SHOW_PATH}`,
+		getEnv("PI_OLLAMA_LOCAL_SHOW_URL", "OLLAMA_LOCAL_SHOW_URL") ?? appendPath(resolvedOrigin, DEFAULT_OLLAMA_SHOW_PATH),
 	);
 	const modelsUrl = stripTrailingSlash(
-		getEnv("PI_OLLAMA_CLOUD_MODELS_URL") ?? getEnv("OLLAMA_CLOUD_MODELS_URL") ?? `${apiUrl}${DEFAULT_OLLAMA_CLOUD_MODELS_PATH}`,
+		getEnv("PI_OLLAMA_LOCAL_MODELS_URL", "OLLAMA_LOCAL_MODELS_URL") ?? appendPath(apiUrl, DEFAULT_OLLAMA_MODELS_PATH),
 	);
-	return { origin, apiUrl, keysUrl, showUrl, modelsUrl };
+	return { origin: resolvedOrigin, apiUrl, showUrl, modelsUrl };
 }
 
+export function getOllamaCloudRuntimeConfig(): OllamaCloudRuntimeConfig {
+	const explicitApiUrl = getEnv("PI_OLLAMA_CLOUD_API_URL", "OLLAMA_CLOUD_API_URL");
+	const explicitOrigin = getEnv("PI_OLLAMA_CLOUD_ORIGIN", "OLLAMA_CLOUD_ORIGIN", "OLLAMA_HOST_CLOUD");
+	const origin = stripTrailingSlash(explicitOrigin ?? DEFAULT_OLLAMA_CLOUD_ORIGIN);
+	const apiUrl = normalizeApiUrl(explicitApiUrl ?? origin, DEFAULT_OLLAMA_CLOUD_ORIGIN);
+	const resolvedOrigin = deriveOriginFromApiUrl(apiUrl, DEFAULT_OLLAMA_CLOUD_ORIGIN);
+	const keysUrl = stripTrailingSlash(
+		getEnv("PI_OLLAMA_CLOUD_KEYS_URL", "OLLAMA_CLOUD_KEYS_URL") ?? appendPath(resolvedOrigin, DEFAULT_OLLAMA_KEYS_PATH),
+	);
+	const showUrl = stripTrailingSlash(
+		getEnv("PI_OLLAMA_CLOUD_SHOW_URL", "OLLAMA_CLOUD_SHOW_URL") ?? appendPath(resolvedOrigin, DEFAULT_OLLAMA_SHOW_PATH),
+	);
+	const modelsUrl = stripTrailingSlash(
+		getEnv("PI_OLLAMA_CLOUD_MODELS_URL", "OLLAMA_CLOUD_MODELS_URL") ?? appendPath(apiUrl, DEFAULT_OLLAMA_MODELS_PATH),
+	);
+	return { origin: resolvedOrigin, apiUrl, keysUrl, showUrl, modelsUrl };
+}
+
+export const OLLAMA_LOCAL_PROVIDER = "ollama";
 export const OLLAMA_CLOUD_PROVIDER = "ollama-cloud";
-export const OLLAMA_CLOUD_API = "openai-completions" as const;
+export const OLLAMA_API = "openai-completions" as const;
+export const OLLAMA_LOCAL_API_KEY_LITERAL = "ollama";
 export const OLLAMA_CLOUD_API_KEY_ENV = "OLLAMA_API_KEY";
 export const OLLAMA_CLOUD_AUTH_DOCS_URL = "https://docs.ollama.com/api/authentication";
-export const OLLAMA_CLOUD_LIST_DOCS_URL = "https://docs.ollama.com/api/tags";

--- a/packages/ollama/index.ts
+++ b/packages/ollama/index.ts
@@ -1,76 +1,277 @@
 import type { ExtensionAPI } from "@mariozechner/pi-coding-agent";
 import {
 	createOllamaCloudOAuthProvider,
+	loginOllamaCloud,
 	refreshOllamaCloudCredential,
 	refreshOllamaCloudCredentialModels,
 } from "./auth.js";
-import { OLLAMA_CLOUD_API, OLLAMA_CLOUD_PROVIDER, getOllamaCloudRuntimeConfig } from "./config.js";
-import { getCredentialModels, getFallbackOllamaCloudModels, toProviderModels, type OllamaCloudCredentials } from "./models.js";
+import {
+	OLLAMA_API,
+	OLLAMA_CLOUD_API_KEY_ENV,
+	OLLAMA_CLOUD_PROVIDER,
+	OLLAMA_LOCAL_API_KEY_LITERAL,
+	OLLAMA_LOCAL_PROVIDER,
+	getOllamaCloudRuntimeConfig,
+	getOllamaLocalRuntimeConfig,
+} from "./config.js";
+import {
+	discoverOllamaCloudModels,
+	discoverOllamaLocalModels,
+	getCredentialModels,
+	getFallbackOllamaCloudModels,
+	toProviderModels,
+	type OllamaCloudCredentials,
+	type OllamaProviderModel,
+} from "./models.js";
 
-function registerOllamaCloudProvider(pi: ExtensionAPI): void {
-	pi.registerProvider(OLLAMA_CLOUD_PROVIDER, {
-		api: OLLAMA_CLOUD_API,
-		apiKey: "OLLAMA_API_KEY",
-		baseUrl: getOllamaCloudRuntimeConfig().apiUrl,
-		oauth: createOllamaCloudOAuthProvider(),
-		models: toProviderModels(getFallbackOllamaCloudModels()),
+type RuntimeDiscoveryState = {
+	models: OllamaProviderModel[];
+	lastRefresh: number | null;
+	lastError: string | null;
+};
+
+const localDiscoveryState: RuntimeDiscoveryState = {
+	models: [],
+	lastRefresh: null,
+	lastError: null,
+};
+
+const cloudEnvDiscoveryState: RuntimeDiscoveryState = {
+	models: [],
+	lastRefresh: null,
+	lastError: null,
+};
+
+function registerOllamaLocalProvider(pi: ExtensionAPI): void {
+	pi.registerProvider(OLLAMA_LOCAL_PROVIDER, {
+		api: OLLAMA_API,
+		apiKey: OLLAMA_LOCAL_API_KEY_LITERAL,
+		baseUrl: getOllamaLocalRuntimeConfig().apiUrl,
+		models: toProviderModels(localDiscoveryState.models),
 	});
 }
 
-function registerOllamaCloudCommand(pi: ExtensionAPI): void {
-	pi.registerCommand("ollama-cloud", {
-		description: "Inspect or refresh the Ollama Cloud provider: /ollama-cloud [status|refresh-models]",
+function registerOllamaCloudProvider(pi: ExtensionAPI): void {
+	pi.registerProvider(OLLAMA_CLOUD_PROVIDER, {
+		api: OLLAMA_API,
+		apiKey: OLLAMA_CLOUD_API_KEY_ENV,
+		baseUrl: getOllamaCloudRuntimeConfig().apiUrl,
+		oauth: createOllamaCloudOAuthProvider(),
+		models: toProviderModels(cloudEnvDiscoveryState.models),
+	});
+}
+
+async function refreshRegisteredLocalModels(pi: ExtensionAPI): Promise<OllamaProviderModel[]> {
+	try {
+		localDiscoveryState.models = (await discoverOllamaLocalModels()) ?? [];
+		localDiscoveryState.lastError = null;
+	} catch (error) {
+		localDiscoveryState.models = [];
+		localDiscoveryState.lastError = error instanceof Error ? error.message : String(error);
+	}
+	localDiscoveryState.lastRefresh = Date.now();
+	registerOllamaLocalProvider(pi);
+	return localDiscoveryState.models;
+}
+
+async function refreshRegisteredCloudEnvModels(pi: ExtensionAPI): Promise<OllamaProviderModel[]> {
+	const apiKey = process.env[OLLAMA_CLOUD_API_KEY_ENV]?.trim();
+	if (!apiKey) {
+		cloudEnvDiscoveryState.models = [];
+		cloudEnvDiscoveryState.lastError = null;
+		cloudEnvDiscoveryState.lastRefresh = Date.now();
+		registerOllamaCloudProvider(pi);
+		return cloudEnvDiscoveryState.models;
+	}
+
+	try {
+		cloudEnvDiscoveryState.models = (await discoverOllamaCloudModels(apiKey)) ?? getFallbackOllamaCloudModels();
+		cloudEnvDiscoveryState.lastError = null;
+	} catch (error) {
+		cloudEnvDiscoveryState.models = getFallbackOllamaCloudModels();
+		cloudEnvDiscoveryState.lastError = error instanceof Error ? error.message : String(error);
+	}
+	cloudEnvDiscoveryState.lastRefresh = Date.now();
+	registerOllamaCloudProvider(pi);
+	return cloudEnvDiscoveryState.models;
+}
+
+function registerOllamaCommands(pi: ExtensionAPI): void {
+	pi.registerCommand("ollama", {
+		description: "Inspect or refresh local + cloud Ollama providers: /ollama [status|refresh-models|info <model>]",
 		async handler(args, ctx) {
-			const action = args.trim().toLowerCase() || "status";
-			const authStorage = ctx.modelRegistry.authStorage;
-			const credential = authStorage.get(OLLAMA_CLOUD_PROVIDER);
-			const envConfigured = Boolean(process.env.OLLAMA_API_KEY?.trim());
+			const trimmed = args.trim();
+			const [rawAction = "status", ...rest] = trimmed ? trimmed.split(/\s+/) : ["status"];
+			const action = rawAction.toLowerCase();
+			const credential = getStoredCloudCredential(ctx);
 
 			if (action === "refresh-models") {
-				if (!credential || credential.type !== "oauth") {
-					ctx.ui.notify(
-						envConfigured
-							? "OLLAMA_API_KEY is set in the environment, but there is no persisted Ollama Cloud login to refresh. Run /login ollama-cloud to store a reusable credential."
-							: "Not logged in to Ollama Cloud. Run /login ollama-cloud first.",
-						"warning",
-					);
-					return;
-				}
-
-				const refreshed = credential.expires <= Date.now()
-					? await refreshOllamaCloudCredential(credential)
-					: await refreshOllamaCloudCredentialModels(credential as OllamaCloudCredentials);
-				authStorage.set(OLLAMA_CLOUD_PROVIDER, { type: "oauth", ...refreshed });
+				const localModels = await refreshRegisteredLocalModels(pi);
+						const cloudModels = await refreshCloudModels(pi, ctx, credential);
 				ctx.modelRegistry.refresh();
-				ctx.ui.notify(`Refreshed Ollama Cloud models (${getCredentialModels(refreshed).length} available).`, "info");
+				const cloudStatus = credential || process.env[OLLAMA_CLOUD_API_KEY_ENV]?.trim()
+					? `${cloudModels.length} cloud available`
+					: "cloud not configured";
+				ctx.ui.notify(`Refreshed Ollama models (${localModels.length} local, ${cloudStatus}).`, "info");
 				return;
 			}
 
-			const models = credential && credential.type === "oauth" ? getCredentialModels(credential as OllamaCloudCredentials) : [];
-			const authSource = credential?.type === "oauth" ? "stored via /login" : envConfigured ? "environment only" : "not configured";
-			ctx.ui.notify(
-				[
-					`Ollama Cloud auth: ${authSource}`,
-					`Discovered models: ${models.length}`,
-					`Base URL: ${getOllamaCloudRuntimeConfig().apiUrl}`,
-				].join("\n"),
-				"info",
-			);
+			if (action === "info") {
+				const query = rest.join(" ").trim();
+				if (!query) {
+					ctx.ui.notify("Usage: /ollama info <model>", "warning");
+					return;
+				}
+				const model = findModelForQuery(query, collectOllamaModels(credential));
+				if (!model) {
+					ctx.ui.notify(`No Ollama model matched \"${query}\". Run /ollama refresh-models first.`, "warning");
+					return;
+				}
+				ctx.ui.notify(renderModelInfo(model), "info");
+				return;
+			}
+
+			ctx.ui.notify(renderUnifiedStatus(credential), "info");
+		},
+	});
+
+	pi.registerCommand("ollama-cloud", {
+		description: "Backward-compatible alias for cloud-only Ollama status and refresh: /ollama-cloud [status|refresh-models]",
+		async handler(args, ctx) {
+			const action = args.trim().toLowerCase() || "status";
+			const credential = getStoredCloudCredential(ctx);
+
+			if (action === "refresh-models") {
+				const cloudModels = await refreshCloudModels(pi, ctx, credential);
+				ctx.modelRegistry.refresh();
+				if (!credential && !process.env[OLLAMA_CLOUD_API_KEY_ENV]?.trim()) {
+					ctx.ui.notify("Ollama Cloud is not configured. Run /login ollama-cloud or set OLLAMA_API_KEY.", "warning");
+					return;
+				}
+				ctx.ui.notify(`Refreshed Ollama Cloud models (${cloudModels.length} available).`, "info");
+				return;
+			}
+
+			ctx.ui.notify(renderCloudStatus(credential), "info");
 		},
 	});
 }
 
-export { createOllamaCloudOAuthProvider, loginOllamaCloud, refreshOllamaCloudCredential } from "./auth.js";
+async function refreshCloudModels(
+	pi: ExtensionAPI,
+	ctx: { modelRegistry: { authStorage: { set: (provider: string, credential: any) => void } } },
+	credential: OllamaCloudCredentials | null,
+): Promise<OllamaProviderModel[]> {
+	if (credential) {
+		const refreshed = credential.expires <= Date.now()
+			? await refreshOllamaCloudCredential(credential)
+			: await refreshOllamaCloudCredentialModels(credential);
+		ctx.modelRegistry.authStorage.set(OLLAMA_CLOUD_PROVIDER, { type: "oauth", ...refreshed });
+		return getCredentialModels(refreshed);
+	}
+	return refreshRegisteredCloudEnvModels(pi);
+}
+
+function renderUnifiedStatus(credential: OllamaCloudCredentials | null): string {
+	const localConfig = getOllamaLocalRuntimeConfig();
+	const cloudConfig = getOllamaCloudRuntimeConfig();
+	const localState = localDiscoveryState.lastError
+		? `unreachable (${localDiscoveryState.lastError})`
+		: localDiscoveryState.lastRefresh
+			? "reachable"
+			: "probing";
+	const cloudModels = credential ? getCredentialModels(credential) : cloudEnvDiscoveryState.models;
+	const cloudAuth = credential ? "stored via /login" : process.env[OLLAMA_CLOUD_API_KEY_ENV]?.trim() ? "environment only" : "not configured";
+	return [
+		`Ollama local: ${localState}`,
+		`Local models: ${localDiscoveryState.models.length}`,
+		`Local base URL: ${localConfig.apiUrl}`,
+		`Ollama cloud auth: ${cloudAuth}`,
+		`Cloud models: ${cloudModels.length}`,
+		`Cloud base URL: ${cloudConfig.apiUrl}`,
+	].join("\n");
+}
+
+function renderCloudStatus(credential: OllamaCloudCredentials | null): string {
+	const config = getOllamaCloudRuntimeConfig();
+	const cloudModels = credential ? getCredentialModels(credential) : cloudEnvDiscoveryState.models;
+	const cloudAuth = credential ? "stored via /login" : process.env[OLLAMA_CLOUD_API_KEY_ENV]?.trim() ? "environment only" : "not configured";
+	return [
+		`Ollama cloud auth: ${cloudAuth}`,
+		`Cloud models: ${cloudModels.length}`,
+		`Cloud base URL: ${config.apiUrl}`,
+	].join("\n");
+}
+
+function collectOllamaModels(credential: OllamaCloudCredentials | null): Array<OllamaProviderModel & { provider: string; baseUrl: string }> {
+	const localConfig = getOllamaLocalRuntimeConfig();
+	const cloudConfig = getOllamaCloudRuntimeConfig();
+	const cloudModels = credential ? getCredentialModels(credential) : cloudEnvDiscoveryState.models;
+	return [
+		...localDiscoveryState.models.map((model) => ({ ...model, provider: OLLAMA_LOCAL_PROVIDER, baseUrl: localConfig.apiUrl })),
+		...cloudModels.map((model) => ({ ...model, provider: OLLAMA_CLOUD_PROVIDER, baseUrl: cloudConfig.apiUrl })),
+	];
+}
+
+function findModelForQuery(
+	query: string,
+	models: Array<OllamaProviderModel & { provider: string; baseUrl: string }>,
+): (OllamaProviderModel & { provider: string; baseUrl: string }) | null {
+	const normalized = query.trim().toLowerCase();
+	if (!normalized) {
+		return null;
+	}
+	return (
+		models.find((model) => `${model.provider}/${model.id}`.toLowerCase() === normalized) ??
+		models.find((model) => model.id.toLowerCase() === normalized) ??
+		models.find((model) => model.name.toLowerCase() === normalized) ??
+		models.find((model) => `${model.provider}/${model.id}`.toLowerCase().includes(normalized)) ??
+		models.find((model) => model.id.toLowerCase().includes(normalized)) ??
+		models.find((model) => model.name.toLowerCase().includes(normalized)) ??
+		null
+	);
+}
+
+function renderModelInfo(model: OllamaProviderModel & { provider: string; baseUrl: string }): string {
+	return [
+		`${model.provider}/${model.id}`,
+		`Name: ${model.name}`,
+		`Inputs: ${model.input.join(", ")}`,
+		`Reasoning: ${model.reasoning ? "yes" : "no"}`,
+		`Context window: ${model.contextWindow.toLocaleString()}`,
+		`Max tokens: ${model.maxTokens.toLocaleString()}`,
+		`Base URL: ${model.baseUrl}`,
+	].join("\n");
+}
+
+function getStoredCloudCredential(ctx: { modelRegistry: { authStorage: { get: (provider: string) => unknown } } }): OllamaCloudCredentials | null {
+	const credential = ctx.modelRegistry.authStorage.get(OLLAMA_CLOUD_PROVIDER);
+	return credential && typeof credential === "object" && (credential as { type?: string }).type === "oauth"
+		? (credential as OllamaCloudCredentials)
+		: null;
+}
+
+function bootstrapOllamaProviders(pi: ExtensionAPI): void {
+	registerOllamaLocalProvider(pi);
+	registerOllamaCloudProvider(pi);
+	void refreshRegisteredLocalModels(pi);
+	if (process.env[OLLAMA_CLOUD_API_KEY_ENV]?.trim()) {
+		void refreshRegisteredCloudEnvModels(pi);
+	}
+}
+
 export {
+	createOllamaCloudOAuthProvider,
 	discoverOllamaCloudModels,
+	discoverOllamaLocalModels,
 	getCredentialModels,
 	getFallbackOllamaCloudModels,
-	toOllamaCloudModel,
-	type OllamaCloudCredentials,
-	type OllamaCloudProviderModel,
-} from "./models.js";
+	loginOllamaCloud,
+	refreshOllamaCloudCredential,
+};
+export { toOllamaModel, toOllamaCloudModel, type OllamaCloudCredentials, type OllamaProviderModel } from "./models.js";
 
-export default function ollamaCloudProviderExtension(pi: ExtensionAPI): void {
-	registerOllamaCloudProvider(pi);
-	registerOllamaCloudCommand(pi);
+export default function ollamaProviderExtension(pi: ExtensionAPI): void {
+	bootstrapOllamaProviders(pi);
+	registerOllamaCommands(pi);
 }

--- a/packages/ollama/index.ts
+++ b/packages/ollama/index.ts
@@ -98,7 +98,7 @@ async function refreshRegisteredCloudEnvModels(pi: ExtensionAPI): Promise<Ollama
 
 function registerOllamaCommands(pi: ExtensionAPI): void {
 	pi.registerCommand("ollama", {
-		description: "Inspect or refresh local + cloud Ollama providers: /ollama [status|refresh-models|info <model>]",
+		description: "Inspect or refresh local + cloud Ollama providers: /ollama [status|refresh-models|models|info <model>]",
 		async handler(args, ctx) {
 			const trimmed = args.trim();
 			const [rawAction = "status", ...rest] = trimmed ? trimmed.split(/\s+/) : ["status"];
@@ -113,6 +113,11 @@ function registerOllamaCommands(pi: ExtensionAPI): void {
 					? `${cloudModels.length} cloud available`
 					: "cloud not configured";
 				ctx.ui.notify(`Refreshed Ollama models (${localModels.length} local, ${cloudStatus}).`, "info");
+				return;
+			}
+
+			if (action === "models") {
+				ctx.ui.notify(renderModelList(collectOllamaModels(credential)), "info");
 				return;
 			}
 
@@ -180,15 +185,18 @@ function renderUnifiedStatus(credential: OllamaCloudCredentials | null): string 
 		: localDiscoveryState.lastRefresh
 			? "reachable"
 			: "probing";
+	const localRefresh = formatRefreshAge(localDiscoveryState.lastRefresh);
+	const cloudRefresh = formatRefreshAge(credential?.lastModelRefresh ?? cloudEnvDiscoveryState.lastRefresh);
 	const cloudModels = credential ? getCredentialModels(credential) : cloudEnvDiscoveryState.models;
 	const cloudAuth = credential ? "stored via /login" : process.env[OLLAMA_CLOUD_API_KEY_ENV]?.trim() ? "environment only" : "not configured";
 	return [
 		`Ollama local: ${localState}`,
-		`Local models: ${localDiscoveryState.models.length}`,
+		`Local models: ${localDiscoveryState.models.length}${localRefresh}`,
 		`Local base URL: ${localConfig.apiUrl}`,
 		`Ollama cloud auth: ${cloudAuth}`,
-		`Cloud models: ${cloudModels.length}`,
+		`Cloud models: ${cloudModels.length}${cloudRefresh}`,
 		`Cloud base URL: ${cloudConfig.apiUrl}`,
+		`Tip: run /ollama models to compare local and cloud choices.`,
 	].join("\n");
 }
 
@@ -198,7 +206,7 @@ function renderCloudStatus(credential: OllamaCloudCredentials | null): string {
 	const cloudAuth = credential ? "stored via /login" : process.env[OLLAMA_CLOUD_API_KEY_ENV]?.trim() ? "environment only" : "not configured";
 	return [
 		`Ollama cloud auth: ${cloudAuth}`,
-		`Cloud models: ${cloudModels.length}`,
+		`Cloud models: ${cloudModels.length}${formatRefreshAge(credential?.lastModelRefresh ?? cloudEnvDiscoveryState.lastRefresh)}`,
 		`Cloud base URL: ${config.apiUrl}`,
 	].join("\n");
 }
@@ -233,15 +241,108 @@ function findModelForQuery(
 }
 
 function renderModelInfo(model: OllamaProviderModel & { provider: string; baseUrl: string }): string {
-	return [
-		`${model.provider}/${model.id}`,
+	const lines = [
+		`${sourceIcon(model.provider)} ${model.provider}/${model.id}`,
 		`Name: ${model.name}`,
+		`Source: ${model.provider === OLLAMA_LOCAL_PROVIDER ? "Local Ollama daemon" : "Ollama Cloud"}`,
 		`Inputs: ${model.input.join(", ")}`,
 		`Reasoning: ${model.reasoning ? "yes" : "no"}`,
 		`Context window: ${model.contextWindow.toLocaleString()}`,
 		`Max tokens: ${model.maxTokens.toLocaleString()}`,
 		`Base URL: ${model.baseUrl}`,
-	].join("\n");
+	];
+	if (model.family) {
+		lines.splice(4, 0, `Family: ${model.family}`);
+	}
+	if (model.parameterSize) {
+		lines.splice(5, 0, `Parameter size: ${model.parameterSize}`);
+	}
+	if (model.quantization) {
+		lines.splice(6, 0, `Quantization: ${model.quantization}`);
+	}
+	const capabilitySummary = summarizeCapabilities(model);
+	if (capabilitySummary) {
+		lines.splice(lines.length - 1, 0, `Capabilities: ${capabilitySummary}`);
+	}
+	return lines.join("\n");
+}
+
+function renderModelList(models: Array<OllamaProviderModel & { provider: string; baseUrl: string }>): string {
+	if (models.length === 0) {
+		return "No Ollama models are currently registered. Run /ollama refresh-models.";
+	}
+	const sections = [
+		{
+			title: "Local",
+			models: models.filter((model) => model.provider === OLLAMA_LOCAL_PROVIDER),
+		},
+		{
+			title: "Cloud",
+			models: models.filter((model) => model.provider === OLLAMA_CLOUD_PROVIDER),
+		},
+	].filter((section) => section.models.length > 0);
+	return sections
+		.map((section) => [
+			`Ollama ${section.title}:`,
+			...section.models
+				.sort((left, right) => left.id.localeCompare(right.id))
+				.map(
+					(model) =>
+						`  ${sourceIcon(model.provider)} ${model.provider}/${model.id} — ${model.name}${renderModelBadges(model)} · ${model.contextWindow.toLocaleString()} ctx`,
+				),
+		].join("\n"))
+		.join("\n\n");
+}
+
+function renderModelBadges(model: OllamaProviderModel): string {
+	const badges: string[] = [];
+	if (model.input.includes("image")) {
+		badges.push("vision");
+	}
+	if (model.reasoning) {
+		badges.push("reasoning");
+	}
+	if (model.parameterSize) {
+		badges.push(model.parameterSize);
+	}
+	return badges.length > 0 ? ` [${badges.join(" · ")}]` : "";
+}
+
+function summarizeCapabilities(model: OllamaProviderModel): string | null {
+	const values = new Set<string>();
+	for (const capability of model.capabilities ?? []) {
+		values.add(capability);
+	}
+	if (model.input.includes("image")) {
+		values.add("vision");
+	}
+	if (model.reasoning) {
+		values.add("thinking");
+	}
+	return values.size > 0 ? [...values].join(", ") : null;
+}
+
+function sourceIcon(provider: string): string {
+	return provider === OLLAMA_LOCAL_PROVIDER ? "⌂" : "☁";
+}
+
+function formatRefreshAge(timestamp: number | null | undefined): string {
+	if (!timestamp) {
+		return "";
+	}
+	const seconds = Math.max(0, Math.round((Date.now() - timestamp) / 1000));
+	if (seconds < 5) {
+		return " (just refreshed)";
+	}
+	if (seconds < 60) {
+		return ` (${seconds}s ago)`;
+	}
+	const minutes = Math.round(seconds / 60);
+	if (minutes < 60) {
+		return ` (${minutes}m ago)`;
+	}
+	const hours = Math.round(minutes / 60);
+	return ` (${hours}h ago)`;
 }
 
 function getStoredCloudCredential(ctx: { modelRegistry: { authStorage: { get: (provider: string) => unknown } } }): OllamaCloudCredentials | null {

--- a/packages/ollama/models.ts
+++ b/packages/ollama/models.ts
@@ -18,6 +18,10 @@ export type OllamaProviderModel = {
 	maxTokens: number;
 	compat?: Model<Api>["compat"];
 	source?: OllamaModelSource;
+	family?: string;
+	parameterSize?: string;
+	quantization?: string;
+	capabilities?: string[];
 };
 
 export type OllamaCloudProviderModel = OllamaProviderModel;
@@ -35,6 +39,7 @@ type OllamaListedModel = {
 type OllamaShowResponse = {
 	capabilities?: unknown;
 	model_info?: Record<string, unknown>;
+	details?: Record<string, unknown>;
 };
 
 const DEFAULT_CONTEXT_WINDOW = 128_000;
@@ -148,7 +153,7 @@ export function toOllamaModel(model: Partial<OllamaProviderModel> & Pick<OllamaP
 	const maxTokens = normalizePositiveInteger(model.maxTokens, inferMaxTokens(contextWindow));
 	return {
 		id: model.id,
-		name: model.name?.trim() || formatDisplayName(model.id),
+		name: applySourceSuffix(model.name?.trim() || formatDisplayName(model.id), model.source),
 		reasoning: model.reasoning ?? false,
 		input: sanitizeInput(model.input),
 		cost: model.cost ? { ...model.cost } : { input: 0, output: 0, cacheRead: 0, cacheWrite: 0 },
@@ -156,6 +161,10 @@ export function toOllamaModel(model: Partial<OllamaProviderModel> & Pick<OllamaP
 		maxTokens,
 		compat: { ...OLLAMA_OPENAI_COMPAT, ...(model.compat ?? {}) },
 		source: model.source,
+		family: sanitizeOptionalString(model.family),
+		parameterSize: sanitizeOptionalString(model.parameterSize),
+		quantization: sanitizeOptionalString(model.quantization),
+		capabilities: sanitizeCapabilities(model.capabilities),
 	};
 }
 
@@ -207,6 +216,7 @@ function cloneModel(model: OllamaProviderModel): OllamaProviderModel {
 		input: [...model.input],
 		cost: { ...model.cost },
 		compat: model.compat ? { ...model.compat } : undefined,
+		capabilities: model.capabilities ? [...model.capabilities] : undefined,
 	};
 }
 
@@ -232,6 +242,10 @@ function normalizeDiscoveredModel(
 		input: capabilitySet.has("vision") ? ["text", "image"] : (fallback?.input ?? ["text"]),
 		contextWindow,
 		maxTokens: fallback?.maxTokens ?? inferMaxTokens(contextWindow),
+		family: extractDetailField(payload.details, "family") ?? fallback?.family,
+		parameterSize: extractDetailField(payload.details, "parameter_size") ?? fallback?.parameterSize,
+		quantization: extractDetailField(payload.details, "quantization_level") ?? fallback?.quantization,
+		capabilities,
 	});
 }
 
@@ -292,6 +306,32 @@ function formatDisplayName(id: string): string {
 			return `${part.slice(0, 1).toUpperCase()}${part.slice(1)}`;
 		})
 		.join(" ");
+}
+
+function applySourceSuffix(name: string, source: OllamaModelSource | undefined): string {
+	if (!source) {
+		return name;
+	}
+	if (/\((local|cloud)\)$/i.test(name)) {
+		return name;
+	}
+	return `${name} (${source === "local" ? "Local" : "Cloud"})`;
+}
+
+function sanitizeOptionalString(value: string | undefined): string | undefined {
+	return typeof value === "string" && value.trim().length > 0 ? value.trim() : undefined;
+}
+
+function sanitizeCapabilities(capabilities: string[] | undefined): string[] | undefined {
+	if (!Array.isArray(capabilities) || capabilities.length === 0) {
+		return undefined;
+	}
+	return [...new Set(capabilities.map((capability) => capability.trim()).filter(Boolean))];
+}
+
+function extractDetailField(details: Record<string, unknown> | undefined, key: string): string | undefined {
+	const value = details?.[key];
+	return typeof value === "string" && value.trim().length > 0 ? value.trim() : undefined;
 }
 
 function createDiscoveryHeaders(apiKey?: string): Record<string, string> {

--- a/packages/ollama/models.ts
+++ b/packages/ollama/models.ts
@@ -1,7 +1,9 @@
-import type { OAuthCredentials, Model, Api } from "@mariozechner/pi-ai";
-import { getOllamaCloudRuntimeConfig } from "./config.js";
+import type { Api, Model, OAuthCredentials } from "@mariozechner/pi-ai";
+import { getOllamaCloudRuntimeConfig, getOllamaLocalRuntimeConfig, type OllamaRuntimeConfig } from "./config.js";
 
-export type OllamaCloudProviderModel = {
+export type OllamaModelSource = "local" | "cloud";
+
+export type OllamaProviderModel = {
 	id: string;
 	name: string;
 	reasoning: boolean;
@@ -15,19 +17,22 @@ export type OllamaCloudProviderModel = {
 	contextWindow: number;
 	maxTokens: number;
 	compat?: Model<Api>["compat"];
+	source?: OllamaModelSource;
 };
 
+export type OllamaCloudProviderModel = OllamaProviderModel;
+
 export type OllamaCloudCredentials = OAuthCredentials & {
-	models?: OllamaCloudProviderModel[];
+	models?: OllamaProviderModel[];
 	lastModelRefresh?: number;
 };
 
-type OllamaCloudListedModel = {
+type OllamaListedModel = {
 	id?: string;
 	object?: string;
 };
 
-type OllamaCloudShowResponse = {
+type OllamaShowResponse = {
 	capabilities?: unknown;
 	model_info?: Record<string, unknown>;
 };
@@ -36,7 +41,7 @@ const DEFAULT_CONTEXT_WINDOW = 128_000;
 const DEFAULT_MAX_TOKENS = 16_384;
 const MAX_DISCOVERY_CONCURRENCY = 6;
 
-const OLLAMA_OPENAI_COMPAT: NonNullable<OllamaCloudProviderModel["compat"]> = {
+const OLLAMA_OPENAI_COMPAT: NonNullable<OllamaProviderModel["compat"]> = {
 	supportsDeveloperRole: false,
 	supportsReasoningEffort: true,
 	reasoningEffortMap: {
@@ -49,87 +54,78 @@ const OLLAMA_OPENAI_COMPAT: NonNullable<OllamaCloudProviderModel["compat"]> = {
 	maxTokensField: "max_tokens",
 };
 
-const FALLBACK_OLLAMA_CLOUD_MODELS: OllamaCloudProviderModel[] = [
-	toOllamaCloudModel({ id: "cogito-2.1:671b", reasoning: true, input: ["text"], contextWindow: 163_840, maxTokens: 20_480 }),
-	toOllamaCloudModel({ id: "deepseek-v3.1:671b", reasoning: true, input: ["text"], contextWindow: 163_840, maxTokens: 20_480 }),
-	toOllamaCloudModel({ id: "deepseek-v3.2", reasoning: true, input: ["text"], contextWindow: 163_840, maxTokens: 20_480 }),
-	toOllamaCloudModel({ id: "devstral-2:123b", reasoning: false, input: ["text"], contextWindow: 262_144, maxTokens: 32_768 }),
-	toOllamaCloudModel({ id: "devstral-small-2:24b", reasoning: false, input: ["text", "image"], contextWindow: 262_144, maxTokens: 32_768 }),
-	toOllamaCloudModel({ id: "gemini-3-flash-preview", reasoning: true, input: ["text"], contextWindow: 1_048_576, maxTokens: 65_536 }),
-	toOllamaCloudModel({ id: "gemma3:12b", reasoning: false, input: ["text", "image"], contextWindow: 131_072, maxTokens: 16_384 }),
-	toOllamaCloudModel({ id: "gemma3:27b", reasoning: false, input: ["text", "image"], contextWindow: 131_072, maxTokens: 16_384 }),
-	toOllamaCloudModel({ id: "gemma3:4b", reasoning: false, input: ["text", "image"], contextWindow: 131_072, maxTokens: 16_384 }),
-	toOllamaCloudModel({ id: "gemma4:31b", reasoning: true, input: ["text", "image"], contextWindow: 262_144, maxTokens: 32_768 }),
-	toOllamaCloudModel({ id: "glm-4.6", reasoning: true, input: ["text"], contextWindow: 202_752, maxTokens: 25_344 }),
-	toOllamaCloudModel({ id: "glm-4.7", reasoning: true, input: ["text"], contextWindow: 202_752, maxTokens: 25_344 }),
-	toOllamaCloudModel({ id: "glm-5", reasoning: true, input: ["text"], contextWindow: 202_752, maxTokens: 25_344 }),
-	toOllamaCloudModel({ id: "gpt-oss:120b", reasoning: true, input: ["text"], contextWindow: 131_072, maxTokens: 16_384 }),
-	toOllamaCloudModel({ id: "gpt-oss:20b", reasoning: true, input: ["text"], contextWindow: 131_072, maxTokens: 16_384 }),
-	toOllamaCloudModel({ id: "kimi-k2-thinking", reasoning: true, input: ["text"], contextWindow: 262_144, maxTokens: 32_768 }),
-	toOllamaCloudModel({ id: "kimi-k2.5", reasoning: true, input: ["text", "image"], contextWindow: 262_144, maxTokens: 32_768 }),
-	toOllamaCloudModel({ id: "kimi-k2:1t", reasoning: false, input: ["text"], contextWindow: 262_144, maxTokens: 32_768 }),
-	toOllamaCloudModel({ id: "minimax-m2", reasoning: false, input: ["text"], contextWindow: 204_800, maxTokens: 25_600 }),
-	toOllamaCloudModel({ id: "minimax-m2.1", reasoning: true, input: ["text"], contextWindow: 204_800, maxTokens: 25_600 }),
-	toOllamaCloudModel({ id: "minimax-m2.5", reasoning: true, input: ["text"], contextWindow: 204_800, maxTokens: 25_600 }),
-	toOllamaCloudModel({ id: "minimax-m2.7", reasoning: true, input: ["text"], contextWindow: 204_800, maxTokens: 25_600 }),
-	toOllamaCloudModel({ id: "ministral-3:14b", reasoning: false, input: ["text", "image"], contextWindow: 262_144, maxTokens: 32_768 }),
-	toOllamaCloudModel({ id: "ministral-3:3b", reasoning: false, input: ["text", "image"], contextWindow: 262_144, maxTokens: 32_768 }),
-	toOllamaCloudModel({ id: "ministral-3:8b", reasoning: false, input: ["text", "image"], contextWindow: 262_144, maxTokens: 32_768 }),
-	toOllamaCloudModel({ id: "mistral-large-3:675b", reasoning: false, input: ["text", "image"], contextWindow: 262_144, maxTokens: 32_768 }),
-	toOllamaCloudModel({ id: "nemotron-3-nano:30b", reasoning: true, input: ["text"], contextWindow: 1_048_576, maxTokens: 65_536 }),
-	toOllamaCloudModel({ id: "nemotron-3-super", reasoning: true, input: ["text"], contextWindow: 262_144, maxTokens: 32_768 }),
-	toOllamaCloudModel({ id: "qwen3-coder-next", reasoning: false, input: ["text"], contextWindow: 262_144, maxTokens: 32_768 }),
-	toOllamaCloudModel({ id: "qwen3-coder:480b", reasoning: false, input: ["text"], contextWindow: 262_144, maxTokens: 32_768 }),
-	toOllamaCloudModel({ id: "qwen3-next:80b", reasoning: true, input: ["text"], contextWindow: 262_144, maxTokens: 32_768 }),
-	toOllamaCloudModel({ id: "qwen3-vl:235b", reasoning: true, input: ["text", "image"], contextWindow: 262_144, maxTokens: 32_768 }),
-	toOllamaCloudModel({ id: "qwen3-vl:235b-instruct", reasoning: false, input: ["text", "image"], contextWindow: 262_144, maxTokens: 32_768 }),
-	toOllamaCloudModel({ id: "qwen3.5:397b", reasoning: true, input: ["text", "image"], contextWindow: 262_144, maxTokens: 32_768 }),
-	toOllamaCloudModel({ id: "rnj-1:8b", reasoning: false, input: ["text"], contextWindow: 32_768, maxTokens: 16_384 }),
+const FALLBACK_OLLAMA_CLOUD_MODELS: OllamaProviderModel[] = [
+	toOllamaModel({ id: "cogito-2.1:671b", source: "cloud", reasoning: true, input: ["text"], contextWindow: 163_840, maxTokens: 20_480 }),
+	toOllamaModel({ id: "deepseek-v3.1:671b", source: "cloud", reasoning: true, input: ["text"], contextWindow: 163_840, maxTokens: 20_480 }),
+	toOllamaModel({ id: "deepseek-v3.2", source: "cloud", reasoning: true, input: ["text"], contextWindow: 163_840, maxTokens: 20_480 }),
+	toOllamaModel({ id: "devstral-2:123b", source: "cloud", reasoning: false, input: ["text"], contextWindow: 262_144, maxTokens: 32_768 }),
+	toOllamaModel({ id: "devstral-small-2:24b", source: "cloud", reasoning: false, input: ["text", "image"], contextWindow: 262_144, maxTokens: 32_768 }),
+	toOllamaModel({ id: "gemini-3-flash-preview", source: "cloud", reasoning: true, input: ["text"], contextWindow: 1_048_576, maxTokens: 65_536 }),
+	toOllamaModel({ id: "gemma3:12b", source: "cloud", reasoning: false, input: ["text", "image"], contextWindow: 131_072, maxTokens: 16_384 }),
+	toOllamaModel({ id: "gemma3:27b", source: "cloud", reasoning: false, input: ["text", "image"], contextWindow: 131_072, maxTokens: 16_384 }),
+	toOllamaModel({ id: "gemma3:4b", source: "cloud", reasoning: false, input: ["text", "image"], contextWindow: 131_072, maxTokens: 16_384 }),
+	toOllamaModel({ id: "gemma4:31b", source: "cloud", reasoning: true, input: ["text", "image"], contextWindow: 262_144, maxTokens: 32_768 }),
+	toOllamaModel({ id: "glm-4.6", source: "cloud", reasoning: true, input: ["text"], contextWindow: 202_752, maxTokens: 25_344 }),
+	toOllamaModel({ id: "glm-4.7", source: "cloud", reasoning: true, input: ["text"], contextWindow: 202_752, maxTokens: 25_344 }),
+	toOllamaModel({ id: "glm-5", source: "cloud", reasoning: true, input: ["text"], contextWindow: 202_752, maxTokens: 25_344 }),
+	toOllamaModel({ id: "gpt-oss:120b", source: "cloud", reasoning: true, input: ["text"], contextWindow: 131_072, maxTokens: 16_384 }),
+	toOllamaModel({ id: "gpt-oss:20b", source: "cloud", reasoning: true, input: ["text"], contextWindow: 131_072, maxTokens: 16_384 }),
+	toOllamaModel({ id: "kimi-k2-thinking", source: "cloud", reasoning: true, input: ["text"], contextWindow: 262_144, maxTokens: 32_768 }),
+	toOllamaModel({ id: "kimi-k2.5", source: "cloud", reasoning: true, input: ["text", "image"], contextWindow: 262_144, maxTokens: 32_768 }),
+	toOllamaModel({ id: "kimi-k2:1t", source: "cloud", reasoning: false, input: ["text"], contextWindow: 262_144, maxTokens: 32_768 }),
+	toOllamaModel({ id: "minimax-m2", source: "cloud", reasoning: false, input: ["text"], contextWindow: 204_800, maxTokens: 25_600 }),
+	toOllamaModel({ id: "minimax-m2.1", source: "cloud", reasoning: true, input: ["text"], contextWindow: 204_800, maxTokens: 25_600 }),
+	toOllamaModel({ id: "minimax-m2.5", source: "cloud", reasoning: true, input: ["text"], contextWindow: 204_800, maxTokens: 25_600 }),
+	toOllamaModel({ id: "minimax-m2.7", source: "cloud", reasoning: true, input: ["text"], contextWindow: 204_800, maxTokens: 25_600 }),
+	toOllamaModel({ id: "ministral-3:14b", source: "cloud", reasoning: false, input: ["text", "image"], contextWindow: 262_144, maxTokens: 32_768 }),
+	toOllamaModel({ id: "ministral-3:3b", source: "cloud", reasoning: false, input: ["text", "image"], contextWindow: 262_144, maxTokens: 32_768 }),
+	toOllamaModel({ id: "ministral-3:8b", source: "cloud", reasoning: false, input: ["text", "image"], contextWindow: 262_144, maxTokens: 32_768 }),
+	toOllamaModel({ id: "mistral-large-3:675b", source: "cloud", reasoning: false, input: ["text", "image"], contextWindow: 262_144, maxTokens: 32_768 }),
+	toOllamaModel({ id: "nemotron-3-nano:30b", source: "cloud", reasoning: true, input: ["text"], contextWindow: 1_048_576, maxTokens: 65_536 }),
+	toOllamaModel({ id: "nemotron-3-super", source: "cloud", reasoning: true, input: ["text"], contextWindow: 262_144, maxTokens: 32_768 }),
+	toOllamaModel({ id: "qwen3-coder-next", source: "cloud", reasoning: false, input: ["text"], contextWindow: 262_144, maxTokens: 32_768 }),
+	toOllamaModel({ id: "qwen3-coder:480b", source: "cloud", reasoning: false, input: ["text"], contextWindow: 262_144, maxTokens: 32_768 }),
+	toOllamaModel({ id: "qwen3-next:80b", source: "cloud", reasoning: true, input: ["text"], contextWindow: 262_144, maxTokens: 32_768 }),
+	toOllamaModel({ id: "qwen3-vl:235b", source: "cloud", reasoning: true, input: ["text", "image"], contextWindow: 262_144, maxTokens: 32_768 }),
+	toOllamaModel({ id: "qwen3-vl:235b-instruct", source: "cloud", reasoning: false, input: ["text", "image"], contextWindow: 262_144, maxTokens: 32_768 }),
+	toOllamaModel({ id: "qwen3.5:397b", source: "cloud", reasoning: true, input: ["text", "image"], contextWindow: 262_144, maxTokens: 32_768 }),
+	toOllamaModel({ id: "rnj-1:8b", source: "cloud", reasoning: false, input: ["text"], contextWindow: 32_768, maxTokens: 16_384 }),
 ];
 
-export function getFallbackOllamaCloudModels(): OllamaCloudProviderModel[] {
+export function getFallbackOllamaCloudModels(): OllamaProviderModel[] {
 	return FALLBACK_OLLAMA_CLOUD_MODELS.map(cloneModel);
 }
 
-export function getCredentialModels(credentials: OllamaCloudCredentials): OllamaCloudProviderModel[] {
+export function getFallbackOllamaLocalModels(): OllamaProviderModel[] {
+	return [];
+}
+
+export function getCredentialModels(credentials: OllamaCloudCredentials): OllamaProviderModel[] {
 	const models = Array.isArray(credentials.models) ? credentials.models : [];
 	return models.length > 0 ? sanitizeStoredModels(models) : getFallbackOllamaCloudModels();
 }
 
-export async function discoverOllamaCloudModels(apiKey: string, options: { signal?: AbortSignal } = {}): Promise<OllamaCloudProviderModel[] | null> {
-	const config = getOllamaCloudRuntimeConfig();
-	const listed = await fetchJson<{ data?: OllamaCloudListedModel[] }>(config.modelsUrl, {
-		headers: createDiscoveryHeaders(apiKey),
+export async function discoverOllamaLocalModels(options: { signal?: AbortSignal } = {}): Promise<OllamaProviderModel[] | null> {
+	return discoverOllamaModels(getOllamaLocalRuntimeConfig(), {
+		source: "local",
 		signal: options.signal,
 	});
-	const modelIds = Array.isArray(listed.data)
-		? listed.data
-				.map((entry) => (typeof entry?.id === "string" ? entry.id.trim() : ""))
-				.filter(Boolean)
-				.sort((left, right) => left.localeCompare(right))
-		: [];
-	if (modelIds.length === 0) {
-		return null;
-	}
+}
 
-	const discovered = await mapConcurrent(modelIds, MAX_DISCOVERY_CONCURRENCY, async (id) => {
-		const payload = await fetchJson<OllamaCloudShowResponse>(config.showUrl, {
-			method: "POST",
-			headers: createDiscoveryHeaders(apiKey),
-			body: JSON.stringify({ model: id }),
-			signal: options.signal,
-		});
-		return normalizeDiscoveredModel(id, payload);
+export async function discoverOllamaCloudModels(apiKey: string, options: { signal?: AbortSignal } = {}): Promise<OllamaProviderModel[] | null> {
+	return discoverOllamaModels(getOllamaCloudRuntimeConfig(), {
+		source: "cloud",
+		apiKey,
+		fallbackModels: getFallbackOllamaCloudModels(),
+		signal: options.signal,
 	});
-	const models = discovered.filter((model): model is OllamaCloudProviderModel => model !== null);
-	return models.length > 0 ? models : null;
 }
 
 export async function enrichOllamaCloudCredentials(
 	credentials: OAuthCredentials,
 	options: { previous?: OllamaCloudCredentials; signal?: AbortSignal } = {},
 ): Promise<OllamaCloudCredentials> {
-	let models: OllamaCloudProviderModel[] | undefined;
+	let models: OllamaProviderModel[] | undefined;
 	try {
 		models = (await discoverOllamaCloudModels(credentials.access, { signal: options.signal })) ?? undefined;
 	} catch {
@@ -143,13 +139,11 @@ export async function enrichOllamaCloudCredentials(
 	};
 }
 
-export function toProviderModels(models: OllamaCloudProviderModel[]): OllamaCloudProviderModel[] {
+export function toProviderModels(models: OllamaProviderModel[]): OllamaProviderModel[] {
 	return sanitizeStoredModels(models);
 }
 
-export function toOllamaCloudModel(
-	model: Partial<OllamaCloudProviderModel> & Pick<OllamaCloudProviderModel, "id">,
-): OllamaCloudProviderModel {
+export function toOllamaModel(model: Partial<OllamaProviderModel> & Pick<OllamaProviderModel, "id">): OllamaProviderModel {
 	const contextWindow = normalizePositiveInteger(model.contextWindow, DEFAULT_CONTEXT_WINDOW);
 	const maxTokens = normalizePositiveInteger(model.maxTokens, inferMaxTokens(contextWindow));
 	return {
@@ -161,14 +155,53 @@ export function toOllamaCloudModel(
 		contextWindow,
 		maxTokens,
 		compat: { ...OLLAMA_OPENAI_COMPAT, ...(model.compat ?? {}) },
+		source: model.source,
 	};
 }
 
-function sanitizeStoredModels(models: readonly OllamaCloudProviderModel[]): OllamaCloudProviderModel[] {
-	return models.map((model) => toOllamaCloudModel(model));
+export const toOllamaCloudModel = toOllamaModel;
+
+async function discoverOllamaModels(
+	config: OllamaRuntimeConfig,
+	options: {
+		source: OllamaModelSource;
+		apiKey?: string;
+		fallbackModels?: readonly OllamaProviderModel[];
+		signal?: AbortSignal;
+	},
+): Promise<OllamaProviderModel[] | null> {
+	const listed = await fetchJson<{ data?: OllamaListedModel[] }>(config.modelsUrl, {
+		headers: createDiscoveryHeaders(options.apiKey),
+		signal: options.signal,
+	});
+	const modelIds = Array.isArray(listed.data)
+		? listed.data
+				.map((entry) => (typeof entry?.id === "string" ? entry.id.trim() : ""))
+				.filter(Boolean)
+				.sort((left, right) => left.localeCompare(right))
+		: [];
+	if (modelIds.length === 0) {
+		return null;
+	}
+
+	const discovered = await mapConcurrent(modelIds, MAX_DISCOVERY_CONCURRENCY, async (id) => {
+		const payload = await fetchJson<OllamaShowResponse>(config.showUrl, {
+			method: "POST",
+			headers: createDiscoveryHeaders(options.apiKey),
+			body: JSON.stringify({ model: id, verbose: true }),
+			signal: options.signal,
+		}).catch(() => null);
+		return normalizeDiscoveredModel(id, payload, options.source, options.fallbackModels ?? []);
+	});
+	const models = discovered.filter((model): model is OllamaProviderModel => model !== null);
+	return models.length > 0 ? models : null;
 }
 
-function cloneModel(model: OllamaCloudProviderModel): OllamaCloudProviderModel {
+function sanitizeStoredModels(models: readonly OllamaProviderModel[]): OllamaProviderModel[] {
+	return models.map((model) => toOllamaModel(model));
+}
+
+function cloneModel(model: OllamaProviderModel): OllamaProviderModel {
 	return {
 		...model,
 		input: [...model.input],
@@ -177,18 +210,28 @@ function cloneModel(model: OllamaCloudProviderModel): OllamaCloudProviderModel {
 	};
 }
 
-function normalizeDiscoveredModel(id: string, payload: OllamaCloudShowResponse): OllamaCloudProviderModel | null {
+function normalizeDiscoveredModel(
+	id: string,
+	payload: OllamaShowResponse | null,
+	source: OllamaModelSource,
+	fallbackModels: readonly OllamaProviderModel[],
+): OllamaProviderModel | null {
+	const fallback = fallbackModels.find((model) => model.id === id);
+	if (!payload) {
+		return fallback ? cloneModel(fallback) : toOllamaModel({ id, source });
+	}
 	const capabilities = Array.isArray(payload.capabilities)
 		? payload.capabilities.filter((capability): capability is string => typeof capability === "string")
 		: [];
 	const capabilitySet = new Set(capabilities.map((capability) => capability.toLowerCase()));
-	const contextWindow = extractContextWindow(payload.model_info) ?? findFallbackModel(id)?.contextWindow ?? DEFAULT_CONTEXT_WINDOW;
-	return toOllamaCloudModel({
+	const contextWindow = extractContextWindow(payload.model_info) ?? fallback?.contextWindow ?? DEFAULT_CONTEXT_WINDOW;
+	return toOllamaModel({
 		id,
-		reasoning: capabilitySet.has("thinking"),
-		input: capabilitySet.has("vision") ? ["text", "image"] : ["text"],
+		source,
+		reasoning: capabilitySet.has("thinking") || fallback?.reasoning,
+		input: capabilitySet.has("vision") ? ["text", "image"] : (fallback?.input ?? ["text"]),
 		contextWindow,
-		maxTokens: inferMaxTokens(contextWindow),
+		maxTokens: fallback?.maxTokens ?? inferMaxTokens(contextWindow),
 	});
 }
 
@@ -208,7 +251,7 @@ function extractContextWindow(modelInfo: Record<string, unknown> | undefined): n
 	return null;
 }
 
-function sanitizeInput(input: OllamaCloudProviderModel["input"] | undefined): ("text" | "image")[] {
+function sanitizeInput(input: OllamaProviderModel["input"] | undefined): ("text" | "image")[] {
 	const next = Array.isArray(input) && input.includes("image") ? (["text", "image"] as const) : (["text"] as const);
 	return [...next];
 }
@@ -251,15 +294,15 @@ function formatDisplayName(id: string): string {
 		.join(" ");
 }
 
-function findFallbackModel(id: string): OllamaCloudProviderModel | undefined {
-	return FALLBACK_OLLAMA_CLOUD_MODELS.find((model) => model.id === id);
-}
-
-function createDiscoveryHeaders(apiKey: string): Record<string, string> {
-	return {
-		Authorization: `Bearer ${apiKey}`,
-		"Content-Type": "application/json",
-	};
+function createDiscoveryHeaders(apiKey?: string): Record<string, string> {
+	return apiKey
+		? {
+				Authorization: `Bearer ${apiKey}`,
+				"Content-Type": "application/json",
+			}
+		: {
+				"Content-Type": "application/json",
+			};
 }
 
 async function fetchJson<T>(
@@ -279,7 +322,7 @@ async function fetchJson<T>(
 	});
 	if (!response.ok) {
 		const body = await response.text();
-		throw new Error(`Ollama Cloud request failed (${response.status}): ${body || response.statusText}`);
+		throw new Error(`Ollama request failed (${response.status}): ${body || response.statusText}`);
 	}
 	return (await response.json()) as T;
 }

--- a/packages/ollama/package.json
+++ b/packages/ollama/package.json
@@ -1,7 +1,7 @@
 {
-	"name": "@ifi/pi-provider-ollama-cloud",
+	"name": "@ifi/pi-provider-ollama",
 	"version": "0.4.4",
-	"description": "Experimental Ollama Cloud provider for pi with /login support and dynamic model discovery.",
+	"description": "Experimental Ollama provider for pi with local discovery and cloud login support.",
 	"type": "module",
 	"keywords": [
 		"pi-package",
@@ -9,6 +9,7 @@
 		"pi-coding-agent",
 		"ollama",
 		"provider",
+		"local",
 		"cloud",
 		"experimental"
 	],

--- a/packages/ollama/tests/auth.test.ts
+++ b/packages/ollama/tests/auth.test.ts
@@ -1,6 +1,6 @@
 import { afterEach, describe, expect, it, vi } from "vitest";
 import { createOllamaCloudOAuthProvider, loginOllamaCloud, refreshOllamaCloudCredential } from "../auth.js";
-import { createTestOllamaCloudBackend } from "./test-backend.js";
+import { createTestOllamaBackend } from "./test-backend.js";
 
 const envSnapshot = { ...process.env };
 
@@ -15,11 +15,11 @@ afterEach(() => {
 
 describe("ollama cloud auth", () => {
 	it("opens the keys page and exchanges a pasted API key for a static credential with discovered models", async () => {
-		const backend = await createTestOllamaCloudBackend();
+		const backend = await createTestOllamaBackend();
 		backend.setModels([{ id: "gpt-oss:120b", capabilities: ["completion", "tools", "thinking"], contextWindow: 131072 }]);
 		process.env.PI_OLLAMA_CLOUD_API_URL = backend.apiUrl;
 		process.env.PI_OLLAMA_CLOUD_MODELS_URL = `${backend.apiUrl}/models`;
-		process.env.PI_OLLAMA_CLOUD_SHOW_URL = `${backend.apiUrl.replace(/\/v1$/, "")}/api/show`;
+		process.env.PI_OLLAMA_CLOUD_SHOW_URL = `${backend.origin}/api/show`;
 		process.env.PI_OLLAMA_CLOUD_KEYS_URL = backend.keysUrl;
 
 		let openedUrl = "";
@@ -37,17 +37,17 @@ describe("ollama cloud auth", () => {
 	});
 
 	it("refreshes credentials and preserves discovered models when discovery fails", async () => {
-		const backend = await createTestOllamaCloudBackend();
+		const backend = await createTestOllamaBackend();
 		backend.setRejectAuth(true);
 		process.env.PI_OLLAMA_CLOUD_API_URL = backend.apiUrl;
 		process.env.PI_OLLAMA_CLOUD_MODELS_URL = `${backend.apiUrl}/models`;
-		process.env.PI_OLLAMA_CLOUD_SHOW_URL = `${backend.apiUrl.replace(/\/v1$/, "")}/api/show`;
+		process.env.PI_OLLAMA_CLOUD_SHOW_URL = `${backend.origin}/api/show`;
 
 		const refreshed = await refreshOllamaCloudCredential({
 			refresh: "test-key",
 			access: "test-key",
 			expires: Date.now() - 1000,
-			models: [{ id: "qwen3-next:80b", name: "Qwen3 Next 80B", reasoning: true, input: ["text"], cost: { input: 0, output: 0, cacheRead: 0, cacheWrite: 0 }, contextWindow: 262144, maxTokens: 32768 }],
+			models: [{ id: "qwen3-next:80b", name: "Qwen3 Next 80B", reasoning: true, input: ["text"], cost: { input: 0, output: 0, cacheRead: 0, cacheWrite: 0 }, contextWindow: 262144, maxTokens: 32768, source: "cloud" }],
 		} as never);
 
 		expect(refreshed.models?.[0]?.id).toBe("qwen3-next:80b");
@@ -64,7 +64,7 @@ describe("ollama cloud auth", () => {
 				refresh: "r",
 				access: "a",
 				expires: Date.now() + 1000,
-				models: [{ id: "gpt-oss:120b", name: "GPT OSS 120B", reasoning: true, input: ["text"], cost: { input: 0, output: 0, cacheRead: 0, cacheWrite: 0 }, contextWindow: 131072, maxTokens: 16384 }],
+				models: [{ id: "gpt-oss:120b", name: "GPT OSS 120B", reasoning: true, input: ["text"], cost: { input: 0, output: 0, cacheRead: 0, cacheWrite: 0 }, contextWindow: 131072, maxTokens: 16384, source: "cloud" }],
 			} as never,
 		);
 

--- a/packages/ollama/tests/models.test.ts
+++ b/packages/ollama/tests/models.test.ts
@@ -1,11 +1,12 @@
 import { afterEach, describe, expect, it } from "vitest";
 import {
 	discoverOllamaCloudModels,
+	discoverOllamaLocalModels,
 	getCredentialModels,
 	getFallbackOllamaCloudModels,
-	toOllamaCloudModel,
+	toOllamaModel,
 } from "../models.js";
-import { createTestOllamaCloudBackend } from "./test-backend.js";
+import { createTestOllamaBackend } from "./test-backend.js";
 
 const envSnapshot = { ...process.env };
 
@@ -18,30 +19,30 @@ afterEach(() => {
 	Object.assign(process.env, envSnapshot);
 });
 
-describe("ollama cloud models", () => {
-	it("returns a fallback catalog", () => {
+describe("ollama models", () => {
+	it("returns a cloud fallback catalog", () => {
 		const models = getFallbackOllamaCloudModels();
 		expect(models.some((model) => model.id === "gpt-oss:120b")).toBe(true);
 		expect(models.some((model) => model.id === "qwen3-vl:235b")).toBe(true);
 	});
 
 	it("normalizes model defaults", () => {
-		const model = toOllamaCloudModel({ id: "gpt-oss:120b", reasoning: true, input: ["text"] });
+		const model = toOllamaModel({ id: "gpt-oss:120b", source: "cloud", reasoning: true, input: ["text"] });
 		const compat = model.compat as { supportsDeveloperRole?: boolean; maxTokensField?: string } | undefined;
 		expect(model.name).toContain("GPT");
 		expect(compat?.supportsDeveloperRole).toBe(false);
 		expect(compat?.maxTokensField).toBe("max_tokens");
 	});
 
-	it("discovers models from the cloud API and uses bearer auth", async () => {
-		const backend = await createTestOllamaCloudBackend();
+	it("discovers cloud models with bearer auth", async () => {
+		const backend = await createTestOllamaBackend();
 		backend.setModels([
 			{ id: "gpt-oss:120b", capabilities: ["completion", "tools", "thinking"], contextWindow: 131072 },
 			{ id: "qwen3-vl:235b", capabilities: ["completion", "tools", "thinking", "vision"], contextWindow: 262144 },
 		]);
 		process.env.PI_OLLAMA_CLOUD_API_URL = backend.apiUrl;
 		process.env.PI_OLLAMA_CLOUD_MODELS_URL = `${backend.apiUrl}/models`;
-		process.env.PI_OLLAMA_CLOUD_SHOW_URL = `${backend.apiUrl.replace(/\/v1$/, "")}/api/show`;
+		process.env.PI_OLLAMA_CLOUD_SHOW_URL = `${backend.origin}/api/show`;
 		const models = await discoverOllamaCloudModels("test-key");
 		expect(models?.map((model) => model.id)).toEqual(["gpt-oss:120b", "qwen3-vl:235b"]);
 		expect(models?.[0]?.reasoning).toBe(true);
@@ -50,12 +51,43 @@ describe("ollama cloud models", () => {
 		await backend.close();
 	});
 
+	it("discovers local models without auth", async () => {
+		const backend = await createTestOllamaBackend();
+		backend.setModels([
+			{ id: "gemma3:4b", capabilities: ["completion", "vision"], contextWindow: 131072 },
+			{ id: "qwen2.5-coder:7b", capabilities: ["completion"], contextWindow: 32768 },
+		]);
+		process.env.OLLAMA_HOST = backend.origin;
+		const models = await discoverOllamaLocalModels();
+		expect(models?.map((model) => model.id)).toEqual(["gemma3:4b", "qwen2.5-coder:7b"]);
+		expect(models?.[0]?.input).toEqual(["text", "image"]);
+		expect(backend.getAuthHeaders()).toEqual(["", "", ""]);
+		await backend.close();
+	});
+
+	it("falls back per model when metadata discovery fails", async () => {
+		const backend = await createTestOllamaBackend();
+		backend.setModels([
+			{ id: "gpt-oss:120b", capabilities: ["completion", "tools", "thinking"], contextWindow: 131072 },
+			{ id: "qwen3-vl:235b", capabilities: ["completion", "tools", "thinking", "vision"], contextWindow: 262144 },
+		]);
+		backend.setRejectedModelShows(["qwen3-vl:235b"]);
+		process.env.PI_OLLAMA_CLOUD_API_URL = backend.apiUrl;
+		process.env.PI_OLLAMA_CLOUD_MODELS_URL = `${backend.apiUrl}/models`;
+		process.env.PI_OLLAMA_CLOUD_SHOW_URL = `${backend.origin}/api/show`;
+		const models = await discoverOllamaCloudModels("test-key");
+		expect(models?.map((model) => model.id)).toEqual(["gpt-oss:120b", "qwen3-vl:235b"]);
+		expect(models?.[1]?.input).toEqual(["text", "image"]);
+		expect(models?.[1]?.reasoning).toBe(true);
+		await backend.close();
+	});
+
 	it("prefers models stored with the login credential", () => {
 		const models = getCredentialModels({
 			refresh: "r",
 			access: "a",
 			expires: Date.now() + 1000,
-			models: [toOllamaCloudModel({ id: "qwen3-next:80b", reasoning: true, input: ["text"], contextWindow: 262144, maxTokens: 32768 })],
+			models: [toOllamaModel({ id: "qwen3-next:80b", source: "cloud", reasoning: true, input: ["text"], contextWindow: 262144, maxTokens: 32768 })],
 		});
 		expect(models).toHaveLength(1);
 		expect(models[0]?.id).toBe("qwen3-next:80b");

--- a/packages/ollama/tests/models.test.ts
+++ b/packages/ollama/tests/models.test.ts
@@ -30,6 +30,7 @@ describe("ollama models", () => {
 		const model = toOllamaModel({ id: "gpt-oss:120b", source: "cloud", reasoning: true, input: ["text"] });
 		const compat = model.compat as { supportsDeveloperRole?: boolean; maxTokensField?: string } | undefined;
 		expect(model.name).toContain("GPT");
+		expect(model.name).toContain("(Cloud)");
 		expect(compat?.supportsDeveloperRole).toBe(false);
 		expect(compat?.maxTokensField).toBe("max_tokens");
 	});
@@ -37,8 +38,8 @@ describe("ollama models", () => {
 	it("discovers cloud models with bearer auth", async () => {
 		const backend = await createTestOllamaBackend();
 		backend.setModels([
-			{ id: "gpt-oss:120b", capabilities: ["completion", "tools", "thinking"], contextWindow: 131072 },
-			{ id: "qwen3-vl:235b", capabilities: ["completion", "tools", "thinking", "vision"], contextWindow: 262144 },
+			{ id: "gpt-oss:120b", capabilities: ["completion", "tools", "thinking"], contextWindow: 131072, family: "gpt-oss", parameterSize: "120B", quantization: "Q4_K_M" },
+			{ id: "qwen3-vl:235b", capabilities: ["completion", "tools", "thinking", "vision"], contextWindow: 262144, family: "qwen3-vl", parameterSize: "235B" },
 		]);
 		process.env.PI_OLLAMA_CLOUD_API_URL = backend.apiUrl;
 		process.env.PI_OLLAMA_CLOUD_MODELS_URL = `${backend.apiUrl}/models`;
@@ -46,6 +47,9 @@ describe("ollama models", () => {
 		const models = await discoverOllamaCloudModels("test-key");
 		expect(models?.map((model) => model.id)).toEqual(["gpt-oss:120b", "qwen3-vl:235b"]);
 		expect(models?.[0]?.reasoning).toBe(true);
+		expect(models?.[0]?.name).toContain("(Cloud)");
+		expect(models?.[0]?.parameterSize).toBe("120B");
+		expect(models?.[0]?.quantization).toBe("Q4_K_M");
 		expect(models?.[1]?.input).toEqual(["text", "image"]);
 		expect(backend.getAuthHeaders().every((header) => header === "Bearer test-key")).toBe(true);
 		await backend.close();
@@ -54,13 +58,15 @@ describe("ollama models", () => {
 	it("discovers local models without auth", async () => {
 		const backend = await createTestOllamaBackend();
 		backend.setModels([
-			{ id: "gemma3:4b", capabilities: ["completion", "vision"], contextWindow: 131072 },
-			{ id: "qwen2.5-coder:7b", capabilities: ["completion"], contextWindow: 32768 },
+			{ id: "gemma3:4b", capabilities: ["completion", "vision"], contextWindow: 131072, family: "gemma3", parameterSize: "4.3B" },
+			{ id: "qwen2.5-coder:7b", capabilities: ["completion"], contextWindow: 32768, family: "qwen2.5-coder", parameterSize: "7B" },
 		]);
 		process.env.OLLAMA_HOST = backend.origin;
 		const models = await discoverOllamaLocalModels();
 		expect(models?.map((model) => model.id)).toEqual(["gemma3:4b", "qwen2.5-coder:7b"]);
+		expect(models?.[0]?.name).toContain("(Local)");
 		expect(models?.[0]?.input).toEqual(["text", "image"]);
+		expect(models?.[0]?.parameterSize).toBe("4.3B");
 		expect(backend.getAuthHeaders()).toEqual(["", "", ""]);
 		await backend.close();
 	});

--- a/packages/ollama/tests/smoke.test.ts
+++ b/packages/ollama/tests/smoke.test.ts
@@ -1,13 +1,15 @@
 import { describe, expect, it } from "vitest";
 import { createExtensionHarness } from "../../../test-utils/extension-runtime-harness.js";
-import ollamaCloudProviderExtension from "../index.js";
+import ollamaProviderExtension from "../index.js";
 
-describe("ollama cloud provider smoke tests", () => {
-	it("registers the ollama cloud provider and command without crashing", () => {
+describe("ollama provider smoke tests", () => {
+	it("registers local + cloud ollama providers and commands without crashing", () => {
 		const harness = createExtensionHarness();
-		ollamaCloudProviderExtension(harness.pi as never);
+		ollamaProviderExtension(harness.pi as never);
 
+		expect(harness.commands.has("ollama")).toBe(true);
 		expect(harness.commands.has("ollama-cloud")).toBe(true);
+		expect(harness.providers.has("ollama")).toBe(true);
 		expect(harness.providers.has("ollama-cloud")).toBe(true);
 	});
 });

--- a/packages/ollama/tests/test-backend.ts
+++ b/packages/ollama/tests/test-backend.ts
@@ -1,18 +1,21 @@
 import http from "node:http";
 import type { AddressInfo } from "node:net";
 
-export interface TestOllamaCloudBackend {
+export interface TestOllamaBackend {
 	apiUrl: string;
+	origin: string;
 	keysUrl: string;
 	setModels(models: Array<{ id: string; capabilities?: string[]; contextWindow?: number }>): void;
 	setRejectAuth(reject: boolean): void;
+	setRejectedModelShows(modelIds: string[]): void;
 	getAuthHeaders(): string[];
 	close(): Promise<void>;
 }
 
-export async function createTestOllamaCloudBackend(): Promise<TestOllamaCloudBackend> {
+export async function createTestOllamaBackend(): Promise<TestOllamaBackend> {
 	let models: Array<{ id: string; capabilities?: string[]; contextWindow?: number }> = [];
 	let rejectAuth = false;
+	let rejectedModelShows = new Set<string>();
 	const authHeaders: string[] = [];
 
 	const server = http.createServer((req, res) => {
@@ -44,6 +47,11 @@ export async function createTestOllamaCloudBackend(): Promise<TestOllamaCloudBac
 			});
 			req.on("end", () => {
 				const parsed = JSON.parse(body || "{}") as { model?: string };
+				if (parsed.model && rejectedModelShows.has(parsed.model)) {
+					res.writeHead(500, { "Content-Type": "text/plain" });
+					res.end("show failed");
+					return;
+				}
 				const match = models.find((model) => model.id === parsed.model);
 				if (!match) {
 					res.writeHead(404, { "Content-Type": "text/plain" });
@@ -78,12 +86,16 @@ export async function createTestOllamaCloudBackend(): Promise<TestOllamaCloudBac
 
 	return {
 		apiUrl: `${origin}/v1`,
+		origin,
 		keysUrl: `${origin}/settings/keys`,
 		setModels(nextModels) {
 			models = nextModels;
 		},
 		setRejectAuth(reject) {
 			rejectAuth = reject;
+		},
+		setRejectedModelShows(modelIds) {
+			rejectedModelShows = new Set(modelIds);
 		},
 		getAuthHeaders() {
 			return [...authHeaders];

--- a/packages/ollama/tests/test-backend.ts
+++ b/packages/ollama/tests/test-backend.ts
@@ -5,7 +5,7 @@ export interface TestOllamaBackend {
 	apiUrl: string;
 	origin: string;
 	keysUrl: string;
-	setModels(models: Array<{ id: string; capabilities?: string[]; contextWindow?: number }>): void;
+	setModels(models: Array<{ id: string; capabilities?: string[]; contextWindow?: number; family?: string; parameterSize?: string; quantization?: string }>): void;
 	setRejectAuth(reject: boolean): void;
 	setRejectedModelShows(modelIds: string[]): void;
 	getAuthHeaders(): string[];
@@ -13,7 +13,7 @@ export interface TestOllamaBackend {
 }
 
 export async function createTestOllamaBackend(): Promise<TestOllamaBackend> {
-	let models: Array<{ id: string; capabilities?: string[]; contextWindow?: number }> = [];
+	let models: Array<{ id: string; capabilities?: string[]; contextWindow?: number; family?: string; parameterSize?: string; quantization?: string }> = [];
 	let rejectAuth = false;
 	let rejectedModelShows = new Set<string>();
 	const authHeaders: string[] = [];
@@ -64,6 +64,11 @@ export async function createTestOllamaBackend(): Promise<TestOllamaBackend> {
 					JSON.stringify({
 						capabilities: match.capabilities ?? ["completion", "tools"],
 						model_info: { [`${family}.context_length`]: match.contextWindow ?? 131072 },
+						details: {
+							family: match.family ?? family,
+							parameter_size: match.parameterSize ?? undefined,
+							quantization_level: match.quantization ?? undefined,
+						},
 					}),
 				);
 			});

--- a/scripts/package-classes.mjs
+++ b/scripts/package-classes.mjs
@@ -18,7 +18,7 @@ export const publishedPackages = [
 	{ name: "@ifi/pi-plan", dir: "packages/plan" },
 	{ name: "@ifi/pi-spec", dir: "packages/spec" },
 	{ name: "@ifi/pi-provider-cursor", dir: "packages/cursor" },
-	{ name: "@ifi/pi-provider-ollama-cloud", dir: "packages/ollama" },
+	{ name: "@ifi/pi-provider-ollama", dir: "packages/ollama" },
 	{ name: "@ifi/pi-web-remote", dir: "packages/web-remote" },
 	{ name: "@ifi/oh-pi", dir: "packages/oh-pi" },
 ];


### PR DESCRIPTION
## Summary
- rename the experimental Ollama package to `@ifi/pi-provider-ollama` and support both local and cloud providers
- add a unified `/ollama` workflow for refreshing local + cloud catalogs and inspecting model metadata
- extend `/usage` and `usage_report` with best-effort Ollama local/cloud status and any exposed rate-limit headers

## Testing
- pnpm docs:check
- pnpm lint
- pnpm security:check
- pnpm typecheck
- pnpm build
- pnpm test