### PR TITLE
feat(extensions): add external editor draft sync

### DIFF
--- a/.changeset/external-editor-extension.md
+++ b/.changeset/external-editor-extension.md
@@ -1,0 +1,5 @@
+---
+default: minor
+---
+
+Add an `external-editor` oh-pi extension with a `/external-editor` command and `Ctrl+Shift+E` shortcut for opening the current draft in `$VISUAL` or `$EDITOR`, then syncing the saved text back into pi.

--- a/README.md
+++ b/README.md
@@ -53,7 +53,7 @@ This is a monorepo. Install everything at once with `npx @ifi/oh-pi`, or pick in
 | ------------------------------------------------ | ---------------------------------- | -------------------------------------- |
 | [`@ifi/oh-pi`](./packages/oh-pi)                 | One-command installer for all pkgs | `npx @ifi/oh-pi`                       |
 | [`@ifi/oh-pi-core`](./packages/core)             | Shared types, registries, i18n     | (library, not installed directly)      |
-| [`@ifi/oh-pi-extensions`](./packages/extensions)          | 9 extensions (see below)                    | `pi install npm:@ifi/oh-pi-extensions`      |
+| [`@ifi/oh-pi-extensions`](./packages/extensions)          | 13 extensions (see below)                   | `pi install npm:@ifi/oh-pi-extensions`      |
 | [`@ifi/oh-pi-ant-colony`](./packages/ant-colony)          | Multi-agent swarm extension                 | `pi install npm:@ifi/oh-pi-ant-colony`      |
 | [`@ifi/pi-extension-subagents`](./packages/subagents)     | Full-featured subagent delegation extension | `pi install npm:@ifi/pi-extension-subagents` |
 | [`@ifi/pi-plan`](./packages/plan)                         | Branch-aware planning mode extension        | `pi install npm:@ifi/pi-plan`               |
@@ -251,6 +251,16 @@ with the new version and install command. Never blocks — fully async.
 
 **How it works:** On `session_start`, runs `npm view oh-pi version` in the background via
 `pi.exec()`. Compares with the local version using semver.
+
+### ⌨️ External Editor (`external-editor`) — **default: on**
+
+Adds a discoverable `/external-editor` command and a `Ctrl+Shift+E` shortcut for opening the
+current draft in `$VISUAL` or `$EDITOR`, then syncing the saved text back into pi.
+
+**Commands:** `/external-editor` | `/external-editor status`
+
+**Notes:** This complements pi's built-in `app.editor.external` binding (`Ctrl+G` by default).
+Users who want a different primary key can still remap that binding in `keybindings.json`.
 
 ### ⏳ Background Process (`bg-process`) — **default: off**
 

--- a/package.json
+++ b/package.json
@@ -11,6 +11,7 @@
 			"./packages/extensions/extensions/btw.ts",
 			"./packages/extensions/extensions/compact-header.ts",
 			"./packages/extensions/extensions/custom-footer.ts",
+			"./packages/extensions/extensions/external-editor.ts",
 			"./packages/extensions/extensions/git-guard.ts",
 			"./packages/extensions/extensions/safe-guard.ts",
 			"./packages/extensions/extensions/scheduler.ts",

--- a/packages/extensions/README.md
+++ b/packages/extensions/README.md
@@ -11,6 +11,7 @@ This package includes extensions such as:
 - auto-session-name
 - custom-footer
 - compact-header
+- external-editor / /external-editor
 - auto-update
 - bg-process
 - usage-tracker
@@ -33,9 +34,21 @@ npx @ifi/oh-pi
 ## What it provides
 
 These extensions add commands, tools, UI widgets, safety checks, background process handling,
-usage monitoring, adaptive model routing, scheduling features, and runtime performance protection (`/watchdog`, `/safe-mode`) to pi.
+usage monitoring, adaptive model routing, scheduling features, external-editor integration, and runtime performance protection (`/watchdog`, `/safe-mode`) to pi.
 
 `git-guard` also blocks git bash invocations that are likely to open an interactive editor in agent environments (for example `git rebase --continue` without non-interactive editor overrides), preventing hangs before they happen.
+
+## External editor
+
+The `external-editor` extension adds:
+
+- `/external-editor` — open the current draft in `$VISUAL` or `$EDITOR`
+- `/external-editor status` — show the configured editor and available bindings
+- `Ctrl+Shift+E` — open the current draft in the configured external editor
+
+When the editor exits successfully, the updated text is synced back into pi's main draft editor.
+This complements pi's built-in `app.editor.external` binding (`Ctrl+G` by default) with a
+discoverable slash command and an extra shortcut.
 
 ## Adaptive routing
 

--- a/packages/extensions/extensions/external-editor-shared.test.ts
+++ b/packages/extensions/extensions/external-editor-shared.test.ts
@@ -1,0 +1,65 @@
+import { describe, expect, it, vi } from "vitest";
+import { getConfiguredExternalEditor, openTextInExternalEditor } from "./external-editor-shared";
+
+describe("external editor shared helpers", () => {
+	it("prefers VISUAL over EDITOR", () => {
+		expect(getConfiguredExternalEditor({ VISUAL: "hx", EDITOR: "vim" })).toBe("hx");
+		expect(getConfiguredExternalEditor({ EDITOR: "vim" })).toBe("vim");
+		expect(getConfiguredExternalEditor({ VISUAL: "   ", EDITOR: "" })).toBeUndefined();
+	});
+
+	it("returns unavailable when no editor is configured", () => {
+		const result = openTextInExternalEditor("draft", { env: {} });
+		expect(result).toEqual({
+			kind: "unavailable",
+			reason: "No external editor configured. Set $VISUAL or $EDITOR first.",
+		});
+	});
+
+	it("writes the draft, launches the editor, restores tui, and returns saved text", () => {
+		const calls: string[] = [];
+		const result = openTextInExternalEditor("hello", {
+			env: { EDITOR: "hx" },
+			now: () => 42,
+			tmpDir: () => "/tmp/test-editor",
+			writeFile: vi.fn(() => {
+				calls.push("write");
+			}),
+			readFile: vi.fn(() => {
+				calls.push("read");
+				return "updated\n";
+			}),
+			unlinkFile: vi.fn(() => {
+				calls.push("unlink");
+			}),
+			spawn: vi.fn(() => {
+				calls.push("spawn");
+				return { status: 0 } as never;
+			}),
+			suspendTui: () => {
+				calls.push("stop");
+			},
+			resumeTui: () => {
+				calls.push("start");
+			},
+			requestRender: () => {
+				calls.push("render");
+			},
+		});
+
+		expect(result).toEqual({ kind: "saved", text: "updated" });
+		expect(calls).toEqual(["write", "stop", "spawn", "read", "unlink", "start", "render"]);
+	});
+
+	it("keeps the existing draft when the editor exits non-zero", () => {
+		const result = openTextInExternalEditor("hello", {
+			env: { EDITOR: "hx" },
+			writeFile: vi.fn(),
+			readFile: vi.fn(),
+			unlinkFile: vi.fn(),
+			spawn: vi.fn(() => ({ status: 1 }) as never),
+		});
+
+		expect(result).toEqual({ kind: "cancelled" });
+	});
+});

--- a/packages/extensions/extensions/external-editor-shared.ts
+++ b/packages/extensions/extensions/external-editor-shared.ts
@@ -1,0 +1,108 @@
+import { type SpawnSyncReturns, spawnSync } from "node:child_process";
+import { readFileSync, unlinkSync, writeFileSync } from "node:fs";
+import { tmpdir } from "node:os";
+import path from "node:path";
+
+export type ExternalEditorLaunchResult =
+	| { kind: "saved"; text: string }
+	| { kind: "cancelled" }
+	| { kind: "unavailable"; reason: string }
+	| { kind: "failed"; reason: string };
+
+export type ExternalEditorDependencies = {
+	env?: NodeJS.ProcessEnv;
+	platform?: NodeJS.Platform;
+	now?: () => number;
+	tmpDir?: () => string;
+	spawn?: typeof spawnSync;
+	writeFile?: typeof writeFileSync;
+	readFile?: typeof readFileSync;
+	unlinkFile?: typeof unlinkSync;
+	suspendTui?: () => void;
+	resumeTui?: () => void;
+	requestRender?: (force?: boolean) => void;
+};
+
+function toErrorMessage(error: unknown): string {
+	if (error instanceof Error && error.message) {
+		return error.message;
+	}
+
+	return String(error);
+}
+
+export function getConfiguredExternalEditor(env: NodeJS.ProcessEnv = process.env): string | undefined {
+	const visual = env.VISUAL?.trim();
+	if (visual) {
+		return visual;
+	}
+
+	const editor = env.EDITOR?.trim();
+	return editor || undefined;
+}
+
+export function openTextInExternalEditor(
+	text: string,
+	dependencies: ExternalEditorDependencies = {},
+): ExternalEditorLaunchResult {
+	const env = dependencies.env ?? process.env;
+	const editorCommand = getConfiguredExternalEditor(env);
+	if (!editorCommand) {
+		return {
+			kind: "unavailable",
+			reason: "No external editor configured. Set $VISUAL or $EDITOR first.",
+		};
+	}
+
+	const platform = dependencies.platform ?? process.platform;
+	const now = dependencies.now ?? Date.now;
+	const tmpDir = dependencies.tmpDir ?? tmpdir;
+	const spawn = dependencies.spawn ?? spawnSync;
+	const writeFile = dependencies.writeFile ?? writeFileSync;
+	const readFile = dependencies.readFile ?? readFileSync;
+	const unlinkFile = dependencies.unlinkFile ?? unlinkSync;
+	const tmpFilePath = path.join(tmpDir(), `oh-pi-editor-${now()}.md`);
+	const [editor, ...editorArgs] = editorCommand.split(" ");
+	let tuiSuspended = false;
+
+	try {
+		writeFile(tmpFilePath, text, "utf-8");
+		dependencies.suspendTui?.();
+		tuiSuspended = true;
+
+		const result = spawn(editor, [...editorArgs, tmpFilePath], {
+			stdio: "inherit",
+			shell: platform === "win32",
+		}) as SpawnSyncReturns<Buffer>;
+
+		if (result.error) {
+			return {
+				kind: "failed",
+				reason: `Failed to launch external editor: ${toErrorMessage(result.error)}`,
+			};
+		}
+
+		if (result.status !== 0) {
+			return { kind: "cancelled" };
+		}
+
+		const nextText = readFile(tmpFilePath, "utf-8").replace(/\n$/, "");
+		return { kind: "saved", text: nextText };
+	} catch (error) {
+		return {
+			kind: "failed",
+			reason: `External editor failed: ${toErrorMessage(error)}`,
+		};
+	} finally {
+		try {
+			unlinkFile(tmpFilePath);
+		} catch {
+			/* ignore cleanup errors */
+		}
+
+		if (tuiSuspended) {
+			dependencies.resumeTui?.();
+			dependencies.requestRender?.(true);
+		}
+	}
+}

--- a/packages/extensions/extensions/external-editor.test.ts
+++ b/packages/extensions/extensions/external-editor.test.ts
@@ -1,0 +1,101 @@
+import { describe, expect, it, vi } from "vitest";
+import { createExtensionHarness } from "../../../test-utils/extension-runtime-harness.js";
+import externalEditorExtension from "./external-editor.js";
+
+describe("external-editor extension", () => {
+	it("registers the command and shortcut", () => {
+		const harness = createExtensionHarness();
+		externalEditorExtension(harness.pi as never);
+
+		expect(harness.commands.has("external-editor")).toBe(true);
+		expect(harness.shortcuts.has("ctrl+shift+e")).toBe(true);
+	});
+
+	it("shows status for the configured editor", async () => {
+		const harness = createExtensionHarness();
+		externalEditorExtension(harness.pi as never);
+		const originalVisual = process.env.VISUAL;
+		const originalEditor = process.env.EDITOR;
+		process.env.VISUAL = "hx";
+		process.env.EDITOR = "vim";
+
+		try {
+			await harness.commands.get("external-editor").handler("status", harness.ctx);
+		} finally {
+			process.env.VISUAL = originalVisual;
+			process.env.EDITOR = originalEditor;
+		}
+
+		expect(harness.notifications.at(-1)?.msg).toContain("External editor: hx");
+	});
+
+	it("warns instead of opening when no editor is configured", async () => {
+		const harness = createExtensionHarness();
+		externalEditorExtension(harness.pi as never);
+		const custom = vi.fn();
+		harness.ctx.ui.custom = custom;
+		const originalVisual = process.env.VISUAL;
+		const originalEditor = process.env.EDITOR;
+		Reflect.deleteProperty(process.env, "VISUAL");
+		Reflect.deleteProperty(process.env, "EDITOR");
+
+		try {
+			await harness.commands.get("external-editor").handler("", harness.ctx);
+		} finally {
+			process.env.VISUAL = originalVisual;
+			process.env.EDITOR = originalEditor;
+		}
+
+		expect(custom).not.toHaveBeenCalled();
+		expect(harness.notifications.at(-1)).toEqual({
+			msg: "No external editor configured. Set $VISUAL or $EDITOR first.",
+			type: "warning",
+		});
+	});
+
+	it("syncs the saved draft back into pi after command launch", async () => {
+		const harness = createExtensionHarness();
+		externalEditorExtension(harness.pi as never);
+		harness.editorState.text = "before";
+		harness.ctx.ui.custom = vi.fn(async () => ({ kind: "saved", text: "after" }));
+		const originalStdinTty = process.stdin.isTTY;
+		const originalStdoutTty = process.stdout.isTTY;
+		const originalVisual = process.env.VISUAL;
+		Object.defineProperty(process.stdin, "isTTY", { value: true, configurable: true });
+		Object.defineProperty(process.stdout, "isTTY", { value: true, configurable: true });
+		process.env.VISUAL = "hx";
+
+		try {
+			await harness.commands.get("external-editor").handler("", harness.ctx);
+		} finally {
+			Object.defineProperty(process.stdin, "isTTY", { value: originalStdinTty, configurable: true });
+			Object.defineProperty(process.stdout, "isTTY", { value: originalStdoutTty, configurable: true });
+			process.env.VISUAL = originalVisual;
+		}
+
+		expect(harness.editorState.text).toBe("after");
+	});
+
+	it("uses the shortcut handler to launch the same flow", async () => {
+		const harness = createExtensionHarness();
+		externalEditorExtension(harness.pi as never);
+		harness.editorState.text = "before";
+		harness.ctx.ui.custom = vi.fn(async () => ({ kind: "saved", text: "after shortcut" }));
+		const originalStdinTty = process.stdin.isTTY;
+		const originalStdoutTty = process.stdout.isTTY;
+		const originalEditor = process.env.EDITOR;
+		Object.defineProperty(process.stdin, "isTTY", { value: true, configurable: true });
+		Object.defineProperty(process.stdout, "isTTY", { value: true, configurable: true });
+		process.env.EDITOR = "vim";
+
+		try {
+			await harness.shortcuts.get("ctrl+shift+e").handler(harness.ctx);
+		} finally {
+			Object.defineProperty(process.stdin, "isTTY", { value: originalStdinTty, configurable: true });
+			Object.defineProperty(process.stdout, "isTTY", { value: originalStdoutTty, configurable: true });
+			process.env.EDITOR = originalEditor;
+		}
+
+		expect(harness.editorState.text).toBe("after shortcut");
+	});
+});

--- a/packages/extensions/extensions/external-editor.ts
+++ b/packages/extensions/extensions/external-editor.ts
@@ -1,0 +1,117 @@
+import type { ExtensionAPI, ExtensionCommandContext } from "@mariozechner/pi-coding-agent";
+import type { Component, KeybindingsManager, TUI } from "@mariozechner/pi-tui";
+import { truncateToWidth } from "@mariozechner/pi-tui";
+import {
+	type ExternalEditorLaunchResult,
+	getConfiguredExternalEditor,
+	openTextInExternalEditor,
+} from "./external-editor-shared";
+
+const SHORTCUT = "ctrl+shift+e";
+const COMMAND = "external-editor";
+
+class ExternalEditorLauncher implements Component {
+	private launched = false;
+
+	constructor(
+		private readonly tui: TUI,
+		private readonly initialText: string,
+		private readonly done: (result: ExternalEditorLaunchResult) => void,
+	) {}
+
+	render(width: number): string[] {
+		if (!this.launched) {
+			this.launched = true;
+			queueMicrotask(() => {
+				const result = openTextInExternalEditor(this.initialText, {
+					suspendTui: () => this.tui.stop(),
+					resumeTui: () => this.tui.start(),
+					requestRender: (force) => this.tui.requestRender(force),
+				});
+				this.done(result);
+			});
+		}
+
+		return [truncateToWidth("Opening external editor...", width)];
+	}
+
+	invalidate(): void {
+		/* stateless */
+	}
+}
+
+function showExternalEditorStatus(ctx: ExtensionCommandContext): void {
+	const editorCommand = getConfiguredExternalEditor();
+	if (!editorCommand) {
+		ctx.ui.notify("No external editor configured. Set $VISUAL or $EDITOR first.", "warning");
+		return;
+	}
+
+	ctx.ui.notify(
+		[
+			`External editor: ${editorCommand}`,
+			`Use /${COMMAND} or ${SHORTCUT} to edit the current draft.`,
+			"Pi's built-in app.editor.external binding (Ctrl+G by default) still works too.",
+		].join(" "),
+		"info",
+	);
+}
+
+async function launchExternalEditorForDraft(ctx: ExtensionCommandContext): Promise<void> {
+	const editorCommand = getConfiguredExternalEditor();
+	if (!editorCommand) {
+		ctx.ui.notify("No external editor configured. Set $VISUAL or $EDITOR first.", "warning");
+		return;
+	}
+
+	if (!(process.stdin.isTTY && process.stdout.isTTY)) {
+		ctx.ui.notify("External editor launch only works in interactive terminal mode.", "warning");
+		return;
+	}
+
+	const currentText = typeof ctx.ui.getEditorText === "function" ? ctx.ui.getEditorText() : "";
+	const result = await ctx.ui.custom<ExternalEditorLaunchResult>((tui: TUI, _theme, _kb: KeybindingsManager, done) => {
+		return new ExternalEditorLauncher(tui, currentText, done);
+	});
+
+	if (!result || result.kind === "cancelled") {
+		return;
+	}
+
+	if (result.kind === "unavailable" || result.kind === "failed") {
+		ctx.ui.notify(result.reason, "warning");
+		return;
+	}
+
+	if (typeof ctx.ui.setEditorText === "function") {
+		ctx.ui.setEditorText(result.text);
+	}
+}
+
+export default function externalEditorExtension(pi: ExtensionAPI): void {
+	pi.registerCommand(COMMAND, {
+		description: "Open the current draft in $VISUAL/$EDITOR and sync the result back into pi.",
+		getArgumentCompletions(prefix) {
+			const items = [
+				{ value: "status", label: "status", description: "Show the configured editor and available bindings" },
+			];
+			const filtered = items.filter((item) => item.value.startsWith(prefix.trim()));
+			return filtered.length > 0 ? filtered : null;
+		},
+		handler: async (args, ctx) => {
+			if (args.trim() === "status") {
+				showExternalEditorStatus(ctx);
+				return;
+			}
+
+			await launchExternalEditorForDraft(ctx);
+		},
+	});
+
+	pi.registerShortcut(SHORTCUT, {
+		description: "Open the current draft in the configured external editor",
+		handler: async (ctx) => {
+			await launchExternalEditorForDraft(ctx as ExtensionCommandContext);
+		},
+	});
+}

--- a/packages/extensions/extensions/smoke.test.ts
+++ b/packages/extensions/extensions/smoke.test.ts
@@ -3,6 +3,7 @@ import { createExtensionHarness } from "../../../test-utils/extension-runtime-ha
 import adaptiveRoutingExtension from "./adaptive-routing.js";
 import autoUpdateExtension from "./auto-update.js";
 import btwExtension from "./btw.js";
+import externalEditorExtension from "./external-editor.js";
 import safeGuardExtension from "./safe-guard.js";
 import schedulerExtension from "./scheduler.js";
 import usageTrackerExtension from "./usage-tracker.js";
@@ -73,6 +74,13 @@ describe("extensions runtime smoke tests", () => {
 		const harness = createExtensionHarness();
 		adaptiveRoutingExtension(harness.pi as never);
 		expect(harness.commands.has("route")).toBe(true);
+	});
+
+	it("registers external editor command and shortcut without crashing", () => {
+		const harness = createExtensionHarness();
+		externalEditorExtension(harness.pi as never);
+		expect(harness.commands.has("external-editor")).toBe(true);
+		expect(harness.shortcuts.has("ctrl+shift+e")).toBe(true);
 	});
 
 	it("blocks protected writes in headless mode via safe-guard", async () => {

--- a/packages/extensions/package.json
+++ b/packages/extensions/package.json
@@ -14,6 +14,7 @@
       "./extensions/btw.ts",
       "./extensions/compact-header.ts",
       "./extensions/custom-footer.ts",
+      "./extensions/external-editor.ts",
       "./extensions/git-guard.ts",
       "./extensions/safe-guard.ts",
       "./extensions/scheduler.ts",

--- a/packages/oh-pi/README.md
+++ b/packages/oh-pi/README.md
@@ -24,7 +24,7 @@ npx @ifi/oh-pi --remove             # uninstall all oh-pi packages from pi
 
 | Package                 | Contents                                                                                    |
 | ----------------------- | ------------------------------------------------------------------------------------------- |
-| `@ifi/oh-pi-extensions`      | safe-guard, git-guard, auto-session, custom-footer, compact-header, auto-update, bg-process, watchdog |
+| `@ifi/oh-pi-extensions`      | safe-guard, git-guard, auto-session, custom-footer, compact-header, external-editor, auto-update, bg-process, watchdog |
 | `@ifi/oh-pi-ant-colony`       | Multi-agent swarm extension (`/colony`, colony commands)                                     |
 | `@ifi/pi-extension-subagents` | Subagent orchestration extension (`subagent`, `subagent_status`, `/run`, `/chain`, `/parallel`) |
 | `@ifi/pi-plan`                | Planning mode extension (`/plan`, `Alt+P`, `task_agents`, `set_plan`)                       |

--- a/test-utils/extension-runtime-harness.js
+++ b/test-utils/extension-runtime-harness.js
@@ -10,6 +10,8 @@ export function createExtensionHarness() {
 	const notifications = [];
 	const statusMap = new Map();
 	const shortcuts = new Map();
+	let editorText = "";
+	let editorComponentFactory;
 	const messageRenderers = new Map();
 	const providers = new Map();
 	const eventBus = new EventEmitter();
@@ -115,6 +117,15 @@ export function createExtensionHarness() {
 				}
 			},
 			setWidget() {},
+			setEditorText(text) {
+				editorText = text;
+			},
+			getEditorText() {
+				return editorText;
+			},
+			setEditorComponent(factory) {
+				editorComponentFactory = factory;
+			},
 			select: async () => null,
 			confirm: async () => true,
 			input: async () => null,
@@ -134,6 +145,17 @@ export function createExtensionHarness() {
 		notifications,
 		statusMap,
 		shortcuts,
+		editorState: {
+			get text() {
+				return editorText;
+			},
+			set text(value) {
+				editorText = value;
+			},
+			get factory() {
+				return editorComponentFactory;
+			},
+		},
 		messageRenderers,
 		providers,
 		emit(event, ...args) {

--- a/test-utils/extension-runtime-harness.ts
+++ b/test-utils/extension-runtime-harness.ts
@@ -10,6 +10,8 @@ export function createExtensionHarness() {
 	const notifications: Array<{ msg: string; type: string }> = [];
 	const statusMap = new Map<string, any>();
 	const shortcuts = new Map<string, any>();
+	let editorText = "";
+	let editorComponentFactory: any;
 	const messageRenderers = new Map<string, any>();
 	const providers = new Map<string, any>();
 	const eventBus = new EventEmitter();
@@ -115,6 +117,15 @@ export function createExtensionHarness() {
 				}
 			},
 			setWidget() {},
+			setEditorText(text: string) {
+				editorText = text;
+			},
+			getEditorText() {
+				return editorText;
+			},
+			setEditorComponent(factory: any) {
+				editorComponentFactory = factory;
+			},
 			select: async () => null,
 			confirm: async () => true,
 			input: async () => null,
@@ -134,6 +145,17 @@ export function createExtensionHarness() {
 		notifications,
 		statusMap,
 		shortcuts,
+		editorState: {
+			get text() {
+				return editorText;
+			},
+			set text(value: string) {
+				editorText = value;
+			},
+			get factory() {
+				return editorComponentFactory;
+			},
+		},
 		messageRenderers,
 		providers,
 		emit(event: string, ...args: any[]) {


### PR DESCRIPTION
## Summary
- add an `external-editor` oh-pi extension with a slash command and shortcut for editing the current draft in `$VISUAL` or `$EDITOR`
- sync the saved external-editor result back into pi's draft editor and handle missing-editor / non-interactive cases gracefully
- document the feature, add manifest coverage, and extend the extension harness for editor state testing

## Testing
- pnpm --filter @ifi/oh-pi-core build
- pnpm test
- pnpm typecheck
- pnpm lint