### PR TITLE
feat(scheduler): track task creator origins

### DIFF
--- a/.changeset/feat-scheduler-origin-controls.md
+++ b/.changeset/feat-scheduler-origin-controls.md
@@ -1,0 +1,5 @@
+---
+default: minor
+---
+
+Track which scheduler tasks were created by the current pi instance, surface that origin in the scheduler UI, and add clear-other controls for deleting tasks not created in this instance.

--- a/packages/extensions/extensions/scheduler-registration.ts
+++ b/packages/extensions/extensions/scheduler-registration.ts
@@ -23,6 +23,7 @@ const SchedulePromptToolParams = Type.Object({
 			Type.Literal("adopt"),
 			Type.Literal("release"),
 			Type.Literal("clear_foreign"),
+			Type.Literal("clear_other"),
 		],
 		{ description: "Action to perform" },
 	),
@@ -158,7 +159,7 @@ export function registerCommands(pi: ExtensionAPI, runtime: SchedulerRuntime) {
 
 	pi.registerCommand("schedule", {
 		description:
-			"Manage scheduled reminders and future check-ins. No args opens TUI manager. Also: list | enable <id> | disable <id> | delete <id> | clear | adopt <id|all> | release <id|all> | clear-foreign",
+			"Manage scheduled reminders and future check-ins. No args opens TUI manager. Also: list | enable <id> | disable <id> | delete <id> | clear | clear-other | adopt <id|all> | release <id|all> | clear-foreign",
 		// biome-ignore lint/complexity/noExcessiveCognitiveComplexity: Command router with multiple subcommands.
 		handler: async (args, ctx) => {
 			const trimmed = args.trim();
@@ -214,6 +215,15 @@ export function registerCommands(pi: ExtensionAPI, runtime: SchedulerRuntime) {
 				return;
 			}
 
+			if (action === "clear-other") {
+				const result = runtime.clearTasksNotCreatedHere();
+				ctx.ui.notify(
+					`Cleared ${result.count} scheduled task${result.count === 1 ? "" : "s"} not created in this instance.`,
+					"info",
+				);
+				return;
+			}
+
 			if (action === "adopt") {
 				const target = rawArg?.trim() || "all";
 				const result = runtime.adoptTasks(target);
@@ -261,7 +271,7 @@ export function registerCommands(pi: ExtensionAPI, runtime: SchedulerRuntime) {
 			}
 
 			ctx.ui.notify(
-				"Usage: /schedule [tui|list|enable <id>|disable <id>|delete <id>|clear|adopt <id|all>|release <id|all>|clear-foreign]",
+				"Usage: /schedule [tui|list|enable <id>|disable <id>|delete <id>|clear|clear-other|adopt <id|all>|release <id|all>|clear-foreign]",
 				"warning",
 			);
 		},
@@ -290,9 +300,9 @@ export function registerTools(pi: ExtensionAPI, runtime: SchedulerRuntime) {
 		name: "schedule_prompt",
 		label: "Schedule Prompt",
 		description:
-			"Create/list/enable/disable/delete/adopt/release/clear scheduled prompts. Use this when the user asks for reminders, to check back later, or to follow up on PRs, CI, builds, deployments, or any recurring check. add requires prompt; once tasks require duration; recurring supports interval (duration) or cron expression (cron).",
+			"Create/list/enable/disable/delete/adopt/release/clear scheduled prompts. Supports clear_other for tasks not created in this instance and clear_foreign for tasks owned by another instance. Use this when the user asks for reminders, to check back later, or to follow up on PRs, CI, builds, deployments, or any recurring check. add requires prompt; once tasks require duration; recurring supports interval (duration) or cron expression (cron).",
 		promptSnippet:
-			"Create/list/enable/disable/delete/adopt/release/clear scheduled prompts for one-time reminders, future follow-ups, and recurring PR/CI/build/deployment checks. Supports intervals/cron and one-time reminders while this pi instance remains active unless scope='workspace' is used.",
+			"Create/list/enable/disable/delete/adopt/release/clear scheduled prompts for one-time reminders, future follow-ups, and recurring PR/CI/build/deployment checks. Supports clear_other for tasks not created in this instance, clear_foreign for tasks owned by another instance, intervals/cron, and one-time reminders while this pi instance remains active unless scope='workspace' is used.",
 		promptGuidelines: [
 			"Use this tool when the user asks to remind/check back later, revisit something in the future, or monitor PRs, CI, builds, deploys, or background work.",
 			"For recurring tasks use kind='recurring' with duration like 5m or 2h, or provide cron.",
@@ -341,6 +351,9 @@ export function registerTools(pi: ExtensionAPI, runtime: SchedulerRuntime) {
 			if (action === "clear_foreign") {
 				return handleToolClearForeign(runtime);
 			}
+			if (action === "clear_other") {
+				return handleToolClearOther(runtime);
+			}
 			if (action === "add") {
 				return handleToolAdd(params, runtime);
 			}
@@ -365,16 +378,17 @@ function handleToolList(runtime: SchedulerRuntime): ToolResult {
 				? "-"
 				: (task.cronExpression ?? formatDurationShort(task.intervalMs ?? DEFAULT_LOOP_INTERVAL));
 		const schedule = task.continueUntilComplete ? `${scheduleBase} (until-complete)` : scheduleBase;
+		const creator = task.creatorInstanceId ?? "legacy";
 		const state = task.resumeRequired ? `due:${task.resumeReason ?? "unknown"}` : task.enabled ? "on" : "off";
 		const status = task.resumeRequired ? "resume_required" : (task.lastStatus ?? "pending");
 		const last = task.lastRunAt ? runtime.formatRelativeTime(task.lastRunAt) : "never";
-		return `${task.id}\t${state}\t${task.kind}\t${task.scope ?? "instance"}\t${schedule}\t${runtime.formatRelativeTime(task.nextRunAt)}\t${task.runCount}\t${last}\t${status}\t${task.prompt}`;
+		return `${task.id}\t${creator}\t${state}\t${task.kind}\t${task.scope ?? "instance"}\t${schedule}\t${runtime.formatRelativeTime(task.nextRunAt)}\t${task.runCount}\t${last}\t${status}\t${task.prompt}`;
 	});
 	return {
 		content: [
 			{
 				type: "text",
-				text: `Scheduled tasks (id\tstate\tkind\tscope\tschedule\tnext\truns\tlast\tstatus\tprompt):\n${lines.join("\n")}`,
+				text: `Scheduled tasks (id\tcreator\tstate\tkind\tscope\tschedule\tnext\truns\tlast\tstatus\tprompt):\n${lines.join("\n")}`,
 			},
 		],
 		details: { action: "list", tasks: list },
@@ -470,6 +484,24 @@ function handleToolClearForeign(runtime: SchedulerRuntime): ToolResult {
 			{ type: "text", text: `Cleared ${result.count} foreign scheduled task${result.count === 1 ? "" : "s"}.` },
 		],
 		details: { action: "clear_foreign", cleared: result.count },
+	};
+}
+
+function handleToolClearOther(runtime: SchedulerRuntime): ToolResult {
+	const result = runtime.clearTasksNotCreatedHere();
+	return {
+		content: [
+			{
+				type: "text",
+				text: `Cleared ${result.count} scheduled task${result.count === 1 ? "" : "s"} not created in this instance.`,
+			},
+		],
+		details: {
+			action: "clear_other",
+			cleared: result.count,
+			otherCount: result.otherCount ?? 0,
+			legacyCount: result.legacyCount ?? 0,
+		},
 	};
 }
 

--- a/packages/extensions/extensions/scheduler-shared.ts
+++ b/packages/extensions/extensions/scheduler-shared.ts
@@ -45,6 +45,8 @@ export interface ScheduleTask {
 	maxAttempts?: number;
 	awaitingCompletion?: boolean;
 	lastOutcomeSnippet?: string;
+	creatorInstanceId?: string;
+	creatorSessionId?: string | null;
 }
 
 export interface SchedulerLease {

--- a/packages/extensions/extensions/scheduler.test.ts
+++ b/packages/extensions/extensions/scheduler.test.ts
@@ -767,6 +767,25 @@ describe("SchedulerRuntime", () => {
 			const task = runtime.addOneShotTask("remind", 5 * ONE_MINUTE);
 			expect(task.scope).toBe("instance");
 			expect(task.ownerInstanceId).toBe(runtime.currentInstanceId);
+			expect(task.creatorInstanceId).toBe(runtime.currentInstanceId);
+		});
+
+		it("can clear tasks not created in this instance", () => {
+			const localTask = runtime.addRecurringIntervalTask("local", 5 * ONE_MINUTE);
+			const otherTask = runtime.addRecurringIntervalTask("other", 10 * ONE_MINUTE);
+			const legacyTask = runtime.addOneShotTask("legacy", 30 * ONE_MINUTE);
+
+			otherTask.creatorInstanceId = "foreign-instance";
+			otherTask.creatorSessionId = "/mock-home/.pi/agent/sessions/foreign.jsonl";
+			legacyTask.creatorInstanceId = undefined;
+			legacyTask.creatorSessionId = undefined;
+
+			const result = runtime.clearTasksNotCreatedHere();
+
+			expect(result).toMatchObject({ count: 2, otherCount: 1, legacyCount: 1 });
+			expect(runtime.getTask(localTask.id)).toBeDefined();
+			expect(runtime.getTask(otherTask.id)).toBeUndefined();
+			expect(runtime.getTask(legacyTask.id)).toBeUndefined();
 		});
 
 		it("adopts and releases tasks explicitly", () => {
@@ -881,6 +900,7 @@ describe("SchedulerRuntime", () => {
 			expect(list).toContain("Scheduled tasks for /mock-project/apps/api:");
 			expect(list).toContain("check build");
 			expect(list).toContain("every 5m");
+			expect(list).toContain("creator=this instance");
 			expect(list).toContain("runs=0");
 		});
 
@@ -1764,6 +1784,25 @@ describe("command handlers", () => {
 			expect(ctx._notifications.some((n: any) => n.msg.includes("Cleared 2 tasks"))).toBe(true);
 		});
 
+		it("clears tasks not created in this instance", async () => {
+			await pi._commands.get("loop").handler("5m check local", ctx);
+			await pi._commands.get("loop").handler("10m check other", ctx);
+			const localId = ctx._notifications[0].msg.match(/id: (\w+)/)?.[1];
+			const otherId = ctx._notifications[1].msg.match(/id: (\w+)/)?.[1];
+			const otherTask = pi._tools.get("schedule_prompt");
+			const listBefore = await otherTask.execute("id", { action: "list" });
+			const external = listBefore.details.tasks.find((task: any) => task.id === otherId);
+			external.creatorInstanceId = "foreign-instance";
+			external.creatorSessionId = "/mock-home/.pi/agent/sessions/foreign.jsonl";
+			ctx._notifications.length = 0;
+
+			await pi._commands.get("schedule").handler("clear-other", ctx);
+			const listAfter = await otherTask.execute("id", { action: "list" });
+			expect(ctx._notifications.some((n: any) => n.msg.includes("not created in this instance"))).toBe(true);
+			expect(listAfter.details.tasks).toHaveLength(1);
+			expect(listAfter.details.tasks[0].id).toBe(localId);
+		});
+
 		it("handles singular task in clear message", async () => {
 			await pi._commands.get("loop").handler("5m check a", ctx);
 			ctx._notifications.length = 0;
@@ -2063,6 +2102,21 @@ describe("schedule_prompt tool", () => {
 			const result = await tool.execute("id", { action: "clear" });
 			expect(result.content[0].text).toContain("Cleared 2");
 			expect(result.details.cleared).toBe(2);
+		});
+
+		it("clears tasks not created in this instance", async () => {
+			const first = await tool.execute("id", { action: "add", prompt: "local", duration: "5m" });
+			const second = await tool.execute("id", { action: "add", prompt: "other", duration: "10m" });
+			second.details.task.creatorInstanceId = "foreign-instance";
+			second.details.task.creatorSessionId = "/mock-home/.pi/agent/sessions/foreign.jsonl";
+
+			const result = await tool.execute("id", { action: "clear_other" });
+			expect(result.content[0].text).toContain("not created in this instance");
+			expect(result.details).toMatchObject({ cleared: 1, otherCount: 1, legacyCount: 0 });
+
+			const listResult = await tool.execute("id", { action: "list" });
+			expect(listResult.details.tasks).toHaveLength(1);
+			expect(listResult.details.tasks[0].id).toBe(first.details.task.id);
 		});
 
 		it("handles clear with zero tasks", async () => {
@@ -2591,7 +2645,7 @@ describe("edge cases", () => {
 		expect(ctx._notifications.some((n: any) => n.msg.includes("No scheduled tasks"))).toBe(true);
 	});
 
-	it("shows workspace in the task manager and full prompt after selecting a task", async () => {
+	it("shows workspace, creator, and full prompt after selecting a task", async () => {
 		const prompt = "check the full deployment pipeline and report every failing stage";
 		await pi._commands.get("loop").handler(`5m ${prompt}`, ctx);
 		const select = vi
@@ -2605,10 +2659,16 @@ describe("edge cases", () => {
 		expect(select).toHaveBeenNthCalledWith(
 			1,
 			"Scheduled tasks for /mock-project/apps/api (select one)",
-			expect.arrayContaining([expect.stringContaining("every 5m"), "🗑 Clear all", "+ Close"]),
+			expect.arrayContaining([
+				expect.stringContaining("this pi"),
+				expect.stringContaining("every 5m"),
+				"🗑 Clear all",
+				"+ Close",
+			]),
 		);
 		const actionTitle = select.mock.calls[1][0];
 		expect(actionTitle).toContain("Workspace: /mock-project/apps/api");
+		expect(actionTitle).toContain("Created by: this instance");
 		expect(actionTitle).toContain(`Prompt: ${prompt}`);
 	});
 
@@ -2629,6 +2689,31 @@ describe("edge cases", () => {
 		expect(pi._messages.some((m: any) => m.content.includes("No scheduled tasks"))).toBe(false);
 		await pi._commands.get("schedule").handler("list", ctx);
 		expect(pi._messages.some((m: any) => m.content.includes("No scheduled tasks"))).toBe(true);
+	});
+
+	it("can clear tasks not created here directly from the task manager list", async () => {
+		await pi._commands.get("loop").handler("5m check local queue", ctx);
+		await pi._commands.get("loop").handler("10m check foreign queue", ctx);
+		const tool = pi._tools.get("schedule_prompt");
+		const before = await tool.execute("id", { action: "list" });
+		const foreignTask = before.details.tasks.find((task: any) => task.prompt.includes("foreign queue"));
+		foreignTask.creatorInstanceId = "foreign-instance";
+		foreignTask.creatorSessionId = "/mock-home/.pi/agent/sessions/foreign.jsonl";
+
+		const select = vi.fn().mockResolvedValueOnce("🧹 Clear tasks not created here (1)");
+		const confirm = vi.fn().mockResolvedValueOnce(true);
+		const taskCtx = createMockCtx({ cwd: "/mock-project/apps/api", select, confirm });
+
+		await pi._commands.get("schedule").handler("", taskCtx);
+
+		expect(confirm).toHaveBeenCalledWith(
+			"Clear tasks not created here?",
+			"Delete 1 scheduled task for /mock-project/apps/api not created in this instance? (1 created by another instance)",
+		);
+		expect(taskCtx._notifications.some((n: any) => n.msg.includes("not created in this instance"))).toBe(true);
+		const after = await tool.execute("id", { action: "list" });
+		expect(after.details.tasks).toHaveLength(1);
+		expect(after.details.tasks[0].prompt).toContain("local queue");
 	});
 
 	it("creates and then deletes a task via different commands", async () => {

--- a/packages/extensions/extensions/scheduler.ts
+++ b/packages/extensions/extensions/scheduler.ts
@@ -109,6 +109,8 @@ type SchedulerDispatchMode = "auto" | "observer";
 
 type TaskMutationResult = {
 	count: number;
+	otherCount?: number;
+	legacyCount?: number;
 	error?: string;
 };
 
@@ -255,6 +257,35 @@ export class SchedulerRuntime {
 		return count;
 	}
 
+	clearTasksNotCreatedHere(): TaskMutationResult {
+		let count = 0;
+		let otherCount = 0;
+		let legacyCount = 0;
+
+		for (const task of Array.from(this.tasks.values())) {
+			const origin = this.getTaskCreatorOrigin(task);
+			if (origin === "current") {
+				continue;
+			}
+
+			this.tasks.delete(task.id);
+			count += 1;
+
+			if (origin === "other") {
+				otherCount += 1;
+			} else {
+				legacyCount += 1;
+			}
+		}
+
+		if (count > 0) {
+			this.persistTasks();
+			this.updateStatus();
+		}
+
+		return { count, otherCount, legacyCount };
+	}
+
 	adoptTasks(target = "all"): TaskMutationResult {
 		const matching = this.resolveTaskTargets(target, (task) => task.ownerInstanceId !== this.instanceId);
 		if (matching.error) {
@@ -353,7 +384,9 @@ export class SchedulerRuntime {
 			const status = this.taskStatusLabel(task);
 			const preview = task.prompt.length > 72 ? `${task.prompt.slice(0, 69)}...` : task.prompt;
 			lines.push(`${task.id}  ${state}  ${mode}  next ${next}`);
-			lines.push(`  owner=${this.taskOwnerLabel(task)}  runs=${task.runCount}  last=${last}  status=${status}`);
+			lines.push(
+				`  creator=${this.taskCreatorLabel(task)}  owner=${this.taskOwnerLabel(task)}  runs=${task.runCount}  last=${last}  status=${status}`,
+			);
 			if (task.lastOutcomeSnippet) {
 				lines.push(`  outcome=${this.truncateText(task.lastOutcomeSnippet, 72)}`);
 			}
@@ -393,6 +426,7 @@ export class SchedulerRuntime {
 			maxAttempts: options.maxAttempts,
 			awaitingCompletion: false,
 		};
+		this.assignCreator(task);
 		this.assignOwner(task, task.scope ?? "instance");
 		this.tasks.set(id, task);
 		this.persistTasks();
@@ -436,6 +470,7 @@ export class SchedulerRuntime {
 			maxAttempts: options.maxAttempts,
 			awaitingCompletion: false,
 		};
+		this.assignCreator(task);
 		this.assignOwner(task, task.scope ?? "instance");
 		this.tasks.set(id, task);
 		this.persistTasks();
@@ -467,6 +502,7 @@ export class SchedulerRuntime {
 			maxAttempts: options.maxAttempts,
 			awaitingCompletion: false,
 		};
+		this.assignCreator(task);
 		this.assignOwner(task, task.scope ?? "instance");
 		this.tasks.set(id, task);
 		this.persistTasks();
@@ -742,26 +778,17 @@ export class SchedulerRuntime {
 				return;
 			}
 
-			const options = list.map((task) => this.taskOptionLabel(task));
-			options.push("🗑 Clear all");
-			options.push("+ Close");
-
+			const otherTasks = this.getTasksNotCreatedHere();
+			const clearOtherLabel =
+				otherTasks.length > 0 ? `🧹 Clear tasks not created here (${otherTasks.length})` : undefined;
+			const options = this.buildTaskManagerOptions(list, clearOtherLabel);
 			const selected = await ctx.ui.select(`Scheduled tasks for ${this.getWorkspaceLabel(ctx)} (select one)`, options);
-			if (!selected || selected === "+ Close") {
+			const selection = await this.handleTaskManagerSelection(ctx, selected, list, otherTasks, clearOtherLabel);
+			if (selection === "close") {
 				return;
 			}
-			if (selected === "🗑 Clear all") {
-				const count = list.length;
-				const ok = await ctx.ui.confirm(
-					"Clear all scheduled tasks?",
-					`Delete ${count} scheduled task${count === 1 ? "" : "s"} for ${this.getWorkspaceLabel(ctx)}?`,
-				);
-				if (!ok) {
-					continue;
-				}
-				this.clearTasks();
-				ctx.ui.notify(`Cleared ${count} scheduled task${count === 1 ? "" : "s"}.`, "info");
-				return;
+			if (selection === "refresh") {
+				continue;
 			}
 
 			const taskId = selected.slice(0, 8);
@@ -778,6 +805,60 @@ export class SchedulerRuntime {
 		}
 	}
 
+	private buildTaskManagerOptions(list: ScheduleTask[], clearOtherLabel?: string): string[] {
+		const options = list.map((task) => this.taskOptionLabel(task));
+		if (clearOtherLabel) {
+			options.push(clearOtherLabel);
+		}
+		options.push("🗑 Clear all");
+		options.push("+ Close");
+		return options;
+	}
+
+	private async handleTaskManagerSelection(
+		ctx: ExtensionContext,
+		selected: string | null,
+		list: ScheduleTask[],
+		otherTasks: ScheduleTask[],
+		clearOtherLabel?: string,
+	): Promise<"open-task" | "refresh" | "close"> {
+		if (!selected || selected === "+ Close") {
+			return "close";
+		}
+
+		if (clearOtherLabel && selected === clearOtherLabel) {
+			const ok = await ctx.ui.confirm(
+				"Clear tasks not created here?",
+				this.describeExternalCreatorClear(otherTasks, ctx),
+			);
+			if (!ok) {
+				return "refresh";
+			}
+			const result = this.clearTasksNotCreatedHere();
+			ctx.ui.notify(
+				`Cleared ${result.count} scheduled task${result.count === 1 ? "" : "s"} not created in this instance.`,
+				"info",
+			);
+			return "refresh";
+		}
+
+		if (selected === "🗑 Clear all") {
+			const count = list.length;
+			const ok = await ctx.ui.confirm(
+				"Clear all scheduled tasks?",
+				`Delete ${count} scheduled task${count === 1 ? "" : "s"} for ${this.getWorkspaceLabel(ctx)}?`,
+			);
+			if (!ok) {
+				return "refresh";
+			}
+			this.clearTasks();
+			ctx.ui.notify(`Cleared ${count} scheduled task${count === 1 ? "" : "s"}.`, "info");
+			return "close";
+		}
+
+		return "open-task";
+	}
+
 	// biome-ignore lint/complexity/noExcessiveCognitiveComplexity: TUI flow with multiple interactive branches.
 	private async openTaskActions(ctx: ExtensionContext, taskId: string): Promise<boolean> {
 		while (true) {
@@ -787,9 +868,13 @@ export class SchedulerRuntime {
 				return false;
 			}
 
+			const createdHere = this.wasCreatedHere(task);
+			const deleteLabel = createdHere ? "🗑 Delete" : "🧹 Clear (not created here)";
 			const title = [
 				`${task.id} • ${this.taskMode(task)} • next ${this.formatRelativeTime(task.nextRunAt)} (${this.formatClock(task.nextRunAt)})`,
 				`Workspace: ${this.getWorkspaceLabel(ctx)}`,
+				`Created by: ${this.taskCreatorLabel(task)}`,
+				`Owner: ${this.taskOwnerLabel(task)}`,
 				`Prompt: ${task.prompt}`,
 			].join("\n");
 			const options = [
@@ -798,7 +883,7 @@ export class SchedulerRuntime {
 				"Run now",
 				"Adopt",
 				"Release",
-				"🗑 Delete",
+				deleteLabel,
 				"↩ Back",
 				"✕ Close",
 			];
@@ -838,15 +923,23 @@ export class SchedulerRuntime {
 				continue;
 			}
 
-			if (action === "🗑 Delete") {
-				const ok = await ctx.ui.confirm("Delete scheduled task?", `${task.id}: ${task.prompt}`);
+			if (action === deleteLabel) {
+				const ok = await ctx.ui.confirm(
+					createdHere ? "Delete scheduled task?" : "Clear task not created here?",
+					`${task.id}: ${task.prompt}`,
+				);
 				if (!ok) {
 					continue;
 				}
 				this.tasks.delete(task.id);
 				this.persistTasks();
 				this.updateStatus();
-				ctx.ui.notify(`Deleted scheduled task ${task.id}.`, "info");
+				ctx.ui.notify(
+					createdHere
+						? `Deleted scheduled task ${task.id}.`
+						: `Cleared scheduled task ${task.id} because it was not created in this instance.`,
+					"info",
+				);
 				return false;
 			}
 
@@ -1179,8 +1272,9 @@ export class SchedulerRuntime {
 	}
 
 	private taskOptionLabel(task: ScheduleTask): string {
+		const origin = this.taskCreatorShortLabel(task);
 		const state = task.resumeRequired ? `! ${task.resumeReason ?? "review"}` : task.enabled ? "+" : "-";
-		return `${task.id} • ${state} [${task.scope ?? "instance"}] ${this.taskMode(task)} • ${this.formatRelativeTime(task.nextRunAt)} • ${this.truncateText(task.prompt, 50)}`;
+		return `${task.id} • ${origin} • ${state} [${task.scope ?? "instance"}] ${this.taskMode(task)} • ${this.formatRelativeTime(task.nextRunAt)} • ${this.truncateText(task.prompt, 50)}`;
 	}
 
 	private getWorkspaceLabel(ctx?: ExtensionContext): string {
@@ -1223,6 +1317,11 @@ export class SchedulerRuntime {
 		}
 	}
 
+	private assignCreator(task: ScheduleTask) {
+		task.creatorInstanceId = this.instanceId;
+		task.creatorSessionId = this.sessionId;
+	}
+
 	private assignOwner(task: ScheduleTask, scope: ScheduleScope) {
 		task.scope = scope;
 		task.ownerInstanceId = this.instanceId;
@@ -1253,6 +1352,10 @@ export class SchedulerRuntime {
 		return Array.from(this.tasks.values()).filter(
 			(task) => task.ownerInstanceId && task.ownerInstanceId !== this.instanceId,
 		).length;
+	}
+
+	private getTasksNotCreatedHere(): ScheduleTask[] {
+		return this.getSortedTasks().filter((task) => !this.wasCreatedHere(task));
 	}
 
 	private hasManagedTasksForLease(): boolean {
@@ -1564,6 +1667,8 @@ export class SchedulerRuntime {
 							: undefined,
 					awaitingCompletion: false,
 					lastOutcomeSnippet: task.lastOutcomeSnippet,
+					creatorInstanceId: task.creatorInstanceId,
+					creatorSessionId: task.creatorSessionId,
 				};
 				if (normalized.kind === "recurring" && normalized.expiresAt && now >= normalized.expiresAt) {
 					mutated = true;
@@ -1638,6 +1743,42 @@ export class SchedulerRuntime {
 		return task.lastStatus ?? "pending";
 	}
 
+	private getTaskCreatorOrigin(task: ScheduleTask): "current" | "other" | "legacy" {
+		if (task.creatorInstanceId === this.instanceId) {
+			return "current";
+		}
+		if (task.creatorInstanceId) {
+			return "other";
+		}
+		return "legacy";
+	}
+
+	private wasCreatedHere(task: ScheduleTask): boolean {
+		return this.getTaskCreatorOrigin(task) === "current";
+	}
+
+	private taskCreatorShortLabel(task: ScheduleTask): string {
+		switch (this.getTaskCreatorOrigin(task)) {
+			case "current":
+				return "this pi";
+			case "other":
+				return "other pi";
+			default:
+				return "legacy";
+		}
+	}
+
+	private taskCreatorLabel(task: ScheduleTask): string {
+		switch (this.getTaskCreatorOrigin(task)) {
+			case "current":
+				return `this instance (${this.instanceId})`;
+			case "other":
+				return `${task.creatorInstanceId}${task.creatorSessionId ? ` (${task.creatorSessionId})` : ""}`;
+			default:
+				return "unknown (legacy task)";
+		}
+	}
+
 	private taskOwnerLabel(task: ScheduleTask): string {
 		if (task.ownerInstanceId === this.instanceId) {
 			return `this:${this.instanceId}`;
@@ -1646,6 +1787,19 @@ export class SchedulerRuntime {
 			return `${task.ownerInstanceId}${task.ownerSessionId ? ` (${task.ownerSessionId})` : ""}`;
 		}
 		return "unowned";
+	}
+
+	private describeExternalCreatorClear(tasks: ScheduleTask[], ctx?: ExtensionContext): string {
+		const otherCount = tasks.filter((task) => this.getTaskCreatorOrigin(task) === "other").length;
+		const legacyCount = tasks.length - otherCount;
+		const parts = [];
+		if (otherCount > 0) {
+			parts.push(`${otherCount} created by another instance`);
+		}
+		if (legacyCount > 0) {
+			parts.push(`${legacyCount} legacy task${legacyCount === 1 ? "" : "s"} with unknown creator`);
+		}
+		return `Delete ${tasks.length} scheduled task${tasks.length === 1 ? "" : "s"} for ${this.getWorkspaceLabel(ctx)} not created in this instance? (${parts.join(", ")})`;
 	}
 
 	notifyResumeRequiredTasks() {


### PR DESCRIPTION
## Summary
- track the instance/session that originally created each scheduler task
- surface creator origin in the scheduler TUI and make per-task delete actions switch to clear mode when a task was not created here
- add bulk clear-other controls in the TUI, `/schedule`, and `schedule_prompt` tool for tasks not created in this instance

## UI
- task list rows now show `this pi`, `other pi`, or `legacy` origin badges
- task details now show `Created by` and `Owner` lines
- the task manager adds `🧹 Clear tasks not created here (N)` when applicable
- tasks not created here swap `🗑 Delete` for `🧹 Clear (not created here)` in the task action menu

## Testing
- pnpm exec biome check packages/extensions/extensions/scheduler.ts packages/extensions/extensions/scheduler-registration.ts packages/extensions/extensions/scheduler-shared.ts packages/extensions/extensions/scheduler.test.ts
- pnpm test packages/extensions/extensions/scheduler.test.ts
- pnpm typecheck
- pnpm mdt check