### PR TITLE
feat(repo): include experimental providers in pi source switcher

### DIFF
--- a/.changeset/pi-source-switcher-experimental.md
+++ b/.changeset/pi-source-switcher-experimental.md
@@ -1,0 +1,5 @@
+---
+default: minor
+---
+
+Extend the local pi source switcher to manage the experimental provider packages too, and warn users to fully restart pi instead of relying on `/reload` after switching sources.

--- a/README.md
+++ b/README.md
@@ -550,7 +550,11 @@ What it does:
 - rewrites only the managed oh-pi package sources in your pi settings
 - preserves package-specific config objects already in `settings.json`
 - runs `pi update` for each managed package so the switched source is ready to use
+- includes the experimental provider packages in addition to the main installer set
 - lets you validate a branch or detached worktree before you publish
+
+After switching, fully restart `pi`. Do not rely on `/reload` for source switches because it can
+keep previously loaded package modules alive.
 
 This is intended to be the normal development loop for testing a branch locally before cutting a
 release.

--- a/packages/oh-pi/bin/oh-pi.mjs
+++ b/packages/oh-pi/bin/oh-pi.mjs
@@ -12,7 +12,7 @@
 
 import { execFileSync } from "node:child_process";
 import process from "node:process";
-import { PACKAGES } from "./package-list.mjs";
+import { INSTALLER_PACKAGES } from "./package-list.mjs";
 
 const IS_WINDOWS = process.platform === "win32";
 
@@ -63,7 +63,7 @@ Options:
   -h, --help            Show this help
 
 Packages installed:
-${PACKAGES.map((p) => `  • ${p}`).join("\n")}
+${INSTALLER_PACKAGES.map((p) => `  • ${p}`).join("\n")}
 `.trim());
 }
 
@@ -119,7 +119,7 @@ const localFlag = opts.local ? ["-l"] : [];
 if (opts.remove) {
 	console.log("\n🐜 Removing oh-pi packages from pi...\n");
 	let failures = 0;
-	for (const pkg of PACKAGES) {
+	for (const pkg of INSTALLER_PACKAGES) {
 		const ok = run(pi, "remove", [`npm:${pkg}`, ...localFlag], { label: pkg });
 		if (!ok) failures++;
 	}
@@ -133,7 +133,7 @@ const scope = opts.local ? "project" : "global";
 console.log(`\n🐜 Installing oh-pi packages into pi (${scope})...\n`);
 
 let failures = 0;
-for (const pkg of PACKAGES) {
+for (const pkg of INSTALLER_PACKAGES) {
 	const source = `npm:${pkg}${suffix}`;
 	const ok = run(pi, "install", [source, ...localFlag], { label: pkg });
 	if (!ok) failures++;

--- a/packages/oh-pi/bin/package-list.mjs
+++ b/packages/oh-pi/bin/package-list.mjs
@@ -1,4 +1,4 @@
-export const PACKAGES = [
+export const INSTALLER_PACKAGES = [
 	"@ifi/oh-pi-extensions",
 	"@ifi/oh-pi-ant-colony",
 	"@ifi/pi-extension-subagents",
@@ -9,3 +9,7 @@ export const PACKAGES = [
 	"@ifi/oh-pi-skills",
 	"@ifi/pi-web-remote",
 ];
+
+export const EXPERIMENTAL_PACKAGES = ["@ifi/pi-provider-cursor", "@ifi/pi-provider-ollama"];
+
+export const SWITCHER_PACKAGES = [...INSTALLER_PACKAGES, ...EXPERIMENTAL_PACKAGES];

--- a/scripts/pi-source-switch.mts
+++ b/scripts/pi-source-switch.mts
@@ -6,7 +6,7 @@ import { homedir } from "node:os";
 import path from "node:path";
 import process from "node:process";
 import { fileURLToPath } from "node:url";
-import { PACKAGES } from "../packages/oh-pi/bin/package-list.mjs";
+import { SWITCHER_PACKAGES } from "../packages/oh-pi/bin/package-list.mjs";
 
 const IS_WINDOWS = process.platform === "win32";
 
@@ -157,7 +157,7 @@ export function rewriteManagedPackageSources(
 		return currentSource === nextSource ? entry : withPackageSource(entry, nextSource);
 	});
 
-	for (const packageName of PACKAGES) {
+	for (const packageName of SWITCHER_PACKAGES) {
 		if (!remainingPackages.has(packageName)) {
 			continue;
 		}
@@ -254,6 +254,10 @@ Examples:
   pnpm pi:published
   pnpm pi:switch remote -- --version 0.4.4
   pnpm pi:switch local -- --pi-local
+
+Notes:
+  - local/remote mode also manages the experimental provider packages
+  - fully restart pi after switching; /reload can keep old package modules alive
 `.trim());
 }
 
@@ -300,7 +304,7 @@ function collectManagedPackageSources(
 		}
 
 		const packageName = resolvePackageName(source);
-		if (!packageName || !PACKAGES.includes(packageName)) {
+		if (!packageName || !SWITCHER_PACKAGES.includes(packageName)) {
 			continue;
 		}
 
@@ -312,18 +316,18 @@ function collectManagedPackageSources(
 function buildDesiredSources(options: Options): Map<string, string> {
 	if (options.mode === "remote") {
 		const suffix = options.version ? `@${options.version}` : "";
-		return new Map(PACKAGES.map((packageName) => [packageName, `npm:${packageName}${suffix}`]));
+		return new Map(SWITCHER_PACKAGES.map((packageName) => [packageName, `npm:${packageName}${suffix}`]));
 	}
 
 	if (options.mode === "local") {
-		return resolveWorkspacePackageSources(options.repoPath, PACKAGES);
+		return resolveWorkspacePackageSources(options.repoPath, SWITCHER_PACKAGES);
 	}
 
 	throw new Error(`Unsupported mode: ${options.mode}`);
 }
 
 function describeChanges(currentSources: ReadonlyMap<string, string>, desiredSources: ReadonlyMap<string, string>): Change[] {
-	return PACKAGES.map((packageName) => ({
+	return SWITCHER_PACKAGES.map((packageName) => ({
 		packageName,
 		currentSource: currentSources.get(packageName),
 		nextSource: desiredSources.get(packageName) ?? "",
@@ -356,7 +360,7 @@ function printStatus(currentSources: ReadonlyMap<string, string>, settingsPath: 
 	console.log(`\noh-pi managed package sources (${scope} settings)`);
 	console.log(`Settings: ${settingsPath}`);
 	console.log("");
-	for (const packageName of PACKAGES) {
+	for (const packageName of SWITCHER_PACKAGES) {
 		console.log(`  ${packageName}`);
 		console.log(`    ${currentSources.get(packageName) ?? "<not configured>"}`);
 	}
@@ -365,7 +369,7 @@ function printStatus(currentSources: ReadonlyMap<string, string>, settingsPath: 
 function updatePiSources(pi: string, desiredSources: ReadonlyMap<string, string>) {
 	let failures = 0;
 	console.log("\nUpdating packages with pi...\n");
-	for (const packageName of PACKAGES) {
+	for (const packageName of SWITCHER_PACKAGES) {
 		const source = desiredSources.get(packageName);
 		if (!source) {
 			continue;
@@ -412,13 +416,15 @@ function main() {
 	const nextSettings: SettingsFile = { ...settings, packages: nextEntries };
 	if (options.dryRun) {
 		console.log("\nDry run only — settings were not written and pi update was not run.");
+		console.log("When you apply this switch, fully restart pi; /reload can keep old package modules alive.");
 		return;
 	}
 
 	writeSettings(settingsPath, nextSettings);
 	const pi = findPi();
 	updatePiSources(pi, desiredSources);
-	console.log("\n✅ Done. Restart pi to reload the switched packages.");
+	console.log("\n✅ Done. Fully restart pi to reload the switched packages.");
+	console.log("⚠️  Avoid /reload after switching sources; it can keep previously loaded package modules alive.");
 }
 
 const currentFilePath = realpathSync(fileURLToPath(import.meta.url));

--- a/scripts/pi-source-switch.test.ts
+++ b/scripts/pi-source-switch.test.ts
@@ -36,6 +36,7 @@ describe("pi source switcher helpers", () => {
 			new Map([
 				["@ifi/oh-pi-extensions", "/repo/packages/extensions"],
 				["@ifi/oh-pi-themes", "/repo/packages/themes"],
+				["@ifi/pi-provider-cursor", "/repo/packages/cursor"],
 			]),
 			(source) => parseNpmPackageName(source),
 		);
@@ -44,6 +45,7 @@ describe("pi source switcher helpers", () => {
 			"npm:@ifi/oh-pi",
 			{ source: "/repo/packages/extensions", extensions: ["-extensions/safe-guard.ts"] },
 			"/repo/packages/themes",
+			"/repo/packages/cursor",
 		]);
 	});
 


### PR DESCRIPTION
## Summary
- extend the pi source switcher to manage experimental provider packages (`@ifi/pi-provider-cursor`, `@ifi/pi-provider-ollama`)
- keep `npx @ifi/oh-pi` installer behavior unchanged by splitting installer vs switcher package lists
- add explicit guidance and runtime warnings to fully restart pi after switching sources instead of relying on `/reload`

## Testing
- pnpm exec vitest run scripts/pi-source-switch.test.ts
- pnpm --filter @ifi/oh-pi-core build
- pnpm test
- pnpm typecheck
- pnpm lint