### PR TITLE
feat(scheduler): add continue-until-complete retry mode

### DIFF
--- a/.changes/scheduler-until-complete-retries.md
+++ b/.changes/scheduler-until-complete-retries.md
@@ -1,0 +1,9 @@
+---
+default: patch
+---
+
+Add scheduler support for completion-aware retries.
+
+- extend `schedule_prompt add` with `continueUntilComplete`, `completionSignal`, `retryInterval`, and `maxAttempts`
+- keep compatible tasks in an `awaiting_completion` state and evaluate completion on `agent_end` before deleting or rescheduling
+- persist per-task completion settings and outcome snippets for better `/schedule` and tool observability

--- a/packages/extensions/README.md
+++ b/packages/extensions/README.md
@@ -81,6 +81,9 @@ The scheduler extension adds recurring checks, one-time reminders, and the LLM-c
 checks. Tasks run only while pi is active and idle, and scheduler state is persisted in shared pi
 storage using a workspace-mirrored path.
 
+Use `continueUntilComplete: true` (plus optional `completionSignal`, `retryInterval`, and
+`maxAttempts`) when a scheduled check should keep retrying until completion is detected.
+
 <!-- {/extensionsSchedulerOverview} -->
 
 ## Package layout

--- a/packages/extensions/README.md
+++ b/packages/extensions/README.md
@@ -81,10 +81,10 @@ The scheduler extension adds recurring checks, one-time reminders, and the LLM-c
 checks. Tasks run only while pi is active and idle, and scheduler state is persisted in shared pi
 storage using a workspace-mirrored path.
 
+<!-- {/extensionsSchedulerOverview} -->
+
 Use `continueUntilComplete: true` (plus optional `completionSignal`, `retryInterval`, and
 `maxAttempts`) when a scheduled check should keep retrying until completion is detected.
-
-<!-- {/extensionsSchedulerOverview} -->
 
 ## Package layout
 

--- a/packages/extensions/extensions/scheduler-registration.ts
+++ b/packages/extensions/extensions/scheduler-registration.ts
@@ -3,6 +3,8 @@ import { Type } from "@sinclair/typebox";
 import type { SchedulerRuntime } from "./scheduler.js";
 import {
 	formatDurationShort,
+	normalizeDuration,
+	parseDuration,
 	parseLoopScheduleArgs,
 	parseRemindScheduleArgs,
 	validateSchedulePromptAddInput,
@@ -44,6 +46,24 @@ const SchedulePromptToolParams = Type.Object({
 		}),
 	),
 	id: Type.Optional(Type.String({ description: "Task id for delete/enable/disable/adopt/release action" })),
+	continueUntilComplete: Type.Optional(
+		Type.Union([Type.Literal(true), Type.Literal(false)], {
+			description: "Keep re-running this task until completion is detected.",
+		}),
+	),
+	completionSignal: Type.Optional(
+		Type.String({
+			description: "Optional completion marker (substring or /regex/flags) that indicates the task is complete.",
+		}),
+	),
+	retryInterval: Type.Optional(
+		Type.String({
+			description: "Delay between retries while waiting for completion (e.g. 2m, 10m).",
+		}),
+	),
+	maxAttempts: Type.Optional(
+		Type.Number({ description: "Optional maximum number of runs when continueUntilComplete is enabled." }),
+	),
 });
 
 type ToolResult = { content: { type: "text"; text: string }[]; details: Record<string, unknown> };
@@ -277,6 +297,7 @@ export function registerTools(pi: ExtensionAPI, runtime: SchedulerRuntime) {
 			"Use this tool when the user asks to remind/check back later, revisit something in the future, or monitor PRs, CI, builds, deploys, or background work.",
 			"For recurring tasks use kind='recurring' with duration like 5m or 2h, or provide cron.",
 			"For one-time reminders use kind='once' with duration like 30m or 1h.",
+			"Set continueUntilComplete=true when the user explicitly wants retries until the task is done.",
 			"Default scope is instance. Use scope='workspace' only for monitors that should be adoptable across pi instances in the same workspace.",
 			"Scheduled tasks run only while pi is active and idle. Persisted overdue or foreign-owned tasks are restored for manual review instead of auto-running at startup.",
 		],
@@ -291,6 +312,10 @@ export function registerTools(pi: ExtensionAPI, runtime: SchedulerRuntime) {
 				cron?: string;
 				scope?: ScheduleScope;
 				id?: string;
+				continueUntilComplete?: boolean;
+				completionSignal?: string;
+				retryInterval?: string;
+				maxAttempts?: number;
 			},
 		): Promise<{ content: { type: "text"; text: string }[]; details: Record<string, unknown> }> => {
 			const { action } = params;
@@ -335,10 +360,11 @@ function handleToolList(runtime: SchedulerRuntime): ToolResult {
 	}
 
 	const lines = list.map((task) => {
-		const schedule =
+		const scheduleBase =
 			task.kind === "once"
 				? "-"
 				: (task.cronExpression ?? formatDurationShort(task.intervalMs ?? DEFAULT_LOOP_INTERVAL));
+		const schedule = task.continueUntilComplete ? `${scheduleBase} (until-complete)` : scheduleBase;
 		const state = task.resumeRequired ? `due:${task.resumeReason ?? "unknown"}` : task.enabled ? "on" : "off";
 		const status = task.resumeRequired ? "resume_required" : (task.lastStatus ?? "pending");
 		const last = task.lastRunAt ? runtime.formatRelativeTime(task.lastRunAt) : "never";
@@ -464,8 +490,78 @@ function validationErrorMessage(error: string): string {
 	}
 }
 
+function resolveCompletionOptions(params: {
+	continueUntilComplete?: boolean;
+	completionSignal?: string;
+	retryInterval?: string;
+	maxAttempts?: number;
+}):
+	| {
+			ok: true;
+			options: {
+				continueUntilComplete?: boolean;
+				completionSignal?: string;
+				retryIntervalMs?: number;
+				maxAttempts?: number;
+			};
+			note?: string;
+	  }
+	| { ok: false; error: string } {
+	if (!params.continueUntilComplete) {
+		return {
+			ok: true,
+			options: {
+				continueUntilComplete: false,
+			},
+		};
+	}
+
+	let retryIntervalMs: number | undefined;
+	let note: string | undefined;
+	if (params.retryInterval) {
+		const parsed = parseDuration(params.retryInterval);
+		if (!parsed) {
+			return { ok: false, error: "invalid_retry_interval" };
+		}
+		const normalized = normalizeDuration(parsed);
+		retryIntervalMs = normalized.durationMs;
+		note = normalized.note;
+	}
+
+	let maxAttempts: number | undefined;
+	if (params.maxAttempts !== undefined) {
+		if (!Number.isFinite(params.maxAttempts) || params.maxAttempts < 1) {
+			return { ok: false, error: "invalid_max_attempts" };
+		}
+		maxAttempts = Math.floor(params.maxAttempts);
+	}
+
+	const completionSignal = params.completionSignal?.trim();
+	return {
+		ok: true,
+		options: {
+			continueUntilComplete: true,
+			completionSignal: completionSignal || undefined,
+			retryIntervalMs,
+			maxAttempts,
+		},
+		note,
+	};
+}
+
+// biome-ignore lint/complexity/noExcessiveCognitiveComplexity: Handles validation + messaging for multiple schedule modes and completion policies.
 function handleToolAdd(
-	params: { kind?: TaskKind; prompt?: string; duration?: string; cron?: string; scope?: ScheduleScope },
+	params: {
+		kind?: TaskKind;
+		prompt?: string;
+		duration?: string;
+		cron?: string;
+		scope?: ScheduleScope;
+		continueUntilComplete?: boolean;
+		completionSignal?: string;
+		retryInterval?: string;
+		maxAttempts?: number;
+	},
 	runtime: SchedulerRuntime,
 ): ToolResult {
 	const prompt = params.prompt?.trim();
@@ -483,6 +579,27 @@ function handleToolAdd(
 		};
 	}
 
+	const completion = resolveCompletionOptions({
+		continueUntilComplete: params.continueUntilComplete,
+		completionSignal: params.completionSignal,
+		retryInterval: params.retryInterval,
+		maxAttempts: params.maxAttempts,
+	});
+	if (!completion.ok) {
+		return {
+			content: [
+				{
+					type: "text",
+					text:
+						completion.error === "invalid_retry_interval"
+							? "Error: retryInterval must be a duration like 2m, 10m, or 1h."
+							: "Error: maxAttempts must be a positive number.",
+				},
+			],
+			details: { action: "add", error: completion.error },
+		};
+	}
+
 	const validated = validateSchedulePromptAddInput({
 		kind: params.kind,
 		duration: params.duration,
@@ -496,13 +613,18 @@ function handleToolAdd(
 	}
 
 	if (validated.plan.kind === "once") {
-		const task = runtime.addOneShotTask(prompt, validated.plan.durationMs, { scope: params.scope });
+		const task = runtime.addOneShotTask(prompt, validated.plan.durationMs, {
+			scope: params.scope,
+			...completion.options,
+		});
 		return {
 			content: [
 				{
 					type: "text",
 					text: `Reminder scheduled (id: ${task.id}) for ${runtime.formatRelativeTime(task.nextRunAt)} as ${task.scope ?? "instance"}-scoped.${
 						validated.plan.note ? ` ${validated.plan.note}` : ""
+					}${completion.options.continueUntilComplete ? " Will retry until marked complete." : ""}${
+						completion.note ? ` ${completion.note}` : ""
 					}`,
 				},
 			],
@@ -511,7 +633,10 @@ function handleToolAdd(
 	}
 
 	if (validated.plan.mode === "cron") {
-		const task = runtime.addRecurringCronTask(prompt, validated.plan.cronExpression, { scope: params.scope });
+		const task = runtime.addRecurringCronTask(prompt, validated.plan.cronExpression, {
+			scope: params.scope,
+			...completion.options,
+		});
 		if (!task) {
 			return {
 				content: [
@@ -526,6 +651,8 @@ function handleToolAdd(
 					type: "text",
 					text: `Recurring cron task scheduled (id: ${task.id}) with '${task.cronExpression}' as ${task.scope ?? "instance"}-scoped. Expires in 3 days.${
 						validated.plan.note ? ` ${validated.plan.note}` : ""
+					}${completion.options.continueUntilComplete ? " Will retry until marked complete." : ""}${
+						completion.note ? ` ${completion.note}` : ""
 					}`,
 				},
 			],
@@ -533,13 +660,18 @@ function handleToolAdd(
 		};
 	}
 
-	const task = runtime.addRecurringIntervalTask(prompt, validated.plan.durationMs, { scope: params.scope });
+	const task = runtime.addRecurringIntervalTask(prompt, validated.plan.durationMs, {
+		scope: params.scope,
+		...completion.options,
+	});
 	return {
 		content: [
 			{
 				type: "text",
 				text: `Recurring task scheduled (id: ${task.id}) every ${formatDurationShort(validated.plan.durationMs)} as ${task.scope ?? "instance"}-scoped. Expires in 3 days.${
 					validated.plan.note ? ` ${validated.plan.note}` : ""
+				}${completion.options.continueUntilComplete ? " Will retry until marked complete." : ""}${
+					completion.note ? ` ${completion.note}` : ""
 				}`,
 			},
 		],
@@ -563,6 +695,10 @@ export function registerEvents(pi: ExtensionAPI, runtime: SchedulerRuntime) {
 	pi.on("session_switch", refreshRuntimeContext);
 	pi.on("session_fork", refreshRuntimeContext);
 	pi.on("session_tree", refreshRuntimeContext);
+
+	pi.on("agent_end", (event) => {
+		runtime.handleAgentEnd(event as { messages?: Array<{ role?: string; content?: unknown }> });
+	});
 
 	pi.on("session_shutdown", async (_event, ctx) => {
 		runtime.setRuntimeContext(ctx);

--- a/packages/extensions/extensions/scheduler-shared.ts
+++ b/packages/extensions/extensions/scheduler-shared.ts
@@ -39,6 +39,12 @@ export interface ScheduleTask {
 	resumeReason?: ResumeReason;
 	ownerInstanceId?: string;
 	ownerSessionId?: string | null;
+	continueUntilComplete?: boolean;
+	completionSignal?: string;
+	retryIntervalMs?: number;
+	maxAttempts?: number;
+	awaitingCompletion?: boolean;
+	lastOutcomeSnippet?: string;
 }
 
 export interface SchedulerLease {

--- a/packages/extensions/extensions/scheduler.test.ts
+++ b/packages/extensions/extensions/scheduler.test.ts
@@ -2675,4 +2675,50 @@ describe("edge cases", () => {
 		await pi._commands.get("unschedule").handler(`  ${taskId}  `, ctx);
 		expect(ctx._notifications.some((n: any) => n.msg.includes("Deleted"))).toBe(true);
 	});
+
+	it("supports continue-until-complete options in schedule_prompt add", async () => {
+		const tool = pi._tools.get("schedule_prompt");
+		const result = await tool.execute("id", {
+			action: "add",
+			prompt: "check deployment and keep going",
+			duration: "5m",
+			continueUntilComplete: true,
+			retryInterval: "90s",
+			completionSignal: "DEPLOYMENT_DONE",
+			maxAttempts: 4,
+		});
+
+		expect(result.content[0].text).toContain("Will retry until marked complete");
+		expect(result.details.task.continueUntilComplete).toBe(true);
+		expect(result.details.task.retryIntervalMs).toBe(2 * ONE_MINUTE);
+		expect(result.details.task.completionSignal).toBe("DEPLOYMENT_DONE");
+		expect(result.details.task.maxAttempts).toBe(4);
+	});
+
+	it("retries until completion for continue-until-complete one-shot tasks", () => {
+		const runtime = new SchedulerRuntime(pi as any);
+		runtime.setRuntimeContext(ctx as any);
+		const task = runtime.addOneShotTask("check build status", ONE_MINUTE, {
+			continueUntilComplete: true,
+			completionSignal: "BUILD_DONE",
+			retryIntervalMs: ONE_MINUTE,
+			maxAttempts: 3,
+		});
+
+		runtime.dispatchTask(task);
+		expect(pi._userMessages.at(-1)).toBe("check build status");
+		expect(runtime.getTask(task.id)?.awaitingCompletion).toBe(true);
+		expect(runtime.getTask(task.id)?.lastStatus).toBe("pending");
+
+		runtime.handleAgentEnd({ messages: [{ role: "assistant", content: "still running, not complete yet" }] });
+		expect(runtime.getTask(task.id)).toBeDefined();
+		expect(runtime.getTask(task.id)?.awaitingCompletion).toBe(false);
+		expect(runtime.getTask(task.id)?.lastStatus).toBe("pending");
+
+		const retryTask = runtime.getTask(task.id);
+		expect(retryTask).toBeDefined();
+		runtime.dispatchTask(retryTask!);
+		runtime.handleAgentEnd({ messages: [{ role: "assistant", content: "BUILD_DONE" }] });
+		expect(runtime.getTask(task.id)).toBeUndefined();
+	});
 });

--- a/packages/extensions/extensions/scheduler.ts
+++ b/packages/extensions/extensions/scheduler.ts
@@ -112,6 +112,13 @@ type TaskMutationResult = {
 	error?: string;
 };
 
+type CompletionOptions = {
+	continueUntilComplete?: boolean;
+	completionSignal?: string;
+	retryIntervalMs?: number;
+	maxAttempts?: number;
+};
+
 // ── Runtime ─────────────────────────────────────────────────────────────────
 
 export class SchedulerRuntime {
@@ -128,6 +135,7 @@ export class SchedulerRuntime {
 	private dispatchMode: SchedulerDispatchMode = "auto";
 	private startupOwnershipHandled = false;
 	private safeModeEnabled = false;
+	private awaitingTaskId: string | null = null;
 
 	constructor(private readonly pi: ExtensionAPI) {}
 
@@ -211,6 +219,10 @@ export class SchedulerRuntime {
 		task.enabled = enabled;
 		if (!enabled) {
 			task.pending = false;
+			task.awaitingCompletion = false;
+			if (this.awaitingTaskId === task.id) {
+				this.awaitingTaskId = null;
+			}
 		}
 		if (enabled && task.resumeReason === "overdue") {
 			task.resumeRequired = false;
@@ -225,6 +237,9 @@ export class SchedulerRuntime {
 	deleteTask(id: string): boolean {
 		const removed = this.tasks.delete(id);
 		if (removed) {
+			if (this.awaitingTaskId === id) {
+				this.awaitingTaskId = null;
+			}
 			this.persistTasks();
 			this.updateStatus();
 		}
@@ -234,6 +249,7 @@ export class SchedulerRuntime {
 	clearTasks(): number {
 		const count = this.tasks.size;
 		this.tasks.clear();
+		this.awaitingTaskId = null;
 		this.persistTasks();
 		this.updateStatus();
 		return count;
@@ -338,12 +354,19 @@ export class SchedulerRuntime {
 			const preview = task.prompt.length > 72 ? `${task.prompt.slice(0, 69)}...` : task.prompt;
 			lines.push(`${task.id}  ${state}  ${mode}  next ${next}`);
 			lines.push(`  owner=${this.taskOwnerLabel(task)}  runs=${task.runCount}  last=${last}  status=${status}`);
+			if (task.lastOutcomeSnippet) {
+				lines.push(`  outcome=${this.truncateText(task.lastOutcomeSnippet, 72)}`);
+			}
 			lines.push(`  ${preview}`);
 		}
 		return lines.join("\n");
 	}
 
-	addRecurringIntervalTask(prompt: string, intervalMs: number, options: { scope?: ScheduleScope } = {}): ScheduleTask {
+	addRecurringIntervalTask(
+		prompt: string,
+		intervalMs: number,
+		options: { scope?: ScheduleScope } & CompletionOptions = {},
+	): ScheduleTask {
 		const id = this.createId();
 		const createdAt = Date.now();
 		const safeIntervalMs = Number.isFinite(intervalMs)
@@ -364,6 +387,11 @@ export class SchedulerRuntime {
 			jitterMs,
 			runCount: 0,
 			pending: false,
+			continueUntilComplete: options.continueUntilComplete ?? false,
+			completionSignal: options.completionSignal?.trim() || undefined,
+			retryIntervalMs: options.retryIntervalMs,
+			maxAttempts: options.maxAttempts,
+			awaitingCompletion: false,
 		};
 		this.assignOwner(task, task.scope ?? "instance");
 		this.tasks.set(id, task);
@@ -375,7 +403,7 @@ export class SchedulerRuntime {
 	addRecurringCronTask(
 		prompt: string,
 		cronExpression: string,
-		options: { scope?: ScheduleScope } = {},
+		options: { scope?: ScheduleScope } & CompletionOptions = {},
 	): ScheduleTask | undefined {
 		const normalizedCron = normalizeCronExpression(cronExpression);
 		if (!normalizedCron) {
@@ -402,6 +430,11 @@ export class SchedulerRuntime {
 			jitterMs: 0,
 			runCount: 0,
 			pending: false,
+			continueUntilComplete: options.continueUntilComplete ?? false,
+			completionSignal: options.completionSignal?.trim() || undefined,
+			retryIntervalMs: options.retryIntervalMs,
+			maxAttempts: options.maxAttempts,
+			awaitingCompletion: false,
 		};
 		this.assignOwner(task, task.scope ?? "instance");
 		this.tasks.set(id, task);
@@ -410,7 +443,11 @@ export class SchedulerRuntime {
 		return task;
 	}
 
-	addOneShotTask(prompt: string, delayMs: number, options: { scope?: ScheduleScope } = {}): ScheduleTask {
+	addOneShotTask(
+		prompt: string,
+		delayMs: number,
+		options: { scope?: ScheduleScope } & CompletionOptions = {},
+	): ScheduleTask {
 		const id = this.createId();
 		const createdAt = Date.now();
 		const task: ScheduleTask = {
@@ -424,6 +461,11 @@ export class SchedulerRuntime {
 			jitterMs: 0,
 			runCount: 0,
 			pending: false,
+			continueUntilComplete: options.continueUntilComplete ?? false,
+			completionSignal: options.completionSignal?.trim() || undefined,
+			retryIntervalMs: options.retryIntervalMs,
+			maxAttempts: options.maxAttempts,
+			awaitingCompletion: false,
 		};
 		this.assignOwner(task, task.scope ?? "instance");
 		this.tasks.set(id, task);
@@ -566,7 +608,7 @@ export class SchedulerRuntime {
 				continue;
 			}
 
-			if (!task.enabled || task.resumeRequired) {
+			if (!task.enabled || task.resumeRequired || task.awaitingCompletion) {
 				continue;
 			}
 			if (now >= task.nextRunAt) {
@@ -612,7 +654,9 @@ export class SchedulerRuntime {
 		}
 
 		const nextTask = Array.from(this.tasks.values())
-			.filter((task) => task.enabled && task.pending && this.canCurrentInstanceDispatchTask(task))
+			.filter(
+				(task) => task.enabled && task.pending && !task.awaitingCompletion && this.canCurrentInstanceDispatchTask(task),
+			)
 			.sort((a, b) => a.nextRunAt - b.nextRunAt)[0];
 
 		if (!nextTask) {
@@ -941,9 +985,18 @@ export class SchedulerRuntime {
 		task.resumeRequired = false;
 		task.resumeReason = undefined;
 		task.lastRunAt = now;
-		task.lastStatus = "success";
 		task.runCount += 1;
 
+		if (task.continueUntilComplete) {
+			task.awaitingCompletion = true;
+			task.lastStatus = "pending";
+			this.awaitingTaskId = task.id;
+			this.persistTasks();
+			this.updateStatus();
+			return;
+		}
+
+		task.lastStatus = "success";
 		if (task.kind === "once") {
 			this.tasks.delete(task.id);
 			this.persistTasks();
@@ -951,17 +1004,139 @@ export class SchedulerRuntime {
 			return;
 		}
 
+		this.scheduleRecurringNextRun(task, now);
+		this.persistTasks();
+		this.updateStatus();
+	}
+
+	handleAgentEnd(event: { messages?: Array<{ role?: string; content?: unknown }> }) {
+		if (!this.awaitingTaskId) {
+			return;
+		}
+
+		const task = this.tasks.get(this.awaitingTaskId);
+		this.awaitingTaskId = null;
+		if (!task?.continueUntilComplete) {
+			return;
+		}
+
+		task.awaitingCompletion = false;
+		const now = Date.now();
+		const latestAssistantText = this.extractLatestAssistantText(event.messages ?? []);
+		task.lastOutcomeSnippet = latestAssistantText.slice(0, 220) || undefined;
+
+		const completed = this.isCompletionDetected(task, latestAssistantText);
+		if (completed) {
+			task.lastStatus = "success";
+			if (task.kind === "once") {
+				this.tasks.delete(task.id);
+			} else {
+				this.scheduleRecurringNextRun(task, now);
+			}
+			this.persistTasks();
+			this.updateStatus();
+			return;
+		}
+
+		const maxAttempts = task.maxAttempts;
+		if (Number.isFinite(maxAttempts) && (task.runCount ?? 0) >= (maxAttempts ?? 0)) {
+			task.enabled = false;
+			task.lastStatus = "error";
+			task.pending = false;
+			task.nextRunAt = now + (task.retryIntervalMs ?? ONE_MINUTE);
+			if (this.runtimeCtx?.hasUI && !this.safeModeEnabled) {
+				this.runtimeCtx.ui.notify(
+					`Scheduler task ${task.id} paused after ${task.runCount} attempt${task.runCount === 1 ? "" : "s"} without completion.`,
+					"warning",
+				);
+			}
+			this.persistTasks();
+			this.updateStatus();
+			return;
+		}
+
+		task.lastStatus = "pending";
+		task.pending = false;
+		task.nextRunAt = now + (task.retryIntervalMs ?? task.intervalMs ?? ONE_MINUTE);
+		this.persistTasks();
+		this.updateStatus();
+	}
+
+	private extractLatestAssistantText(messages: Array<{ role?: string; content?: unknown }>): string {
+		for (let i = messages.length - 1; i >= 0; i--) {
+			const message = messages[i];
+			if (message?.role !== "assistant") {
+				continue;
+			}
+			const content = message.content;
+			if (typeof content === "string") {
+				return content.trim();
+			}
+			if (Array.isArray(content)) {
+				return content
+					.map((item) =>
+						typeof item === "object" && item && "text" in item && typeof item.text === "string" ? item.text : "",
+					)
+					.join(" ")
+					.trim();
+			}
+		}
+		return "";
+	}
+
+	private isCompletionDetected(task: ScheduleTask, assistantText: string): boolean {
+		const text = assistantText.trim();
+		if (!text) {
+			return false;
+		}
+
+		const signal = task.completionSignal?.trim();
+		if (signal) {
+			const regexMatch = signal.match(/^\/(.*)\/([gimsuy]*)$/);
+			if (regexMatch) {
+				try {
+					return new RegExp(regexMatch[1], regexMatch[2]).test(text);
+				} catch {
+					// Ignore invalid regex and fall back to substring matching.
+				}
+			}
+			if (text.toLowerCase().includes(signal.toLowerCase())) {
+				return true;
+			}
+		}
+
+		const lower = text.toLowerCase();
+		if (
+			lower.includes("not complete") ||
+			lower.includes("still running") ||
+			lower.includes("in progress") ||
+			lower.includes("pending")
+		) {
+			return false;
+		}
+
+		return (
+			lower.includes("task complete") ||
+			lower.includes("completed") ||
+			lower.includes("finished") ||
+			lower.includes("done") ||
+			lower.includes("resolved") ||
+			lower.includes("success")
+		);
+	}
+
+	private scheduleRecurringNextRun(task: ScheduleTask, now: number) {
+		if (task.kind === "once") {
+			return;
+		}
+
 		if (task.cronExpression) {
 			const next = computeNextCronRunAt(task.cronExpression, now + 1_000);
 			if (!next) {
 				this.tasks.delete(task.id);
-				this.persistTasks();
-				this.updateStatus();
 				return;
 			}
 			task.nextRunAt = next;
-			this.persistTasks();
-			this.updateStatus();
 			return;
 		}
 
@@ -982,10 +1157,7 @@ export class SchedulerRuntime {
 		if (!Number.isFinite(next) || guard >= 10_000) {
 			next = now + intervalMs;
 		}
-
 		task.nextRunAt = next;
-		this.persistTasks();
-		this.updateStatus();
 	}
 
 	createId(): string {
@@ -997,13 +1169,13 @@ export class SchedulerRuntime {
 	}
 
 	taskMode(task: ScheduleTask): string {
-		if (task.kind === "once") {
-			return "once";
-		}
-		if (task.cronExpression) {
-			return `cron ${task.cronExpression}`;
-		}
-		return `every ${formatDurationShort(task.intervalMs ?? DEFAULT_LOOP_INTERVAL)}`;
+		const base =
+			task.kind === "once"
+				? "once"
+				: task.cronExpression
+					? `cron ${task.cronExpression}`
+					: `every ${formatDurationShort(task.intervalMs ?? DEFAULT_LOOP_INTERVAL)}`;
+		return task.continueUntilComplete ? `${base} until-complete` : base;
 	}
 
 	private taskOptionLabel(task: ScheduleTask): string {
@@ -1380,6 +1552,18 @@ export class SchedulerRuntime {
 					runCount: task.runCount ?? 0,
 					resumeRequired: task.resumeRequired ?? false,
 					resumeReason: task.resumeReason,
+					continueUntilComplete: task.continueUntilComplete ?? false,
+					completionSignal: task.completionSignal?.trim() || undefined,
+					retryIntervalMs:
+						typeof task.retryIntervalMs === "number" && Number.isFinite(task.retryIntervalMs)
+							? Math.max(task.retryIntervalMs, ONE_MINUTE)
+							: undefined,
+					maxAttempts:
+						typeof task.maxAttempts === "number" && Number.isFinite(task.maxAttempts)
+							? Math.max(1, Math.floor(task.maxAttempts))
+							: undefined,
+					awaitingCompletion: false,
+					lastOutcomeSnippet: task.lastOutcomeSnippet,
 				};
 				if (normalized.kind === "recurring" && normalized.expiresAt && now >= normalized.expiresAt) {
 					mutated = true;
@@ -1447,6 +1631,9 @@ export class SchedulerRuntime {
 	private taskStatusLabel(task: ScheduleTask): string {
 		if (task.resumeRequired) {
 			return `resume_required (${task.resumeReason ?? "unknown"})`;
+		}
+		if (task.awaitingCompletion) {
+			return "awaiting_completion";
 		}
 		return task.lastStatus ?? "pending";
 	}


### PR DESCRIPTION
## Summary
- extend schedule_prompt add with continueUntilComplete, completionSignal, retryInterval, and maxAttempts
- keep opted-in tasks in awaiting_completion state and evaluate completion on agent_end
- retry incomplete tasks until they complete (or maxAttempts is reached)
- persist completion metadata and last outcome snippets for improved schedule visibility
- add scheduler tests covering the new completion-aware behavior

## Validation
- pnpm test packages/extensions/extensions/scheduler.test.ts packages/extensions/extensions/smoke.test.ts
