### PR TITLE
fix(ollama): expand cloud catalog and local downloads

### DIFF
--- a/.changeset/fix-ollama-cloud-public-catalog.md
+++ b/.changeset/fix-ollama-cloud-public-catalog.md
@@ -1,0 +1,5 @@
+---
+default: patch
+---
+
+Fix the Ollama Cloud provider to discover the public model catalog during bootstrap and refreshes even before login, keep that broader public catalog visible even when authenticated discovery is narrower, extend the bundled fallback catalog with `glm-5.1`, and add CLI-aware local download prompts plus local context-window metadata sourced from the cloud catalog.

--- a/packages/ollama/README.md
+++ b/packages/ollama/README.md
@@ -5,12 +5,15 @@ Experimental Ollama provider package for pi with both local and cloud support.
 ## What it does
 
 - Registers a local `ollama` provider via `pi.registerProvider(...)`
+- Detects whether the Ollama CLI is available on Windows and Unix-like systems
 - Auto-discovers installed local Ollama models from the running daemon
+- Surfaces downloadable local candidates from the cloud catalog with context-window metadata
 - Adds `/login ollama-cloud` support using an Ollama API key flow
-- Discovers the current Ollama Cloud model catalog and stores it with the login credential
+- Discovers the current Ollama Cloud model catalog even before login, then stores refreshed metadata with the login credential
 - Exposes local models in `/model` as `ollama/<model-id>`
 - Exposes cloud models in `/model` as `ollama-cloud/<model-id>`
-- Adds `/ollama status|refresh-models|models|info` for a unified local + cloud workflow
+- Prompts to download a missing local model when you select `ollama/<model-id>` and uses the Ollama CLI to pull it
+- Adds `/ollama status|refresh-models|models|info|pull` for a unified local + cloud workflow
 
 ## Install
 
@@ -25,32 +28,38 @@ This package is intentionally separate from `@ifi/oh-pi` for now.
 ### Local Ollama
 
 1. Install the package
-2. Start Ollama locally
+2. Make sure the `ollama` CLI is installed and a local Ollama instance is running
 3. Open `/model` and select an `ollama/...` model
-4. Run `/ollama refresh-models` whenever you pull or remove local models
+4. If the model is not installed yet, pi will prompt to download it with the Ollama CLI
+5. Run `/ollama refresh-models` whenever you pull or remove local models outside pi
 
 ### Ollama Cloud
 
 1. Install the package
-2. Run `/login ollama-cloud`
-3. Create an API key on Ollama when pi opens the keys page
-4. Paste the key back into pi
-5. Open `/model` and select an `ollama-cloud/...` model
-6. Optionally run `/ollama refresh-models` later to refresh both local and cloud catalogs
+2. Open `/model` or run `/ollama models` to browse the public Ollama Cloud catalog
+3. Run `/login ollama-cloud` before using an `ollama-cloud/...` model
+4. Create an API key on Ollama when pi opens the keys page
+5. Paste the key back into pi
+6. Open `/model` and select an `ollama-cloud/...` model
+7. Optionally run `/ollama refresh-models` later to refresh both local and cloud catalogs
 
 ## Commands
 
-- `/ollama status` — show local daemon status and cloud auth/catalog status
+- `/ollama status` — show local CLI + daemon status, local install/download counts, and cloud auth/catalog status
 - `/ollama refresh-models` — refresh both local and cloud Ollama models
 - `/ollama models` — list local and cloud Ollama models with source/capability badges for easier selection
-- `/ollama info <model>` — show detailed metadata for a local or cloud Ollama model
+- `/ollama info <model>` — show detailed metadata for a local or cloud Ollama model, including context window size
+- `/ollama pull <model>` — manually download a local Ollama model via the Ollama CLI
 - `/ollama-cloud status` — backward-compatible cloud-only status alias
 - `/ollama-cloud refresh-models` — backward-compatible cloud-only refresh alias
 
 ## Notes
 
 - Local Ollama uses the daemon's OpenAI-compatible `/v1` API plus `/api/show` metadata.
-- Cloud Ollama uses Ollama's documented API-key flow for third-party access.
+- If the Ollama CLI is missing, pi warns that only `ollama-cloud/...` models are available because Ollama is not installed locally.
+- pi prefers the broader cloud catalog for browsing and uses the cloud metadata to annotate local download candidates with accurate context sizes.
+- Cloud Ollama always discovers the public catalog first, then merges any authenticated metadata so login cannot shrink the visible model list.
+- Ollama's documented API-key flow is still used for actual cloud access.
 - Local model discovery is dynamic and installation-specific, so there is no static local fallback catalog.
 - Cloud model discovery falls back to a bundled cloud catalog when live discovery is unavailable.
 - Costs are currently left at zero because Ollama does not expose stable per-token pricing for local or cloud use in a way that pi can rely on here.

--- a/packages/ollama/index.ts
+++ b/packages/ollama/index.ts
@@ -1,5 +1,12 @@
 import type { ExtensionAPI } from "@mariozechner/pi-coding-agent";
 import {
+	type AssistantMessageEventStream,
+	type Context,
+	type Model,
+	type SimpleStreamOptions,
+	streamSimpleOpenAICompletions,
+} from "@mariozechner/pi-ai";
+import {
 	createOllamaCloudOAuthProvider,
 	loginOllamaCloud,
 	refreshOllamaCloudCredential,
@@ -14,11 +21,14 @@ import {
 	getOllamaCloudRuntimeConfig,
 	getOllamaLocalRuntimeConfig,
 } from "./config.js";
+import { clearOllamaCliStatusCache, getOllamaCliStatus, pullOllamaModel, type OllamaCliStatus } from "./local.js";
 import {
 	discoverOllamaCloudModels,
 	discoverOllamaLocalModels,
 	getCredentialModels,
 	getFallbackOllamaCloudModels,
+	mergeOllamaLocalCatalog,
+	toDownloadableOllamaLocalModel,
 	toProviderModels,
 	type OllamaCloudCredentials,
 	type OllamaProviderModel,
@@ -28,6 +38,33 @@ type RuntimeDiscoveryState = {
 	models: OllamaProviderModel[];
 	lastRefresh: number | null;
 	lastError: string | null;
+};
+
+type ModelRegistryAuthStorage = {
+	get: (provider: string) => unknown;
+	set: (provider: string, credential: any) => void;
+};
+
+type ModelRegistryLike = {
+	authStorage: ModelRegistryAuthStorage;
+	refresh?: () => void;
+};
+
+type UiLike = {
+	notify: (msg: string, type?: "error" | "info" | "warning") => void;
+	setStatus: (key: string, value: string | undefined) => void;
+	confirm?: (title: string, message: string) => Promise<boolean>;
+};
+
+type CommandContextLike = {
+	hasUI?: boolean;
+	ui: UiLike;
+	modelRegistry: ModelRegistryLike;
+};
+
+type CollectedOllamaModel = OllamaProviderModel & {
+	provider: string;
+	baseUrl: string;
 };
 
 const localDiscoveryState: RuntimeDiscoveryState = {
@@ -42,12 +79,19 @@ const cloudEnvDiscoveryState: RuntimeDiscoveryState = {
 	lastError: null,
 };
 
+const activeLocalPulls = new Map<string, Promise<boolean>>();
+const PULL_STATUS_KEY = "ollama.pull";
+
+let ollamaCliStatus: OllamaCliStatus | null = null;
+let missingCliWarningShown = false;
+
 function registerOllamaLocalProvider(pi: ExtensionAPI): void {
 	pi.registerProvider(OLLAMA_LOCAL_PROVIDER, {
 		api: OLLAMA_API,
 		apiKey: OLLAMA_LOCAL_API_KEY_LITERAL,
 		baseUrl: getOllamaLocalRuntimeConfig().apiUrl,
-		models: toProviderModels(localDiscoveryState.models),
+		models: toProviderModels(getRegisteredLocalModels()),
+		streamSimple: streamSimpleOllamaLocal,
 	});
 }
 
@@ -61,7 +105,16 @@ function registerOllamaCloudProvider(pi: ExtensionAPI): void {
 	});
 }
 
-async function refreshRegisteredLocalModels(pi: ExtensionAPI): Promise<OllamaProviderModel[]> {
+async function refreshRegisteredLocalModels(pi: ExtensionAPI, options: { forceCli?: boolean } = {}): Promise<OllamaProviderModel[]> {
+	ollamaCliStatus = await getOllamaCliStatus({ force: options.forceCli });
+	if (!ollamaCliStatus.available) {
+		localDiscoveryState.models = [];
+		localDiscoveryState.lastError = null;
+		localDiscoveryState.lastRefresh = Date.now();
+		registerOllamaLocalProvider(pi);
+		return [];
+	}
+
 	try {
 		localDiscoveryState.models = (await discoverOllamaLocalModels()) ?? [];
 		localDiscoveryState.lastError = null;
@@ -69,6 +122,7 @@ async function refreshRegisteredLocalModels(pi: ExtensionAPI): Promise<OllamaPro
 		localDiscoveryState.models = [];
 		localDiscoveryState.lastError = error instanceof Error ? error.message : String(error);
 	}
+
 	localDiscoveryState.lastRefresh = Date.now();
 	registerOllamaLocalProvider(pi);
 	return localDiscoveryState.models;
@@ -76,13 +130,6 @@ async function refreshRegisteredLocalModels(pi: ExtensionAPI): Promise<OllamaPro
 
 async function refreshRegisteredCloudEnvModels(pi: ExtensionAPI): Promise<OllamaProviderModel[]> {
 	const apiKey = process.env[OLLAMA_CLOUD_API_KEY_ENV]?.trim();
-	if (!apiKey) {
-		cloudEnvDiscoveryState.models = [];
-		cloudEnvDiscoveryState.lastError = null;
-		cloudEnvDiscoveryState.lastRefresh = Date.now();
-		registerOllamaCloudProvider(pi);
-		return cloudEnvDiscoveryState.models;
-	}
 
 	try {
 		cloudEnvDiscoveryState.models = (await discoverOllamaCloudModels(apiKey)) ?? getFallbackOllamaCloudModels();
@@ -91,14 +138,16 @@ async function refreshRegisteredCloudEnvModels(pi: ExtensionAPI): Promise<Ollama
 		cloudEnvDiscoveryState.models = getFallbackOllamaCloudModels();
 		cloudEnvDiscoveryState.lastError = error instanceof Error ? error.message : String(error);
 	}
+
 	cloudEnvDiscoveryState.lastRefresh = Date.now();
 	registerOllamaCloudProvider(pi);
+	registerOllamaLocalProvider(pi);
 	return cloudEnvDiscoveryState.models;
 }
 
 function registerOllamaCommands(pi: ExtensionAPI): void {
 	pi.registerCommand("ollama", {
-		description: "Inspect or refresh local + cloud Ollama providers: /ollama [status|refresh-models|models|info <model>]",
+		description: "Inspect or refresh local + cloud Ollama providers: /ollama [status|refresh-models|models|info <model>|pull <model>]",
 		async handler(args, ctx) {
 			const trimmed = args.trim();
 			const [rawAction = "status", ...rest] = trimmed ? trimmed.split(/\s+/) : ["status"];
@@ -106,18 +155,41 @@ function registerOllamaCommands(pi: ExtensionAPI): void {
 			const credential = getStoredCloudCredential(ctx);
 
 			if (action === "refresh-models") {
-				const localModels = await refreshRegisteredLocalModels(pi);
-						const cloudModels = await refreshCloudModels(pi, ctx, credential);
-				ctx.modelRegistry.refresh();
-				const cloudStatus = credential || process.env[OLLAMA_CLOUD_API_KEY_ENV]?.trim()
+				clearOllamaCliStatusCache();
+				const localModels = await refreshRegisteredLocalModels(pi, { forceCli: true });
+				const cloudModels = await refreshCloudModels(pi, ctx, credential);
+				ctx.modelRegistry.refresh?.();
+				const cloudStatus = hasCloudAuth(credential)
 					? `${cloudModels.length} cloud available`
-					: "cloud not configured";
-				ctx.ui.notify(`Refreshed Ollama models (${localModels.length} local, ${cloudStatus}).`, "info");
+					: `${cloudModels.length} public cloud discovered; run /login ollama-cloud to use them`;
+				ctx.ui.notify(`Refreshed Ollama models (${localModels.length} local installed, ${cloudStatus}).`, "info");
 				return;
 			}
 
 			if (action === "models") {
 				ctx.ui.notify(renderModelList(collectOllamaModels(credential)), "info");
+				return;
+			}
+
+			if (action === "pull" || action === "download") {
+				const query = rest.join(" ").trim();
+				if (!query) {
+					ctx.ui.notify("Usage: /ollama pull <model>", "warning");
+					return;
+				}
+
+				const localModel = findLocalModelForQuery(query, credential);
+				if (!localModel) {
+					ctx.ui.notify(`No Ollama model matched \"${query}\". Run /ollama refresh-models first.`, "warning");
+					return;
+				}
+
+				if (localModel.localAvailability === "installed") {
+					ctx.ui.notify(`ollama/${localModel.id} is already installed locally.`, "info");
+					return;
+				}
+
+				await pullLocalModel(pi, ctx, localModel.id);
 				return;
 			}
 
@@ -148,12 +220,11 @@ function registerOllamaCommands(pi: ExtensionAPI): void {
 
 			if (action === "refresh-models") {
 				const cloudModels = await refreshCloudModels(pi, ctx, credential);
-				ctx.modelRegistry.refresh();
-				if (!credential && !process.env[OLLAMA_CLOUD_API_KEY_ENV]?.trim()) {
-					ctx.ui.notify("Ollama Cloud is not configured. Run /login ollama-cloud or set OLLAMA_API_KEY.", "warning");
-					return;
-				}
-				ctx.ui.notify(`Refreshed Ollama Cloud models (${cloudModels.length} available).`, "info");
+				ctx.modelRegistry.refresh?.();
+				const suffix = hasCloudAuth(credential)
+					? `${cloudModels.length} available`
+					: `${cloudModels.length} public models discovered; run /login ollama-cloud to use them`;
+				ctx.ui.notify(`Refreshed Ollama Cloud models (${suffix}).`, "info");
 				return;
 			}
 
@@ -162,11 +233,68 @@ function registerOllamaCommands(pi: ExtensionAPI): void {
 	});
 }
 
-async function refreshCloudModels(
-	pi: ExtensionAPI,
-	ctx: { modelRegistry: { authStorage: { set: (provider: string, credential: any) => void } } },
-	credential: OllamaCloudCredentials | null,
-): Promise<OllamaProviderModel[]> {
+function registerOllamaLifecycle(pi: ExtensionAPI): void {
+	pi.on("session_start", async (_event, ctx) => {
+		ollamaCliStatus = await getOllamaCliStatus();
+		registerOllamaLocalProvider(pi);
+
+		if (!ollamaCliStatus.available && ctx.hasUI && !missingCliWarningShown) {
+			missingCliWarningShown = true;
+			ctx.ui.notify(
+				"Ollama CLI not found. Only ollama-cloud models are available right now because Ollama is not installed.",
+				"warning",
+			);
+		}
+	});
+
+	pi.on("model_select", async (event, ctx) => {
+		if (event.model.provider !== OLLAMA_LOCAL_PROVIDER) {
+			return;
+		}
+
+		const localModel = getRegisteredLocalModels().find((model) => model.id === event.model.id);
+		if (!localModel || localModel.localAvailability !== "downloadable") {
+			return;
+		}
+
+		ollamaCliStatus = await getOllamaCliStatus();
+		if (!ollamaCliStatus.available) {
+			ctx.ui.notify(
+				"Ollama CLI not found. Only ollama-cloud models are available right now because Ollama is not installed.",
+				"warning",
+			);
+			return;
+		}
+
+		if (event.source === "restore" || !ctx.hasUI || typeof ctx.ui.confirm !== "function") {
+			ctx.ui.notify(
+				`ollama/${event.model.id} is not installed locally yet. Run /ollama pull ${event.model.id} to download it.`,
+				"warning",
+			);
+			return;
+		}
+
+		const shouldDownload = await ctx.ui.confirm(
+			"Download local Ollama model?",
+			[
+				"Would you like to download this model?",
+				"",
+				`ollama/${event.model.id}`,
+				"",
+				`pi will use the Ollama CLI against ${getOllamaLocalRuntimeConfig().origin}.`,
+				`Ollama Cloud is usually faster for the same model: ollama-cloud/${event.model.id}`,
+			].join("\n"),
+		);
+		if (!shouldDownload) {
+			ctx.ui.notify(`Skipped local download for ollama/${event.model.id}.`, "info");
+			return;
+		}
+
+		await pullLocalModel(pi, ctx, event.model.id);
+	});
+}
+
+async function refreshCloudModels(pi: ExtensionAPI, ctx: CommandContextLike, credential: OllamaCloudCredentials | null): Promise<OllamaProviderModel[]> {
 	if (credential) {
 		const refreshed = credential.expires <= Date.now()
 			? await refreshOllamaCloudCredential(credential)
@@ -177,54 +305,129 @@ async function refreshCloudModels(
 	return refreshRegisteredCloudEnvModels(pi);
 }
 
+async function pullLocalModel(pi: ExtensionAPI, ctx: CommandContextLike, modelId: string): Promise<boolean> {
+	const existing = activeLocalPulls.get(modelId);
+	if (existing) {
+		return existing;
+	}
+
+	const run = (async () => {
+		clearOllamaCliStatusCache();
+		ollamaCliStatus = await getOllamaCliStatus({ force: true });
+		if (!ollamaCliStatus.available) {
+			registerOllamaLocalProvider(pi);
+			ctx.ui.notify(
+				"Ollama CLI not found. Only ollama-cloud models are available right now because Ollama is not installed.",
+				"warning",
+			);
+			return false;
+		}
+
+		ctx.ui.notify(`Downloading ollama/${modelId} via the Ollama CLI...`, "info");
+		ctx.ui.setStatus(PULL_STATUS_KEY, `Pulling ${modelId}...`);
+
+		try {
+			await pullOllamaModel(modelId, {
+				env: createOllamaProcessEnv(),
+				onOutput: (line) => {
+					ctx.ui.setStatus(PULL_STATUS_KEY, `Pulling ${modelId} — ${line}`);
+				},
+			});
+
+			await refreshRegisteredLocalModels(pi);
+			ctx.modelRegistry.refresh?.();
+			if (!isLocalModelInstalled(modelId)) {
+				throw new Error(`Downloaded ${modelId}, but pi could not rediscover it from the local Ollama instance.`);
+			}
+
+			ctx.ui.notify(`Downloaded ollama/${modelId}.`, "info");
+			return true;
+		} catch (error) {
+			ctx.ui.notify(`Failed to download ollama/${modelId}: ${error instanceof Error ? error.message : String(error)}`, "error");
+			return false;
+		} finally {
+			ctx.ui.setStatus(PULL_STATUS_KEY, undefined);
+			activeLocalPulls.delete(modelId);
+		}
+	})();
+
+	activeLocalPulls.set(modelId, run);
+	return run;
+}
+
+function streamSimpleOllamaLocal(model: Model<any>, context: Context, options?: SimpleStreamOptions): AssistantMessageEventStream {
+	if (!isLocalModelInstalled(model.id)) {
+		if (!ollamaCliStatus?.available) {
+			throw new Error("Ollama CLI is not installed. Only ollama-cloud models are available right now.");
+		}
+		throw new Error(
+			`ollama/${model.id} is not installed locally yet. Select it again to download it, or run /ollama pull ${model.id}.`,
+		);
+	}
+
+	return streamSimpleOpenAICompletions(model as Model<"openai-completions">, context, options);
+}
+
 function renderUnifiedStatus(credential: OllamaCloudCredentials | null): string {
 	const localConfig = getOllamaLocalRuntimeConfig();
 	const cloudConfig = getOllamaCloudRuntimeConfig();
-	const localState = localDiscoveryState.lastError
-		? `unreachable (${localDiscoveryState.lastError})`
-		: localDiscoveryState.lastRefresh
-			? "reachable"
-			: "probing";
-	const localRefresh = formatRefreshAge(localDiscoveryState.lastRefresh);
-	const cloudRefresh = formatRefreshAge(credential?.lastModelRefresh ?? cloudEnvDiscoveryState.lastRefresh);
+	const localModels = getRegisteredLocalModels();
+	const downloadableLocalModels = localModels.filter((model) => model.localAvailability === "downloadable");
 	const cloudModels = credential ? getCredentialModels(credential) : cloudEnvDiscoveryState.models;
-	const cloudAuth = credential ? "stored via /login" : process.env[OLLAMA_CLOUD_API_KEY_ENV]?.trim() ? "environment only" : "not configured";
 	return [
-		`Ollama local: ${localState}`,
-		`Local models: ${localDiscoveryState.models.length}${localRefresh}`,
+		`Ollama CLI: ${describeLocalCliStatus()}`,
+		`Ollama local: ${describeLocalRuntime()}`,
+		`Local installed: ${localDiscoveryState.models.length}${formatRefreshAge(localDiscoveryState.lastRefresh)}`,
+		`Local download candidates: ${downloadableLocalModels.length}`,
 		`Local base URL: ${localConfig.apiUrl}`,
-		`Ollama cloud auth: ${cloudAuth}`,
-		`Cloud models: ${cloudModels.length}${cloudRefresh}`,
+		`Ollama cloud auth: ${describeCloudAuth(credential)}`,
+		`Cloud models: ${cloudModels.length}${formatRefreshAge(credential?.lastModelRefresh ?? cloudEnvDiscoveryState.lastRefresh)}`,
 		`Cloud base URL: ${cloudConfig.apiUrl}`,
-		`Tip: run /ollama models to compare local and cloud choices.`,
+		`Tip: prefer ollama-cloud/... for speed, and use /ollama pull <model> only when you need a local copy.`,
 	].join("\n");
 }
 
 function renderCloudStatus(credential: OllamaCloudCredentials | null): string {
 	const config = getOllamaCloudRuntimeConfig();
 	const cloudModels = credential ? getCredentialModels(credential) : cloudEnvDiscoveryState.models;
-	const cloudAuth = credential ? "stored via /login" : process.env[OLLAMA_CLOUD_API_KEY_ENV]?.trim() ? "environment only" : "not configured";
 	return [
-		`Ollama cloud auth: ${cloudAuth}`,
+		`Ollama cloud auth: ${describeCloudAuth(credential)}`,
 		`Cloud models: ${cloudModels.length}${formatRefreshAge(credential?.lastModelRefresh ?? cloudEnvDiscoveryState.lastRefresh)}`,
 		`Cloud base URL: ${config.apiUrl}`,
 	].join("\n");
 }
 
-function collectOllamaModels(credential: OllamaCloudCredentials | null): Array<OllamaProviderModel & { provider: string; baseUrl: string }> {
+function collectOllamaModels(credential: OllamaCloudCredentials | null): CollectedOllamaModel[] {
 	const localConfig = getOllamaLocalRuntimeConfig();
 	const cloudConfig = getOllamaCloudRuntimeConfig();
 	const cloudModels = credential ? getCredentialModels(credential) : cloudEnvDiscoveryState.models;
 	return [
-		...localDiscoveryState.models.map((model) => ({ ...model, provider: OLLAMA_LOCAL_PROVIDER, baseUrl: localConfig.apiUrl })),
 		...cloudModels.map((model) => ({ ...model, provider: OLLAMA_CLOUD_PROVIDER, baseUrl: cloudConfig.apiUrl })),
+		...getRegisteredLocalModels().map((model) => ({ ...model, provider: OLLAMA_LOCAL_PROVIDER, baseUrl: localConfig.apiUrl })),
 	];
 }
 
-function findModelForQuery(
-	query: string,
-	models: Array<OllamaProviderModel & { provider: string; baseUrl: string }>,
-): (OllamaProviderModel & { provider: string; baseUrl: string }) | null {
+function findLocalModelForQuery(query: string, credential: OllamaCloudCredentials | null): OllamaProviderModel | null {
+	const localModels = getRegisteredLocalModels();
+	const localCollectedModels = localModels.map((model) => ({ ...model, provider: OLLAMA_LOCAL_PROVIDER, baseUrl: getOllamaLocalRuntimeConfig().apiUrl }));
+	const localMatch = findModelForQuery(query, localCollectedModels);
+	if (localMatch) {
+		return localMatch;
+	}
+
+	const cloudModels = (credential ? getCredentialModels(credential) : cloudEnvDiscoveryState.models).map((model) => ({
+		...model,
+		provider: OLLAMA_CLOUD_PROVIDER,
+		baseUrl: getOllamaCloudRuntimeConfig().apiUrl,
+	}));
+	const cloudMatch = findModelForQuery(query, cloudModels);
+	if (!cloudMatch) {
+		return null;
+	}
+	return localModels.find((model) => model.id === cloudMatch.id) ?? toDownloadableOllamaLocalModel(cloudMatch);
+}
+
+function findModelForQuery(query: string, models: CollectedOllamaModel[]): CollectedOllamaModel | null {
 	const normalized = query.trim().toLowerCase();
 	if (!normalized) {
 		return null;
@@ -240,7 +443,7 @@ function findModelForQuery(
 	);
 }
 
-function renderModelInfo(model: OllamaProviderModel & { provider: string; baseUrl: string }): string {
+function renderModelInfo(model: CollectedOllamaModel): string {
 	const lines = [
 		`${sourceIcon(model.provider)} ${model.provider}/${model.id}`,
 		`Name: ${model.name}`,
@@ -251,6 +454,9 @@ function renderModelInfo(model: OllamaProviderModel & { provider: string; baseUr
 		`Max tokens: ${model.maxTokens.toLocaleString()}`,
 		`Base URL: ${model.baseUrl}`,
 	];
+	if (model.provider === OLLAMA_LOCAL_PROVIDER) {
+		lines.splice(3, 0, `Local availability: ${model.localAvailability === "downloadable" ? "download required" : "installed"}`);
+	}
 	if (model.family) {
 		lines.splice(4, 0, `Family: ${model.family}`);
 	}
@@ -267,25 +473,27 @@ function renderModelInfo(model: OllamaProviderModel & { provider: string; baseUr
 	return lines.join("\n");
 }
 
-function renderModelList(models: Array<OllamaProviderModel & { provider: string; baseUrl: string }>): string {
+function renderModelList(models: CollectedOllamaModel[]): string {
 	if (models.length === 0) {
 		return "No Ollama models are currently registered. Run /ollama refresh-models.";
 	}
+
 	const sections = [
-		{
-			title: "Local",
-			models: models.filter((model) => model.provider === OLLAMA_LOCAL_PROVIDER),
-		},
 		{
 			title: "Cloud",
 			models: models.filter((model) => model.provider === OLLAMA_CLOUD_PROVIDER),
 		},
+		{
+			title: "Local",
+			models: models.filter((model) => model.provider === OLLAMA_LOCAL_PROVIDER),
+		},
 	].filter((section) => section.models.length > 0);
+
 	return sections
 		.map((section) => [
 			`Ollama ${section.title}:`,
 			...section.models
-				.sort((left, right) => left.id.localeCompare(right.id))
+				.sort((left, right) => sortCollectedModels(left, right))
 				.map(
 					(model) =>
 						`  ${sourceIcon(model.provider)} ${model.provider}/${model.id} — ${model.name}${renderModelBadges(model)} · ${model.contextWindow.toLocaleString()} ctx`,
@@ -296,6 +504,9 @@ function renderModelList(models: Array<OllamaProviderModel & { provider: string;
 
 function renderModelBadges(model: OllamaProviderModel): string {
 	const badges: string[] = [];
+	if (model.localAvailability === "downloadable") {
+		badges.push("download");
+	}
 	if (model.input.includes("image")) {
 		badges.push("vision");
 	}
@@ -313,6 +524,9 @@ function summarizeCapabilities(model: OllamaProviderModel): string | null {
 	for (const capability of model.capabilities ?? []) {
 		values.add(capability);
 	}
+	if (model.localAvailability === "downloadable") {
+		values.add("download");
+	}
 	if (model.input.includes("image")) {
 		values.add("vision");
 	}
@@ -320,6 +534,63 @@ function summarizeCapabilities(model: OllamaProviderModel): string | null {
 		values.add("thinking");
 	}
 	return values.size > 0 ? [...values].join(", ") : null;
+}
+
+function getRegisteredLocalModels(): OllamaProviderModel[] {
+	if (!ollamaCliStatus?.available) {
+		return [];
+	}
+	const cloudCatalog = cloudEnvDiscoveryState.models.length > 0 ? cloudEnvDiscoveryState.models : getFallbackOllamaCloudModels();
+	return mergeOllamaLocalCatalog(localDiscoveryState.models, cloudCatalog);
+}
+
+function isLocalModelInstalled(modelId: string): boolean {
+	return localDiscoveryState.models.some((model) => model.id === modelId);
+}
+
+function hasCloudAuth(credential: OllamaCloudCredentials | null): boolean {
+	return Boolean(credential || process.env[OLLAMA_CLOUD_API_KEY_ENV]?.trim());
+}
+
+function describeCloudAuth(credential: OllamaCloudCredentials | null): string {
+	if (credential) {
+		return "stored via /login";
+	}
+	if (process.env[OLLAMA_CLOUD_API_KEY_ENV]?.trim()) {
+		return "environment only";
+	}
+	return "public catalog only (run /login ollama-cloud to use models)";
+}
+
+function describeLocalCliStatus(): string {
+	if (ollamaCliStatus?.available) {
+		return ollamaCliStatus.version ? `available (${ollamaCliStatus.version})` : "available";
+	}
+	return "missing (only cloud instances are available right now because Ollama is not installed)";
+}
+
+function describeLocalRuntime(): string {
+	if (!ollamaCliStatus?.available) {
+		return "downloads unavailable";
+	}
+	if (localDiscoveryState.lastError) {
+		return `unreachable (${localDiscoveryState.lastError})`;
+	}
+	if (localDiscoveryState.lastRefresh) {
+		return "reachable";
+	}
+	return "probing";
+}
+
+function sortCollectedModels(left: CollectedOllamaModel, right: CollectedOllamaModel): number {
+	if (left.provider === right.provider && left.provider === OLLAMA_LOCAL_PROVIDER) {
+		const leftWeight = left.localAvailability === "downloadable" ? 1 : 0;
+		const rightWeight = right.localAvailability === "downloadable" ? 1 : 0;
+		if (leftWeight !== rightWeight) {
+			return leftWeight - rightWeight;
+		}
+	}
+	return left.id.localeCompare(right.id);
 }
 
 function sourceIcon(provider: string): string {
@@ -352,13 +623,19 @@ function getStoredCloudCredential(ctx: { modelRegistry: { authStorage: { get: (p
 		: null;
 }
 
-function bootstrapOllamaProviders(pi: ExtensionAPI): void {
-	registerOllamaLocalProvider(pi);
-	registerOllamaCloudProvider(pi);
-	void refreshRegisteredLocalModels(pi);
-	if (process.env[OLLAMA_CLOUD_API_KEY_ENV]?.trim()) {
-		void refreshRegisteredCloudEnvModels(pi);
+function createOllamaProcessEnv(): NodeJS.ProcessEnv {
+	const env = { ...process.env };
+	if (!env.OLLAMA_HOST) {
+		env.OLLAMA_HOST = getOllamaLocalRuntimeConfig().origin;
 	}
+	return env;
+}
+
+function bootstrapOllamaProviders(pi: ExtensionAPI): void {
+	registerOllamaCloudProvider(pi);
+	registerOllamaLocalProvider(pi);
+	void refreshRegisteredCloudEnvModels(pi);
+	void refreshRegisteredLocalModels(pi);
 }
 
 export {
@@ -375,4 +652,5 @@ export { toOllamaModel, toOllamaCloudModel, type OllamaCloudCredentials, type Ol
 export default function ollamaProviderExtension(pi: ExtensionAPI): void {
 	bootstrapOllamaProviders(pi);
 	registerOllamaCommands(pi);
+	registerOllamaLifecycle(pi);
 }

--- a/packages/ollama/local.ts
+++ b/packages/ollama/local.ts
@@ -1,0 +1,134 @@
+import { type ChildProcessByStdio, execFileSync, spawn } from "node:child_process";
+import process from "node:process";
+import type { Readable } from "node:stream";
+
+const IS_WINDOWS = process.platform === "win32";
+const OLLAMA_COMMAND_CANDIDATES = IS_WINDOWS ? ["ollama.exe", "ollama"] : ["ollama"];
+
+type OllamaCliStatus = {
+	available: boolean;
+	command?: string;
+	version?: string;
+	error?: string;
+};
+
+let cachedCliStatus: OllamaCliStatus | null = null;
+let pendingCliStatus: Promise<OllamaCliStatus> | null = null;
+
+export async function getOllamaCliStatus(options: { force?: boolean } = {}): Promise<OllamaCliStatus> {
+	if (!options.force && cachedCliStatus) {
+		return cachedCliStatus;
+	}
+
+	if (pendingCliStatus) {
+		return pendingCliStatus;
+	}
+
+	pendingCliStatus = Promise.resolve(detectOllamaCli()).finally(() => {
+		pendingCliStatus = null;
+	});
+	cachedCliStatus = await pendingCliStatus;
+	return cachedCliStatus;
+}
+
+export async function pullOllamaModel(
+	modelId: string,
+	options: {
+		env?: NodeJS.ProcessEnv;
+		signal?: AbortSignal;
+		onOutput?: (line: string) => void;
+	} = {},
+): Promise<void> {
+	const cli = await getOllamaCliStatus();
+	if (!cli.available || !cli.command) {
+		throw new Error("Ollama CLI is not installed.");
+	}
+
+	const command = cli.command;
+	await new Promise<void>((resolve, reject) => {
+		const child = spawn(command, ["pull", modelId], {
+			env: options.env,
+			stdio: ["ignore", "pipe", "pipe"],
+			shell: IS_WINDOWS,
+		}) as ChildProcessByStdio<null, Readable, Readable>;
+		let stderr = "";
+		let stdout = "";
+
+		child.stdout.on("data", (chunk: Buffer | string) => {
+			const text = String(chunk);
+			stdout += text;
+			emitOutputLines(text, options.onOutput);
+		});
+
+		child.stderr.on("data", (chunk: Buffer | string) => {
+			const text = String(chunk);
+			stderr += text;
+			emitOutputLines(text, options.onOutput);
+		});
+
+		child.on("error", (error: Error) => {
+			reject(error);
+		});
+
+		child.on("close", (code: number | null) => {
+			if (code === 0) {
+				resolve();
+				return;
+			}
+			reject(new Error(stderr.trim() || stdout.trim() || `ollama pull ${modelId} exited with code ${code ?? "unknown"}`));
+		});
+
+		options.signal?.addEventListener(
+			"abort",
+			() => {
+				child.kill();
+				reject(new Error(`ollama pull ${modelId} was aborted.`));
+			},
+			{ once: true },
+		);
+	});
+}
+
+export function clearOllamaCliStatusCache(): void {
+	cachedCliStatus = null;
+}
+
+function detectOllamaCli(): OllamaCliStatus {
+	let lastError = "Ollama CLI not found.";
+	for (const command of OLLAMA_COMMAND_CANDIDATES) {
+		try {
+			const output = execFileSync(command, ["--version"], {
+				encoding: "utf-8",
+				stdio: ["ignore", "pipe", "pipe"],
+				shell: IS_WINDOWS,
+			}).trim();
+			return {
+				available: true,
+				command,
+				version: output || undefined,
+			};
+		} catch (error) {
+			lastError = error instanceof Error ? error.message : String(error);
+		}
+	}
+
+	return {
+		available: false,
+		error: lastError,
+	};
+}
+
+function emitOutputLines(text: string, onOutput: ((line: string) => void) | undefined): void {
+	if (!onOutput) {
+		return;
+	}
+
+	for (const line of text.split(/\r?\n/)) {
+		const trimmed = line.trim();
+		if (trimmed) {
+			onOutput(trimmed);
+		}
+	}
+}
+
+export type { OllamaCliStatus };

--- a/packages/ollama/models.ts
+++ b/packages/ollama/models.ts
@@ -2,6 +2,7 @@ import type { Api, Model, OAuthCredentials } from "@mariozechner/pi-ai";
 import { getOllamaCloudRuntimeConfig, getOllamaLocalRuntimeConfig, type OllamaRuntimeConfig } from "./config.js";
 
 export type OllamaModelSource = "local" | "cloud";
+export type OllamaLocalAvailability = "installed" | "downloadable";
 
 export type OllamaProviderModel = {
 	id: string;
@@ -18,6 +19,7 @@ export type OllamaProviderModel = {
 	maxTokens: number;
 	compat?: Model<Api>["compat"];
 	source?: OllamaModelSource;
+	localAvailability?: OllamaLocalAvailability;
 	family?: string;
 	parameterSize?: string;
 	quantization?: string;
@@ -73,6 +75,7 @@ const FALLBACK_OLLAMA_CLOUD_MODELS: OllamaProviderModel[] = [
 	toOllamaModel({ id: "glm-4.6", source: "cloud", reasoning: true, input: ["text"], contextWindow: 202_752, maxTokens: 25_344 }),
 	toOllamaModel({ id: "glm-4.7", source: "cloud", reasoning: true, input: ["text"], contextWindow: 202_752, maxTokens: 25_344 }),
 	toOllamaModel({ id: "glm-5", source: "cloud", reasoning: true, input: ["text"], contextWindow: 202_752, maxTokens: 25_344 }),
+	toOllamaModel({ id: "glm-5.1", source: "cloud", reasoning: true, input: ["text"], contextWindow: 202_752, maxTokens: 25_344 }),
 	toOllamaModel({ id: "gpt-oss:120b", source: "cloud", reasoning: true, input: ["text"], contextWindow: 131_072, maxTokens: 16_384 }),
 	toOllamaModel({ id: "gpt-oss:20b", source: "cloud", reasoning: true, input: ["text"], contextWindow: 131_072, maxTokens: 16_384 }),
 	toOllamaModel({ id: "kimi-k2-thinking", source: "cloud", reasoning: true, input: ["text"], contextWindow: 262_144, maxTokens: 32_768 }),
@@ -117,13 +120,24 @@ export async function discoverOllamaLocalModels(options: { signal?: AbortSignal 
 	});
 }
 
-export async function discoverOllamaCloudModels(apiKey: string, options: { signal?: AbortSignal } = {}): Promise<OllamaProviderModel[] | null> {
-	return discoverOllamaModels(getOllamaCloudRuntimeConfig(), {
+export async function discoverOllamaCloudModels(apiKey?: string, options: { signal?: AbortSignal } = {}): Promise<OllamaProviderModel[] | null> {
+	const config = getOllamaCloudRuntimeConfig();
+	const fallbackModels = getFallbackOllamaCloudModels();
+	const publicModels = await discoverOllamaModels(config, {
 		source: "cloud",
-		apiKey,
-		fallbackModels: getFallbackOllamaCloudModels(),
+		fallbackModels,
 		signal: options.signal,
 	});
+	if (!apiKey) {
+		return publicModels;
+	}
+	const authenticatedModels = await discoverOllamaModels(config, {
+		source: "cloud",
+		apiKey,
+		fallbackModels,
+		signal: options.signal,
+	}).catch(() => null);
+	return mergeDiscoveredModels(publicModels, authenticatedModels);
 }
 
 export async function enrichOllamaCloudCredentials(
@@ -148,6 +162,37 @@ export function toProviderModels(models: OllamaProviderModel[]): OllamaProviderM
 	return sanitizeStoredModels(models);
 }
 
+export function toDownloadableOllamaLocalModel(model: OllamaProviderModel): OllamaProviderModel {
+	return toOllamaModel({
+		...model,
+		source: "local",
+		localAvailability: "downloadable",
+		name: `${stripSourceSuffix(model.name)} (Local download)`,
+	});
+}
+
+export function mergeOllamaLocalCatalog(
+	installedModels: readonly OllamaProviderModel[],
+	downloadableModels: readonly OllamaProviderModel[],
+): OllamaProviderModel[] {
+	const merged = new Map<string, OllamaProviderModel>();
+	for (const model of downloadableModels) {
+		merged.set(model.id, toDownloadableOllamaLocalModel(model));
+	}
+	for (const model of installedModels) {
+		merged.set(
+			model.id,
+			toOllamaModel({
+				...model,
+				source: "local",
+				localAvailability: "installed",
+				name: `${stripSourceSuffix(model.name)} (Local)`,
+			}),
+		);
+	}
+	return [...merged.values()].sort((left, right) => left.id.localeCompare(right.id));
+}
+
 export function toOllamaModel(model: Partial<OllamaProviderModel> & Pick<OllamaProviderModel, "id">): OllamaProviderModel {
 	const contextWindow = normalizePositiveInteger(model.contextWindow, DEFAULT_CONTEXT_WINDOW);
 	const maxTokens = normalizePositiveInteger(model.maxTokens, inferMaxTokens(contextWindow));
@@ -161,6 +206,7 @@ export function toOllamaModel(model: Partial<OllamaProviderModel> & Pick<OllamaP
 		maxTokens,
 		compat: { ...OLLAMA_OPENAI_COMPAT, ...(model.compat ?? {}) },
 		source: model.source,
+		localAvailability: sanitizeLocalAvailability(model.localAvailability),
 		family: sanitizeOptionalString(model.family),
 		parameterSize: sanitizeOptionalString(model.parameterSize),
 		quantization: sanitizeOptionalString(model.quantization),
@@ -216,6 +262,7 @@ function cloneModel(model: OllamaProviderModel): OllamaProviderModel {
 		input: [...model.input],
 		cost: { ...model.cost },
 		compat: model.compat ? { ...model.compat } : undefined,
+		localAvailability: model.localAvailability,
 		capabilities: model.capabilities ? [...model.capabilities] : undefined,
 	};
 }
@@ -228,7 +275,9 @@ function normalizeDiscoveredModel(
 ): OllamaProviderModel | null {
 	const fallback = fallbackModels.find((model) => model.id === id);
 	if (!payload) {
-		return fallback ? cloneModel(fallback) : toOllamaModel({ id, source });
+		return fallback
+			? cloneModel(fallback)
+			: toOllamaModel({ id, source, localAvailability: source === "local" ? "installed" : undefined });
 	}
 	const capabilities = Array.isArray(payload.capabilities)
 		? payload.capabilities.filter((capability): capability is string => typeof capability === "string")
@@ -238,6 +287,7 @@ function normalizeDiscoveredModel(
 	return toOllamaModel({
 		id,
 		source,
+		localAvailability: source === "local" ? "installed" : undefined,
 		reasoning: capabilitySet.has("thinking") || fallback?.reasoning,
 		input: capabilitySet.has("vision") ? ["text", "image"] : (fallback?.input ?? ["text"]),
 		contextWindow,
@@ -312,14 +362,22 @@ function applySourceSuffix(name: string, source: OllamaModelSource | undefined):
 	if (!source) {
 		return name;
 	}
-	if (/\((local|cloud)\)$/i.test(name)) {
+	if (/\((local|cloud|local download)\)$/i.test(name)) {
 		return name;
 	}
 	return `${name} (${source === "local" ? "Local" : "Cloud"})`;
 }
 
+function stripSourceSuffix(name: string): string {
+	return name.replace(/\s*\((local|cloud|local download)\)$/i, "").trim();
+}
+
 function sanitizeOptionalString(value: string | undefined): string | undefined {
 	return typeof value === "string" && value.trim().length > 0 ? value.trim() : undefined;
+}
+
+function sanitizeLocalAvailability(value: OllamaProviderModel["localAvailability"] | undefined): OllamaLocalAvailability | undefined {
+	return value === "installed" || value === "downloadable" ? value : undefined;
 }
 
 function sanitizeCapabilities(capabilities: string[] | undefined): string[] | undefined {
@@ -365,6 +423,29 @@ async function fetchJson<T>(
 		throw new Error(`Ollama request failed (${response.status}): ${body || response.statusText}`);
 	}
 	return (await response.json()) as T;
+}
+
+function mergeDiscoveredModels(
+	publicModels: OllamaProviderModel[] | null,
+	authenticatedModels: OllamaProviderModel[] | null,
+): OllamaProviderModel[] | null {
+	const merged = new Map<string, OllamaProviderModel>();
+	for (const model of publicModels ?? []) {
+		merged.set(model.id, cloneModel(model));
+	}
+	for (const model of authenticatedModels ?? []) {
+		const existing = merged.get(model.id);
+		merged.set(model.id, {
+			...cloneModel(existing ?? model),
+			...cloneModel(model),
+			input: [...new Set([...(existing?.input ?? []), ...model.input])] as ("text" | "image")[],
+			capabilities: sanitizeCapabilities([...(existing?.capabilities ?? []), ...(model.capabilities ?? [])]),
+		});
+	}
+	if (merged.size > 0) {
+		return [...merged.values()].sort((left, right) => left.id.localeCompare(right.id));
+	}
+	return null;
 }
 
 async function mapConcurrent<T, TResult>(

--- a/packages/ollama/tests/download.test.ts
+++ b/packages/ollama/tests/download.test.ts
@@ -1,0 +1,162 @@
+import { EventEmitter } from "node:events";
+import { PassThrough } from "node:stream";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import { createExtensionHarness } from "../../../test-utils/extension-runtime-harness.js";
+import { createTestOllamaBackend, type TestOllamaBackend } from "./test-backend.js";
+
+const execFileSyncMock = vi.fn();
+const spawnMock = vi.fn();
+const envSnapshot = { ...process.env };
+const backends: TestOllamaBackend[] = [];
+
+vi.mock("node:child_process", () => ({
+	execFileSync: execFileSyncMock,
+	spawn: spawnMock,
+}));
+
+beforeEach(() => {
+	execFileSyncMock.mockReset();
+	spawnMock.mockReset();
+});
+
+afterEach(async () => {
+	for (const backend of backends.splice(0)) {
+		await backend.close();
+	}
+
+	for (const key of Object.keys(process.env)) {
+		if (!(key in envSnapshot)) {
+			delete process.env[key];
+		}
+	}
+	Object.assign(process.env, envSnapshot);
+	vi.resetModules();
+});
+
+describe("ollama local downloads", () => {
+	it("registers downloadable local models with cloud context metadata when the CLI is available", async () => {
+		execFileSyncMock.mockReturnValue("ollama version 0.8.0");
+
+		const cloudBackend = await createTestOllamaBackend();
+		backends.push(cloudBackend);
+		cloudBackend.setModels([
+			{ id: "glm-5.1", capabilities: ["completion", "tools", "thinking"], contextWindow: 202752 },
+			{ id: "kimi-k2.5", capabilities: ["completion", "tools", "thinking", "vision"], contextWindow: 262144 },
+		]);
+
+		const localBackend = await createTestOllamaBackend();
+		backends.push(localBackend);
+		localBackend.setModels([]);
+
+		process.env.PI_OLLAMA_CLOUD_API_URL = cloudBackend.apiUrl;
+		process.env.PI_OLLAMA_CLOUD_MODELS_URL = `${cloudBackend.apiUrl}/models`;
+		process.env.PI_OLLAMA_CLOUD_SHOW_URL = `${cloudBackend.origin}/api/show`;
+		process.env.OLLAMA_HOST = localBackend.origin;
+
+		const { default: ollamaProviderExtension } = await import("../index.js");
+		const harness = createExtensionHarness();
+		ollamaProviderExtension(harness.pi as never);
+
+		await waitFor(() => ((harness.providers.get("ollama")?.models as Array<{ id: string }> | undefined)?.length ?? 0) === 2);
+
+		const models = harness.providers.get("ollama")?.models as
+			| Array<{ id: string; contextWindow: number; localAvailability?: string }>
+			| undefined;
+		expect(models?.map((model) => model.id)).toEqual(["glm-5.1", "kimi-k2.5"]);
+		expect(models?.[0]?.contextWindow).toBe(202752);
+		expect(models?.every((model) => model.localAvailability === "downloadable")).toBe(true);
+	});
+
+	it("prompts to download a local model and refreshes the installed catalog", async () => {
+		execFileSyncMock.mockReturnValue("ollama version 0.8.0");
+
+		const cloudBackend = await createTestOllamaBackend();
+		backends.push(cloudBackend);
+		cloudBackend.setModels([{ id: "glm-5.1", capabilities: ["completion", "tools", "thinking"], contextWindow: 202752 }]);
+
+		const localBackend = await createTestOllamaBackend();
+		backends.push(localBackend);
+		localBackend.setModels([]);
+
+		spawnMock.mockImplementation(() => {
+			const child = new EventEmitter() as EventEmitter & {
+				stdout: PassThrough;
+				stderr: PassThrough;
+				kill: ReturnType<typeof vi.fn>;
+			};
+			child.stdout = new PassThrough();
+			child.stderr = new PassThrough();
+			child.kill = vi.fn();
+			queueMicrotask(() => {
+				localBackend.setModels([{ id: "glm-5.1", capabilities: ["completion", "tools", "thinking"], contextWindow: 202752 }]);
+				child.stdout.write("pulling glm-5.1\n");
+				child.stdout.end();
+				child.stderr.end();
+				child.emit("close", 0);
+			});
+			return child;
+		});
+
+		process.env.PI_OLLAMA_CLOUD_API_URL = cloudBackend.apiUrl;
+		process.env.PI_OLLAMA_CLOUD_MODELS_URL = `${cloudBackend.apiUrl}/models`;
+		process.env.PI_OLLAMA_CLOUD_SHOW_URL = `${cloudBackend.origin}/api/show`;
+		process.env.OLLAMA_HOST = localBackend.origin;
+
+		const { default: ollamaProviderExtension } = await import("../index.js");
+		const harness = createExtensionHarness();
+		harness.ctx.ui.confirm = vi.fn(async () => true);
+		(harness.ctx.modelRegistry as { refresh?: ReturnType<typeof vi.fn> }).refresh = vi.fn();
+		ollamaProviderExtension(harness.pi as never);
+
+		await waitFor(() => ((harness.providers.get("ollama")?.models as Array<{ id: string }> | undefined)?.length ?? 0) === 1);
+
+		await harness.emitAsync("model_select", {
+			type: "model_select",
+			model: { provider: "ollama", id: "glm-5.1" },
+			previousModel: undefined,
+			source: "set",
+		}, harness.ctx);
+
+		await waitFor(() => {
+			const models = harness.providers.get("ollama")?.models as Array<{ id: string; localAvailability?: string }> | undefined;
+			return models?.[0]?.localAvailability === "installed";
+		});
+
+		expect(harness.ctx.ui.confirm).toHaveBeenCalledTimes(1);
+		expect(spawnMock).toHaveBeenCalledTimes(1);
+		expect((harness.ctx.modelRegistry as { refresh?: ReturnType<typeof vi.fn> }).refresh).toHaveBeenCalledTimes(1);
+	});
+
+	it("warns on session start when the Ollama CLI is missing", async () => {
+		execFileSyncMock.mockImplementation(() => {
+			throw new Error("command not found");
+		});
+
+		const cloudBackend = await createTestOllamaBackend();
+		backends.push(cloudBackend);
+		cloudBackend.setModels([{ id: "kimi-k2.5", capabilities: ["completion", "tools", "thinking", "vision"], contextWindow: 262144 }]);
+		process.env.PI_OLLAMA_CLOUD_API_URL = cloudBackend.apiUrl;
+		process.env.PI_OLLAMA_CLOUD_MODELS_URL = `${cloudBackend.apiUrl}/models`;
+		process.env.PI_OLLAMA_CLOUD_SHOW_URL = `${cloudBackend.origin}/api/show`;
+
+		const { default: ollamaProviderExtension } = await import("../index.js");
+		const harness = createExtensionHarness();
+		ollamaProviderExtension(harness.pi as never);
+
+		await harness.emitAsync("session_start", { type: "session_start" }, harness.ctx);
+		await waitFor(() => harness.notifications.some((item) => item.msg.includes("Only ollama-cloud models are available right now")));
+
+		expect(harness.notifications.some((item) => item.type === "warning")).toBe(true);
+		expect((harness.providers.get("ollama")?.models as Array<{ id: string }> | undefined) ?? []).toEqual([]);
+	});
+});
+
+async function waitFor(check: () => boolean, timeoutMs = 2000): Promise<void> {
+	const startedAt = Date.now();
+	while (!check()) {
+		if (Date.now() - startedAt > timeoutMs) {
+			throw new Error("Timed out waiting for condition.");
+		}
+		await new Promise((resolve) => setTimeout(resolve, 10));
+	}
+}

--- a/packages/ollama/tests/models.test.ts
+++ b/packages/ollama/tests/models.test.ts
@@ -24,6 +24,7 @@ describe("ollama models", () => {
 		const models = getFallbackOllamaCloudModels();
 		expect(models.some((model) => model.id === "gpt-oss:120b")).toBe(true);
 		expect(models.some((model) => model.id === "qwen3-vl:235b")).toBe(true);
+		expect(models.some((model) => model.id === "glm-5.1")).toBe(true);
 	});
 
 	it("normalizes model defaults", () => {
@@ -51,7 +52,42 @@ describe("ollama models", () => {
 		expect(models?.[0]?.parameterSize).toBe("120B");
 		expect(models?.[0]?.quantization).toBe("Q4_K_M");
 		expect(models?.[1]?.input).toEqual(["text", "image"]);
-		expect(backend.getAuthHeaders().every((header) => header === "Bearer test-key")).toBe(true);
+		expect(backend.getAuthHeaders()).toEqual(["", "", "", "Bearer test-key", "Bearer test-key", "Bearer test-key"]);
+		await backend.close();
+	});
+
+	it("prefers the public cloud catalog when authenticated discovery is narrower", async () => {
+		const backend = await createTestOllamaBackend();
+		backend.setPublicModels([
+			{ id: "glm-5.1", capabilities: ["completion", "tools", "thinking"], contextWindow: 202752, family: "glm5.1", parameterSize: "756B", quantization: "FP8" },
+			{ id: "kimi-k2.5", capabilities: ["completion", "tools", "thinking", "vision"], contextWindow: 262144, family: "kimi-k2.5", parameterSize: "1T" },
+			{ id: "qwen3-next:80b", capabilities: ["completion", "tools", "thinking"], contextWindow: 262144, family: "qwen3-next", parameterSize: "80B" },
+		]);
+		backend.setAuthenticatedModels([
+			{ id: "glm-5.1", capabilities: ["completion", "tools", "thinking"], contextWindow: 202752, family: "glm5.1", parameterSize: "756B", quantization: "FP8" },
+		]);
+		process.env.PI_OLLAMA_CLOUD_API_URL = backend.apiUrl;
+		process.env.PI_OLLAMA_CLOUD_MODELS_URL = `${backend.apiUrl}/models`;
+		process.env.PI_OLLAMA_CLOUD_SHOW_URL = `${backend.origin}/api/show`;
+		const models = await discoverOllamaCloudModels("test-key");
+		expect(models?.map((model) => model.id)).toEqual(["glm-5.1", "kimi-k2.5", "qwen3-next:80b"]);
+		await backend.close();
+	});
+
+	it("discovers public cloud models without auth", async () => {
+		const backend = await createTestOllamaBackend();
+		backend.setModels([
+			{ id: "glm-5.1", capabilities: ["completion", "tools", "thinking"], contextWindow: 202752, family: "glm5.1", parameterSize: "756B", quantization: "FP8" },
+			{ id: "kimi-k2.5", capabilities: ["completion", "tools", "thinking", "vision"], contextWindow: 262144, family: "kimi-k2.5", parameterSize: "1T" },
+		]);
+		process.env.PI_OLLAMA_CLOUD_API_URL = backend.apiUrl;
+		process.env.PI_OLLAMA_CLOUD_MODELS_URL = `${backend.apiUrl}/models`;
+		process.env.PI_OLLAMA_CLOUD_SHOW_URL = `${backend.origin}/api/show`;
+		const models = await discoverOllamaCloudModels();
+		expect(models?.map((model) => model.id)).toEqual(["glm-5.1", "kimi-k2.5"]);
+		expect(models?.[0]?.reasoning).toBe(true);
+		expect(models?.[1]?.input).toEqual(["text", "image"]);
+		expect(backend.getAuthHeaders()).toEqual(["", "", ""]);
 		await backend.close();
 	});
 

--- a/packages/ollama/tests/smoke.test.ts
+++ b/packages/ollama/tests/smoke.test.ts
@@ -1,6 +1,18 @@
-import { describe, expect, it } from "vitest";
+import { afterEach, describe, expect, it } from "vitest";
 import { createExtensionHarness } from "../../../test-utils/extension-runtime-harness.js";
 import ollamaProviderExtension from "../index.js";
+import { createTestOllamaBackend } from "./test-backend.js";
+
+const envSnapshot = { ...process.env };
+
+afterEach(() => {
+	for (const key of Object.keys(process.env)) {
+		if (!(key in envSnapshot)) {
+			delete process.env[key];
+		}
+	}
+	Object.assign(process.env, envSnapshot);
+});
 
 describe("ollama provider smoke tests", () => {
 	it("registers local + cloud ollama providers and commands without crashing", () => {
@@ -11,5 +23,35 @@ describe("ollama provider smoke tests", () => {
 		expect(harness.commands.has("ollama-cloud")).toBe(true);
 		expect(harness.providers.has("ollama")).toBe(true);
 		expect(harness.providers.has("ollama-cloud")).toBe(true);
+	});
+
+	it("bootstraps the public cloud catalog without an API key", async () => {
+		const backend = await createTestOllamaBackend();
+		backend.setModels([
+			{ id: "glm-5.1", capabilities: ["completion", "tools", "thinking"], contextWindow: 202752 },
+			{ id: "kimi-k2.5", capabilities: ["completion", "tools", "thinking", "vision"], contextWindow: 262144 },
+		]);
+		process.env.PI_OLLAMA_CLOUD_API_URL = backend.apiUrl;
+		process.env.PI_OLLAMA_CLOUD_MODELS_URL = `${backend.apiUrl}/models`;
+		process.env.PI_OLLAMA_CLOUD_SHOW_URL = `${backend.origin}/api/show`;
+		delete process.env.OLLAMA_API_KEY;
+
+		const harness = createExtensionHarness();
+		ollamaProviderExtension(harness.pi as never);
+
+		for (let attempt = 0; attempt < 40; attempt += 1) {
+			const models = harness.providers.get("ollama-cloud")?.models as Array<{ id: string }> | undefined;
+			if (models?.length === 2) {
+				break;
+			}
+			await new Promise((resolve) => setTimeout(resolve, 10));
+		}
+
+		expect((harness.providers.get("ollama-cloud")?.models as Array<{ id: string }> | undefined)?.map((model) => model.id)).toEqual([
+			"glm-5.1",
+			"kimi-k2.5",
+		]);
+		expect(backend.getAuthHeaders()).toEqual(["", "", ""]);
+		await backend.close();
 	});
 });

--- a/packages/ollama/tests/test-backend.ts
+++ b/packages/ollama/tests/test-backend.ts
@@ -1,11 +1,15 @@
 import http from "node:http";
 import type { AddressInfo } from "node:net";
 
+type BackendModel = { id: string; capabilities?: string[]; contextWindow?: number; family?: string; parameterSize?: string; quantization?: string };
+
 export interface TestOllamaBackend {
 	apiUrl: string;
 	origin: string;
 	keysUrl: string;
-	setModels(models: Array<{ id: string; capabilities?: string[]; contextWindow?: number; family?: string; parameterSize?: string; quantization?: string }>): void;
+	setModels(models: BackendModel[]): void;
+	setPublicModels(models: BackendModel[]): void;
+	setAuthenticatedModels(models: BackendModel[]): void;
 	setRejectAuth(reject: boolean): void;
 	setRejectedModelShows(modelIds: string[]): void;
 	getAuthHeaders(): string[];
@@ -13,30 +17,33 @@ export interface TestOllamaBackend {
 }
 
 export async function createTestOllamaBackend(): Promise<TestOllamaBackend> {
-	let models: Array<{ id: string; capabilities?: string[]; contextWindow?: number; family?: string; parameterSize?: string; quantization?: string }> = [];
+	let models: BackendModel[] = [];
+	let publicModels: BackendModel[] | null = null;
+	let authenticatedModels: BackendModel[] | null = null;
 	let rejectAuth = false;
 	let rejectedModelShows = new Set<string>();
 	const authHeaders: string[] = [];
 
 	const server = http.createServer((req, res) => {
 		const url = req.url ?? "/";
+		const auth = String(req.headers.authorization ?? "");
+		const usingAuth = auth.length > 0;
+		const activeModels = usingAuth ? (authenticatedModels ?? models) : (publicModels ?? models);
 		if (url === "/v1/models" && req.method === "GET") {
-			const auth = String(req.headers.authorization ?? "");
 			authHeaders.push(auth);
-			if (rejectAuth) {
+			if (rejectAuth && usingAuth) {
 				res.writeHead(401, { "Content-Type": "text/plain" });
 				res.end("unauthorized");
 				return;
 			}
 			res.writeHead(200, { "Content-Type": "application/json" });
-			res.end(JSON.stringify({ data: models.map((model) => ({ id: model.id, object: "model" })) }));
+			res.end(JSON.stringify({ data: activeModels.map((model) => ({ id: model.id, object: "model" })) }));
 			return;
 		}
 
 		if (url === "/api/show" && req.method === "POST") {
-			const auth = String(req.headers.authorization ?? "");
 			authHeaders.push(auth);
-			if (rejectAuth) {
+			if (rejectAuth && usingAuth) {
 				res.writeHead(401, { "Content-Type": "text/plain" });
 				res.end("unauthorized");
 				return;
@@ -52,7 +59,7 @@ export async function createTestOllamaBackend(): Promise<TestOllamaBackend> {
 					res.end("show failed");
 					return;
 				}
-				const match = models.find((model) => model.id === parsed.model);
+				const match = activeModels.find((model) => model.id === parsed.model);
 				if (!match) {
 					res.writeHead(404, { "Content-Type": "text/plain" });
 					res.end("model not found");
@@ -95,6 +102,14 @@ export async function createTestOllamaBackend(): Promise<TestOllamaBackend> {
 		keysUrl: `${origin}/settings/keys`,
 		setModels(nextModels) {
 			models = nextModels;
+			publicModels = null;
+			authenticatedModels = null;
+		},
+		setPublicModels(nextModels) {
+			publicModels = nextModels;
+		},
+		setAuthenticatedModels(nextModels) {
+			authenticatedModels = nextModels;
 		},
 		setRejectAuth(reject) {
 			rejectAuth = reject;


### PR DESCRIPTION
## Summary
- keep the public Ollama Cloud catalog visible even before login and even when authenticated discovery is narrower
- add `glm-5.1` plus broader cloud metadata/context handling for local download candidates
- detect the Ollama CLI on Windows and Unix-like systems, warn when it is missing, and prompt to pull missing local models via the CLI

## Testing
- `cd packages/ollama && pnpm run build`
