### PR TITLE
fix(subagents): secure async config temp file creation

### DIFF
--- a/packages/subagents/async-execution.ts
+++ b/packages/subagents/async-execution.ts
@@ -99,8 +99,9 @@ export function isAsyncAvailable(): boolean {
 function spawnRunner(cfg: object, suffix: string, cwd: string): number | undefined {
 	if (!jitiCliPath) return undefined;
 
-	const cfgPath = path.join(os.tmpdir(), `pi-async-cfg-${suffix}.json`);
-	fs.writeFileSync(cfgPath, JSON.stringify(cfg));
+	const tmpDir = fs.mkdtempSync(path.join(os.tmpdir(), `pi-async-cfg-`));
+	const cfgPath = path.join(tmpDir, `${suffix}.json`);
+	fs.writeFileSync(cfgPath, JSON.stringify(cfg), { mode: 0o600 });
 	const runner = path.join(path.dirname(fileURLToPath(import.meta.url)), "subagent-runner.ts");
 
 	const proc = spawn("node", [jitiCliPath, runner, cfgPath], {


### PR DESCRIPTION
## Summary

- Replaces predictable `pi-async-cfg-{id}.json` temp file path with `mkdtempSync` random directory
- Adds `mode: 0o600` to config file write, consistent with other temp files in the subagents package

## Context

The async runner writes config (containing system prompts, task strings, tool configurations) to a predictable path in the system temp directory without restricted permissions. Other temp file operations in the same codebase (`execution.ts`, `subagent-runner.ts`) already use the secure `mkdtempSync` + `mode: 0o600` pattern. This brings the async config writer in line with that existing practice.

Closes #97

## Test plan

- [ ] Verify async agent execution still works end-to-end
- [ ] Verify config file is created in a random subdirectory of tmpdir
- [ ] Verify config file permissions are 0o600