### PR TITLE
fix: use pi shell resolution in bg-process

### DIFF
--- a/.changeset/fix-bg-process-windows-shell.md
+++ b/.changeset/fix-bg-process-windows-shell.md
@@ -1,0 +1,5 @@
+---
+default: patch
+---
+
+Fix the `bg-process` bash tool override to use pi's shell resolution on Windows instead of hardcoding `spawn("bash")`, and write background logs to the platform temp directory.

--- a/packages/extensions/extensions/bg-process.test.ts
+++ b/packages/extensions/extensions/bg-process.test.ts
@@ -1,0 +1,110 @@
+import { EventEmitter } from "node:events";
+import { delimiter, join } from "node:path";
+import { afterEach, describe, expect, it, vi } from "vitest";
+
+const { getShellConfigMock, spawnMock } = vi.hoisted(() => ({
+	getShellConfigMock: vi.fn(() => ({ shell: "C:/Program Files/Git/bin/bash.exe", args: ["-c"] })),
+	spawnMock: vi.fn(),
+}));
+
+vi.mock("node:child_process", () => ({
+	spawn: spawnMock,
+}));
+
+vi.mock("@mariozechner/pi-coding-agent", () => ({
+	getAgentDir: () => "/mock-home/.pi/agent",
+	getShellConfig: getShellConfigMock,
+}));
+
+vi.mock("@mariozechner/pi-ai", () => ({
+	StringEnum: (values: readonly string[], options?: Record<string, unknown>) => ({
+		type: "string",
+		enum: [...values],
+		...options,
+	}),
+}));
+
+vi.mock("@sinclair/typebox", () => ({
+	Type: {
+		Object: (schema: unknown) => schema,
+		String: (options?: Record<string, unknown>) => ({ type: "string", ...options }),
+		Number: (options?: Record<string, unknown>) => ({ type: "number", ...options }),
+		Optional: (value: unknown) => ({ optional: true, ...((value as object | undefined) ?? {}) }),
+	},
+}));
+
+import bgProcessExtension, { createBgProcessShellEnv, getBgProcessLogFilePath } from "./bg-process.js";
+
+function createMockPi() {
+	const tools = new Map<string, any>();
+	return {
+		registerTool(tool: any) {
+			tools.set(tool.name, tool);
+		},
+		on() {},
+		sendMessage() {},
+		tools,
+	};
+}
+
+function createMockChild() {
+	const child = new EventEmitter() as EventEmitter & {
+		pid: number;
+		stdout: EventEmitter;
+		stderr: EventEmitter;
+		unref: ReturnType<typeof vi.fn>;
+		kill: ReturnType<typeof vi.fn>;
+	};
+	child.pid = 4321;
+	child.stdout = new EventEmitter();
+	child.stderr = new EventEmitter();
+	child.unref = vi.fn();
+	child.kill = vi.fn();
+	return child;
+}
+
+afterEach(() => {
+	vi.clearAllMocks();
+	getShellConfigMock.mockReturnValue({ shell: "C:/Program Files/Git/bin/bash.exe", args: ["-c"] });
+});
+
+describe("bg-process", () => {
+	it("adds the pi managed bin dir to the active PATH key", () => {
+		const env = createBgProcessShellEnv({ Path: "/usr/bin" }, "/mock-home/.pi/agent");
+		expect(env.Path?.split(delimiter)[0]).toBe(join("/mock-home/.pi/agent", "bin"));
+		expect(env.PATH).toBeUndefined();
+	});
+
+	it("uses the system temp directory for background logs", () => {
+		expect(getBgProcessLogFilePath(123, "C:/Temp")).toBe(join("C:/Temp", "oh-pi-bg-123.log"));
+	});
+
+	it("uses pi shell resolution instead of spawning a bare bash command", async () => {
+		const child = createMockChild();
+		spawnMock.mockReturnValueOnce(child);
+
+		const pi = createMockPi();
+		bgProcessExtension(pi as never);
+		const tool = pi.tools.get("bash");
+
+		const resultPromise = tool.execute("tool-1", { command: "echo hello" });
+		child.stdout.emit("data", Buffer.from("hello\n"));
+		child.emit("close", 0);
+
+		const result = await resultPromise;
+
+		expect(getShellConfigMock).toHaveBeenCalledOnce();
+		expect(spawnMock).toHaveBeenCalledWith(
+			"C:/Program Files/Git/bin/bash.exe",
+			["-c", "echo hello"],
+			expect.objectContaining({
+				cwd: process.cwd(),
+				stdio: ["ignore", "pipe", "pipe"],
+				env: expect.objectContaining({
+					PATH: expect.stringContaining(join("/mock-home/.pi/agent", "bin")),
+				}),
+			}),
+		);
+		expect(result.content[0].text).toBe("hello");
+	});
+});

--- a/packages/extensions/extensions/bg-process.ts
+++ b/packages/extensions/extensions/bg-process.ts
@@ -13,8 +13,10 @@
  */
 import { spawn } from "node:child_process";
 import { appendFileSync, existsSync, readFileSync, writeFileSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { delimiter, join } from "node:path";
 import { StringEnum } from "@mariozechner/pi-ai";
-import type { ExtensionAPI } from "@mariozechner/pi-coding-agent";
+import { type ExtensionAPI, getAgentDir, getShellConfig } from "@mariozechner/pi-coding-agent";
 import { Type } from "@sinclair/typebox";
 
 /** Timeout threshold in ms — commands exceeding this are automatically backgrounded. */
@@ -38,6 +40,28 @@ function isAlive(pid: number): boolean {
 	} catch {
 		return false;
 	}
+}
+
+export function createBgProcessShellEnv(
+	env: NodeJS.ProcessEnv = process.env,
+	agentDir: string = getAgentDir(),
+): NodeJS.ProcessEnv {
+	const pathKey = Object.keys(env).find((key) => key.toLowerCase() === "path") ?? "PATH";
+	const currentPath = env[pathKey] ?? "";
+	const binDir = join(agentDir, "bin");
+	const pathEntries = currentPath.split(delimiter).filter(Boolean);
+	const updatedPath = pathEntries.includes(binDir)
+		? currentPath
+		: [binDir, currentPath].filter(Boolean).join(delimiter);
+
+	return {
+		...env,
+		[pathKey]: updatedPath,
+	};
+}
+
+export function getBgProcessLogFilePath(now: number = Date.now(), tempDir: string = tmpdir()): string {
+	return join(tempDir, `oh-pi-bg-${now}.log`);
 }
 
 /**
@@ -68,9 +92,10 @@ export default function (pi: ExtensionAPI) {
 				let settled = false;
 				let backgrounded = false;
 
-				const child = spawn("bash", ["-c", command], {
+				const { shell, args } = getShellConfig();
+				const child = spawn(shell, [...args, command], {
 					cwd: process.cwd(),
-					env: { ...process.env },
+					env: createBgProcessShellEnv(),
 					stdio: ["ignore", "pipe", "pipe"],
 				});
 
@@ -108,7 +133,7 @@ export default function (pi: ExtensionAPI) {
 					backgrounded = true;
 					child.unref();
 
-					const logFile = `/tmp/oh-pi-bg-${Date.now()}.log`;
+					const logFile = getBgProcessLogFilePath();
 					writeFileSync(logFile, stdout + stderr);
 
 					const proc: BgProcess = {

--- a/packages/web-server/package.json
+++ b/packages/web-server/package.json
@@ -26,8 +26,8 @@
   },
   "license": "MIT",
   "dependencies": {
-    "hono": "^4.7.0",
-    "@hono/node-server": "^1.14.0",
+    "hono": "^4.12.12",
+    "@hono/node-server": "^1.19.13",
     "ws": "^8.18.0"
   },
   "devDependencies": {

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -311,13 +311,13 @@ importers:
   packages/web-server:
     dependencies:
       '@hono/node-server':
-        specifier: '>=1.19.13'
+        specifier: ^1.19.13
         version: 1.19.13(hono@4.12.12)
       '@mariozechner/pi-coding-agent':
         specifier: '>=0.56.1'
         version: 0.56.1(ws@8.19.0)(zod@3.25.76)
       hono:
-        specifier: '>=4.12.12'
+        specifier: ^4.12.12
         version: 4.12.12
       ws:
         specifier: ^8.18.0


### PR DESCRIPTION
## Summary
- use pi's shell resolution in `bg-process` instead of hardcoding `spawn("bash")`
- prepend pi's managed bin directory to the spawned shell environment and write background logs to the platform temp directory
- add regression coverage for the Windows shell-resolution path and refresh vulnerable transitive dependencies so CI can pass again

Fixes #96

## Validation
- `./node_modules/.bin/vitest run packages/extensions/extensions/bg-process.test.ts`
- `./node_modules/.bin/vitest run packages/extensions/extensions/bg-process.test.ts packages/extensions/extensions/smoke.test.ts packages/web-server/tests/token.test.ts`
- `pnpm docs:check`
- `pnpm lint`
- `pnpm typecheck`
- `pnpm security:check`
- `pnpm build`
- `pnpm test` *(passed on rerun after one transient `@ifi/oh-pi-core` resolution flake in the root Vitest run)*
