### PR TITLE
feat(extensions): attribute watchdog slowdowns

### DIFF
--- a/.changeset/watchdog-extension-attribution.md
+++ b/.changeset/watchdog-extension-attribution.md
@@ -1,0 +1,5 @@
+---
+default: minor
+---
+
+Teach the watchdog to profile extension runtime activity, surface likely slowdown culprits in `/watchdog`, and emit scheduler task pressure diagnostics for faster blame and safe-mode triage.

--- a/package.json
+++ b/package.json
@@ -4,6 +4,7 @@
 	"workspaces": ["packages/*"],
 	"pi": {
 		"extensions": [
+			"./packages/extensions/extensions/watchdog.ts",
 			"./packages/extensions/extensions/adaptive-routing.ts",
 			"./packages/extensions/extensions/auto-session-name.ts",
 			"./packages/extensions/extensions/auto-update.ts",
@@ -17,7 +18,6 @@
 			"./packages/extensions/extensions/scheduler.ts",
 			"./packages/extensions/extensions/tool-metadata.ts",
 			"./packages/extensions/extensions/usage-tracker.ts",
-			"./packages/extensions/extensions/watchdog.ts",
 			"./packages/ant-colony/extensions/ant-colony/index.ts",
 			"./packages/subagents/index.ts",
 			"./packages/subagents/notify.ts",

--- a/packages/extensions/README.md
+++ b/packages/extensions/README.md
@@ -35,7 +35,7 @@ npx @ifi/oh-pi
 ## What it provides
 
 These extensions add commands, tools, UI widgets, safety checks, background process handling,
-usage monitoring, adaptive model routing, scheduling features, tool execution metadata, external-editor integration, and runtime performance protection (`/watchdog`, `/safe-mode`) to pi.
+usage monitoring, adaptive model routing, scheduling features, tool execution metadata, external-editor integration, and runtime performance protection (`/watchdog`, `/watchdog blame`, `/safe-mode`) to pi.
 
 `git-guard` also blocks git bash invocations that are likely to open an interactive editor in agent environments (for example `git rebase --continue` without non-interactive editor overrides), preventing hangs before they happen.
 

--- a/packages/extensions/extensions/scheduler.ts
+++ b/packages/extensions/extensions/scheduler.ts
@@ -57,6 +57,7 @@ import {
 	type ScheduleTask,
 	THREE_DAYS,
 } from "./scheduler-shared.js";
+import { RUNTIME_DIAGNOSTICS_EVENT } from "./watchdog-runtime-diagnostics.js";
 
 export {
 	computeCronCadenceMs,
@@ -505,7 +506,21 @@ export class SchedulerRuntime {
 		this.startScheduler();
 	}
 
+	private emitRuntimeDiagnostics(note?: string) {
+		const enabledTasks = Array.from(this.tasks.values()).filter((task) => task.enabled);
+		const dueTasks = enabledTasks.filter((task) => task.resumeRequired || task.pending).length;
+		this.pi.events.emit(RUNTIME_DIAGNOSTICS_EVENT, {
+			extensionId: "scheduler",
+			pendingTasks: this.tasks.size,
+			activeTasks: enabledTasks.length,
+			dueTasks,
+			mode: this.dispatchMode,
+			note,
+		});
+	}
+
 	updateStatus() {
+		this.emitRuntimeDiagnostics();
 		if (!this.runtimeCtx?.hasUI) {
 			return;
 		}
@@ -643,6 +658,7 @@ export class SchedulerRuntime {
 			return;
 		}
 		if (!this.hasDispatchCapacity(now)) {
+			this.emitRuntimeDiagnostics("dispatch throttled");
 			this.notifyRateLimit(now);
 			return;
 		}
@@ -967,6 +983,7 @@ export class SchedulerRuntime {
 		const now = Date.now();
 		if (!this.hasDispatchCapacity(now)) {
 			task.pending = true;
+			this.emitRuntimeDiagnostics("dispatch throttled");
 			this.notifyRateLimit(now);
 			return;
 		}

--- a/packages/extensions/extensions/watchdog-runtime-diagnostics.test.ts
+++ b/packages/extensions/extensions/watchdog-runtime-diagnostics.test.ts
@@ -1,0 +1,43 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import {
+	formatExtensionDiagnostic,
+	getExtensionDiagnostics,
+	recordRuntimeMetric,
+	recordRuntimeSample,
+	recordRuntimeUiActivity,
+	resetRuntimeDiagnosticsForTests,
+} from "./watchdog-runtime-diagnostics.js";
+
+describe("watchdog runtime diagnostics", () => {
+	beforeEach(() => {
+		vi.useFakeTimers();
+		vi.setSystemTime(new Date("2026-04-15T10:00:00Z"));
+		resetRuntimeDiagnosticsForTests();
+	});
+
+	afterEach(() => {
+		vi.useRealTimers();
+		resetRuntimeDiagnosticsForTests();
+	});
+
+	it("ranks likely culprit extensions using recent runtime activity", () => {
+		recordRuntimeSample("scheduler", "event", "turn_end", 140, "scheduler");
+		recordRuntimeUiActivity("scheduler", "status", "scheduler");
+		recordRuntimeUiActivity("scheduler", "status", "scheduler");
+		recordRuntimeMetric({ extensionId: "scheduler", pendingTasks: 6, dueTasks: 2, note: "observer mode" });
+
+		recordRuntimeSample("git-guard", "event", "tool_call", 20, "git-guard");
+
+		const diagnostics = getExtensionDiagnostics();
+		expect(diagnostics[0]?.extensionId).toBe("scheduler");
+		expect(formatExtensionDiagnostic(diagnostics[0])).toContain("queued tasks");
+		expect(diagnostics[0]?.reasons.join(" ")).toContain("due tasks");
+	});
+
+	it("drops stale activity outside the recent diagnostic window", async () => {
+		recordRuntimeSample("bg-process", "tool", "bash", 200, "bg-process");
+		await vi.advanceTimersByTimeAsync(125_000);
+
+		expect(getExtensionDiagnostics()).toEqual([]);
+	});
+});

--- a/packages/extensions/extensions/watchdog-runtime-diagnostics.ts
+++ b/packages/extensions/extensions/watchdog-runtime-diagnostics.ts
@@ -1,0 +1,449 @@
+import path from "node:path";
+import type { ExtensionAPI } from "@mariozechner/pi-coding-agent";
+
+const DIAGNOSTIC_WINDOW_MS = 2 * 60_000;
+const SAMPLE_LIMIT = 64;
+const INSTALL_SYMBOL = Symbol.for("oh-pi.watchdog-runtime-diagnostics.installed");
+
+type RuntimeChannel = "event" | "tool" | "command";
+type UiActivityKind = "status" | "notify" | "overlay" | "widget" | "footer";
+
+type RuntimeSample = {
+	name: string;
+	durationMs: number;
+	timestamp: number;
+};
+
+type RuntimeProfile = {
+	extensionId: string;
+	source: string;
+	registrations: {
+		events: Set<string>;
+		tools: Set<string>;
+		commands: Set<string>;
+		shortcuts: Set<string>;
+	};
+	eventSamples: RuntimeSample[];
+	toolSamples: RuntimeSample[];
+	commandSamples: RuntimeSample[];
+	ui: Record<UiActivityKind, number[]>;
+	metric: RuntimeDiagnosticsMetric;
+};
+
+export type RuntimeDiagnosticsMetric = {
+	extensionId: string;
+	source?: string;
+	pendingTasks?: number;
+	dueTasks?: number;
+	activeTasks?: number;
+	mode?: string;
+	note?: string;
+	timestamp?: number;
+};
+
+export type ExtensionDiagnostic = {
+	extensionId: string;
+	source: string;
+	score: number;
+	recentHandlerMs: number;
+	recentStatusUpdates: number;
+	recentNotifications: number;
+	recentOverlays: number;
+	pendingTasks: number;
+	dueTasks: number;
+	reasons: string[];
+};
+
+export const RUNTIME_DIAGNOSTICS_EVENT = "oh-pi:runtime-diagnostics:metric";
+
+const profiles = new Map<string, RuntimeProfile>();
+const wrappedContextCache = new WeakMap<object, Map<string, unknown>>();
+
+function pushBounded<T>(items: T[], item: T, limit = SAMPLE_LIMIT): void {
+	items.push(item);
+	if (items.length > limit) {
+		items.splice(0, items.length - limit);
+	}
+}
+
+function pruneTimestamps(items: number[], now: number): void {
+	const cutoff = now - DIAGNOSTIC_WINDOW_MS;
+	let firstValid = 0;
+	while (firstValid < items.length && items[firstValid] < cutoff) {
+		firstValid += 1;
+	}
+	if (firstValid > 0) {
+		items.splice(0, firstValid);
+	}
+}
+
+function profileSourceToId(source: string): string {
+	const ext = path.extname(source);
+	const base = path.basename(source, ext);
+	if (base !== "index") {
+		return base || "unknown";
+	}
+
+	const parts = source.split(path.sep).filter(Boolean);
+	for (let index = parts.length - 2; index >= 0; index--) {
+		const candidate = parts[index];
+		if (candidate !== "extensions" && candidate !== "extension") {
+			return candidate;
+		}
+	}
+
+	return "unknown";
+}
+
+function inferExtensionSourceFromStack(stack = new Error().stack): string {
+	const lines = stack?.split("\n") ?? [];
+	for (const line of lines) {
+		if (line.includes("watchdog-runtime-diagnostics")) {
+			continue;
+		}
+		const match = line.match(/((?:file:\/\/)?[^\s)]+\.(?:ts|js))/);
+		const rawPath = match?.[1];
+		if (!rawPath) {
+			continue;
+		}
+		const normalized = rawPath.replace(/^file:\/\//, "");
+		if (
+			normalized.includes(`${path.sep}packages${path.sep}`) ||
+			normalized.includes(`${path.sep}.pi${path.sep}extensions${path.sep}`)
+		) {
+			return normalized;
+		}
+	}
+	return "unknown";
+}
+
+function ensureProfile(extensionId: string, source = extensionId): RuntimeProfile {
+	const existing = profiles.get(extensionId);
+	if (existing) {
+		if (existing.source === "unknown" && source !== "unknown") {
+			existing.source = source;
+		}
+		return existing;
+	}
+
+	const profile: RuntimeProfile = {
+		extensionId,
+		source,
+		registrations: {
+			events: new Set<string>(),
+			tools: new Set<string>(),
+			commands: new Set<string>(),
+			shortcuts: new Set<string>(),
+		},
+		eventSamples: [],
+		toolSamples: [],
+		commandSamples: [],
+		ui: {
+			status: [],
+			notify: [],
+			overlay: [],
+			widget: [],
+			footer: [],
+		},
+		metric: { extensionId, source },
+	};
+	profiles.set(extensionId, profile);
+	return profile;
+}
+
+function recentDuration(samples: RuntimeSample[], since: number): number {
+	let total = 0;
+	for (const sample of samples) {
+		if (sample.timestamp >= since) {
+			total += sample.durationMs;
+		}
+	}
+	return total;
+}
+
+function recentCount(items: number[], since: number): number {
+	let total = 0;
+	for (const timestamp of items) {
+		if (timestamp >= since) {
+			total += 1;
+		}
+	}
+	return total;
+}
+
+function noteRegistration(
+	extensionId: string,
+	source: string,
+	kind: keyof RuntimeProfile["registrations"],
+	name: string,
+): void {
+	ensureProfile(extensionId, source).registrations[kind].add(name);
+}
+
+export function recordRuntimeSample(
+	extensionId: string,
+	channel: RuntimeChannel,
+	name: string,
+	durationMs: number,
+	source = extensionId,
+	timestamp = Date.now(),
+): void {
+	const profile = ensureProfile(extensionId, source);
+	const sample: RuntimeSample = { name, durationMs: Math.max(0, durationMs), timestamp };
+	if (channel === "event") {
+		pushBounded(profile.eventSamples, sample);
+		return;
+	}
+	if (channel === "tool") {
+		pushBounded(profile.toolSamples, sample);
+		return;
+	}
+	pushBounded(profile.commandSamples, sample);
+}
+
+export function recordRuntimeUiActivity(
+	extensionId: string,
+	kind: UiActivityKind,
+	source = extensionId,
+	timestamp = Date.now(),
+): void {
+	const profile = ensureProfile(extensionId, source);
+	pushBounded(profile.ui[kind], timestamp);
+}
+
+export function recordRuntimeMetric(metric: RuntimeDiagnosticsMetric): void {
+	const timestamp = metric.timestamp ?? Date.now();
+	const profile = ensureProfile(metric.extensionId, metric.source ?? metric.extensionId);
+	profile.metric = {
+		...profile.metric,
+		...metric,
+		timestamp,
+	};
+}
+
+export function getExtensionDiagnostics(now = Date.now()): ExtensionDiagnostic[] {
+	const since = now - DIAGNOSTIC_WINDOW_MS;
+	const diagnostics: ExtensionDiagnostic[] = [];
+
+	for (const profile of profiles.values()) {
+		pruneTimestamps(profile.ui.status, now);
+		pruneTimestamps(profile.ui.notify, now);
+		pruneTimestamps(profile.ui.overlay, now);
+		pruneTimestamps(profile.ui.widget, now);
+		pruneTimestamps(profile.ui.footer, now);
+
+		const recentHandlerMs =
+			recentDuration(profile.eventSamples, since) +
+			recentDuration(profile.toolSamples, since) +
+			recentDuration(profile.commandSamples, since);
+		const recentStatusUpdates = recentCount(profile.ui.status, since);
+		const recentNotifications = recentCount(profile.ui.notify, since);
+		const recentOverlays = recentCount(profile.ui.overlay, since);
+		const pendingTasks = profile.metric.pendingTasks ?? 0;
+		const dueTasks = profile.metric.dueTasks ?? 0;
+
+		const score =
+			recentHandlerMs +
+			recentStatusUpdates * 18 +
+			recentNotifications * 30 +
+			recentOverlays * 40 +
+			pendingTasks * 10 +
+			dueTasks * 18;
+		if (score <= 0) {
+			continue;
+		}
+
+		const reasons: string[] = [];
+		if (recentHandlerMs > 0) {
+			reasons.push(`${Math.round(recentHandlerMs)}ms recent handler time`);
+		}
+		if (recentStatusUpdates > 0) {
+			reasons.push(`${recentStatusUpdates} status updates`);
+		}
+		if (recentNotifications > 0) {
+			reasons.push(`${recentNotifications} notifications`);
+		}
+		if (recentOverlays > 0) {
+			reasons.push(`${recentOverlays} overlays`);
+		}
+		if (pendingTasks > 0) {
+			reasons.push(`${pendingTasks} queued tasks`);
+		}
+		if (dueTasks > 0) {
+			reasons.push(`${dueTasks} due tasks`);
+		}
+		if (profile.metric.note) {
+			reasons.push(profile.metric.note);
+		}
+
+		diagnostics.push({
+			extensionId: profile.extensionId,
+			source: profile.source,
+			score,
+			recentHandlerMs,
+			recentStatusUpdates,
+			recentNotifications,
+			recentOverlays,
+			pendingTasks,
+			dueTasks,
+			reasons,
+		});
+	}
+
+	return diagnostics.sort(
+		(left, right) => right.score - left.score || left.extensionId.localeCompare(right.extensionId),
+	);
+}
+
+export function formatExtensionDiagnostic(diagnostic: ExtensionDiagnostic): string {
+	return `${diagnostic.extensionId} · ${diagnostic.reasons.join(" · ")}`;
+}
+
+function wrapContext<T>(ctx: T, extensionId: string, source: string): T {
+	if (!ctx || typeof ctx !== "object") {
+		return ctx;
+	}
+	const candidate = ctx as { ui?: Record<string, (...args: unknown[]) => unknown> };
+	if (!candidate.ui || typeof candidate.ui !== "object") {
+		return ctx;
+	}
+
+	let byExtension = wrappedContextCache.get(ctx as object);
+	if (!byExtension) {
+		byExtension = new Map<string, unknown>();
+		wrappedContextCache.set(ctx as object, byExtension);
+	}
+	const cached = byExtension.get(extensionId);
+	if (cached) {
+		return cached as T;
+	}
+
+	const ui = candidate.ui;
+	const wrapped = {
+		...(ctx as Record<string, unknown>),
+		ui: {
+			...ui,
+			setStatus: (...args: unknown[]) => {
+				recordRuntimeUiActivity(extensionId, "status", source);
+				return ui.setStatus?.(...args);
+			},
+			notify: (...args: unknown[]) => {
+				recordRuntimeUiActivity(extensionId, "notify", source);
+				return ui.notify?.(...args);
+			},
+			custom: (...args: unknown[]) => {
+				recordRuntimeUiActivity(extensionId, "overlay", source);
+				return ui.custom?.(...args);
+			},
+			setWidget: (...args: unknown[]) => {
+				recordRuntimeUiActivity(extensionId, "widget", source);
+				return ui.setWidget?.(...args);
+			},
+			setFooter: (...args: unknown[]) => {
+				recordRuntimeUiActivity(extensionId, "footer", source);
+				return ui.setFooter?.(...args);
+			},
+		},
+	} as T;
+	byExtension.set(extensionId, wrapped);
+	return wrapped;
+}
+
+function wrapArgsWithContext(args: unknown[], extensionId: string, source: string): unknown[] {
+	const index = args.findIndex((arg) =>
+		Boolean(arg && typeof arg === "object" && "ui" in (arg as Record<string, unknown>)),
+	);
+	if (index === -1) {
+		return args;
+	}
+	const nextArgs = [...args];
+	nextArgs[index] = wrapContext(nextArgs[index], extensionId, source);
+	return nextArgs;
+}
+
+function inferCallerIdentity(): { extensionId: string; source: string } {
+	const source = inferExtensionSourceFromStack();
+	return {
+		extensionId: profileSourceToId(source),
+		source,
+	};
+}
+
+function wrapWithTiming<T extends (...args: unknown[]) => unknown>(
+	extensionId: string,
+	source: string,
+	channel: RuntimeChannel,
+	name: string,
+	fn: T,
+): T {
+	return (async (...args: unknown[]) => {
+		const startedAt = Date.now();
+		try {
+			return await fn(...wrapArgsWithContext(args, extensionId, source));
+		} finally {
+			recordRuntimeSample(extensionId, channel, name, Date.now() - startedAt, source);
+		}
+	}) as T;
+}
+
+export function installRuntimeDiagnostics(pi: ExtensionAPI): void {
+	const profileTarget = pi as ExtensionAPI & { [INSTALL_SYMBOL]?: boolean };
+	if (profileTarget[INSTALL_SYMBOL]) {
+		return;
+	}
+	profileTarget[INSTALL_SYMBOL] = true;
+
+	const originalOn = pi.on.bind(pi);
+	pi.on = ((eventName: string, handler: (...args: unknown[]) => unknown) => {
+		const { extensionId, source } = inferCallerIdentity();
+		noteRegistration(extensionId, source, "events", eventName);
+		return originalOn(eventName, wrapWithTiming(extensionId, source, "event", eventName, handler));
+	}) as ExtensionAPI["on"];
+
+	const originalRegisterCommand = pi.registerCommand.bind(pi);
+	pi.registerCommand = ((
+		name: string,
+		spec: { handler?: (...args: unknown[]) => unknown } & Record<string, unknown>,
+	) => {
+		const { extensionId, source } = inferCallerIdentity();
+		noteRegistration(extensionId, source, "commands", name);
+		const nextSpec = spec.handler
+			? { ...spec, handler: wrapWithTiming(extensionId, source, "command", name, spec.handler) }
+			: spec;
+		return originalRegisterCommand(name, nextSpec);
+	}) as ExtensionAPI["registerCommand"];
+
+	const originalRegisterTool = pi.registerTool.bind(pi);
+	pi.registerTool = ((tool: { name: string; execute?: (...args: unknown[]) => unknown } & Record<string, unknown>) => {
+		const { extensionId, source } = inferCallerIdentity();
+		noteRegistration(extensionId, source, "tools", tool.name);
+		const nextTool = tool.execute
+			? { ...tool, execute: wrapWithTiming(extensionId, source, "tool", tool.name, tool.execute) }
+			: tool;
+		return originalRegisterTool(nextTool);
+	}) as ExtensionAPI["registerTool"];
+
+	if (typeof pi.registerShortcut === "function") {
+		const originalRegisterShortcut = pi.registerShortcut.bind(pi);
+		pi.registerShortcut = ((name: string, spec: Record<string, unknown>) => {
+			const { extensionId, source } = inferCallerIdentity();
+			noteRegistration(extensionId, source, "shortcuts", name);
+			return originalRegisterShortcut(name, spec as never);
+		}) as ExtensionAPI["registerShortcut"];
+	}
+
+	pi.events.on(RUNTIME_DIAGNOSTICS_EVENT, (payload: unknown) => {
+		if (!payload || typeof payload !== "object") {
+			return;
+		}
+		const extensionId = (payload as RuntimeDiagnosticsMetric).extensionId;
+		if (typeof extensionId !== "string" || extensionId.length === 0) {
+			return;
+		}
+		recordRuntimeMetric(payload as RuntimeDiagnosticsMetric);
+	});
+}
+
+export function resetRuntimeDiagnosticsForTests(): void {
+	profiles.clear();
+}

--- a/packages/extensions/extensions/watchdog.test.ts
+++ b/packages/extensions/extensions/watchdog.test.ts
@@ -45,10 +45,13 @@ import watchdogExtension, {
 	resolveWatchdogThresholds,
 	WATCHDOG_CONFIG_PATH,
 } from "./watchdog";
+import { recordRuntimeMetric, resetRuntimeDiagnosticsForTests } from "./watchdog-runtime-diagnostics";
 
 function createMockPi() {
 	const handlers = new Map<string, ((...args: any[]) => any)[]>();
 	const commands = new Map<string, any>();
+	const tools = new Map<string, any>();
+	const shortcuts = new Map<string, any>();
 	const eventHandlers = new Map<string, ((data: unknown) => void)[]>();
 
 	return {
@@ -60,6 +63,12 @@ function createMockPi() {
 		},
 		registerCommand(name: string, command: any) {
 			commands.set(name, command);
+		},
+		registerTool(tool: any) {
+			tools.set(tool.name, tool);
+		},
+		registerShortcut(name: string, shortcut: any) {
+			shortcuts.set(name, shortcut);
 		},
 		events: {
 			on(event: string, handler: (data: unknown) => void) {
@@ -75,6 +84,8 @@ function createMockPi() {
 			},
 		},
 		_commands: commands,
+		_tools: tools,
+		_shortcuts: shortcuts,
 		async _emit(event: string, ...args: any[]) {
 			for (const handler of handlers.get(event) ?? []) {
 				await handler(...args);
@@ -129,12 +140,14 @@ beforeEach(() => {
 	mockExistsSync.mockReturnValue(false);
 	mockReadFileSync.mockReset();
 	resetSafeModeStateForTests();
+	resetRuntimeDiagnosticsForTests();
 });
 
 afterEach(() => {
 	vi.restoreAllMocks();
 	vi.useRealTimers();
 	resetSafeModeStateForTests();
+	resetRuntimeDiagnosticsForTests();
 });
 
 describe("watchdog helpers", () => {
@@ -326,6 +339,18 @@ describe("watchdog extension", () => {
 			vi.fn(),
 		);
 		expect(component.render(200).join("\n")).toContain("No alerts yet.");
+	});
+
+	it("surfaces likely culprit extensions in watchdog diagnostics", async () => {
+		const pi = createMockPi();
+		const ctx = createMockCtx();
+		watchdogExtension(pi as any);
+		recordRuntimeMetric({ extensionId: "scheduler", pendingTasks: 8, dueTasks: 3, note: "dispatch throttled" });
+
+		await pi._commands.get("watchdog").handler("blame", ctx);
+
+		expect(ctx._notifications.at(-1)?.msg).toContain("scheduler");
+		expect(ctx._notifications.at(-1)?.msg).toContain("queued tasks");
 	});
 
 	it("opens a watchdog overlay dashboard", async () => {

--- a/packages/extensions/extensions/watchdog.ts
+++ b/packages/extensions/extensions/watchdog.ts
@@ -29,6 +29,12 @@ import {
 	setSafeModeState,
 	subscribeSafeMode,
 } from "./runtime-mode";
+import {
+	type ExtensionDiagnostic,
+	formatExtensionDiagnostic,
+	getExtensionDiagnostics,
+	installRuntimeDiagnostics,
+} from "./watchdog-runtime-diagnostics";
 
 const MB = 1024 * 1024;
 const DEFAULT_SAMPLE_INTERVAL_MS = 5_000;
@@ -309,6 +315,14 @@ function shortSafeModeStatus(state: SafeModeState): string {
 	return `safe mode is on (${source}${state.reason ? `: ${state.reason}` : ""})`;
 }
 
+function formatLikelyCulpritSummary(diagnostic: ExtensionDiagnostic | undefined): string | null {
+	if (!diagnostic) {
+		return null;
+	}
+	const details = diagnostic.reasons.slice(0, 2).join(" · ");
+	return details ? `likely culprit ${diagnostic.extensionId} (${details})` : `likely culprit ${diagnostic.extensionId}`;
+}
+
 function buildOverlayLines(
 	theme: { fg: (color: string, text: string) => string; bold?: (text: string) => string },
 	input: {
@@ -319,6 +333,7 @@ function buildOverlayLines(
 		thresholds: WatchdogThresholds;
 		safeModeState: SafeModeState;
 		sampleIntervalMs: number;
+		diagnostics: ExtensionDiagnostic[];
 	},
 ): string[] {
 	const now = Date.now();
@@ -357,6 +372,15 @@ function buildOverlayLines(
 		}
 	}
 	lines.push("");
+	lines.push(theme.fg("accent", "Likely extension culprits"));
+	if (input.diagnostics.length === 0) {
+		lines.push(theme.fg("dim", "No suspicious extension activity recorded."));
+	} else {
+		for (const diagnostic of input.diagnostics.slice(0, 5)) {
+			lines.push(`${theme.fg("warning", diagnostic.extensionId)} · ${diagnostic.reasons.join(" · ")}`);
+		}
+	}
+	lines.push("");
 	lines.push(theme.fg("dim", `Config: ${WATCHDOG_CONFIG_PATH}`));
 	lines.push(theme.fg("dim", "Keys: [r] sample now · [s] toggle safe mode · [q/Esc/Space] close"));
 	return lines;
@@ -374,6 +398,7 @@ terminal.
 <!-- {/extensionsWatchdogAlertBehaviorDocs} -->
 */
 export default function watchdogExtension(pi: ExtensionAPI) {
+	installRuntimeDiagnostics(pi);
 	const config = loadWatchdogConfig();
 	const thresholds = resolveWatchdogThresholds(config);
 	const sampleIntervalMs = resolveWatchdogSampleIntervalMs(config);
@@ -445,7 +470,11 @@ export default function watchdogExtension(pi: ExtensionAPI) {
 
 		consecutiveAlerts += 1;
 		pushBounded(alertHistory, alert, ALERT_HISTORY_LIMIT);
-		latestAlertMessage = `watchdog: ${alert.reasons.join(", ")}`;
+		const culprit = getExtensionDiagnostics(now)[0];
+		const culpritSummary = formatLikelyCulpritSummary(culprit);
+		latestAlertMessage = culpritSummary
+			? `watchdog: ${alert.reasons.join(", ")} · ${culpritSummary}`
+			: `watchdog: ${alert.reasons.join(", ")}`;
 		setAlertStatus(latestAlertMessage);
 
 		if (
@@ -521,7 +550,24 @@ export default function watchdogExtension(pi: ExtensionAPI) {
 
 	const notifyStatus = (ctx: ExtensionCommandContext | ExtensionContext) => {
 		takeSample();
-		ctx.ui.notify(`${formatWatchdogStatus(latestSample)} · ${formatThresholdSummary(thresholds)}`, "info");
+		const culprit = getExtensionDiagnostics()[0];
+		const culpritSummary = formatLikelyCulpritSummary(culprit);
+		ctx.ui.notify(
+			`${formatWatchdogStatus(latestSample)} · ${formatThresholdSummary(thresholds)}${culpritSummary ? ` · ${culpritSummary}` : ""}`,
+			"info",
+		);
+	};
+
+	const notifyBlame = (ctx: ExtensionCommandContext | ExtensionContext) => {
+		const diagnostics = getExtensionDiagnostics();
+		if (diagnostics.length === 0) {
+			ctx.ui.notify("No suspicious extension activity recorded yet.", "info");
+			return;
+		}
+		ctx.ui.notify(
+			`Watchdog diagnostics: ${diagnostics.slice(0, 3).map(formatExtensionDiagnostic).join(" | ")}`,
+			"warning",
+		);
 	};
 
 	const notifyConfig = (ctx: ExtensionCommandContext | ExtensionContext) => {
@@ -546,6 +592,7 @@ export default function watchdogExtension(pi: ExtensionAPI) {
 						thresholds,
 						safeModeState: getSafeModeState(),
 						sampleIntervalMs,
+						diagnostics: getExtensionDiagnostics(),
 					}).map((line) => line.slice(0, width));
 				},
 				handleInput(data: string) {
@@ -584,7 +631,8 @@ export default function watchdogExtension(pi: ExtensionAPI) {
 	});
 
 	pi.registerCommand("watchdog", {
-		description: "Inspect or control the performance watchdog: /watchdog [status|overlay|config|reset|on|off|sample]",
+		description:
+			"Inspect or control the performance watchdog: /watchdog [status|overlay|config|reset|on|off|sample|blame]",
 		async handler(args, ctx) {
 			activeCtx = ctx;
 			setSafeModeStatus();
@@ -616,6 +664,9 @@ export default function watchdogExtension(pi: ExtensionAPI) {
 					return;
 				case "config":
 					notifyConfig(ctx);
+					return;
+				case "blame":
+					notifyBlame(ctx);
 					return;
 				default:
 					notifyStatus(ctx);

--- a/packages/extensions/package.json
+++ b/packages/extensions/package.json
@@ -7,6 +7,7 @@
   ],
   "pi": {
     "extensions": [
+      "./extensions/watchdog.ts",
       "./extensions/adaptive-routing.ts",
       "./extensions/auto-session-name.ts",
       "./extensions/auto-update.ts",
@@ -19,8 +20,7 @@
       "./extensions/safe-guard.ts",
       "./extensions/scheduler.ts",
       "./extensions/tool-metadata.ts",
-      "./extensions/usage-tracker.ts",
-      "./extensions/watchdog.ts"
+      "./extensions/usage-tracker.ts"
     ]
   },
   "files": [


### PR DESCRIPTION
## Summary
- add runtime diagnostics that profile extension handlers, UI churn, and queued work
- surface likely culprit extensions in watchdog status, overlay, and a new `/watchdog blame` command
- emit scheduler task-pressure diagnostics so watchdog can identify scheduler-induced slowdowns

## Validation
- pnpm typecheck
- pnpm exec biome check packages/extensions/extensions/watchdog-runtime-diagnostics.ts packages/extensions/extensions/watchdog-runtime-diagnostics.test.ts packages/extensions/extensions/watchdog.ts packages/extensions/extensions/watchdog.test.ts packages/extensions/extensions/scheduler.ts packages/extensions/package.json package.json
- pnpm exec vitest run packages/extensions/extensions/watchdog-runtime-diagnostics.test.ts packages/extensions/extensions/watchdog.test.ts
- pnpm exec vitest run packages/extensions/extensions/scheduler.test.ts
- pnpm exec vitest run packages/extensions/extensions/package-manifest.test.ts