### PR TITLE
feat(extensions): improve session continuity UX

### DIFF
--- a/.changes/session-ux-continuity.md
+++ b/.changes/session-ux-continuity.md
@@ -1,0 +1,9 @@
+---
+default: patch
+---
+
+Improve long-running session continuity and resume ergonomics.
+
+- update `auto-session-name` to refresh titles when conversation focus shifts instead of freezing on the first prompt
+- auto-send a `continue` follow-up after compaction so manual and automatic compaction flows continue working without extra input
+- emit a shutdown message with a resumable session id hint (`pi --session <id>`) to make resume flows faster

--- a/packages/core/src/registry.ts
+++ b/packages/core/src/registry.ts
@@ -78,7 +78,7 @@ export const EXTENSIONS = [
 	{
 		name: "auto-session-name",
 		get label() {
-			return `${icon("memo")} Auto Session Name — Name sessions from first message`;
+			return `${icon("memo")} Auto Session Name — Dynamic session naming + compact auto-continue`;
 		},
 		default: true,
 	},

--- a/packages/extensions/README.md
+++ b/packages/extensions/README.md
@@ -217,3 +217,9 @@ supported range and falling back to the default interval when no valid override 
 ## Notes
 
 This package ships raw `.ts` extensions for pi to load directly.
+
+## Auto session naming and compaction continuity
+
+`auto-session-name` now keeps session titles fresh as work focus changes, triggers a
+`continue` follow-up after compaction, and emits a shutdown resume hint with the current
+session id.

--- a/packages/extensions/extensions/auto-session-name.test.ts
+++ b/packages/extensions/extensions/auto-session-name.test.ts
@@ -1,0 +1,71 @@
+import { describe, expect, it } from "vitest";
+import { createExtensionHarness } from "../../../test-utils/extension-runtime-harness.js";
+import autoSessionNameExtension from "./auto-session-name.js";
+
+describe("auto-session-name extension", () => {
+	it("names a new session from the first user message", async () => {
+		const harness = createExtensionHarness();
+		autoSessionNameExtension(harness.pi as never);
+
+		harness.emit("session_start", { type: "session_start" }, harness.ctx);
+		await harness.emitAsync(
+			"agent_end",
+			{
+				type: "agent_end",
+				messages: [{ role: "user", content: "Refactor scheduler startup ownership checks and notifications" }],
+			},
+			harness.ctx,
+		);
+
+		expect(harness.sessionName).toContain("Refactor scheduler startup ownership checks");
+	});
+
+	it("refreshes the session name when focus shifts significantly", async () => {
+		const harness = createExtensionHarness();
+		autoSessionNameExtension(harness.pi as never);
+
+		harness.emit("session_start", { type: "session_start" }, harness.ctx);
+		await harness.emitAsync(
+			"agent_end",
+			{
+				type: "agent_end",
+				messages: [{ role: "user", content: "Investigate scheduler ownership handling" }],
+			},
+			harness.ctx,
+		);
+
+		await harness.emitAsync(
+			"agent_end",
+			{
+				type: "agent_end",
+				messages: [
+					{ role: "user", content: "Investigate scheduler ownership handling" },
+					{
+						role: "user",
+						content: "Implement auto-continue after compaction and improve resume hints for shutdown",
+					},
+				],
+			},
+			harness.ctx,
+		);
+
+		expect(harness.sessionName).toContain("Implement auto-continue after compaction");
+	});
+
+	it("queues a continue message when compaction finishes", () => {
+		const harness = createExtensionHarness();
+		autoSessionNameExtension(harness.pi as never);
+
+		harness.emit("compact", { type: "compact" }, harness.ctx);
+		expect(harness.userMessages.at(-1)).toBe("continue");
+	});
+
+	it("emits a resume hint containing the session id on shutdown", () => {
+		const harness = createExtensionHarness();
+		harness.ctx.sessionManager.getSessionFile = () => "/tmp/sessions/test-session.jsonl";
+		autoSessionNameExtension(harness.pi as never);
+
+		harness.emit("session_shutdown", { type: "session_shutdown" }, harness.ctx);
+		expect(harness.messages.at(-1)?.content).toContain("pi --session test-session");
+	});
+});

--- a/packages/extensions/extensions/auto-session-name.ts
+++ b/packages/extensions/extensions/auto-session-name.ts
@@ -1,46 +1,153 @@
-/**
- * oh-pi Auto Session Name Extension
- *
- * Automatically names sessions based on the first user message content.
- * If the session already has a name (e.g. from a previous run), no rename occurs.
- * The name is derived from the first 60 characters of the user's initial message.
- */
+import * as path from "node:path";
 import type { ExtensionAPI } from "@mariozechner/pi-coding-agent";
 
-/**
- * Extension entry point — hooks into `session_start` to check for existing names
- * and `agent_end` to derive and assign a session name from the first user message.
- */
-export default function (pi: ExtensionAPI) {
-	/** Tracks whether this session has already been named. */
-	let named = false;
+const MAX_NAME_LEN = 72;
+const FOCUS_SHIFT_THRESHOLD = 0.35;
+const AUTO_CONTINUE_TEXT = "continue";
 
-	pi.on("session_start", (_event, _ctx) => {
-		named = !!pi.getSessionName();
+type MessageLike = {
+	role?: string;
+	content?: string | Array<{ type?: string; text?: string }>;
+};
+
+function toText(content: MessageLike["content"]): string {
+	if (!content) {
+		return "";
+	}
+	if (typeof content === "string") {
+		return content;
+	}
+	return content
+		.filter((block) => block?.type === "text" && typeof block.text === "string")
+		.map((block) => block.text?.trim() ?? "")
+		.join(" ")
+		.trim();
+}
+
+function normalizeLabel(input: string): string {
+	return input
+		.replaceAll(/\s+/g, " ")
+		.replaceAll(/^[-:–—\s]+|[-:–—\s]+$/g, "")
+		.slice(0, MAX_NAME_LEN)
+		.trim();
+}
+
+function tokenize(input: string): Set<string> {
+	const terms = input.toLowerCase().match(/[a-z0-9]{3,}/g) ?? [];
+	return new Set(terms);
+}
+
+function overlapRatio(a: string, b: string): number {
+	const left = tokenize(a);
+	const right = tokenize(b);
+	if (left.size === 0 || right.size === 0) {
+		return 1;
+	}
+	let shared = 0;
+	for (const term of left) {
+		if (right.has(term)) {
+			shared += 1;
+		}
+	}
+	return shared / Math.max(left.size, right.size);
+}
+
+function deriveSessionId(sessionFile: string | undefined): string | undefined {
+	if (!sessionFile) {
+		return undefined;
+	}
+	return path.basename(sessionFile).replace(/\.jsonl$/i, "") || undefined;
+}
+
+function isFocusShift(firstUserText: string, latestUserText: string): boolean {
+	if (!(firstUserText && latestUserText)) {
+		return false;
+	}
+	if (latestUserText.length < 12) {
+		return false;
+	}
+	return overlapRatio(firstUserText, latestUserText) < FOCUS_SHIFT_THRESHOLD;
+}
+
+function chooseName(messages: MessageLike[], currentName: string): string | undefined {
+	const userTexts = messages
+		.filter((msg) => msg.role === "user")
+		.map((msg) => toText(msg.content))
+		.filter(Boolean);
+	const assistantTexts = messages
+		.filter((msg) => msg.role === "assistant")
+		.map((msg) => toText(msg.content))
+		.filter(Boolean);
+
+	const firstUser = userTexts[0] ?? "";
+	const latestUser = userTexts[userTexts.length - 1] ?? "";
+	const latestAssistant = assistantTexts[assistantTexts.length - 1] ?? "";
+
+	if (!currentName) {
+		return normalizeLabel(latestUser || firstUser || latestAssistant);
+	}
+
+	if (isFocusShift(firstUser, latestUser)) {
+		return normalizeLabel(latestUser);
+	}
+
+	if (latestAssistant) {
+		return normalizeLabel(`${latestUser || currentName} — ${latestAssistant}`);
+	}
+
+	return undefined;
+}
+
+export default function autoSessionNameExtension(pi: ExtensionAPI) {
+	let lastAutoName = "";
+	let compactContinuationQueued = false;
+
+	pi.on("session_start", () => {
+		const existing = (pi.getSessionName?.() ?? "").trim();
+		lastAutoName = existing;
 	});
 
 	pi.on("agent_end", async (event) => {
-		if (named) {
+		const messages = (event as { messages?: MessageLike[] }).messages ?? [];
+		if (messages.length === 0) {
 			return;
 		}
-		const userMsg = event.messages.find((m) => m.role === "user");
-		if (!userMsg) {
+
+		const current = (pi.getSessionName?.() ?? "").trim();
+		const next = chooseName(messages, current);
+		if (!(next && next !== current && next !== lastAutoName)) {
 			return;
 		}
-		const text =
-			typeof userMsg.content === "string"
-				? userMsg.content
-				: userMsg.content
-						.filter((b) => b.type === "text")
-						.map((b) => (b as { text: string }).text)
-						.join(" ");
-		if (!text) {
+
+		pi.setSessionName?.(next);
+		lastAutoName = next;
+	});
+
+	pi.on("compact", () => {
+		if (compactContinuationQueued) {
 			return;
 		}
-		const name = text.slice(0, 60).replace(/\n/g, " ").trim();
-		if (name) {
-			pi.setSessionName(name);
-			named = true;
+		compactContinuationQueued = true;
+		try {
+			pi.sendUserMessage(AUTO_CONTINUE_TEXT);
+		} finally {
+			setTimeout(() => {
+				compactContinuationQueued = false;
+			}, 1_000);
 		}
+	});
+
+	pi.on("session_shutdown", (_event, ctx) => {
+		const sessionFile = ctx.sessionManager?.getSessionFile?.();
+		const sessionId = deriveSessionId(sessionFile);
+		if (!sessionId) {
+			return;
+		}
+
+		pi.sendMessage({
+			customType: "session-resume-hint",
+			content: `Session saved as ${sessionId}. Resume with: pi --session ${sessionId}`,
+			display: true,
+		});
 	});
 }

--- a/test-utils/extension-runtime-harness.js
+++ b/test-utils/extension-runtime-harness.js
@@ -15,6 +15,7 @@ export function createExtensionHarness() {
 	const messageRenderers = new Map();
 	const providers = new Map();
 	const eventBus = new EventEmitter();
+	let sessionName = "";
 
 	let currentThinking = "low";
 	const pi = {
@@ -76,6 +77,12 @@ export function createExtensionHarness() {
 		setActiveTools() {},
 		getFlag(name) {
 			return flags.get(name)?.default;
+		},
+		getSessionName() {
+			return sessionName;
+		},
+		setSessionName(name) {
+			sessionName = name;
 		},
 	};
 
@@ -158,6 +165,9 @@ export function createExtensionHarness() {
 		},
 		messageRenderers,
 		providers,
+		get sessionName() {
+			return sessionName;
+		},
 		emit(event, ...args) {
 			for (const handler of handlers.get(event) ?? []) {
 				handler(...args);

--- a/test-utils/extension-runtime-harness.ts
+++ b/test-utils/extension-runtime-harness.ts
@@ -15,6 +15,7 @@ export function createExtensionHarness() {
 	const messageRenderers = new Map<string, any>();
 	const providers = new Map<string, any>();
 	const eventBus = new EventEmitter();
+	let sessionName = "";
 
 	let currentThinking = "low";
 	const pi = {
@@ -76,6 +77,12 @@ export function createExtensionHarness() {
 		setActiveTools() {},
 		getFlag(name: string) {
 			return flags.get(name)?.default;
+		},
+		getSessionName() {
+			return sessionName;
+		},
+		setSessionName(name: string) {
+			sessionName = name;
 		},
 	};
 
@@ -158,6 +165,9 @@ export function createExtensionHarness() {
 		},
 		messageRenderers,
 		providers,
+		get sessionName() {
+			return sessionName;
+		},
 		emit(event: string, ...args: any[]) {
 			for (const handler of handlers.get(event) ?? []) {
 				handler(...args);


### PR DESCRIPTION
## Summary
- refresh `auto-session-name` titles as work focus changes instead of locking to the first prompt
- auto-send `continue` after compaction so runs keep moving after `/compact` and auto-compaction
- emit a shutdown message with a resumable session id hint (`pi --session <id>`)
- add tests for naming refresh, compaction continuation, and resume hint output

## Validation
- pnpm test packages/extensions/extensions/auto-session-name.test.ts packages/extensions/extensions/smoke.test.ts
