### PR TITLE
feat(extensions): strengthen session resume UX hints

### DIFF
--- a/.changes/resume-hint-switch-and-exit.md
+++ b/.changes/resume-hint-switch-and-exit.md
@@ -1,0 +1,9 @@
+---
+default: patch
+---
+
+Improve session resume guidance for long-running instances.
+
+- extend `auto-session-name` to emit resume command hints on both `session_switch` and `session_shutdown`
+- include both the direct form (`pi --session <id>`) and an alias-path hint (`pi resume <id>`) in the emitted message
+- keep the existing compaction auto-continue and dynamic session title behavior intact

--- a/packages/extensions/README.md
+++ b/packages/extensions/README.md
@@ -224,5 +224,5 @@ This package ships raw `.ts` extensions for pi to load directly.
 ## Auto session naming and compaction continuity
 
 `auto-session-name` now keeps session titles fresh as work focus changes, triggers a
-`continue` follow-up after compaction, and emits a shutdown resume hint with the current
-session id.
+`continue` follow-up after compaction, and emits resume hints (including `pi --session <id>`
+and `pi resume <id>` alias path guidance) whenever you switch sessions or exit.

--- a/packages/extensions/extensions/auto-session-name.test.ts
+++ b/packages/extensions/extensions/auto-session-name.test.ts
@@ -60,12 +60,19 @@ describe("auto-session-name extension", () => {
 		expect(harness.userMessages.at(-1)).toBe("continue");
 	});
 
-	it("emits a resume hint containing the session id on shutdown", () => {
+	it("emits resume hints on session switch and shutdown", () => {
 		const harness = createExtensionHarness();
 		harness.ctx.sessionManager.getSessionFile = () => "/tmp/sessions/test-session.jsonl";
 		autoSessionNameExtension(harness.pi as never);
 
-		harness.emit("session_shutdown", { type: "session_shutdown" }, harness.ctx);
+		harness.emit("session_switch", { type: "session_switch" }, harness.ctx);
+		expect(harness.messages.at(-1)?.content).toContain("Session switched");
 		expect(harness.messages.at(-1)?.content).toContain("pi --session test-session");
+		expect(harness.messages.at(-1)?.content).toContain("pi resume test-session");
+
+		harness.emit("session_shutdown", { type: "session_shutdown" }, harness.ctx);
+		expect(harness.messages.at(-1)?.content).toContain("Session saved");
+		expect(harness.messages.at(-1)?.content).toContain("pi --session test-session");
+		expect(harness.messages.at(-1)?.content).toContain("pi resume test-session");
 	});
 });

--- a/packages/extensions/extensions/auto-session-name.ts
+++ b/packages/extensions/extensions/auto-session-name.ts
@@ -59,6 +59,14 @@ function deriveSessionId(sessionFile: string | undefined): string | undefined {
 	return path.basename(sessionFile).replace(/\.jsonl$/i, "") || undefined;
 }
 
+function buildResumeCommandHint(sessionId: string): string {
+	return [
+		`Session id: ${sessionId}`,
+		`Resume now: pi --session ${sessionId}`,
+		`Alias path (if your shell forwards it): pi resume ${sessionId}`,
+	].join("\n");
+}
+
 function isFocusShift(firstUserText: string, latestUserText: string): boolean {
 	if (!(firstUserText && latestUserText)) {
 		return false;
@@ -102,6 +110,20 @@ export default function autoSessionNameExtension(pi: ExtensionAPI) {
 	let lastAutoName = "";
 	let compactContinuationQueued = false;
 
+	const emitResumeHint = (reason: "shutdown" | "switch", sessionFile: string | undefined) => {
+		const sessionId = deriveSessionId(sessionFile);
+		if (!sessionId) {
+			return;
+		}
+
+		const prefix = reason === "shutdown" ? "Session saved." : "Session switched.";
+		pi.sendMessage({
+			customType: "session-resume-hint",
+			content: `${prefix}\n${buildResumeCommandHint(sessionId)}`,
+			display: true,
+		});
+	};
+
 	pi.on("session_start", () => {
 		const existing = (pi.getSessionName?.() ?? "").trim();
 		lastAutoName = existing;
@@ -137,17 +159,11 @@ export default function autoSessionNameExtension(pi: ExtensionAPI) {
 		}
 	});
 
-	pi.on("session_shutdown", (_event, ctx) => {
-		const sessionFile = ctx.sessionManager?.getSessionFile?.();
-		const sessionId = deriveSessionId(sessionFile);
-		if (!sessionId) {
-			return;
-		}
+	pi.on("session_switch", (_event, ctx) => {
+		emitResumeHint("switch", ctx.sessionManager?.getSessionFile?.());
+	});
 
-		pi.sendMessage({
-			customType: "session-resume-hint",
-			content: `Session saved as ${sessionId}. Resume with: pi --session ${sessionId}`,
-			display: true,
-		});
+	pi.on("session_shutdown", (_event, ctx) => {
+		emitResumeHint("shutdown", ctx.sessionManager?.getSessionFile?.());
 	});
 }


### PR DESCRIPTION
## Summary
- emit resume hints whenever sessions switch and when sessions shut down
- include both `pi --session <id>` and `pi resume <id>` alias-path guidance in the hint output
- keep dynamic session naming + auto-compaction continue behavior intact
- add tests covering switch + shutdown resume hint emission

## Validation
- pnpm test packages/extensions/extensions/auto-session-name.test.ts packages/extensions/extensions/smoke.test.ts
- pnpm exec biome check packages/extensions/extensions/auto-session-name.ts packages/extensions/extensions/auto-session-name.test.ts packages/extensions/README.md
- pnpm mdt check
