### PR TITLE
fix(scheduler): ignore empty scheduler ownership

### DIFF
--- a/.changeset/fix-scheduler-empty-popup.md
+++ b/.changeset/fix-scheduler-empty-popup.md
@@ -1,0 +1,5 @@
+---
+default: patch
+---
+
+Fix the scheduler so empty instances do not hold or prompt about scheduler ownership when there are no scheduled tasks to review.

--- a/packages/extensions/extensions/scheduler.test.ts
+++ b/packages/extensions/extensions/scheduler.test.ts
@@ -987,6 +987,19 @@ describe("SchedulerRuntime", () => {
 			await runtime.tickScheduler();
 			expect(pi._userMessages).toHaveLength(0);
 		});
+
+		it("does not acquire a lease when there are no managed tasks", async () => {
+			const ctx = createMockCtx();
+			runtime.setRuntimeContext(ctx as any);
+
+			await runtime.tickScheduler();
+
+			expect(
+				(writeFileSync as ReturnType<typeof vi.fn>).mock.calls.some(
+					([file]: [string]) => typeof file === "string" && file.endsWith("scheduler.lease.json.tmp"),
+				),
+			).toBe(false);
+		});
 	});
 
 	describe("dispatchTask", () => {
@@ -2202,6 +2215,34 @@ describe("event wiring", () => {
 		expect(pi._userMessages).toHaveLength(0);
 	});
 
+	it("does not prompt when a foreign lease exists but there are no scheduled tasks", async () => {
+		const now = Date.now();
+		(existsSync as ReturnType<typeof vi.fn>).mockImplementation(
+			(file: string) => file.endsWith("scheduler.json") || file.endsWith("scheduler.lease.json"),
+		);
+		(readFileSync as ReturnType<typeof vi.fn>).mockImplementation((file: string) => {
+			if (file.endsWith("scheduler.lease.json")) {
+				return JSON.stringify({
+					version: 1,
+					instanceId: "foreign-instance",
+					sessionId: "/mock-home/.pi/agent/sessions/foreign.jsonl",
+					pid: 123,
+					cwd: "/mock-project",
+					heartbeatAt: now,
+				});
+			}
+			return JSON.stringify({ version: 1, tasks: [] });
+		});
+
+		const ctx = createMockCtx({ select: vi.fn().mockResolvedValue("Review tasks") });
+		pi._emit("session_start", { type: "session_start" }, ctx);
+		await Promise.resolve();
+		await Promise.resolve();
+
+		expect(ctx.ui.select).not.toHaveBeenCalled();
+		expect(ctx._notifications.some((n: any) => n.msg.includes("No scheduled tasks"))).toBe(false);
+	});
+
 	it("updates status on session_switch", () => {
 		const ctx = createMockCtx();
 		pi._emit("session_start", { type: "session_start" }, ctx);
@@ -2426,7 +2467,25 @@ describe("lease heartbeat refresh", () => {
 					heartbeatAt: now,
 				});
 			}
-			return JSON.stringify({ version: 1, tasks: [] });
+			return JSON.stringify({
+				version: 1,
+				tasks: [
+					{
+						id: "owned123",
+						prompt: "check build",
+						kind: "once",
+						enabled: true,
+						createdAt: now - ONE_MINUTE,
+						nextRunAt: now + ONE_MINUTE,
+						jitterMs: 0,
+						runCount: 0,
+						pending: false,
+						scope: "instance",
+						ownerInstanceId: instanceId,
+						ownerSessionId: null,
+					},
+				],
+			});
 		});
 
 		// Create a context that is NOT idle.

--- a/packages/extensions/extensions/scheduler.ts
+++ b/packages/extensions/extensions/scheduler.ts
@@ -557,14 +557,6 @@ export class SchedulerRuntime {
 		}
 
 		const now = Date.now();
-
-		// Refresh the lease heartbeat unconditionally so other instances see this
-		// instance as alive even when pi is busy and not dispatching tasks. Without
-		// this, the lease goes stale after SCHEDULER_LEASE_STALE_AFTER_MS when the
-		// agent is processing messages, causing newer instances to grab the lease
-		// and mark this instance's tasks as stale_owner.
-		this.refreshLeaseHeartbeat(now);
-
 		let mutated = this.reconcileTaskOwnership();
 
 		for (const task of Array.from(this.tasks.values())) {
@@ -582,11 +574,26 @@ export class SchedulerRuntime {
 			}
 		}
 
+		const shouldHoldLease = this.hasManagedTasksForLease();
+		if (shouldHoldLease) {
+			// Refresh the lease heartbeat unconditionally so other instances see this
+			// instance as alive even when pi is busy and not dispatching tasks. Without
+			// this, the lease goes stale after SCHEDULER_LEASE_STALE_AFTER_MS when the
+			// agent is processing messages, causing newer instances to grab the lease
+			// and mark this instance's tasks as stale_owner.
+			this.refreshLeaseHeartbeat(now);
+		} else {
+			this.releaseLeaseIfOwned();
+		}
+
 		if (mutated) {
 			this.persistTasks();
 		}
 		this.updateStatus();
 
+		if (!shouldHoldLease) {
+			return;
+		}
 		if (this.dispatching) {
 			return;
 		}
@@ -626,7 +633,7 @@ export class SchedulerRuntime {
 		}
 		this.startupOwnershipHandled = true;
 		const leaseStatus = this.getLeaseStatus();
-		if (!leaseStatus.activeForeign) {
+		if (!leaseStatus.activeForeign || this.tasks.size === 0) {
 			this.dispatchMode = "auto";
 			return;
 		}
@@ -1074,6 +1081,10 @@ export class SchedulerRuntime {
 		return Array.from(this.tasks.values()).filter(
 			(task) => task.ownerInstanceId && task.ownerInstanceId !== this.instanceId,
 		).length;
+	}
+
+	private hasManagedTasksForLease(): boolean {
+		return Array.from(this.tasks.values()).some((task) => task.enabled && !task.resumeRequired);
 	}
 
 	private readLease(): SchedulerLease | undefined {


### PR DESCRIPTION
## Summary
- stop empty scheduler instances from holding a scheduler lease
- skip the startup ownership prompt when a foreign lease exists but no scheduled tasks were restored
- add regression coverage for the empty-lease and busy-heartbeat cases

## Cause
`tickScheduler()` could acquire and keep a workspace lease even when the scheduler had no tasks at all. A later instance only checked for that foreign lease during startup, so it showed the ownership popup even though opening the task manager reported `No scheduled tasks.`

## Testing
- pnpm exec biome check packages/extensions/extensions/scheduler.ts packages/extensions/extensions/scheduler.test.ts
- pnpm test packages/extensions/extensions/scheduler.test.ts
- pnpm typecheck