### PR TITLE
fix(subagents): validate extension paths in management API

### DIFF
--- a/packages/subagents/agent-management.ts
+++ b/packages/subagents/agent-management.ts
@@ -221,6 +221,20 @@ function parseTools(raw: string): { tools?: string[]; mcpDirectTools?: string[] 
 	};
 }
 
+function validateExtensionPaths(paths: string[]): string | undefined {
+	for (const p of paths) {
+		if (p.startsWith("npm:")) continue;
+		const normalized = path.normalize(p);
+		if (path.isAbsolute(normalized)) {
+			return `Extension path '${p}' is not allowed: absolute paths are rejected. Use relative paths or npm: prefixed package references.`;
+		}
+		if (normalized.startsWith("..") || normalized.includes(`${path.sep}..`) || normalized.includes(`..${path.sep}`)) {
+			return `Extension path '${p}' is not allowed: parent directory traversal is rejected.`;
+		}
+	}
+	return undefined;
+}
+
 function applyAgentConfig(target: AgentConfig, cfg: Record<string, unknown>): string | undefined {
 	if (hasKey(cfg, "systemPrompt")) {
 		if (cfg.systemPrompt === false || cfg.systemPrompt === "") target.systemPrompt = "";
@@ -252,8 +266,12 @@ function applyAgentConfig(target: AgentConfig, cfg: Record<string, unknown>): st
 	if (hasKey(cfg, "extensions")) {
 		if (cfg.extensions === false) target.extensions = undefined;
 		else if (cfg.extensions === "") target.extensions = [];
-		else if (typeof cfg.extensions === "string") target.extensions = parseCsv(cfg.extensions);
-		else return "config.extensions must be a comma-separated string, empty string, or false when provided.";
+		else if (typeof cfg.extensions === "string") {
+			const parsed = parseCsv(cfg.extensions);
+			const extError = validateExtensionPaths(parsed);
+			if (extError) return extError;
+			target.extensions = parsed;
+		} else return "config.extensions must be a comma-separated string, empty string, or false when provided.";
 	}
 	if (hasKey(cfg, "thinking")) {
 		if (cfg.thinking === false || cfg.thinking === "") target.thinking = undefined;


### PR DESCRIPTION
## Summary

- Adds `validateExtensionPaths()` to reject directory traversal (`..`) and absolute paths in extension paths set via the management API
- Allows `npm:` prefixed package references (safe) and relative paths without traversal

## Context

The agent management API's create/update actions accept arbitrary strings in `config.extensions` which are passed as `--extension` CLI args to spawned subprocesses. A malicious or compromised LLM could use this to load arbitrary TypeScript files with system access. This adds input validation at the API boundary.

Closes #98

## Test plan

- [ ] Verify `npm:some-package` extensions still work
- [ ] Verify relative paths like `extensions/foo.ts` still work
- [ ] Verify `../../etc/payload.ts` is rejected
- [ ] Verify `/absolute/path/to/payload.ts` is rejected
- [ ] Verify existing agent create/update flows are unaffected