### PR TITLE
feat(extensions): add adaptive routing mode

### DIFF
--- a/.changeset/add-adaptive-routing-mode.md
+++ b/.changeset/add-adaptive-routing-mode.md
@@ -1,0 +1,5 @@
+---
+default: minor
+---
+
+feat: add adaptive routing mode with shadow mode, local telemetry, and usage-aware model selection

--- a/README.md
+++ b/README.md
@@ -258,6 +258,31 @@ Agent: bash npm run dev
 
 **Commands:** `bg_status list` | `bg_status log --pid 12345` | `bg_status stop --pid 12345`
 
+### 🧭 Adaptive Routing (`adaptive-routing`) — **default: off**
+
+Lets pi operate in a model-agnostic mode by choosing a model and thinking level per prompt based on
+prompt shape, user preferences, live provider headroom, and local fallback policy.
+
+**Key ideas:**
+
+- `shadow` mode suggests a route without changing the current model
+- `auto` mode applies the selected route before the turn starts
+- premium providers can be protected with reserve thresholds
+- route decisions, disagreements, and feedback are stored locally under shared pi storage
+- routed premium fallbacks can include future providers like Cursor when installed
+
+**Commands:**
+
+- `/route status`
+- `/route shadow`
+- `/route auto`
+- `/route off`
+- `/route explain`
+- `/route lock`
+- `/route unlock`
+- `/route feedback <category>`
+- `/route stats`
+
 ### 💰 Usage Tracker (`usage-tracker`) — **default: off**
 
 <!-- {=extensionsUsageTrackerOverview} -->

--- a/docs/plans/adaptive-routing-mode.md
+++ b/docs/plans/adaptive-routing-mode.md
@@ -1,0 +1,531 @@
+# Adaptive Routing Mode Spec
+
+> Goal: let pi operate in a model-agnostic mode where each user prompt is routed to the most appropriate available model and thinking level based on task complexity, task type, user preferences, and remaining provider headroom.
+
+## 1. Problem Statement
+
+Heavy coding workflows increasingly span multiple providers with different strengths, quotas, rate limits, and hidden usage policies. Users are forced to manually guess:
+
+- which model is appropriate for a task
+- how much thinking effort is justified
+- when a premium provider is too depleted to spend on the current task
+- when a comparable fallback from a different provider should be used instead
+
+This guesswork creates three recurring problems:
+
+1. **Wasted premium capacity** — expensive models get used for work that cheaper models could complete.
+2. **Bad manual routing overhead** — the user must repeatedly switch models and thinking levels mid-session.
+3. **Quota cliff failures** — a preferred provider runs low unexpectedly and the session does not smoothly move to the nearest equivalent alternative.
+
+## 2. Product Thesis
+
+Adaptive Routing Mode should treat model selection as a **user-owned policy system**, not a fully autonomous black box.
+
+The system should use a **cheap classifier model** to estimate task characteristics, but the final route must be chosen by a **deterministic local routing engine** that applies:
+
+- user rankings and preferences
+- live model availability from the current pi instance
+- logged-in provider state
+- model capability metadata
+- remaining provider quota / rate-limit headroom
+- specialty bias (for example, design vs. peak reasoning)
+
+## 3. Goals
+
+### Primary goals
+
+- Add an opt-in routing mode that automatically selects model and thinking level per prompt.
+- Minimize unnecessary premium model usage while preserving quality on hard tasks.
+- Prefer the user’s ranked models while gracefully falling back when quota is low or unavailable.
+- Make routing explainable enough that the user can trust and override it.
+
+### Secondary goals
+
+- Reuse existing pi / oh-pi primitives where possible:
+  - `ctx.modelRegistry.getAvailable()`
+  - `pi.setModel(...)`
+  - `pi.setThinkingLevel(...)`
+  - usage-tracker provider windows and cost data
+- Leave room for future providers such as Cursor without redesigning the router.
+- Establish an evaluation harness so routing quality can improve over time.
+
+## 4. Non-Goals (v1)
+
+- No mid-stream or mid-turn model switching.
+- No fully learned router trained on historical traces.
+- No subagent or ant-colony routing in the first release.
+- No attempt to fabricate exact quota data for providers that only expose estimated or opaque usage.
+- No silent hidden routing with zero explanation.
+
+## 5. User Experience
+
+### Core interaction
+
+When Adaptive Routing Mode is enabled and the user submits a prompt:
+
+1. A cheap routing classifier analyzes the prompt.
+2. The classifier returns structured task metadata.
+3. A deterministic local policy engine picks:
+   - the primary model
+   - the thinking level
+   - ordered fallback candidates
+4. The router applies the chosen model and thinking level before agent execution starts.
+5. The UI exposes the decision and the reason.
+
+### User promises
+
+The user should be able to understand:
+
+- what model was chosen
+- why it was chosen
+- what fallback would be used next
+- whether the decision was based on authoritative quota data, estimated quota data, or no quota data
+
+### Expected commands / controls
+
+Adaptive Routing Mode should eventually expose:
+
+- `/route on`
+- `/route off`
+- `/route status`
+- `/route explain`
+- `/route lock`
+- `/route unlock`
+- `/route refresh`
+- `/route feedback good|bad`
+
+## 6. Routing Architecture
+
+## 6.1 Two-stage routing
+
+### Stage A — cheap prompt classification
+
+A low-cost router model classifies the prompt into structured fields such as:
+
+- `intent`
+- `complexity`
+- `risk`
+- `expectedTurns`
+- `toolIntensity`
+- `contextBreadth`
+- `recommendedTier`
+- `recommendedThinking`
+- `confidence`
+- `reason`
+
+The classifier must not directly choose the final model. It only produces structured metadata.
+
+### Stage B — deterministic policy engine
+
+The local router computes the final route using:
+
+- classifier output
+- current model registry availability
+- user preference config
+- provider quota headroom
+- fallback policies
+- model specialty tags
+- thinking support and clamping rules
+
+This stage outputs:
+
+- selected model
+- selected thinking level
+- fallback chain
+- explanation payload
+
+## 6.2 Why deterministic final routing
+
+The router must remain debuggable and user-controllable. The classifier is allowed to estimate task shape, but user policy must decide final model selection. This avoids hidden model roulette and makes the system testable.
+
+## 7. Routing Inputs
+
+### 7.1 Runtime inputs
+
+The router should consume:
+
+- available models from `ctx.modelRegistry.getAvailable()`
+- current selected model / thinking level
+- provider auth availability
+- usage-tracker snapshots via `pi.events` (`usage:query` / `usage:limits`)
+- optional sticky-session state
+
+### 7.2 Model capability inputs
+
+Each candidate model should be normalized into a routing capability record containing at least:
+
+- provider id
+- model id
+- full name
+- reasoning support
+- max supported thinking level
+- context window
+- cost metadata if known
+- task specialty tags
+- provider family / fallback group
+- quota confidence (`authoritative | estimated | unknown`)
+
+### 7.3 User preference inputs
+
+The user should be able to define:
+
+- a global ranked list of preferred models
+- task-intent overrides (for example, design prefers Claude)
+- premium reserve thresholds per provider
+- router classifier model candidates
+- default thinking preferences by task tier
+- sticky routing behavior
+- opt-out model lists
+
+## 8. Classification Schema
+
+The routing classifier should emit strict JSON with a schema like:
+
+```json
+{
+  "intent": "design",
+  "complexity": 4,
+  "risk": "high",
+  "expectedTurns": "few",
+  "toolIntensity": "medium",
+  "contextBreadth": "medium",
+  "recommendedTier": "premium",
+  "recommendedThinking": "high",
+  "confidence": 0.82,
+  "reason": "Design-heavy judgment task with likely iteration."
+}
+```
+
+## 9. Routing Policy
+
+## 9.1 Candidate scoring
+
+Each eligible model should receive a weighted score based on:
+
+- user ranking
+- intent affinity
+- complexity fit
+- thinking support fit
+- provider reserve status
+- quota headroom
+- recent provider errors / rate limits
+- current-model stickiness bonus
+- explicit task overrides
+
+## 9.2 Provider reserve rules
+
+The router should support rules like:
+
+- preserve at least N% of OpenAI premium headroom for peak tasks
+- preserve at least N% of Anthropic premium headroom for design tasks
+- stop spending a provider when it has crossed a configured reserve threshold unless the task is marked peak-critical
+
+## 9.3 Fallback groups
+
+The router should support semantic fallback groups, for example:
+
+- `peak-reasoning`: GPT 5.4 ↔ Claude Opus 4.6 ↔ future Cursor premium model
+- `design-premium`: Claude Opus 4.6 ↔ GPT 5.4
+- `standard-coding`: Claude Sonnet ↔ GPT mini / balanced GPT tier
+- `cheap-router`: Gemini Flash ↔ GPT mini
+
+## 9.4 Thinking-level selection
+
+Thinking level should be selected separately from model choice and then clamped to model/provider support:
+
+- `off`
+- `minimal`
+- `low`
+- `medium`
+- `high`
+- `xhigh`
+
+If a selected model does not support the requested level, the router must clamp and record that in the explanation.
+
+## 10. Quota / Usage Semantics
+
+The router must distinguish:
+
+### Authoritative quota
+
+Real provider window data from usage-tracker or provider APIs.
+
+### Estimated quota
+
+Best-effort usage heuristics where the provider does not expose an authoritative remaining budget.
+
+### Unknown quota
+
+No reliable quota signal is available.
+
+The UI and explanation payload must expose this confidence level explicitly.
+
+## 11. Integration Plan
+
+## 11.1 v1 integration points
+
+- `before_agent_start` hook to apply routing before the agent loop begins
+- `/route` commands for status and control
+- usage-tracker event integration for provider windows and costs
+- footer / status overlay visibility for route decisions
+- a shadow mode that suggests routes before auto-applying them
+
+## 11.2 Future integration points
+
+- subagent default routing
+- ant-colony caste/model routing
+- Cursor provider participation
+- user feedback loop and offline policy tuning
+
+## 12. Configuration Shape (Draft)
+
+```json
+{
+  "enabled": false,
+  "mode": "shadow",
+  "routerModels": [
+    "google/gemini-2.5-flash",
+    "openai/gpt-5-mini"
+  ],
+  "stickyTurns": 1,
+  "telemetry": {
+    "mode": "local",
+    "privacy": "minimal"
+  },
+  "providerReserves": {
+    "openai": { "minRemainingPct": 15 },
+    "anthropic": { "minRemainingPct": 15 },
+    "cursor-agent": { "minRemainingPct": 20, "confidence": "estimated" }
+  },
+  "intentOverrides": {
+    "design": [
+      "anthropic/claude-opus-4.6",
+      "openai/gpt-5.4"
+    ],
+    "architecture": [
+      "openai/gpt-5.4",
+      "anthropic/claude-opus-4.6"
+    ]
+  },
+  "taskClasses": {
+    "quick": {
+      "defaultThinking": "minimal",
+      "candidates": [
+        "google/gemini-2.5-flash",
+        "openai/gpt-5-mini"
+      ]
+    },
+    "design-premium": {
+      "defaultThinking": "high",
+      "candidates": [
+        "anthropic/claude-opus-4.6",
+        "openai/gpt-5.4"
+      ]
+    },
+    "peak": {
+      "defaultThinking": "xhigh",
+      "candidates": [
+        "openai/gpt-5.4",
+        "anthropic/claude-opus-4.6",
+        "cursor-agent/<best-available>"
+      ]
+    }
+  }
+}
+```
+
+## 13. Correctness and Evaluation Strategy
+
+Adaptive Routing Mode must measure correctness at three distinct layers:
+
+1. **Classifier correctness** — did the cheap model estimate task shape reasonably?
+2. **Routing correctness** — given the task estimate and runtime inputs, did the policy engine choose the right model and thinking level?
+3. **Outcome correctness** — did the selected route help the user finish successfully with less unnecessary premium spend?
+
+These layers must be measured separately because a classifier can be imperfect while the policy still recovers, and a reasonable route can still produce a bad outcome.
+
+## 13.1 Offline evaluation corpus
+
+The router should maintain a labeled prompt corpus covering realistic coding workflows. Each fixture should capture:
+
+- prompt text or a privacy-safe canonicalized form
+- expected intent
+- expected complexity bucket
+- expected risk level
+- preferred model tier
+- preferred thinking level
+- acceptable fallback alternatives
+
+The corpus should support:
+
+- classifier field accuracy
+- near-match vs unacceptable mismatch analysis
+- policy-engine route regression checks
+- future tuning without shipping personal user data in the repository
+
+## 13.2 Shadow mode
+
+The first practical rollout should include a **shadow mode** where the router computes and explains a suggested route but does not automatically apply it.
+
+Shadow mode exists to answer:
+
+- how often does the router agree with the user’s manual choice?
+- where does it disagree?
+- are disagreements concentrated around certain intents, providers, or thinking levels?
+
+Shadow mode should log disagreement events locally so the router can be tuned before aggressive automation becomes the default.
+
+## 13.3 Correctness signals
+
+### Explicit feedback
+
+The router should support explicit feedback because it is the cleanest signal available. Useful categories include:
+
+- `good`
+- `bad`
+- `wrong-intent`
+- `overkill`
+- `underpowered`
+- `wrong-provider`
+- `wrong-thinking`
+
+### Implicit signals
+
+The router may also use local implicit signals, but these are weaker and must be treated carefully. Examples include:
+
+- immediate manual model switch after a route decision
+- immediate thinking-level increase after a route decision
+- repeated retries of the same task after a weak result
+- escalation from a cheap route to a premium route
+- unusually high turn counts for a supposedly easy task
+
+Implicit signals should inform diagnostics and tuning, but should not be treated as ground truth without corroboration.
+
+## 14. Telemetry and Privacy Strategy
+
+Telemetry should be **local-first, opt-in, and privacy-preserving**.
+
+The default design should avoid repo pollution and store router telemetry in shared pi storage under the user agent directory.
+
+## 14.1 Telemetry modes
+
+Supported modes should be:
+
+- `off` — no persisted router telemetry
+- `local` — local-only event logs and aggregates under shared pi storage
+- `export` — local collection plus explicit user-triggered export of redacted traces
+
+Remote collection should not be part of the initial design.
+
+## 14.2 Privacy levels
+
+Supported privacy levels should be:
+
+- `minimal` — no raw prompt storage; only hashes and structured route metadata
+- `redacted` — redacted summaries or snippets where feasible
+- `full-local` — raw prompt content stored locally only when explicitly enabled
+
+The default should favor `local` telemetry with `minimal` privacy.
+
+## 14.3 Local telemetry storage
+
+Example storage layout:
+
+- `~/.pi/agent/adaptive-routing/events.jsonl`
+- `~/.pi/agent/adaptive-routing/aggregates.json`
+- `~/.pi/agent/adaptive-routing/evals/`
+
+## 14.4 Suggested event types
+
+The telemetry model should support events like:
+
+- `route_decision`
+- `route_override`
+- `route_feedback`
+- `route_outcome`
+- `route_shadow_disagreement`
+
+A route decision event should include enough information to distinguish classifier error from policy error, including:
+
+- classifier output
+- selected route
+- top candidate scores
+- fallback chain
+- quota confidence state
+- explanation codes
+
+## 14.5 Tuning from telemetry
+
+Telemetry should initially be used for:
+
+- route disagreement reports
+- override-rate analysis
+- premium overuse / underuse analysis
+- per-intent failure clustering
+- user-approved config suggestions
+
+The first tuning system should recommend config changes rather than silently self-modifying policy.
+
+## 15. Acceptance Criteria
+
+### v1 acceptance
+
+- The mode can be enabled and disabled without restarting pi.
+- A prompt entered in routing mode chooses both a model and a thinking level before execution.
+- The chosen route respects available models in the current pi instance.
+- The chosen route prefers configured user rankings and intent overrides.
+- The chosen route responds to live provider headroom when usage-tracker data is available.
+- The system exposes a human-readable explanation of the decision.
+- Manual override remains possible at any time.
+- Shadow mode can suggest routes without auto-applying them.
+
+### quality acceptance
+
+- The user should need to manually override fewer prompts over time.
+- Premium usage should drop for low-complexity work.
+- Peak-quality tasks should still route to premium models when warranted.
+- Route disagreement and feedback data should make misrouting patterns diagnosable locally.
+
+## 16. Risks
+
+- Misclassification from the cheap classifier can route tasks too low.
+- Aggressive reserve policies can over-conserve premium capacity and hurt quality.
+- Opaque “unlimited” plans do not expose exact remaining usage, so confidence labeling is critical.
+- Too much hidden automation will reduce trust even if the routing is technically correct.
+- Implicit telemetry can be noisy and should not be mistaken for ground truth.
+- Over-collecting prompt data would create privacy risks and damage trust.
+
+## 17. Rollout Strategy
+
+### Phase 1
+
+- spec + config schema + pure local decision engine
+
+### Phase 2
+
+- evaluation corpus + cheap classifier integration
+
+### Phase 3
+
+- shadow mode + route disagreement logging
+
+### Phase 4
+
+- interactive routing mode in the main session UI
+
+### Phase 5
+
+- usage-aware fallback tuning + local telemetry reports + feedback-driven tuning
+
+### Phase 6
+
+- subagents / ant-colony / Cursor expansion
+
+## 18. Open Questions
+
+- Which cheap router model should be the default for classification?
+- Should route decisions be sticky for one turn, a whole task, or until manual unlock?
+- Should “design” and “architecture” be hard-coded starter intents or fully user-configurable from day one?
+- How should the router behave when usage-tracker data is stale but still cached?
+- Which implicit signals are strong enough to surface in reports but weak enough to keep out of automatic policy changes?
+- Should user-approved tuning suggestions edit router config directly or generate reviewable proposals first?

--- a/packages/extensions/README.md
+++ b/packages/extensions/README.md
@@ -5,6 +5,7 @@ Core first-party extensions for pi.
 ## Included extensions
 
 This package includes extensions such as:
+- adaptive-routing / route
 - safe-guard
 - git-guard
 - auto-session-name
@@ -32,7 +33,29 @@ npx @ifi/oh-pi
 ## What it provides
 
 These extensions add commands, tools, UI widgets, safety checks, background process handling,
-usage monitoring, scheduling features, and runtime performance protection (`/watchdog`, `/safe-mode`) to pi.
+usage monitoring, adaptive model routing, scheduling features, and runtime performance protection (`/watchdog`, `/safe-mode`) to pi.
+
+## Adaptive routing
+
+Adaptive routing adds a user-friendly `/route` command set and an opt-in model-agnostic mode that can:
+
+- classify prompts with a cheap router model
+- choose model and thinking level before a turn starts
+- respect provider reserve thresholds and fallback groups
+- suggest routes in shadow mode before automatically applying them
+- persist local-only telemetry and feedback under shared pi storage
+
+Key commands:
+
+- `/route status`
+- `/route shadow`
+- `/route auto`
+- `/route off`
+- `/route explain`
+- `/route lock`
+- `/route unlock`
+- `/route feedback <category>`
+- `/route stats`
 
 ## Scheduler follow-ups
 

--- a/packages/extensions/extensions/adaptive-routing.ts
+++ b/packages/extensions/extensions/adaptive-routing.ts
@@ -1,0 +1,3 @@
+import adaptiveRoutingExtension from "./adaptive-routing/index.js";
+
+export default adaptiveRoutingExtension;

--- a/packages/extensions/extensions/adaptive-routing/adaptive-routing.test.ts
+++ b/packages/extensions/extensions/adaptive-routing/adaptive-routing.test.ts
@@ -1,0 +1,149 @@
+import { mkdirSync, mkdtempSync, rmSync, writeFileSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import { createExtensionHarness } from "../../../../test-utils/extension-runtime-harness.js";
+
+const { getAgentDir } = vi.hoisted(() => ({
+	getAgentDir: vi.fn(() => "/mock-home/.pi/agent"),
+}));
+
+vi.mock("@mariozechner/pi-coding-agent", async () => {
+	const actual = await vi.importActual<typeof import("@mariozechner/pi-coding-agent")>("@mariozechner/pi-coding-agent");
+	return {
+		...actual,
+		getAgentDir,
+	};
+});
+
+vi.mock("@mariozechner/pi-ai", async () => {
+	const actual = await vi.importActual<typeof import("@mariozechner/pi-ai")>("@mariozechner/pi-ai");
+	return {
+		...actual,
+		completeSimple: vi.fn(async () => ({
+			role: "assistant",
+			content: [
+				{
+					type: "text",
+					text: JSON.stringify({
+						intent: "design",
+						complexity: 4,
+						risk: "high",
+						expectedTurns: "few",
+						toolIntensity: "medium",
+						contextBreadth: "medium",
+						recommendedTier: "premium",
+						recommendedThinking: "high",
+						confidence: 0.91,
+						reason: "Design-heavy task.",
+					}),
+				},
+			],
+			api: "openai-responses",
+			provider: "openai",
+			model: "gpt-5-mini",
+			usage: {
+				input: 0,
+				output: 0,
+				cacheRead: 0,
+				cacheWrite: 0,
+				totalTokens: 0,
+				cost: { input: 0, output: 0, cacheRead: 0, cacheWrite: 0, total: 0 },
+			},
+			stopReason: "stop",
+			timestamp: Date.now(),
+		})),
+	};
+});
+
+import adaptiveRoutingExtension from "../adaptive-routing.js";
+
+function sampleModel(provider: string, id: string, name = id) {
+	return {
+		provider,
+		id,
+		name,
+		api:
+			provider === "anthropic"
+				? "anthropic-messages"
+				: provider === "google"
+					? "google-generative-ai"
+					: "openai-responses",
+		baseUrl: "https://example.com",
+		reasoning: true,
+		input: ["text"],
+		cost: { input: 1, output: 1, cacheRead: 0, cacheWrite: 0 },
+		contextWindow: 200000,
+		maxTokens: 32768,
+	};
+}
+
+describe("adaptive routing extension", () => {
+	let tempAgentDir: string;
+
+	beforeEach(() => {
+		tempAgentDir = mkdtempSync(join(tmpdir(), "adaptive-routing-ext-"));
+		getAgentDir.mockReturnValue(tempAgentDir);
+		mkdirSync(join(tempAgentDir, "extensions", "adaptive-routing"), { recursive: true });
+	});
+
+	afterEach(() => {
+		rmSync(tempAgentDir, { recursive: true, force: true });
+		vi.clearAllMocks();
+	});
+
+	it("registers route commands and auto-applies a routed premium model", async () => {
+		writeFileSync(
+			join(tempAgentDir, "extensions", "adaptive-routing", "config.json"),
+			`${JSON.stringify({ mode: "auto", models: { ranked: ["anthropic/claude-opus-4.6"] } }, null, 2)}\n`,
+		);
+		const harness = createExtensionHarness();
+		harness.ctx.model = sampleModel("google", "gemini-2.5-flash", "Gemini 2.5 Flash") as never;
+		harness.ctx.modelRegistry = {
+			getAvailable: () => [
+				sampleModel("google", "gemini-2.5-flash", "Gemini 2.5 Flash"),
+				sampleModel("anthropic", "claude-opus-4.6", "Claude Opus 4.6"),
+				sampleModel("openai", "gpt-5.4", "GPT-5.4"),
+			],
+			getApiKey: async () => "key",
+		} as never;
+
+		adaptiveRoutingExtension(harness.pi as never);
+		expect(harness.commands.has("route")).toBe(true);
+
+		await harness.emitAsync(
+			"before_agent_start",
+			{ type: "before_agent_start", prompt: "Design a better settings page UI.", systemPrompt: "system" },
+			harness.ctx,
+		);
+
+		expect(harness.ctx.model).toMatchObject({ provider: "anthropic", id: "claude-opus-4.6" });
+		expect(harness.statusMap.get("adaptive-routing")).toContain("auto");
+	});
+
+	it("suggests a route in shadow mode without changing the active model", async () => {
+		writeFileSync(
+			join(tempAgentDir, "extensions", "adaptive-routing", "config.json"),
+			`${JSON.stringify({ mode: "shadow" }, null, 2)}\n`,
+		);
+		const harness = createExtensionHarness();
+		harness.ctx.model = sampleModel("google", "gemini-2.5-flash", "Gemini 2.5 Flash") as never;
+		harness.ctx.modelRegistry = {
+			getAvailable: () => [
+				sampleModel("google", "gemini-2.5-flash", "Gemini 2.5 Flash"),
+				sampleModel("anthropic", "claude-opus-4.6", "Claude Opus 4.6"),
+			],
+			getApiKey: async () => "key",
+		} as never;
+
+		adaptiveRoutingExtension(harness.pi as never);
+		await harness.emitAsync(
+			"before_agent_start",
+			{ type: "before_agent_start", prompt: "Design a better settings page UI.", systemPrompt: "system" },
+			harness.ctx,
+		);
+
+		expect(harness.ctx.model).toMatchObject({ provider: "google", id: "gemini-2.5-flash" });
+		expect(harness.notifications.some((item) => item.msg.includes("Adaptive route suggestion"))).toBe(true);
+	});
+});

--- a/packages/extensions/extensions/adaptive-routing/classifier.ts
+++ b/packages/extensions/extensions/adaptive-routing/classifier.ts
@@ -1,0 +1,258 @@
+import type { Api, AssistantMessage, Model } from "@mariozechner/pi-ai";
+import { completeSimple } from "@mariozechner/pi-ai";
+import type { ExtensionContext } from "@mariozechner/pi-coding-agent";
+import { buildFallbackClassification } from "./engine.js";
+import { matchesModelRef } from "./normalize.js";
+import type {
+	AdaptiveRoutingConfig,
+	NormalizedRouteCandidate,
+	PromptRouteClassification,
+	RouteIntent,
+	RouteThinkingLevel,
+} from "./types.js";
+
+export async function classifyPrompt(
+	prompt: string,
+	config: AdaptiveRoutingConfig,
+	ctx: Pick<ExtensionContext, "modelRegistry">,
+	candidates: NormalizedRouteCandidate[],
+): Promise<PromptRouteClassification> {
+	const heuristic = classifyPromptHeuristically(prompt);
+	const routerModel = pickRouterModel(config.routerModels, candidates);
+	if (!routerModel) {
+		return heuristic;
+	}
+
+	const apiKey = await resolveApiKey(routerModel.model, ctx);
+	if (!apiKey) {
+		return heuristic;
+	}
+
+	try {
+		const response = await completeSimple(
+			routerModel.model,
+			{
+				systemPrompt:
+					"You classify coding-agent prompts. Return strict JSON only with keys: intent, complexity, risk, expectedTurns, toolIntensity, contextBreadth, recommendedTier, recommendedThinking, confidence, reason. Use only allowed values. Keep reason short.",
+				messages: [
+					{
+						role: "user",
+						content: [{ type: "text", text: buildClassifierPrompt(prompt) }],
+						timestamp: Date.now(),
+					},
+				],
+			},
+			{
+				apiKey,
+				reasoning: routerModel.reasoning ? "minimal" : undefined,
+			},
+		);
+
+		const parsed = parseClassifierResponse(extractAnswer(response));
+		if (!parsed) {
+			return {
+				...heuristic,
+				reason: `${heuristic.reason} (classifier fallback)`,
+				classifierMode: "heuristic",
+			};
+		}
+		return {
+			...parsed,
+			classifierMode: "llm",
+			classifierModel: routerModel.fullId,
+		};
+	} catch {
+		return {
+			...heuristic,
+			reason: `${heuristic.reason} (classifier unavailable)`,
+			classifierMode: "heuristic",
+		};
+	}
+}
+
+export function classifyPromptHeuristically(prompt: string): PromptRouteClassification {
+	const text = prompt.toLowerCase();
+	const intent = detectIntent(text);
+	const complexity = detectComplexity(text, intent);
+	const recommendedTier = detectTier(intent, complexity);
+	const recommendedThinking = detectThinking(recommendedTier, intent);
+
+	return {
+		intent,
+		complexity,
+		risk: intent === "quick-qna" ? "low" : complexity >= 4 ? "high" : "medium",
+		expectedTurns: intent === "quick-qna" ? "one" : complexity >= 4 ? "many" : "few",
+		toolIntensity: ["implementation", "debugging", "refactor", "autonomous"].includes(intent)
+			? "high"
+			: intent === "quick-qna"
+				? "low"
+				: "medium",
+		contextBreadth: complexity >= 4 || intent === "architecture" ? "large" : complexity >= 3 ? "medium" : "small",
+		recommendedTier,
+		recommendedThinking,
+		confidence: 0.5,
+		reason: `heuristic ${intent} classification`,
+		classifierMode: "heuristic",
+	};
+}
+
+function detectIntent(text: string): RouteIntent {
+	if (/(design|ui|ux|layout|visual|styling|theme|color|aesthetic)/.test(text)) {
+		return "design";
+	}
+	if (/(architecture|system design|tradeoff|approach|deep refactor|cross-cutting)/.test(text)) {
+		return "architecture";
+	}
+	if (/(debug|failing|error|stack trace|why is|broken|fix)/.test(text)) {
+		return "debugging";
+	}
+	if (/(review|audit|look over|inspect this change|code review)/.test(text)) {
+		return "review";
+	}
+	if (/(refactor|clean up|restructure)/.test(text)) {
+		return "refactor";
+	}
+	if (/(plan|roadmap|spec|outline|break down|approach this)/.test(text)) {
+		return "planning";
+	}
+	if (/(research|investigate|compare|look up|search)/.test(text)) {
+		return "research";
+	}
+	if (/(autonomous|work through|handle all of|keep going until)/.test(text)) {
+		return "autonomous";
+	}
+	if (/(implement|build|add|create|wire up|integrate)/.test(text)) {
+		return "implementation";
+	}
+	return text.split(/\s+/).length < 18 ? "quick-qna" : "implementation";
+}
+
+function detectComplexity(text: string, intent: RouteIntent): 1 | 2 | 3 | 4 | 5 {
+	let score = 1;
+	const length = text.split(/\s+/).length;
+	if (length > 20) {
+		score += 1;
+	}
+	if (length > 50) {
+		score += 1;
+	}
+	if (/(multiple|across|migration|all of these|thoroughly|deeply|telemetry|fallback|quota|policy)/.test(text)) {
+		score += 1;
+	}
+	if (["architecture", "autonomous", "design"].includes(intent)) {
+		score += 1;
+	}
+	return Math.min(score, 5) as 1 | 2 | 3 | 4 | 5;
+}
+
+function detectTier(intent: RouteIntent, complexity: number) {
+	if (intent === "quick-qna" && complexity <= 2) {
+		return "cheap" as const;
+	}
+	if ((intent === "design" || intent === "architecture" || intent === "autonomous") && complexity >= 4) {
+		return "peak" as const;
+	}
+	if (complexity >= 4 || intent === "debugging" || intent === "refactor") {
+		return "premium" as const;
+	}
+	return complexity <= 2 ? ("cheap" as const) : ("balanced" as const);
+}
+
+function detectThinking(tier: PromptRouteClassification["recommendedTier"], intent: RouteIntent): RouteThinkingLevel {
+	if (tier === "cheap") {
+		return "minimal";
+	}
+	if (tier === "balanced") {
+		return "medium";
+	}
+	if (tier === "premium") {
+		return intent === "design" ? "high" : "high";
+	}
+	return "xhigh";
+}
+
+function pickRouterModel(
+	routerModels: string[],
+	candidates: NormalizedRouteCandidate[],
+): NormalizedRouteCandidate | undefined {
+	for (const ref of routerModels) {
+		const match = candidates.find((candidate) => matchesModelRef(ref, candidate));
+		if (match) {
+			return match;
+		}
+	}
+	return candidates.find((candidate) => candidate.tier === "cheap") ?? candidates[0];
+}
+
+async function resolveApiKey(
+	model: Model<Api>,
+	ctx: Pick<ExtensionContext, "modelRegistry">,
+): Promise<string | undefined> {
+	const registry = ctx.modelRegistry as ExtensionContext["modelRegistry"] & {
+		getApiKeyForProvider?: (provider: string) => Promise<string | undefined>;
+		authStorage?: { getApiKey?: (provider: string) => Promise<string | undefined> };
+	};
+	if (typeof registry.getApiKey === "function") {
+		return registry.getApiKey(model);
+	}
+	if (typeof registry.getApiKeyForProvider === "function") {
+		return registry.getApiKeyForProvider(model.provider);
+	}
+	if (typeof registry.authStorage?.getApiKey === "function") {
+		return registry.authStorage.getApiKey(model.provider);
+	}
+	return undefined;
+}
+
+function buildClassifierPrompt(prompt: string): string {
+	return [
+		"Classify this coding-agent prompt.",
+		"Allowed intent values: quick-qna, planning, research, implementation, debugging, design, architecture, review, refactor, autonomous.",
+		"Allowed complexity values: 1, 2, 3, 4, 5.",
+		"Allowed risk values: low, medium, high.",
+		"Allowed expectedTurns values: one, few, many.",
+		"Allowed toolIntensity values: low, medium, high.",
+		"Allowed contextBreadth values: small, medium, large.",
+		"Allowed recommendedTier values: cheap, balanced, premium, peak.",
+		"Allowed recommendedThinking values: off, minimal, low, medium, high, xhigh.",
+		"Return JSON only.",
+		`Prompt: ${prompt}`,
+	].join("\n");
+}
+
+function parseClassifierResponse(text: string): PromptRouteClassification | undefined {
+	try {
+		const match = text.match(/\{[\s\S]*\}/);
+		if (!match) {
+			return undefined;
+		}
+		const parsed = JSON.parse(match[0]) as Partial<PromptRouteClassification>;
+		if (!(parsed.intent && parsed.recommendedTier && parsed.recommendedThinking)) {
+			return undefined;
+		}
+		return {
+			...buildFallbackClassification(parsed.intent),
+			...parsed,
+			confidence: clampConfidence(parsed.confidence),
+			reason: typeof parsed.reason === "string" && parsed.reason.trim() ? parsed.reason.trim() : "llm classification",
+		};
+	} catch {
+		return undefined;
+	}
+}
+
+function extractAnswer(message: AssistantMessage): string {
+	return message.content
+		.filter((part): part is Extract<AssistantMessage["content"][number], { type: "text" }> => part.type === "text")
+		.map((part) => part.text)
+		.join("")
+		.trim();
+}
+
+function clampConfidence(value: unknown): number {
+	const parsed = Number(value);
+	if (!Number.isFinite(parsed)) {
+		return 0.65;
+	}
+	return Math.max(0, Math.min(1, parsed));
+}

--- a/packages/extensions/extensions/adaptive-routing/config.ts
+++ b/packages/extensions/extensions/adaptive-routing/config.ts
@@ -1,0 +1,334 @@
+import { existsSync, readFileSync } from "node:fs";
+import { join } from "node:path";
+import { getAgentDir } from "@mariozechner/pi-coding-agent";
+import { DEFAULT_ADAPTIVE_ROUTING_CONFIG } from "./defaults.js";
+import type {
+	AdaptiveRoutingConfig,
+	AdaptiveRoutingMode,
+	AdaptiveRoutingModelPreferences,
+	AdaptiveRoutingPrivacyLevel,
+	AdaptiveRoutingTelemetryConfig,
+	AdaptiveRoutingTelemetryMode,
+	FallbackGroupPolicy,
+	IntentRoutingPolicy,
+	ProviderReservePolicy,
+	RouteIntent,
+	RouteThinkingLevel,
+	RouteTier,
+	TaskClassPolicy,
+} from "./types.js";
+
+const ROUTE_INTENTS = new Set<RouteIntent>([
+	"quick-qna",
+	"planning",
+	"research",
+	"implementation",
+	"debugging",
+	"design",
+	"architecture",
+	"review",
+	"refactor",
+	"autonomous",
+]);
+
+const ROUTE_TIERS = new Set<RouteTier>(["cheap", "balanced", "premium", "peak"]);
+const ROUTE_THINKING_LEVELS = new Set<RouteThinkingLevel>(["off", "minimal", "low", "medium", "high", "xhigh"]);
+const ROUTING_MODES = new Set<AdaptiveRoutingMode>(["off", "shadow", "auto"]);
+const TELEMETRY_MODES = new Set<AdaptiveRoutingTelemetryMode>(["off", "local", "export"]);
+const PRIVACY_LEVELS = new Set<AdaptiveRoutingPrivacyLevel>(["minimal", "redacted", "full-local"]);
+
+export function getAdaptiveRoutingConfigPath(): string {
+	return join(getAgentDir(), "extensions", "adaptive-routing", "config.json");
+}
+
+export function readAdaptiveRoutingConfig(): AdaptiveRoutingConfig {
+	const configPath = getAdaptiveRoutingConfigPath();
+	if (!existsSync(configPath)) {
+		return structuredClone(DEFAULT_ADAPTIVE_ROUTING_CONFIG);
+	}
+
+	try {
+		const raw = JSON.parse(readFileSync(configPath, "utf-8")) as unknown;
+		return normalizeAdaptiveRoutingConfig(raw);
+	} catch {
+		return structuredClone(DEFAULT_ADAPTIVE_ROUTING_CONFIG);
+	}
+}
+
+export function normalizeAdaptiveRoutingConfig(raw: unknown): AdaptiveRoutingConfig {
+	const fallback = structuredClone(DEFAULT_ADAPTIVE_ROUTING_CONFIG);
+	if (!raw || typeof raw !== "object") {
+		return fallback;
+	}
+
+	const cfg = raw as Record<string, unknown>;
+	return {
+		mode: normalizeMode(cfg.mode, fallback.mode),
+		routerModels: normalizeStringArray(cfg.routerModels, fallback.routerModels),
+		stickyTurns: normalizeStickyTurns(cfg.stickyTurns, fallback.stickyTurns),
+		telemetry: normalizeTelemetryConfig(cfg.telemetry, fallback.telemetry),
+		models: normalizeModelPreferences(cfg.models, fallback.models),
+		intents: normalizeIntentPolicies(cfg.intents, fallback.intents),
+		taskClasses: normalizeTaskClasses(cfg.taskClasses, fallback.taskClasses),
+		providerReserves: normalizeProviderReserves(cfg.providerReserves, fallback.providerReserves),
+		fallbackGroups: normalizeFallbackGroups(cfg.fallbackGroups, fallback.fallbackGroups),
+	};
+}
+
+function normalizeMode(value: unknown, fallback: AdaptiveRoutingMode): AdaptiveRoutingMode {
+	return typeof value === "string" && ROUTING_MODES.has(value as AdaptiveRoutingMode)
+		? (value as AdaptiveRoutingMode)
+		: fallback;
+}
+
+function normalizeTelemetryConfig(
+	value: unknown,
+	fallback: AdaptiveRoutingTelemetryConfig,
+): AdaptiveRoutingTelemetryConfig {
+	if (!value || typeof value !== "object") {
+		return { ...fallback };
+	}
+	const cfg = value as Record<string, unknown>;
+	return {
+		mode:
+			typeof cfg.mode === "string" && TELEMETRY_MODES.has(cfg.mode as AdaptiveRoutingTelemetryMode)
+				? (cfg.mode as AdaptiveRoutingTelemetryMode)
+				: fallback.mode,
+		privacy:
+			typeof cfg.privacy === "string" && PRIVACY_LEVELS.has(cfg.privacy as AdaptiveRoutingPrivacyLevel)
+				? (cfg.privacy as AdaptiveRoutingPrivacyLevel)
+				: fallback.privacy,
+	};
+}
+
+function normalizeModelPreferences(
+	value: unknown,
+	fallback: AdaptiveRoutingModelPreferences,
+): AdaptiveRoutingModelPreferences {
+	if (!value || typeof value !== "object") {
+		return { ...fallback };
+	}
+	const cfg = value as Record<string, unknown>;
+	return {
+		ranked: normalizeStringArray(cfg.ranked, fallback.ranked),
+		excluded: normalizeStringArray(cfg.excluded, fallback.excluded),
+	};
+}
+
+function normalizeIntentPolicies(
+	value: unknown,
+	fallback: AdaptiveRoutingConfig["intents"],
+): AdaptiveRoutingConfig["intents"] {
+	const next: AdaptiveRoutingConfig["intents"] = { ...fallback };
+	if (!value || typeof value !== "object") {
+		return next;
+	}
+
+	for (const [intent, policy] of Object.entries(value as Record<string, unknown>)) {
+		if (!(ROUTE_INTENTS.has(intent as RouteIntent) && policy) || typeof policy !== "object") {
+			continue;
+		}
+		next[intent as RouteIntent] = normalizeIntentPolicy(policy as Record<string, unknown>, next[intent as RouteIntent]);
+	}
+	return next;
+}
+
+function normalizeIntentPolicy(value: Record<string, unknown>, fallback?: IntentRoutingPolicy): IntentRoutingPolicy {
+	return {
+		preferredModels: normalizeOptionalStringArray(value.preferredModels, fallback?.preferredModels),
+		preferredProviders: normalizeOptionalStringArray(value.preferredProviders, fallback?.preferredProviders),
+		defaultThinking: normalizeOptionalThinking(value.defaultThinking, fallback?.defaultThinking),
+		preferredTier: normalizeOptionalTier(value.preferredTier, fallback?.preferredTier),
+		fallbackGroup: normalizeOptionalString(value.fallbackGroup, fallback?.fallbackGroup),
+	};
+}
+
+function normalizeTaskClasses(
+	value: unknown,
+	fallback: AdaptiveRoutingConfig["taskClasses"],
+): AdaptiveRoutingConfig["taskClasses"] {
+	const next: AdaptiveRoutingConfig["taskClasses"] = { ...fallback };
+	if (!value || typeof value !== "object") {
+		return next;
+	}
+
+	for (const [taskClass, policy] of Object.entries(value as Record<string, unknown>)) {
+		if (!policy || typeof policy !== "object") {
+			continue;
+		}
+		const normalized = normalizeTaskClassPolicy(policy as Record<string, unknown>, next[taskClass]);
+		if (normalized) {
+			next[taskClass] = normalized;
+		}
+	}
+	return next;
+}
+
+function normalizeTaskClassPolicy(
+	value: Record<string, unknown>,
+	fallback?: TaskClassPolicy,
+): TaskClassPolicy | undefined {
+	const defaultThinking = normalizeThinking(value.defaultThinking, fallback?.defaultThinking);
+	const candidates = normalizeStringArray(value.candidates, fallback?.candidates ?? []);
+	if (candidates.length === 0) {
+		return fallback;
+	}
+	return {
+		defaultThinking,
+		candidates,
+		fallbackGroup: normalizeOptionalString(value.fallbackGroup, fallback?.fallbackGroup),
+	};
+}
+
+function normalizeProviderReserves(
+	value: unknown,
+	fallback: AdaptiveRoutingConfig["providerReserves"],
+): AdaptiveRoutingConfig["providerReserves"] {
+	const next: AdaptiveRoutingConfig["providerReserves"] = { ...fallback };
+	if (!value || typeof value !== "object") {
+		return next;
+	}
+	for (const [provider, policy] of Object.entries(value as Record<string, unknown>)) {
+		if (!policy || typeof policy !== "object") {
+			continue;
+		}
+		next[provider] = normalizeProviderReservePolicy(policy as Record<string, unknown>, next[provider]);
+	}
+	return next;
+}
+
+function normalizeProviderReservePolicy(
+	value: Record<string, unknown>,
+	fallback?: ProviderReservePolicy,
+): ProviderReservePolicy {
+	return {
+		minRemainingPct: normalizePercent(value.minRemainingPct, fallback?.minRemainingPct ?? 15),
+		applyToTiers: normalizeOptionalTierArray(value.applyToTiers, fallback?.applyToTiers),
+		allowOverrideForPeak:
+			typeof value.allowOverrideForPeak === "boolean"
+				? value.allowOverrideForPeak
+				: (fallback?.allowOverrideForPeak ?? true),
+		confidence:
+			typeof value.confidence === "string" && ["authoritative", "estimated", "unknown"].includes(value.confidence)
+				? (fallback?.confidence ?? (value.confidence as ProviderReservePolicy["confidence"]))
+				: fallback?.confidence,
+	};
+}
+
+function normalizeFallbackGroups(
+	value: unknown,
+	fallback: AdaptiveRoutingConfig["fallbackGroups"],
+): AdaptiveRoutingConfig["fallbackGroups"] {
+	const next: AdaptiveRoutingConfig["fallbackGroups"] = { ...fallback };
+	if (!value || typeof value !== "object") {
+		return next;
+	}
+	for (const [groupName, policy] of Object.entries(value as Record<string, unknown>)) {
+		if (!policy || typeof policy !== "object") {
+			continue;
+		}
+		const normalized = normalizeFallbackGroupPolicy(policy as Record<string, unknown>, next[groupName]);
+		if (normalized) {
+			next[groupName] = normalized;
+		}
+	}
+	return next;
+}
+
+function normalizeFallbackGroupPolicy(
+	value: Record<string, unknown>,
+	fallback?: FallbackGroupPolicy,
+): FallbackGroupPolicy | undefined {
+	const candidates = normalizeStringArray(value.candidates, fallback?.candidates ?? []);
+	if (candidates.length === 0) {
+		return fallback;
+	}
+	return {
+		candidates,
+		description: normalizeOptionalString(value.description, fallback?.description),
+	};
+}
+
+function normalizeStickyTurns(value: unknown, fallback: number): number {
+	const parsed = Number(value);
+	if (!Number.isFinite(parsed)) {
+		return fallback;
+	}
+	return Math.max(0, Math.min(20, Math.round(parsed)));
+}
+
+function normalizePercent(value: unknown, fallback: number): number {
+	const parsed = Number(value);
+	if (!Number.isFinite(parsed)) {
+		return fallback;
+	}
+	return Math.max(0, Math.min(100, parsed));
+}
+
+function normalizeStringArray(value: unknown, fallback: string[]): string[] {
+	if (!Array.isArray(value)) {
+		return [...fallback];
+	}
+	const normalized = value
+		.filter((item): item is string => typeof item === "string")
+		.map((item) => item.trim())
+		.filter(Boolean);
+	return normalized.length > 0 ? Array.from(new Set(normalized)) : [...fallback];
+}
+
+function normalizeOptionalStringArray(value: unknown, fallback?: string[]): string[] | undefined {
+	if (value === undefined) {
+		return fallback ? [...fallback] : undefined;
+	}
+	if (!Array.isArray(value)) {
+		return fallback ? [...fallback] : undefined;
+	}
+	const normalized = value
+		.filter((item): item is string => typeof item === "string")
+		.map((item) => item.trim())
+		.filter(Boolean);
+	return normalized.length > 0 ? Array.from(new Set(normalized)) : undefined;
+}
+
+function normalizeOptionalString(value: unknown, fallback?: string): string | undefined {
+	if (typeof value !== "string") {
+		return fallback;
+	}
+	const trimmed = value.trim();
+	return trimmed || fallback;
+}
+
+function normalizeThinking(value: unknown, fallback?: RouteThinkingLevel): RouteThinkingLevel {
+	return typeof value === "string" && ROUTE_THINKING_LEVELS.has(value as RouteThinkingLevel)
+		? (value as RouteThinkingLevel)
+		: (fallback ?? "medium");
+}
+
+function normalizeOptionalThinking(value: unknown, fallback?: RouteThinkingLevel): RouteThinkingLevel | undefined {
+	if (value === undefined) {
+		return fallback;
+	}
+	return typeof value === "string" && ROUTE_THINKING_LEVELS.has(value as RouteThinkingLevel)
+		? (value as RouteThinkingLevel)
+		: fallback;
+}
+
+function normalizeOptionalTier(value: unknown, fallback?: RouteTier): RouteTier | undefined {
+	if (value === undefined) {
+		return fallback;
+	}
+	return typeof value === "string" && ROUTE_TIERS.has(value as RouteTier) ? (value as RouteTier) : fallback;
+}
+
+function normalizeOptionalTierArray(value: unknown, fallback?: RouteTier[]): RouteTier[] | undefined {
+	if (value === undefined) {
+		return fallback ? [...fallback] : undefined;
+	}
+	if (!Array.isArray(value)) {
+		return fallback ? [...fallback] : undefined;
+	}
+	const normalized = value.filter(
+		(item): item is RouteTier => typeof item === "string" && ROUTE_TIERS.has(item as RouteTier),
+	);
+	return normalized.length > 0 ? Array.from(new Set(normalized)) : undefined;
+}

--- a/packages/extensions/extensions/adaptive-routing/defaults.ts
+++ b/packages/extensions/extensions/adaptive-routing/defaults.ts
@@ -1,0 +1,126 @@
+import type {
+	AdaptiveRoutingConfig,
+	AdaptiveRoutingExplanationCode,
+	FallbackGroupPolicy,
+	IntentRoutingPolicy,
+	RouteIntent,
+} from "./types.js";
+
+export const ADAPTIVE_ROUTING_EXPLANATION_CODES: AdaptiveRoutingExplanationCode[] = [
+	"intent_design_bias",
+	"intent_architecture_bias",
+	"premium_allowed",
+	"premium_reserved",
+	"quota_low",
+	"quota_unknown",
+	"thinking_clamped",
+	"current_model_sticky",
+	"fallback_group_applied",
+];
+
+export const DEFAULT_INTENT_POLICIES: Record<RouteIntent, IntentRoutingPolicy> = {
+	"quick-qna": {
+		preferredTier: "cheap",
+		defaultThinking: "minimal",
+		fallbackGroup: "cheap-router",
+	},
+	planning: {
+		preferredTier: "balanced",
+		defaultThinking: "medium",
+	},
+	research: {
+		preferredTier: "balanced",
+		defaultThinking: "medium",
+	},
+	implementation: {
+		preferredTier: "balanced",
+		defaultThinking: "medium",
+	},
+	debugging: {
+		preferredTier: "premium",
+		defaultThinking: "high",
+	},
+	design: {
+		preferredTier: "premium",
+		defaultThinking: "high",
+		preferredProviders: ["anthropic"],
+		fallbackGroup: "design-premium",
+	},
+	architecture: {
+		preferredTier: "peak",
+		defaultThinking: "xhigh",
+		preferredProviders: ["openai"],
+		fallbackGroup: "peak-reasoning",
+	},
+	review: {
+		preferredTier: "balanced",
+		defaultThinking: "medium",
+	},
+	refactor: {
+		preferredTier: "premium",
+		defaultThinking: "high",
+	},
+	autonomous: {
+		preferredTier: "peak",
+		defaultThinking: "xhigh",
+		fallbackGroup: "peak-reasoning",
+	},
+};
+
+export const DEFAULT_FALLBACK_GROUPS: Record<string, FallbackGroupPolicy> = {
+	"cheap-router": {
+		candidates: ["google/gemini-2.5-flash", "openai/gpt-5-mini"],
+		description: "Low-cost classifier and quick-turn routing pool.",
+	},
+	"design-premium": {
+		candidates: ["anthropic/claude-opus-4.6", "openai/gpt-5.4"],
+		description: "Premium design-focused routing pool.",
+	},
+	"peak-reasoning": {
+		candidates: ["openai/gpt-5.4", "anthropic/claude-opus-4.6", "cursor-agent/<best-available>"],
+		description: "Peak reasoning pool with premium cross-provider fallbacks.",
+	},
+};
+
+export const DEFAULT_ADAPTIVE_ROUTING_CONFIG: AdaptiveRoutingConfig = {
+	mode: "shadow",
+	routerModels: ["google/gemini-2.5-flash", "openai/gpt-5-mini"],
+	stickyTurns: 1,
+	telemetry: {
+		mode: "local",
+		privacy: "minimal",
+	},
+	models: {
+		ranked: [],
+		excluded: [],
+	},
+	intents: DEFAULT_INTENT_POLICIES,
+	taskClasses: {
+		quick: {
+			defaultThinking: "minimal",
+			candidates: ["google/gemini-2.5-flash", "openai/gpt-5-mini"],
+			fallbackGroup: "cheap-router",
+		},
+		"design-premium": {
+			defaultThinking: "high",
+			candidates: ["anthropic/claude-opus-4.6", "openai/gpt-5.4"],
+			fallbackGroup: "design-premium",
+		},
+		peak: {
+			defaultThinking: "xhigh",
+			candidates: ["openai/gpt-5.4", "anthropic/claude-opus-4.6", "cursor-agent/<best-available>"],
+			fallbackGroup: "peak-reasoning",
+		},
+	},
+	providerReserves: {
+		openai: { minRemainingPct: 15, applyToTiers: ["premium", "peak"], allowOverrideForPeak: true },
+		anthropic: { minRemainingPct: 15, applyToTiers: ["premium", "peak"], allowOverrideForPeak: true },
+		"cursor-agent": {
+			minRemainingPct: 20,
+			applyToTiers: ["premium", "peak"],
+			allowOverrideForPeak: true,
+			confidence: "estimated",
+		},
+	},
+	fallbackGroups: DEFAULT_FALLBACK_GROUPS,
+};

--- a/packages/extensions/extensions/adaptive-routing/engine.test.ts
+++ b/packages/extensions/extensions/adaptive-routing/engine.test.ts
@@ -1,0 +1,139 @@
+import { readFileSync } from "node:fs";
+import { describe, expect, it } from "vitest";
+import { classifyPromptHeuristically } from "./classifier.js";
+import { DEFAULT_ADAPTIVE_ROUTING_CONFIG } from "./defaults.js";
+import { decideRoute } from "./engine.js";
+import { normalizeRouteCandidates } from "./normalize.js";
+
+type CorpusEntry = {
+	name: string;
+	prompt: string;
+	intent: string;
+	expectedModel: string;
+	expectedThinking: string;
+};
+
+const candidates = normalizeRouteCandidates([
+	{
+		provider: "anthropic",
+		id: "claude-opus-4.6",
+		name: "Claude Opus 4.6",
+		api: "anthropic-messages",
+		baseUrl: "https://api.anthropic.com",
+		reasoning: true,
+		input: ["text", "image"],
+		cost: { input: 1, output: 1, cacheRead: 0, cacheWrite: 0 },
+		contextWindow: 200000,
+		maxTokens: 16384,
+	},
+	{
+		provider: "openai",
+		id: "gpt-5.4",
+		name: "GPT-5.4",
+		api: "openai-responses",
+		baseUrl: "https://api.openai.com/v1",
+		reasoning: true,
+		input: ["text"],
+		cost: { input: 1, output: 1, cacheRead: 0, cacheWrite: 0 },
+		contextWindow: 200000,
+		maxTokens: 32768,
+	},
+	{
+		provider: "google",
+		id: "gemini-2.5-flash",
+		name: "Gemini 2.5 Flash",
+		api: "google-generative-ai",
+		baseUrl: "https://generativelanguage.googleapis.com",
+		reasoning: true,
+		input: ["text", "image"],
+		cost: { input: 0, output: 0, cacheRead: 0, cacheWrite: 0 },
+		contextWindow: 1048576,
+		maxTokens: 65536,
+	},
+] as never);
+
+describe("adaptive routing engine", () => {
+	it("routes design-heavy prompts toward Claude premium models", () => {
+		const classification = classifyPromptHeuristically(
+			"Design a polished dashboard with stronger hierarchy and visual tone.",
+		);
+		const decision = decideRoute({
+			config: {
+				...DEFAULT_ADAPTIVE_ROUTING_CONFIG,
+				models: {
+					ranked: ["openai/gpt-5.4", "anthropic/claude-opus-4.6"],
+					excluded: [],
+				},
+			},
+			candidates,
+			classification,
+			currentThinking: "medium",
+			usage: {
+				providers: {
+					anthropic: { confidence: "authoritative", remainingPct: 55 },
+					openai: { confidence: "authoritative", remainingPct: 55 },
+				},
+				updatedAt: Date.now(),
+			},
+		});
+
+		expect(decision?.selectedModel).toBe("anthropic/claude-opus-4.6");
+		expect(decision?.explanation.codes).toContain("intent_design_bias");
+	});
+
+	it("protects low-quota providers when reserve thresholds are crossed", () => {
+		const classification = classifyPromptHeuristically(
+			"Think deeply about a cross-provider architecture migration strategy.",
+		);
+		const decision = decideRoute({
+			config: {
+				...DEFAULT_ADAPTIVE_ROUTING_CONFIG,
+				providerReserves: {
+					...DEFAULT_ADAPTIVE_ROUTING_CONFIG.providerReserves,
+					openai: {
+						...DEFAULT_ADAPTIVE_ROUTING_CONFIG.providerReserves.openai,
+						allowOverrideForPeak: false,
+					},
+				},
+			},
+			candidates,
+			classification,
+			usage: {
+				providers: {
+					openai: { confidence: "authoritative", remainingPct: 5 },
+					anthropic: { confidence: "authoritative", remainingPct: 40 },
+				},
+				updatedAt: Date.now(),
+			},
+		});
+
+		expect(decision?.selectedModel).not.toBe("openai/gpt-5.4");
+		expect(decision?.explanation.codes).toContain("premium_reserved");
+	});
+
+	it("evaluates the routing corpus fixtures", () => {
+		const corpus = JSON.parse(
+			readFileSync(new URL("./fixtures.route-corpus.json", import.meta.url), "utf-8"),
+		) as CorpusEntry[];
+		for (const fixture of corpus) {
+			const classification = classifyPromptHeuristically(fixture.prompt);
+			const decision = decideRoute({
+				config: DEFAULT_ADAPTIVE_ROUTING_CONFIG,
+				candidates,
+				classification,
+				usage: {
+					providers: {
+						anthropic: { confidence: "authoritative", remainingPct: 60 },
+						openai: { confidence: "authoritative", remainingPct: 60 },
+						google: { confidence: "unknown", remainingPct: undefined },
+					},
+					updatedAt: Date.now(),
+				},
+			});
+
+			expect(classification.intent, fixture.name).toBe(fixture.intent);
+			expect(decision?.selectedModel, fixture.name).toBe(fixture.expectedModel);
+			expect(decision?.selectedThinking, fixture.name).toBe(fixture.expectedThinking);
+		}
+	});
+});

--- a/packages/extensions/extensions/adaptive-routing/engine.ts
+++ b/packages/extensions/extensions/adaptive-routing/engine.ts
@@ -1,0 +1,295 @@
+import { matchesModelRef } from "./normalize.js";
+import type {
+	AdaptiveRoutingConfig,
+	NormalizedRouteCandidate,
+	PromptRouteClassification,
+	ProviderUsageState,
+	RouteCandidateScore,
+	RouteDecision,
+	RouteExplanation,
+	RouteIntent,
+	RouteLock,
+	RouteQuotaSnapshot,
+	RouteThinkingLevel,
+	RouteTier,
+} from "./types.js";
+
+export interface RoutingDecisionInput {
+	config: AdaptiveRoutingConfig;
+	candidates: NormalizedRouteCandidate[];
+	classification: PromptRouteClassification;
+	currentModel?: string;
+	currentThinking?: RouteThinkingLevel;
+	usage?: ProviderUsageState;
+	lock?: RouteLock;
+}
+
+export function decideRoute(input: RoutingDecisionInput): RouteDecision | undefined {
+	const { config, candidates, classification, usage, lock } = input;
+	if (candidates.length === 0) {
+		return undefined;
+	}
+
+	if (lock) {
+		const lockedCandidate = candidates.find((candidate) => matchesModelRef(lock.model, candidate));
+		if (lockedCandidate) {
+			const appliedThinking = clampThinking(lock.thinking, lockedCandidate.maxThinkingLevel);
+			return {
+				selectedModel: lockedCandidate.fullId,
+				selectedThinking: appliedThinking,
+				fallbacks: buildFallbacks(candidates, lockedCandidate.fullId, config, classification),
+				explanation: {
+					summary: `locked to ${lockedCandidate.fullId} · ${appliedThinking}`,
+					codes: ["manual_lock_applied"],
+					classification,
+					clampedThinking:
+						appliedThinking === lock.thinking ? undefined : { requested: lock.thinking, applied: appliedThinking },
+					quota: buildQuotaSummary(usage),
+				},
+			};
+		}
+	}
+
+	const scores = candidates.map((candidate) => scoreCandidate(candidate, input));
+	scores.sort((a, b) => b.score - a.score || a.model.localeCompare(b.model));
+	const best = scores[0];
+	if (!best) {
+		return undefined;
+	}
+
+	const selected = candidates.find((candidate) => candidate.fullId === best.model);
+	if (!selected) {
+		return undefined;
+	}
+
+	const selectedThinking = clampThinking(resolveRequestedThinking(config, classification), selected.maxThinkingLevel);
+	const explanation = buildExplanation(selected, selectedThinking, best, scores.slice(0, 3), classification, usage);
+
+	return {
+		selectedModel: selected.fullId,
+		selectedThinking,
+		fallbacks: scores.slice(1, 4).map((score) => score.model),
+		explanation,
+	};
+}
+
+// biome-ignore lint/complexity/noExcessiveCognitiveComplexity: candidate scoring intentionally combines multiple weighted routing signals.
+function scoreCandidate(candidate: NormalizedRouteCandidate, input: RoutingDecisionInput): RouteCandidateScore {
+	const reasons: string[] = [];
+	let score = 0;
+	const { config, classification, currentModel, usage } = input;
+	const intentPolicy = config.intents[classification.intent];
+
+	const rankingIndex = config.models.ranked.findIndex((entry) => matchesModelRef(entry, candidate));
+	if (rankingIndex >= 0) {
+		score += Math.max(30 - rankingIndex * 3, 3);
+		reasons.push(`rank:${rankingIndex + 1}`);
+	}
+
+	if (intentPolicy?.preferredModels?.some((entry) => matchesModelRef(entry, candidate))) {
+		score += 28;
+		reasons.push("intent-model");
+	}
+
+	if (intentPolicy?.preferredProviders?.includes(candidate.provider)) {
+		score += 14;
+		reasons.push("intent-provider");
+	}
+
+	const tierDelta = Math.abs(tierOrder(candidate.tier) - tierOrder(classification.recommendedTier));
+	if (tierDelta === 0) {
+		score += 18;
+		reasons.push(`tier:${candidate.tier}`);
+	} else if (tierDelta === 1) {
+		score += 8;
+		reasons.push("tier-near");
+	} else {
+		score -= 8;
+	}
+
+	if (supportsRequestedThinking(candidate.maxThinkingLevel, resolveRequestedThinking(config, classification))) {
+		score += 6;
+		reasons.push("thinking-fit");
+	} else {
+		score -= 5;
+	}
+
+	if (classification.intent === "design" && candidate.tags.includes("design")) {
+		score += 12;
+		reasons.push("design-fit");
+	}
+
+	if (
+		["architecture", "debugging", "autonomous", "refactor"].includes(classification.intent) &&
+		candidate.tags.includes("architecture")
+	) {
+		score += 10;
+		reasons.push("reasoning-fit");
+	}
+
+	if (currentModel && currentModel === candidate.fullId && config.stickyTurns > 0) {
+		score += 5;
+		reasons.push("sticky");
+	}
+
+	const reserve = config.providerReserves[candidate.provider];
+	const providerQuota = usage?.providers[candidate.provider];
+	if (reserve && shouldApplyReserve(reserve.applyToTiers, candidate.tier)) {
+		if (typeof providerQuota?.remainingPct === "number") {
+			if (providerQuota.remainingPct < reserve.minRemainingPct) {
+				score -= reserve.allowOverrideForPeak && classification.recommendedTier === "peak" ? 20 : 80;
+				reasons.push("reserve-low");
+			} else {
+				score += 4;
+				reasons.push("reserve-ok");
+			}
+		} else if (providerQuota?.confidence === "unknown" || !providerQuota) {
+			reasons.push("quota-unknown");
+		}
+	}
+
+	if (classification.risk === "high" && (candidate.tier === "premium" || candidate.tier === "peak")) {
+		score += 8;
+		reasons.push("risk-fit");
+	}
+
+	if (classification.intent === "quick-qna" && candidate.tier === "cheap") {
+		score += 8;
+		reasons.push("cheap-fit");
+	}
+
+	return {
+		model: candidate.fullId,
+		score,
+		reasons,
+	};
+}
+
+function buildExplanation(
+	selected: NormalizedRouteCandidate,
+	selectedThinking: RouteThinkingLevel,
+	best: RouteCandidateScore,
+	topCandidates: RouteCandidateScore[],
+	classification: PromptRouteClassification,
+	usage?: ProviderUsageState,
+): RouteExplanation {
+	const requestedThinking = classification.recommendedThinking;
+	const codes = new Set<RouteExplanation["codes"][number]>();
+	for (const reason of best.reasons) {
+		if (reason === "design-fit") {
+			codes.add("intent_design_bias");
+		}
+		if (reason === "reasoning-fit") {
+			codes.add("intent_architecture_bias");
+		}
+		if (reason === "sticky") {
+			codes.add("current_model_sticky");
+		}
+		if (reason === "reserve-ok") {
+			codes.add("premium_allowed");
+		}
+		if (reason === "quota-unknown") {
+			codes.add("quota_unknown");
+		}
+	}
+	if (topCandidates.some((candidate) => candidate.reasons.includes("reserve-low"))) {
+		codes.add("premium_reserved");
+	}
+	if (selectedThinking !== requestedThinking) {
+		codes.add("thinking_clamped");
+	}
+	if (selected.fallbackGroups.length > 0) {
+		codes.add("fallback_group_applied");
+	}
+
+	return {
+		summary: `${selected.fullId} · ${selectedThinking} · ${classification.intent} · ${classification.recommendedTier}`,
+		codes: Array.from(codes),
+		classification,
+		clampedThinking:
+			selectedThinking === requestedThinking ? undefined : { requested: requestedThinking, applied: selectedThinking },
+		quota: buildQuotaSummary(usage),
+		candidates: topCandidates,
+	};
+}
+
+function buildFallbacks(
+	candidates: NormalizedRouteCandidate[],
+	excludedModel: string,
+	config: AdaptiveRoutingConfig,
+	classification: PromptRouteClassification,
+): string[] {
+	return candidates
+		.filter((candidate) => candidate.fullId !== excludedModel)
+		.sort((a, b) => tierOrder(b.tier) - tierOrder(a.tier) || a.fullId.localeCompare(b.fullId))
+		.filter((candidate) => !config.models.excluded.some((entry) => matchesModelRef(entry, candidate)))
+		.filter(
+			(candidate) => matchesTier(candidate.tier, classification.recommendedTier) || candidate.fallbackGroups.length > 0,
+		)
+		.slice(0, 3)
+		.map((candidate) => candidate.fullId);
+}
+
+export function resolveRequestedThinking(
+	config: AdaptiveRoutingConfig,
+	classification: PromptRouteClassification,
+): RouteThinkingLevel {
+	return config.intents[classification.intent]?.defaultThinking ?? classification.recommendedThinking;
+}
+
+export function clampThinking(requested: RouteThinkingLevel, maxSupported: RouteThinkingLevel): RouteThinkingLevel {
+	const order: RouteThinkingLevel[] = ["off", "minimal", "low", "medium", "high", "xhigh"];
+	return order[Math.min(order.indexOf(requested), order.indexOf(maxSupported))] ?? maxSupported;
+}
+
+function supportsRequestedThinking(maxSupported: RouteThinkingLevel, requested: RouteThinkingLevel): boolean {
+	return clampThinking(requested, maxSupported) === requested;
+}
+
+function buildQuotaSummary(usage?: ProviderUsageState): Record<string, RouteQuotaSnapshot> | undefined {
+	if (!usage) {
+		return undefined;
+	}
+	const summary: Record<string, RouteQuotaSnapshot> = {};
+	for (const [provider, state] of Object.entries(usage.providers)) {
+		summary[provider] = { confidence: state.confidence, remainingPct: state.remainingPct };
+	}
+	return summary;
+}
+
+function shouldApplyReserve(applyToTiers: RouteTier[] | undefined, recommendedTier: RouteTier): boolean {
+	return !applyToTiers || applyToTiers.includes(recommendedTier);
+}
+
+function tierOrder(tier: RouteTier): number {
+	switch (tier) {
+		case "cheap":
+			return 0;
+		case "balanced":
+			return 1;
+		case "premium":
+			return 2;
+		case "peak":
+			return 3;
+	}
+}
+
+function matchesTier(candidateTier: RouteTier, requestedTier: RouteTier): boolean {
+	return Math.abs(tierOrder(candidateTier) - tierOrder(requestedTier)) <= 1;
+}
+
+export function buildFallbackClassification(intent: RouteIntent): PromptRouteClassification {
+	return {
+		intent,
+		complexity: intent === "design" || intent === "architecture" ? 4 : 3,
+		risk: intent === "quick-qna" ? "low" : "medium",
+		expectedTurns: intent === "quick-qna" ? "one" : "few",
+		toolIntensity: intent === "implementation" || intent === "debugging" ? "high" : "medium",
+		contextBreadth: intent === "architecture" ? "large" : "medium",
+		recommendedTier: intent === "design" || intent === "architecture" ? "premium" : "balanced",
+		recommendedThinking: intent === "quick-qna" ? "minimal" : "medium",
+		confidence: 0.35,
+		reason: "Fallback classification applied.",
+		classifierMode: "heuristic",
+	};
+}

--- a/packages/extensions/extensions/adaptive-routing/fixtures.route-corpus.json
+++ b/packages/extensions/extensions/adaptive-routing/fixtures.route-corpus.json
@@ -1,0 +1,23 @@
+[
+  {
+    "name": "design-premium-prefers-claude",
+    "prompt": "Design a polished settings page with better spacing, hierarchy, and visual tone.",
+    "intent": "design",
+    "expectedModel": "anthropic/claude-opus-4.6",
+    "expectedThinking": "high"
+  },
+  {
+    "name": "peak-architecture-prefers-gpt",
+    "prompt": "Think deeply about the architecture tradeoffs for migrating this multi-package routing system across providers.",
+    "intent": "architecture",
+    "expectedModel": "openai/gpt-5.4",
+    "expectedThinking": "xhigh"
+  },
+  {
+    "name": "quick-question-prefers-cheap-tier",
+    "prompt": "What file registers the scheduler command?",
+    "intent": "quick-qna",
+    "expectedModel": "google/gemini-2.5-flash",
+    "expectedThinking": "minimal"
+  }
+]

--- a/packages/extensions/extensions/adaptive-routing/index.ts
+++ b/packages/extensions/extensions/adaptive-routing/index.ts
@@ -1,0 +1,485 @@
+import type {
+	ExtensionAPI,
+	ExtensionCommandContext,
+	ExtensionContext,
+	ModelSelectEvent,
+} from "@mariozechner/pi-coding-agent";
+import { classifyPrompt } from "./classifier.js";
+import { readAdaptiveRoutingConfig } from "./config.js";
+import { decideRoute } from "./engine.js";
+import { normalizeRouteCandidates } from "./normalize.js";
+import { readAdaptiveRoutingState, writeAdaptiveRoutingState } from "./state.js";
+import {
+	appendTelemetryEvent,
+	computeStats,
+	createDecisionId,
+	createFeedbackEvent,
+	formatStats,
+	hashPrompt,
+	readTelemetryEvents,
+} from "./telemetry.js";
+import type {
+	AdaptiveRoutingMode,
+	AdaptiveRoutingState,
+	ProviderUsageState,
+	RouteDecision,
+	RouteFeedbackCategory,
+	RouteThinkingLevel,
+} from "./types.js";
+
+const STATUS_KEY = "adaptive-routing";
+
+type RuntimeState = {
+	state: AdaptiveRoutingState;
+	usage?: ProviderUsageState;
+	lastDecision?: RouteDecision;
+	lastDecisionPromptHash?: string;
+	lastDecisionTurnCount: number;
+	lastDecisionOverridden: boolean;
+	applyingRoute: boolean;
+};
+
+export default function adaptiveRoutingExtension(pi: ExtensionAPI) {
+	const runtime: RuntimeState = {
+		state: readAdaptiveRoutingState(),
+		usage: undefined,
+		lastDecision: undefined,
+		lastDecisionPromptHash: undefined,
+		lastDecisionTurnCount: 0,
+		lastDecisionOverridden: false,
+		applyingRoute: false,
+	};
+
+	function persistState(): void {
+		writeAdaptiveRoutingState({
+			...runtime.state,
+			lastDecision: runtime.lastDecision,
+		});
+	}
+
+	function getEffectiveMode(): AdaptiveRoutingMode {
+		const config = readAdaptiveRoutingConfig();
+		return runtime.state.mode ?? config.mode;
+	}
+
+	function currentRouteLabel(): string | undefined {
+		const mode = getEffectiveMode();
+		if (mode === "off") {
+			return undefined;
+		}
+		const lockLabel = runtime.state.lock ? ` 🔒 ${runtime.state.lock.model}:${runtime.state.lock.thinking}` : "";
+		const decision = runtime.lastDecision;
+		return decision
+			? `${mode} → ${decision.selectedModel}:${decision.selectedThinking}${lockLabel}`
+			: `${mode}${lockLabel}`;
+	}
+
+	function updateStatus(ctx: ExtensionContext): void {
+		ctx.ui.setStatus(STATUS_KEY, currentRouteLabel());
+	}
+
+	function refreshUsageSnapshot(): void {
+		pi.events.emit("usage:query");
+	}
+
+	pi.events.on("usage:limits", (payload) => {
+		const providers: ProviderUsageState["providers"] = {};
+		if (payload && typeof payload === "object" && payload.providers && typeof payload.providers === "object") {
+			for (const [provider, value] of Object.entries(payload.providers as Record<string, unknown>)) {
+				providers[provider] = {
+					confidence: extractQuotaConfidence(value),
+					remainingPct: extractRemainingPct(value),
+				};
+			}
+		}
+		runtime.usage = {
+			providers,
+			sessionCost: typeof payload?.sessionCost === "number" ? payload.sessionCost : undefined,
+			rolling30dCost: typeof payload?.rolling30dCost === "number" ? payload.rolling30dCost : undefined,
+			perModel: typeof payload?.perModel === "object" ? payload.perModel : undefined,
+			perSource: typeof payload?.perSource === "object" ? payload.perSource : undefined,
+			updatedAt: Date.now(),
+		};
+	});
+
+	pi.on("session_start", async (_event, ctx) => {
+		runtime.state = readAdaptiveRoutingState();
+		refreshUsageSnapshot();
+		updateStatus(ctx);
+	});
+
+	pi.on("model_select", async (event, ctx) => {
+		if (!runtime.applyingRoute && shouldRecordOverride(event, runtime.lastDecision)) {
+			appendTelemetryEvent(readAdaptiveRoutingConfig().telemetry, {
+				type: "route_override",
+				timestamp: Date.now(),
+				decisionId: runtime.lastDecision?.id,
+				from: {
+					model: runtime.lastDecision?.selectedModel ?? "unknown",
+					thinking: runtime.lastDecision?.selectedThinking ?? "off",
+				},
+				to: {
+					model: `${event.model.provider}/${event.model.id}`,
+					thinking: pi.getThinkingLevel() as RouteThinkingLevel,
+				},
+				reason: "manual",
+			});
+			runtime.lastDecisionOverridden = true;
+		}
+		updateStatus(ctx);
+	});
+
+	pi.on("agent_end", async (_event, _ctx) => {
+		if (!runtime.lastDecision?.id) {
+			return;
+		}
+		appendTelemetryEvent(readAdaptiveRoutingConfig().telemetry, {
+			type: "route_outcome",
+			timestamp: Date.now(),
+			decisionId: runtime.lastDecision.id,
+			turnCount: runtime.lastDecisionTurnCount,
+			completed: true,
+			userOverrideOccurred: runtime.lastDecisionOverridden,
+		});
+	});
+
+	pi.on("turn_end", async () => {
+		runtime.lastDecisionTurnCount += 1;
+	});
+
+	pi.on("before_agent_start", async (event, ctx) => {
+		const config = readAdaptiveRoutingConfig();
+		runtime.state = readAdaptiveRoutingState();
+		const mode = runtime.state.mode ?? config.mode;
+		if (mode === "off") {
+			ctx.ui.setStatus(STATUS_KEY, undefined);
+			return;
+		}
+
+		refreshUsageSnapshot();
+		const availableModels = ctx.modelRegistry.getAvailable();
+		const candidates = normalizeRouteCandidates(availableModels).filter(
+			(candidate) => !config.models.excluded.some((entry) => entry === candidate.fullId || entry === candidate.modelId),
+		);
+		if (candidates.length === 0) {
+			ctx.ui.setStatus(STATUS_KEY, `${mode} → no eligible models`);
+			return;
+		}
+
+		const classification = await classifyPrompt(event.prompt, config, ctx, candidates);
+		const currentModel = ctx.model ? `${ctx.model.provider}/${ctx.model.id}` : undefined;
+		const currentThinking = pi.getThinkingLevel() as RouteThinkingLevel;
+		const decision = decideRoute({
+			config,
+			candidates,
+			classification,
+			currentModel,
+			currentThinking,
+			usage: runtime.usage,
+			lock: runtime.state.lock,
+		});
+		if (!decision) {
+			ctx.ui.setStatus(STATUS_KEY, `${mode} → no route`);
+			return;
+		}
+
+		decision.id = createDecisionId();
+		runtime.lastDecision = decision;
+		runtime.lastDecisionPromptHash = hashPrompt(event.prompt);
+		runtime.lastDecisionTurnCount = 0;
+		runtime.lastDecisionOverridden = false;
+		runtime.state.lastDecision = decision;
+		persistState();
+
+		appendTelemetryEvent(config.telemetry, {
+			type: "route_decision",
+			timestamp: Date.now(),
+			decisionId: decision.id,
+			promptHash: runtime.lastDecisionPromptHash,
+			mode,
+			selected: {
+				model: decision.selectedModel,
+				thinking: decision.selectedThinking,
+			},
+			fallbacks: decision.fallbacks,
+			classifier: classification,
+			quota: decision.explanation.quota,
+			candidates: decision.explanation.candidates,
+			explanationCodes: decision.explanation.codes,
+		});
+
+		if (mode === "shadow") {
+			if (currentModel && (currentModel !== decision.selectedModel || currentThinking !== decision.selectedThinking)) {
+				appendTelemetryEvent(config.telemetry, {
+					type: "route_shadow_disagreement",
+					timestamp: Date.now(),
+					decisionId: decision.id,
+					promptHash: runtime.lastDecisionPromptHash,
+					suggested: {
+						model: decision.selectedModel,
+						thinking: decision.selectedThinking,
+					},
+					actual: {
+						model: currentModel,
+						thinking: currentThinking,
+					},
+				});
+			}
+			ctx.ui.notify(`Adaptive route suggestion: ${decision.selectedModel} · ${decision.selectedThinking}`, "info");
+			updateStatus(ctx);
+			return;
+		}
+
+		await applyDecision(pi, ctx, decision, candidates, runtime);
+		updateStatus(ctx);
+	});
+
+	pi.registerCommand("route", {
+		description:
+			"Adaptive routing controls: /route [status|on|off|shadow|auto|explain|lock|unlock|refresh|feedback|stats]",
+		async handler(args, ctx) {
+			const command = args.trim();
+			const [head, ...rest] = command.split(/\s+/).filter(Boolean);
+			const subcommand = (head ?? "status").toLowerCase();
+			runtime.state = readAdaptiveRoutingState();
+
+			switch (subcommand) {
+				case "on":
+				case "auto":
+					runtime.state.mode = "auto";
+					persistState();
+					updateStatus(ctx);
+					ctx.ui.notify("Adaptive routing set to auto mode.", "info");
+					return;
+				case "off":
+					runtime.state.mode = "off";
+					persistState();
+					updateStatus(ctx);
+					ctx.ui.notify("Adaptive routing disabled.", "warning");
+					return;
+				case "shadow":
+					runtime.state.mode = "shadow";
+					persistState();
+					updateStatus(ctx);
+					ctx.ui.notify("Adaptive routing set to shadow mode.", "info");
+					return;
+				case "lock": {
+					if (!ctx.model) {
+						ctx.ui.notify("No active model to lock.", "warning");
+						return;
+					}
+					runtime.state.lock = {
+						model: `${ctx.model.provider}/${ctx.model.id}`,
+						thinking: pi.getThinkingLevel() as RouteThinkingLevel,
+						setAt: Date.now(),
+					};
+					persistState();
+					updateStatus(ctx);
+					ctx.ui.notify(
+						`Adaptive routing locked to ${runtime.state.lock.model}:${runtime.state.lock.thinking}.`,
+						"info",
+					);
+					return;
+				}
+				case "unlock":
+					runtime.state.lock = undefined;
+					persistState();
+					updateStatus(ctx);
+					ctx.ui.notify("Adaptive routing lock cleared.", "info");
+					return;
+				case "refresh":
+					refreshUsageSnapshot();
+					runtime.state = readAdaptiveRoutingState();
+					ctx.ui.notify("Adaptive routing config and usage refreshed.", "info");
+					updateStatus(ctx);
+					return;
+				case "feedback": {
+					const category = normalizeFeedbackCategory(rest[0]);
+					if (!category) {
+						ctx.ui.notify(
+							"Usage: /route feedback <good|bad|wrong-intent|overkill|underpowered|wrong-provider|wrong-thinking>",
+							"warning",
+						);
+						return;
+					}
+					appendTelemetryEvent(
+						readAdaptiveRoutingConfig().telemetry,
+						createFeedbackEvent(runtime.lastDecision, category),
+					);
+					ctx.ui.notify(`Recorded route feedback: ${category}.`, "info");
+					return;
+				}
+				case "stats":
+					await openOverlay(ctx, formatStats(computeStats(readTelemetryEvents())));
+					return;
+				case "explain":
+					await openOverlay(ctx, buildExplanationLines(runtime.lastDecision, runtime.usage));
+					return;
+				default:
+					ctx.ui.notify(buildStatusLine(runtime.state, runtime.lastDecision, getEffectiveMode()), "info");
+			}
+		},
+	});
+}
+
+async function applyDecision(
+	pi: ExtensionAPI,
+	ctx: ExtensionContext,
+	decision: RouteDecision,
+	candidates: ReturnType<typeof normalizeRouteCandidates>,
+	runtime: RuntimeState,
+): Promise<void> {
+	const currentModel = ctx.model ? `${ctx.model.provider}/${ctx.model.id}` : undefined;
+	const currentThinking = pi.getThinkingLevel() as RouteThinkingLevel;
+	if (currentModel === decision.selectedModel && currentThinking === decision.selectedThinking) {
+		return;
+	}
+
+	const target = candidates.find((candidate) => candidate.fullId === decision.selectedModel);
+	if (!target) {
+		ctx.ui.notify(`Adaptive route target unavailable: ${decision.selectedModel}`, "warning");
+		return;
+	}
+
+	runtime.applyingRoute = true;
+	try {
+		if (currentModel !== decision.selectedModel) {
+			const ok = await pi.setModel(target.model);
+			if (!ok) {
+				ctx.ui.notify(`Failed to switch to ${decision.selectedModel}.`, "error");
+				return;
+			}
+		}
+		if (currentThinking !== decision.selectedThinking) {
+			pi.setThinkingLevel(decision.selectedThinking);
+		}
+		ctx.ui.notify(`Adaptive route applied: ${decision.selectedModel} · ${decision.selectedThinking}`, "info");
+	} finally {
+		runtime.applyingRoute = false;
+	}
+}
+
+function shouldRecordOverride(event: ModelSelectEvent, lastDecision: RouteDecision | undefined): boolean {
+	if (!(lastDecision && event.model)) {
+		return false;
+	}
+	return `${event.model.provider}/${event.model.id}` !== lastDecision.selectedModel;
+}
+
+function extractQuotaConfidence(value: unknown): ProviderUsageState["providers"][string]["confidence"] {
+	if (!value || typeof value !== "object") {
+		return "unknown";
+	}
+	if (Array.isArray(value.windows) && value.windows.length > 0) {
+		return "authoritative";
+	}
+	if (value.stale) {
+		return "estimated";
+	}
+	return "unknown";
+}
+
+function extractRemainingPct(value: unknown): number | undefined {
+	if (!value || typeof value !== "object" || !Array.isArray(value.windows)) {
+		return undefined;
+	}
+	const percentages = value.windows
+		.map((window) =>
+			window && typeof window === "object" ? Number((window as { remainingPct?: unknown }).remainingPct) : Number.NaN,
+		)
+		.filter((pct: number) => Number.isFinite(pct));
+	if (percentages.length === 0) {
+		return undefined;
+	}
+	return Math.min(...percentages);
+}
+
+function normalizeFeedbackCategory(value: string | undefined): RouteFeedbackCategory | undefined {
+	switch ((value ?? "").toLowerCase()) {
+		case "good":
+		case "bad":
+		case "wrong-intent":
+		case "overkill":
+		case "underpowered":
+		case "wrong-provider":
+		case "wrong-thinking":
+			return value?.toLowerCase() as RouteFeedbackCategory;
+		default:
+			return undefined;
+	}
+}
+
+function buildStatusLine(
+	state: AdaptiveRoutingState,
+	decision: RouteDecision | undefined,
+	mode: AdaptiveRoutingMode,
+): string {
+	const parts = [`mode=${mode}`];
+	if (state.lock) {
+		parts.push(`lock=${state.lock.model}:${state.lock.thinking}`);
+	}
+	if (decision) {
+		parts.push(`last=${decision.selectedModel}:${decision.selectedThinking}`);
+	}
+	return `adaptive routing · ${parts.join(" · ")}`;
+}
+
+function buildExplanationLines(decision: RouteDecision | undefined, usage: ProviderUsageState | undefined): string[] {
+	if (!decision) {
+		return ["Adaptive Routing", "No route decision recorded yet."];
+	}
+	const lines = [
+		"Adaptive Routing",
+		`Selected: ${decision.selectedModel}`,
+		`Thinking: ${decision.selectedThinking}`,
+		`Summary: ${decision.explanation.summary}`,
+		`Codes: ${decision.explanation.codes.join(", ") || "none"}`,
+	];
+	if (decision.explanation.classification) {
+		const c = decision.explanation.classification;
+		lines.push(`Intent: ${c.intent} · complexity ${c.complexity} · tier ${c.recommendedTier}`);
+		lines.push(`Thinking recommendation: ${c.recommendedThinking} · confidence ${Math.round(c.confidence * 100)}%`);
+		lines.push(`Classifier: ${c.classifierMode}${c.classifierModel ? ` (${c.classifierModel})` : ""}`);
+		lines.push(`Reason: ${c.reason}`);
+	}
+	if (decision.fallbacks.length > 0) {
+		lines.push(`Fallbacks: ${decision.fallbacks.join(" → ")}`);
+	}
+	if (decision.explanation.candidates?.length) {
+		lines.push("Top candidates:");
+		for (const candidate of decision.explanation.candidates) {
+			lines.push(`  - ${candidate.model} (${candidate.score.toFixed(1)}) [${candidate.reasons.join(", ")}]`);
+		}
+	}
+	if (usage && Object.keys(usage.providers).length > 0) {
+		lines.push("Quota snapshot:");
+		for (const [provider, state] of Object.entries(usage.providers)) {
+			lines.push(`  - ${provider}: ${state.remainingPct ?? "?"}% · ${state.confidence}`);
+		}
+	}
+	lines.push("Press q, esc, space, or enter to close.");
+	return lines;
+}
+
+async function openOverlay(ctx: ExtensionCommandContext, lines: string[]): Promise<void> {
+	await ctx.ui.custom(
+		(tui, _theme, _keybindings, done) => ({
+			render(width: number) {
+				return lines.map((line) => line.slice(0, width));
+			},
+			handleInput(data: string) {
+				if (data === "q" || data === "\x1b" || data === " " || data === "\r") {
+					done(undefined);
+					return;
+				}
+				if (data === "r") {
+					tui.requestRender();
+				}
+			},
+			dispose() {
+				// No-op overlay cleanup.
+			},
+		}),
+		{ overlay: true, overlayOptions: { anchor: "center", width: 96, maxHeight: 28 } },
+	);
+}

--- a/packages/extensions/extensions/adaptive-routing/normalize.ts
+++ b/packages/extensions/extensions/adaptive-routing/normalize.ts
@@ -1,0 +1,148 @@
+import type { Api, Model } from "@mariozechner/pi-ai";
+import type { NormalizedRouteCandidate, RouteThinkingLevel, RouteTier } from "./types.js";
+
+export function normalizeRouteCandidates(models: Model<Api>[]): NormalizedRouteCandidate[] {
+	return models.map((model) => {
+		const provider = String(model.provider);
+		const modelId = model.id;
+		const fullId = `${provider}/${modelId}`;
+		const tags = deriveCandidateTags(model);
+		return {
+			fullId,
+			provider,
+			modelId,
+			label: model.name || fullId,
+			reasoning: model.reasoning,
+			maxThinkingLevel: deriveMaxThinkingLevel(model),
+			tier: deriveCandidateTier(model),
+			contextWindow: model.contextWindow,
+			maxTokens: model.maxTokens,
+			input: [...model.input],
+			costKnown: hasKnownCost(model),
+			tags,
+			family: deriveCandidateFamily(model),
+			fallbackGroups: deriveFallbackGroups(model),
+			available: true,
+			authenticated: true,
+			model,
+		};
+	});
+}
+
+export function deriveMaxThinkingLevel(model: Model<Api>): RouteThinkingLevel {
+	if (!model.reasoning) {
+		return "off";
+	}
+
+	const id = model.id.toLowerCase();
+	if (id.includes("gpt-5") || id.includes("opus-4.6") || id.includes("opus-4-6")) {
+		return "xhigh";
+	}
+
+	return "high";
+}
+
+export function deriveCandidateTier(model: Model<Api>): RouteTier {
+	const id = model.id.toLowerCase();
+	const name = model.name.toLowerCase();
+
+	if (id.includes("gpt-5.4") || id.includes("opus-4.6") || id.includes("opus-4-6") || name.includes("ultra")) {
+		return "peak";
+	}
+	if (id.includes("opus") || id.includes("sonnet") || id.includes("pro") || id.includes("gpt-5")) {
+		return "premium";
+	}
+	if (id.includes("flash") || id.includes("mini")) {
+		return "cheap";
+	}
+	return "balanced";
+}
+
+export function deriveCandidateTags(model: Model<Api>): string[] {
+	const tags = new Set<string>();
+	const provider = String(model.provider);
+	const id = model.id.toLowerCase();
+	const name = model.name.toLowerCase();
+	const tier = deriveCandidateTier(model);
+
+	tags.add(provider);
+	tags.add(tier);
+	if (model.reasoning) {
+		tags.add("reasoning");
+	}
+	if (model.input.includes("image")) {
+		tags.add("multimodal");
+	}
+	if (tier === "premium" || tier === "peak") {
+		tags.add("premium");
+	}
+	if (tier === "cheap") {
+		tags.add("cheap");
+	}
+	if (provider === "anthropic" || name.includes("claude")) {
+		tags.add("design");
+	}
+	if (provider === "openai" || id.includes("gpt-5")) {
+		tags.add("architecture");
+	}
+	if (provider === "cursor-agent") {
+		tags.add("architecture");
+		tags.add("premium");
+	}
+	return Array.from(tags);
+}
+
+export function deriveCandidateFamily(model: Model<Api>): string | undefined {
+	const provider = String(model.provider);
+	const tier = deriveCandidateTier(model);
+
+	if (provider === "anthropic") {
+		return `anthropic-${tier}`;
+	}
+	if (provider === "openai") {
+		return `openai-${tier}`;
+	}
+	if (provider === "cursor-agent") {
+		return `cursor-${tier}`;
+	}
+	if (provider === "google") {
+		return `google-${tier}`;
+	}
+	return undefined;
+}
+
+export function deriveFallbackGroups(model: Model<Api>): string[] {
+	const provider = String(model.provider);
+	const id = model.id.toLowerCase();
+	const groups = new Set<string>();
+	const tier = deriveCandidateTier(model);
+
+	if (tier === "cheap") {
+		groups.add("cheap-router");
+	}
+	if (
+		(provider === "anthropic" && (id.includes("opus") || id.includes("sonnet"))) ||
+		(provider === "openai" && id.includes("gpt-5.4"))
+	) {
+		groups.add("design-premium");
+	}
+	if ((provider === "anthropic" && id.includes("opus")) || (provider === "openai" && id.includes("gpt-5.4"))) {
+		groups.add("peak-reasoning");
+	}
+	if (provider === "cursor-agent") {
+		groups.add("peak-reasoning");
+	}
+	return Array.from(groups);
+}
+
+export function matchesModelRef(
+	reference: string,
+	candidate: Pick<NormalizedRouteCandidate, "fullId" | "modelId">,
+): boolean {
+	const normalized = reference.trim();
+	return normalized === candidate.fullId || normalized === candidate.modelId;
+}
+
+function hasKnownCost(model: Model<Api>): boolean {
+	return Object.values(model.cost).some((value) => Number(value) > 0);
+}

--- a/packages/extensions/extensions/adaptive-routing/schema.test.ts
+++ b/packages/extensions/extensions/adaptive-routing/schema.test.ts
@@ -1,0 +1,145 @@
+import { mkdirSync, mkdtempSync, rmSync, writeFileSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { afterEach, describe, expect, it, vi } from "vitest";
+
+const { getAgentDir } = vi.hoisted(() => ({
+	getAgentDir: vi.fn(() => "/mock-home/.pi/agent"),
+}));
+
+vi.mock("@mariozechner/pi-coding-agent", () => ({
+	getAgentDir,
+}));
+
+import { getAdaptiveRoutingConfigPath, normalizeAdaptiveRoutingConfig, readAdaptiveRoutingConfig } from "./config.js";
+import { DEFAULT_ADAPTIVE_ROUTING_CONFIG } from "./defaults.js";
+import { deriveFallbackGroups, deriveMaxThinkingLevel, normalizeRouteCandidates } from "./normalize.js";
+
+describe("adaptive routing config", () => {
+	afterEach(() => {
+		vi.clearAllMocks();
+	});
+
+	it("uses defaults when config is missing", () => {
+		expect(readAdaptiveRoutingConfig()).toEqual(DEFAULT_ADAPTIVE_ROUTING_CONFIG);
+		expect(getAdaptiveRoutingConfigPath()).toBe("/mock-home/.pi/agent/extensions/adaptive-routing/config.json");
+	});
+
+	it("normalizes invalid config values back to safe defaults", () => {
+		const config = normalizeAdaptiveRoutingConfig({
+			mode: "banana",
+			stickyTurns: 999,
+			telemetry: { mode: "bogus", privacy: "bad" },
+			models: { ranked: ["openai/gpt-5.4", 7, " "] },
+			providerReserves: {
+				openai: { minRemainingPct: 120, applyToTiers: ["premium", "fake"] },
+			},
+			taskClasses: {
+				quick: { defaultThinking: "bad", candidates: ["google/gemini-2.5-flash"] },
+			},
+		}) as never;
+
+		expect(config.mode).toBe(DEFAULT_ADAPTIVE_ROUTING_CONFIG.mode);
+		expect(config.stickyTurns).toBe(20);
+		expect(config.telemetry).toEqual(DEFAULT_ADAPTIVE_ROUTING_CONFIG.telemetry);
+		expect(config.models.ranked).toEqual(["openai/gpt-5.4"]);
+		expect(config.providerReserves.openai?.minRemainingPct).toBe(100);
+		expect(config.providerReserves.openai?.applyToTiers).toEqual(["premium"]);
+		expect(config.taskClasses.quick?.defaultThinking).toBe(
+			DEFAULT_ADAPTIVE_ROUTING_CONFIG.taskClasses.quick?.defaultThinking,
+		);
+	});
+
+	it("reads config from the shared pi agent directory", () => {
+		const tempAgentDir = mkdtempSync(join(tmpdir(), "adaptive-routing-config-"));
+		getAgentDir.mockReturnValue(tempAgentDir);
+		mkdirSync(join(tempAgentDir, "extensions", "adaptive-routing"), { recursive: true });
+		writeFileSync(
+			join(tempAgentDir, "extensions", "adaptive-routing", "config.json"),
+			`${JSON.stringify({ mode: "auto", models: { ranked: ["anthropic/claude-opus-4.6"] } }, null, 2)}\n`,
+			"utf-8",
+		);
+
+		try {
+			const config = readAdaptiveRoutingConfig();
+			expect(config.mode).toBe("auto");
+			expect(config.models.ranked).toEqual(["anthropic/claude-opus-4.6"]);
+		} finally {
+			rmSync(tempAgentDir, { recursive: true, force: true });
+		}
+	});
+});
+
+describe("adaptive routing candidate normalization", () => {
+	it("normalizes available models into stable route candidates", () => {
+		const candidates = normalizeRouteCandidates([
+			{
+				provider: "openai",
+				id: "gpt-5.4",
+				name: "GPT-5.4",
+				api: "openai-responses",
+				baseUrl: "https://api.openai.com/v1",
+				reasoning: true,
+				input: ["text"],
+				cost: { input: 1, output: 2, cacheRead: 0, cacheWrite: 0 },
+				contextWindow: 200000,
+				maxTokens: 32768,
+			},
+			{
+				provider: "google",
+				id: "gemini-2.5-flash",
+				name: "Gemini 2.5 Flash",
+				api: "google-generative-ai",
+				baseUrl: "https://generativelanguage.googleapis.com",
+				reasoning: true,
+				input: ["text", "image"],
+				cost: { input: 0, output: 0, cacheRead: 0, cacheWrite: 0 },
+				contextWindow: 1048576,
+				maxTokens: 65536,
+			},
+		] as never);
+
+		expect(candidates).toHaveLength(2);
+		expect(candidates[0]).toMatchObject({
+			fullId: "openai/gpt-5.4",
+			maxThinkingLevel: "xhigh",
+			costKnown: true,
+		});
+		expect(candidates[1]).toMatchObject({
+			fullId: "google/gemini-2.5-flash",
+			costKnown: false,
+		});
+		expect(candidates[1]?.tags).toContain("cheap");
+	});
+
+	it("derives fallback groups and max thinking levels consistently", () => {
+		const premiumModel = {
+			provider: "anthropic",
+			id: "claude-opus-4.6",
+			name: "Claude Opus 4.6",
+			api: "anthropic-messages",
+			baseUrl: "https://api.anthropic.com",
+			reasoning: true,
+			input: ["text", "image"],
+			cost: { input: 1, output: 1, cacheRead: 0, cacheWrite: 0 },
+			contextWindow: 200000,
+			maxTokens: 16384,
+		};
+		const nonReasoningModel = {
+			provider: "openai",
+			id: "gpt-4o",
+			name: "GPT-4o",
+			api: "openai-responses",
+			baseUrl: "https://api.openai.com/v1",
+			reasoning: false,
+			input: ["text", "image"],
+			cost: { input: 1, output: 1, cacheRead: 0, cacheWrite: 0 },
+			contextWindow: 128000,
+			maxTokens: 16384,
+		};
+
+		expect(deriveMaxThinkingLevel(premiumModel as never)).toBe("xhigh");
+		expect(deriveMaxThinkingLevel(nonReasoningModel as never)).toBe("off");
+		expect(deriveFallbackGroups(premiumModel as never)).toEqual(["design-premium", "peak-reasoning"]);
+	});
+});

--- a/packages/extensions/extensions/adaptive-routing/state.ts
+++ b/packages/extensions/extensions/adaptive-routing/state.ts
@@ -1,0 +1,33 @@
+import { existsSync, mkdirSync, readFileSync, writeFileSync } from "node:fs";
+import { dirname, join } from "node:path";
+import { getAgentDir } from "@mariozechner/pi-coding-agent";
+import type { AdaptiveRoutingState } from "./types.js";
+
+const DEFAULT_STATE: AdaptiveRoutingState = {};
+
+export function getAdaptiveRoutingStatePath(): string {
+	return join(getAgentDir(), "extensions", "adaptive-routing", "state.json");
+}
+
+export function readAdaptiveRoutingState(): AdaptiveRoutingState {
+	const path = getAdaptiveRoutingStatePath();
+	try {
+		if (!existsSync(path)) {
+			return { ...DEFAULT_STATE };
+		}
+		const parsed = JSON.parse(readFileSync(path, "utf-8")) as AdaptiveRoutingState;
+		return parsed && typeof parsed === "object" ? parsed : { ...DEFAULT_STATE };
+	} catch {
+		return { ...DEFAULT_STATE };
+	}
+}
+
+export function writeAdaptiveRoutingState(state: AdaptiveRoutingState): void {
+	const path = getAdaptiveRoutingStatePath();
+	try {
+		mkdirSync(dirname(path), { recursive: true });
+		writeFileSync(path, `${JSON.stringify(state, null, 2)}\n`, "utf-8");
+	} catch {
+		// Non-critical persistence only.
+	}
+}

--- a/packages/extensions/extensions/adaptive-routing/telemetry.ts
+++ b/packages/extensions/extensions/adaptive-routing/telemetry.ts
@@ -1,0 +1,138 @@
+import { createHash, randomUUID } from "node:crypto";
+import { existsSync, mkdirSync, readFileSync, writeFileSync } from "node:fs";
+import { dirname, join } from "node:path";
+import { getAgentDir } from "@mariozechner/pi-coding-agent";
+import type {
+	AdaptiveRoutingStats,
+	AdaptiveRoutingTelemetryConfig,
+	AdaptiveRoutingTelemetryEvent,
+	RouteDecision,
+	RouteFeedbackCategory,
+} from "./types.js";
+
+export function getAdaptiveRoutingEventsPath(): string {
+	return join(getAgentDir(), "adaptive-routing", "events.jsonl");
+}
+
+export function getAdaptiveRoutingAggregatesPath(): string {
+	return join(getAgentDir(), "adaptive-routing", "aggregates.json");
+}
+
+export function shouldPersistTelemetry(config: AdaptiveRoutingTelemetryConfig): boolean {
+	return config.mode !== "off";
+}
+
+export function hashPrompt(prompt: string): string {
+	return createHash("sha256").update(prompt).digest("hex");
+}
+
+export function createDecisionId(): string {
+	return randomUUID();
+}
+
+export function appendTelemetryEvent(
+	config: AdaptiveRoutingTelemetryConfig,
+	event: AdaptiveRoutingTelemetryEvent,
+): void {
+	if (!shouldPersistTelemetry(config)) {
+		return;
+	}
+
+	const eventsPath = getAdaptiveRoutingEventsPath();
+	try {
+		mkdirSync(dirname(eventsPath), { recursive: true });
+		const payload = `${JSON.stringify(event)}\n`;
+		if (existsSync(eventsPath)) {
+			writeFileSync(eventsPath, readFileSync(eventsPath, "utf-8") + payload, "utf-8");
+		} else {
+			writeFileSync(eventsPath, payload, "utf-8");
+		}
+		writeAggregates(computeStats(readTelemetryEvents()));
+	} catch {
+		// Telemetry is best-effort only.
+	}
+}
+
+export function readTelemetryEvents(): AdaptiveRoutingTelemetryEvent[] {
+	const eventsPath = getAdaptiveRoutingEventsPath();
+	try {
+		if (!existsSync(eventsPath)) {
+			return [];
+		}
+		return readFileSync(eventsPath, "utf-8")
+			.split("\n")
+			.map((line) => line.trim())
+			.filter(Boolean)
+			.map((line) => JSON.parse(line) as AdaptiveRoutingTelemetryEvent);
+	} catch {
+		return [];
+	}
+}
+
+export function computeStats(events: AdaptiveRoutingTelemetryEvent[]): AdaptiveRoutingStats {
+	const stats: AdaptiveRoutingStats = {
+		decisions: 0,
+		feedback: {},
+		overrides: 0,
+		shadowDisagreements: 0,
+	};
+
+	for (const event of events) {
+		if (event.type === "route_decision") {
+			stats.decisions += 1;
+			stats.lastDecisionAt = Math.max(stats.lastDecisionAt ?? 0, event.timestamp);
+		} else if (event.type === "route_override") {
+			stats.overrides += 1;
+		} else if (event.type === "route_shadow_disagreement") {
+			stats.shadowDisagreements += 1;
+		} else if (event.type === "route_feedback") {
+			stats.feedback[event.category] = (stats.feedback[event.category] ?? 0) + 1;
+		}
+	}
+
+	return stats;
+}
+
+export function formatStats(stats: AdaptiveRoutingStats): string[] {
+	const lines = [
+		"Adaptive Routing Stats",
+		`Decisions: ${stats.decisions}`,
+		`Overrides: ${stats.overrides}`,
+		`Shadow disagreements: ${stats.shadowDisagreements}`,
+	];
+	const feedbackEntries = Object.entries(stats.feedback).sort((a, b) => a[0].localeCompare(b[0]));
+	if (feedbackEntries.length > 0) {
+		lines.push("Feedback:");
+		for (const [category, count] of feedbackEntries) {
+			lines.push(`  - ${category}: ${count}`);
+		}
+	}
+	if (stats.lastDecisionAt) {
+		lines.push(`Last decision: ${new Date(stats.lastDecisionAt).toLocaleString()}`);
+	}
+	return lines;
+}
+
+export function createFeedbackEvent(
+	decision: RouteDecision | undefined,
+	category: RouteFeedbackCategory,
+	sessionId?: string,
+): AdaptiveRoutingTelemetryEvent {
+	return {
+		type: "route_feedback",
+		timestamp: Date.now(),
+		decisionId: decision?.id,
+		sessionId,
+		category,
+	};
+}
+
+function writeAggregates(stats: AdaptiveRoutingStats): void {
+	const aggregatesPath = getAdaptiveRoutingAggregatesPath();
+	try {
+		mkdirSync(dirname(aggregatesPath), { recursive: true });
+		writeFileSync(aggregatesPath, `${JSON.stringify(stats, null, 2)}\n`, "utf-8");
+	} catch {
+		// best effort
+	}
+}

--- a/packages/extensions/extensions/adaptive-routing/types.ts
+++ b/packages/extensions/extensions/adaptive-routing/types.ts
@@ -1,0 +1,263 @@
+import type { Api, Model } from "@mariozechner/pi-ai";
+
+export type AdaptiveRoutingMode = "off" | "shadow" | "auto";
+export type AdaptiveRoutingTelemetryMode = "off" | "local" | "export";
+export type AdaptiveRoutingPrivacyLevel = "minimal" | "redacted" | "full-local";
+export type QuotaConfidence = "authoritative" | "estimated" | "unknown";
+
+export type RouteIntent =
+	| "quick-qna"
+	| "planning"
+	| "research"
+	| "implementation"
+	| "debugging"
+	| "design"
+	| "architecture"
+	| "review"
+	| "refactor"
+	| "autonomous";
+
+export type RouteComplexity = 1 | 2 | 3 | 4 | 5;
+export type RouteRisk = "low" | "medium" | "high";
+export type RouteExpectedTurns = "one" | "few" | "many";
+export type RouteToolIntensity = "low" | "medium" | "high";
+export type RouteContextBreadth = "small" | "medium" | "large";
+export type RouteTier = "cheap" | "balanced" | "premium" | "peak";
+export type RouteThinkingLevel = "off" | "minimal" | "low" | "medium" | "high" | "xhigh";
+export type RouteFeedbackCategory =
+	| "good"
+	| "bad"
+	| "wrong-intent"
+	| "overkill"
+	| "underpowered"
+	| "wrong-provider"
+	| "wrong-thinking";
+
+export interface AdaptiveRoutingTelemetryConfig {
+	mode: AdaptiveRoutingTelemetryMode;
+	privacy: AdaptiveRoutingPrivacyLevel;
+}
+
+export interface AdaptiveRoutingModelPreferences {
+	ranked: string[];
+	excluded: string[];
+}
+
+export interface IntentRoutingPolicy {
+	preferredModels?: string[];
+	preferredProviders?: string[];
+	defaultThinking?: RouteThinkingLevel;
+	preferredTier?: RouteTier;
+	fallbackGroup?: string;
+}
+
+export interface TaskClassPolicy {
+	defaultThinking: RouteThinkingLevel;
+	candidates: string[];
+	fallbackGroup?: string;
+}
+
+export interface ProviderReservePolicy {
+	minRemainingPct: number;
+	applyToTiers?: RouteTier[];
+	allowOverrideForPeak?: boolean;
+	confidence?: QuotaConfidence;
+}
+
+export interface FallbackGroupPolicy {
+	candidates: string[];
+	description?: string;
+}
+
+export interface AdaptiveRoutingConfig {
+	mode: AdaptiveRoutingMode;
+	routerModels: string[];
+	stickyTurns: number;
+	telemetry: AdaptiveRoutingTelemetryConfig;
+	models: AdaptiveRoutingModelPreferences;
+	intents: Partial<Record<RouteIntent, IntentRoutingPolicy>>;
+	taskClasses: Record<string, TaskClassPolicy>;
+	providerReserves: Partial<Record<string, ProviderReservePolicy>>;
+	fallbackGroups: Record<string, FallbackGroupPolicy>;
+}
+
+export interface PromptRouteClassification {
+	intent: RouteIntent;
+	complexity: RouteComplexity;
+	risk: RouteRisk;
+	expectedTurns: RouteExpectedTurns;
+	toolIntensity: RouteToolIntensity;
+	contextBreadth: RouteContextBreadth;
+	recommendedTier: RouteTier;
+	recommendedThinking: RouteThinkingLevel;
+	confidence: number;
+	reason: string;
+	classifierModel?: string;
+	classifierMode?: "heuristic" | "llm";
+}
+
+export interface RouteCandidateScore {
+	model: string;
+	score: number;
+	reasons: string[];
+}
+
+export interface RouteQuotaSnapshot {
+	confidence: QuotaConfidence;
+	remainingPct?: number;
+}
+
+export interface RouteExplanation {
+	summary: string;
+	codes: AdaptiveRoutingExplanationCode[];
+	classification?: PromptRouteClassification;
+	clampedThinking?: {
+		requested: RouteThinkingLevel;
+		applied: RouteThinkingLevel;
+	};
+	quota?: Record<string, RouteQuotaSnapshot>;
+	candidates?: RouteCandidateScore[];
+}
+
+export interface RouteDecision {
+	id?: string;
+	selectedModel: string;
+	selectedThinking: RouteThinkingLevel;
+	fallbacks: string[];
+	explanation: RouteExplanation;
+}
+
+export interface RouteLock {
+	model: string;
+	thinking: RouteThinkingLevel;
+	setAt: number;
+}
+
+export interface AdaptiveRoutingState {
+	mode?: AdaptiveRoutingMode;
+	lock?: RouteLock;
+	lastDecision?: RouteDecision;
+}
+
+export interface ProviderUsageState {
+	providers: Record<
+		string,
+		{
+			confidence: QuotaConfidence;
+			remainingPct?: number;
+		}
+	>;
+	sessionCost?: number;
+	rolling30dCost?: number;
+	perModel?: Record<string, unknown>;
+	perSource?: Record<string, unknown>;
+	updatedAt: number;
+}
+
+export interface NormalizedRouteCandidate {
+	fullId: string;
+	provider: string;
+	modelId: string;
+	label: string;
+	reasoning: boolean;
+	maxThinkingLevel: RouteThinkingLevel;
+	tier: RouteTier;
+	contextWindow?: number;
+	maxTokens?: number;
+	input: ("text" | "image")[];
+	costKnown: boolean;
+	tags: string[];
+	family?: string;
+	fallbackGroups: string[];
+	available: boolean;
+	authenticated: boolean;
+	model: Model<Api>;
+}
+
+export type AdaptiveRoutingExplanationCode =
+	| "intent_design_bias"
+	| "intent_architecture_bias"
+	| "premium_allowed"
+	| "premium_reserved"
+	| "quota_low"
+	| "quota_unknown"
+	| "thinking_clamped"
+	| "current_model_sticky"
+	| "fallback_group_applied"
+	| "manual_lock_applied"
+	| "shadow_disagreement"
+	| "classifier_fallback";
+
+interface TelemetryEventBase {
+	type: string;
+	timestamp: number;
+	decisionId?: string;
+	sessionId?: string;
+	promptHash?: string;
+}
+
+export interface RouteDecisionTelemetryEvent extends TelemetryEventBase {
+	type: "route_decision";
+	mode: AdaptiveRoutingMode;
+	selected: {
+		model: string;
+		thinking: RouteThinkingLevel;
+	};
+	fallbacks: string[];
+	classifier?: PromptRouteClassification;
+	quota?: Record<string, RouteQuotaSnapshot>;
+	candidates?: RouteCandidateScore[];
+	explanationCodes: AdaptiveRoutingExplanationCode[];
+}
+
+export interface RouteOverrideTelemetryEvent extends TelemetryEventBase {
+	type: "route_override";
+	from: {
+		model: string;
+		thinking: RouteThinkingLevel;
+	};
+	to: {
+		model: string;
+		thinking: RouteThinkingLevel;
+	};
+	reason: "manual" | "lock" | "shadow-disagreement";
+}
+
+export interface RouteFeedbackTelemetryEvent extends TelemetryEventBase {
+	type: "route_feedback";
+	category: RouteFeedbackCategory;
+}
+
+export interface RouteOutcomeTelemetryEvent extends TelemetryEventBase {
+	type: "route_outcome";
+	turnCount: number;
+	completed: boolean;
+	userOverrideOccurred: boolean;
+}
+
+export interface RouteShadowDisagreementTelemetryEvent extends TelemetryEventBase {
+	type: "route_shadow_disagreement";
+	suggested: {
+		model: string;
+		thinking: RouteThinkingLevel;
+	};
+	actual: {
+		model: string | null;
+		thinking: RouteThinkingLevel;
+	};
+}
+
+export type AdaptiveRoutingTelemetryEvent =
+	| RouteDecisionTelemetryEvent
+	| RouteOverrideTelemetryEvent
+	| RouteFeedbackTelemetryEvent
+	| RouteOutcomeTelemetryEvent
+	| RouteShadowDisagreementTelemetryEvent;
+
+export interface AdaptiveRoutingStats {
+	decisions: number;
+	feedback: Partial<Record<RouteFeedbackCategory, number>>;
+	overrides: number;
+	shadowDisagreements: number;
+	lastDecisionAt?: number;
+}

--- a/packages/extensions/extensions/smoke.test.ts
+++ b/packages/extensions/extensions/smoke.test.ts
@@ -1,5 +1,6 @@
 import { describe, expect, it } from "vitest";
 import { createExtensionHarness } from "../../../test-utils/extension-runtime-harness.js";
+import adaptiveRoutingExtension from "./adaptive-routing.js";
 import autoUpdateExtension from "./auto-update.js";
 import btwExtension from "./btw.js";
 import safeGuardExtension from "./safe-guard.js";
@@ -49,6 +50,12 @@ describe("extensions runtime smoke tests", () => {
 		autoUpdateExtension(harness.pi as never);
 		harness.emit("session_start", { type: "session_start" }, harness.ctx);
 		expect(harness.notifications.length).toBeGreaterThanOrEqual(0);
+	});
+
+	it("registers adaptive routing commands without crashing", () => {
+		const harness = createExtensionHarness();
+		adaptiveRoutingExtension(harness.pi as never);
+		expect(harness.commands.has("route")).toBe(true);
 	});
 
 	it("blocks protected writes in headless mode via safe-guard", async () => {

--- a/packages/extensions/package.json
+++ b/packages/extensions/package.json
@@ -7,6 +7,7 @@
   ],
   "pi": {
     "extensions": [
+      "./extensions/adaptive-routing.ts",
       "./extensions/auto-session-name.ts",
       "./extensions/auto-update.ts",
       "./extensions/bg-process.ts",

--- a/packages/subagents/chain-execution.ts
+++ b/packages/subagents/chain-execution.ts
@@ -326,9 +326,11 @@ export async function executeChain(params: ChainExecutionParams): Promise<ChainE
 
 				// Resolve model to full provider/model format for consistent display
 				const taskAgentConfig = agents.find((a) => a.name === task.agent);
+				const inheritedModel = ctx.model ? `${ctx.model.provider}/${ctx.model.id}` : undefined;
 				const effectiveModel =
 					(task.model ? resolveModelFullId(task.model, availableModels) : null) ??
-					resolveModelFullId(taskAgentConfig?.model, availableModels);
+					resolveModelFullId(taskAgentConfig?.model, availableModels) ??
+					resolveModelFullId(inheritedModel, availableModels);
 
 				const r = await runSync(ctx.cwd, agents, task.agent, taskStr, {
 					cwd: task.cwd ?? cwd,

--- a/packages/subagents/index.ts
+++ b/packages/subagents/index.ts
@@ -418,7 +418,8 @@ MANAGEMENT (use action field — omit agent/task/chain/tasks):
 
 				// Mutable copies for TUI modifications
 				let tasks = params.tasks.map((t) => t.task);
-				const modelOverrides: (string | undefined)[] = params.tasks.map((t) => (t as { model?: string }).model);
+				const inheritedModel = ctx.model ? `${ctx.model.provider}/${ctx.model.id}` : undefined;
+				const modelOverrides: (string | undefined)[] = params.tasks.map((t) => (t as { model?: string }).model ?? inheritedModel);
 				// Initialize skill overrides from task-level skill params (may be overridden by TUI)
 				const skillOverrides: (string[] | false | undefined)[] = params.tasks.map((t) =>
 					normalizeSkillInput((t as { skill?: string | string[] | boolean }).skill),
@@ -604,7 +605,7 @@ MANAGEMENT (use action field — omit agent/task/chain/tasks):
 				}
 
 				let task = params.task!;
-				let modelOverride: string | undefined = params.model as string | undefined;
+				let modelOverride: string | undefined = (params.model as string | undefined) ?? (ctx.model ? `${ctx.model.provider}/${ctx.model.id}` : undefined);
 				let skillOverride: string[] | false | undefined = normalizeSkillInput(params.skill);
 				// Normalize output: true means "use default" (same as undefined), false means disable
 				const rawOutput = params.output !== undefined ? params.output : agentConfig.output;

--- a/test-utils/extension-runtime-harness.js
+++ b/test-utils/extension-runtime-harness.js
@@ -14,6 +14,7 @@ export function createExtensionHarness() {
 	const providers = new Map();
 	const eventBus = new EventEmitter();
 
+	let currentThinking = "low";
 	const pi = {
 		events: {
 			on(event, handler) {
@@ -54,9 +55,23 @@ export function createExtensionHarness() {
 			userMessages.push(message);
 		},
 		appendEntry() {},
-		getThinkingLevel() {
-			return "low";
+		async setModel(model) {
+			ctx.model = model;
+			return true;
 		},
+		getThinkingLevel() {
+			return currentThinking;
+		},
+		setThinkingLevel(level) {
+			currentThinking = level;
+		},
+		getAllTools() {
+			return Array.from(tools.values());
+		},
+		getActiveTools() {
+			return Array.from(tools.keys());
+		},
+		setActiveTools() {},
 		getFlag(name) {
 			return flags.get(name)?.default;
 		},

--- a/test-utils/extension-runtime-harness.ts
+++ b/test-utils/extension-runtime-harness.ts
@@ -14,6 +14,7 @@ export function createExtensionHarness() {
 	const providers = new Map<string, any>();
 	const eventBus = new EventEmitter();
 
+	let currentThinking = "low";
 	const pi = {
 		events: {
 			on(event: string, handler: (...args: any[]) => any) {
@@ -54,9 +55,23 @@ export function createExtensionHarness() {
 			userMessages.push(message);
 		},
 		appendEntry() {},
-		getThinkingLevel() {
-			return "low";
+		async setModel(model: any) {
+			ctx.model = model;
+			return true;
 		},
+		getThinkingLevel() {
+			return currentThinking;
+		},
+		setThinkingLevel(level: string) {
+			currentThinking = level;
+		},
+		getAllTools() {
+			return Array.from(tools.values());
+		},
+		getActiveTools() {
+			return Array.from(tools.keys());
+		},
+		setActiveTools() {},
 		getFlag(name: string) {
 			return flags.get(name)?.default;
 		},


### PR DESCRIPTION
## Summary
- add an adaptive routing extension with shadow/auto/off modes, route explanations, local telemetry, and usage-aware model selection
- add classifier, deterministic routing engine, persisted routing state, route stats/feedback, and smoke/unit coverage
- propagate the currently routed session model into subagent runs when no explicit override is supplied

## Issue coverage

### Closes #83 — Define the adaptive routing config and capability schema
This PR adds the initial adaptive routing foundation under `packages/extensions/extensions/adaptive-routing/`, including:
- shared routing types and explanation codes
- default policies and fallback groups
- config loading/normalization from shared pi storage
- candidate normalization from available pi models
- schema/config tests

### Closes #84 — Implement the deterministic routing engine for model and thinking selection
This PR adds the first deterministic routing engine, including:
- candidate scoring and selection
- thinking-level clamping
- fallback chain generation
- route explanations
- lock/unlock behavior
- engine tests and route-corpus expectations

## Related progress in this PR

### Advances #85 — Add a routing corpus and evaluation harness
- adds an initial routing corpus fixture used by engine tests
- does **not** yet add a broader evaluation harness/reporting workflow

### Advances #86 — Add a cheap prompt classifier for task and complexity routing
- adds heuristic prompt classification
- adds optional cheap-model classification via `completeSimple`
- does **not** yet add a richer benchmarked classifier pipeline

### Advances #87 — Integrate usage-aware reserves and provider fallback groups
- adds provider reserve-aware scoring
- adds fallback-group policy handling
- integrates available usage state into routing decisions
- does **not** yet complete broader provider reserve tuning/reporting work

### Advances #88 — Add interactive adaptive routing mode, commands, and explanations
- adds `/route status|shadow|auto|off|explain|lock|unlock|refresh|feedback|stats`
- adds status output and explanation flows
- does **not** yet add the full polished interactive UX envisioned in the issue

### Advances #91 — Add shadow mode and route disagreement tracking
- adds `shadow` mode
- tracks whether the active route was overridden later in the turn lifecycle
- does **not** yet add the full disagreement analysis/reporting workflow

### Advances #92 — Add local telemetry, feedback, and tuning reports
- adds local telemetry persistence
- adds local aggregates/stats formatting
- adds explicit route feedback capture
- does **not** yet add the final tuning/report package described in the issue

### Partial progress toward #89 — Extend adaptive routing to subagents, ant-colony, and Cursor families
- subagents now inherit the routed session model by default when no explicit override is supplied
- current routed session decisions naturally flow into ant-colony runs that use the active session model
- Cursor can participate through config/fallback groups when installed
- this PR does **not** fully implement dedicated cross-system routing orchestration yet, so #89 should remain open

## Testing
- pnpm test
- pnpm typecheck
- pnpm lint
- pnpm verify:published-packages
