### PR TITLE
fix(extensions): use platform-aware shell in bg-process

### DIFF
--- a/packages/extensions/extensions/bg-process.ts
+++ b/packages/extensions/extensions/bg-process.ts
@@ -13,7 +13,10 @@
  */
 import { spawn } from "node:child_process";
 import { appendFileSync, existsSync, readFileSync, writeFileSync } from "node:fs";
+import * as os from "node:os";
+import * as path from "node:path";
 import { StringEnum } from "@mariozechner/pi-ai";
+import { getShellConfig } from "@mariozechner/pi-coding-agent";
 import type { ExtensionAPI } from "@mariozechner/pi-coding-agent";
 import { Type } from "@sinclair/typebox";
 
@@ -68,7 +71,8 @@ export default function (pi: ExtensionAPI) {
 				let settled = false;
 				let backgrounded = false;
 
-				const child = spawn("bash", ["-c", command], {
+				const { shell, args: shellArgs } = getShellConfig();
+				const child = spawn(shell, [...shellArgs, command], {
 					cwd: process.cwd(),
 					env: { ...process.env },
 					stdio: ["ignore", "pipe", "pipe"],
@@ -108,7 +112,7 @@ export default function (pi: ExtensionAPI) {
 					backgrounded = true;
 					child.unref();
 
-					const logFile = `/tmp/oh-pi-bg-${Date.now()}.log`;
+					const logFile = path.join(os.tmpdir(), `oh-pi-bg-${Date.now()}.log`);
 					writeFileSync(logFile, stdout + stderr);
 
 					const proc: BgProcess = {


### PR DESCRIPTION
## Summary

- Replaces hardcoded `spawn("bash")` with `getShellConfig()` from `@mariozechner/pi-coding-agent` for cross-platform shell resolution (Windows Git Bash, macOS, Linux)
- Replaces hardcoded `/tmp` log path with `os.tmpdir()` for cross-platform compatibility

## Context

The `bg-process.ts` extension overrides the built-in `bash` tool but hardcodes `spawn("bash", ["-c", command])`, which fails on Windows where `bash` isn't on PATH by default. Pi's own shell resolver (`getShellConfig()`) handles this correctly by checking Git Bash locations on Windows and falling back appropriately on Unix.

Closes #96

## Test plan

- [ ] Verify bash tool works on macOS/Linux (regression test)
- [ ] Verify bash tool works on Windows with Git Bash installed
- [ ] Verify backgrounded commands write logs to the correct temp directory