### PR TITLE
feat(extensions): add tool execution metadata

### DIFF
--- a/.changeset/tool-execution-metadata.md
+++ b/.changeset/tool-execution-metadata.md
@@ -1,0 +1,5 @@
+---
+default: minor
+---
+
+Add a default-on `tool-metadata` extension that appends completion timestamps, elapsed runtimes, approximate tool-context size, and session context snapshots to finished tool results.

--- a/package.json
+++ b/package.json
@@ -15,6 +15,7 @@
 			"./packages/extensions/extensions/git-guard.ts",
 			"./packages/extensions/extensions/safe-guard.ts",
 			"./packages/extensions/extensions/scheduler.ts",
+			"./packages/extensions/extensions/tool-metadata.ts",
 			"./packages/extensions/extensions/usage-tracker.ts",
 			"./packages/extensions/extensions/watchdog.ts",
 			"./packages/ant-colony/extensions/ant-colony/index.ts",

--- a/packages/core/src/registry.test.ts
+++ b/packages/core/src/registry.test.ts
@@ -86,6 +86,12 @@ describe("EXTENSIONS", () => {
 		expect(spec).toBeDefined();
 		expect(spec?.default).toBe(false);
 	});
+
+	it("enables tool metadata by default", () => {
+		const toolMetadata = EXTENSIONS.find((ext) => ext.name === "tool-metadata");
+		expect(toolMetadata).toBeDefined();
+		expect(toolMetadata?.default).toBe(true);
+	});
 });
 
 describe("KEYBINDING_SCHEMES", () => {

--- a/packages/core/src/registry.ts
+++ b/packages/core/src/registry.ts
@@ -90,6 +90,13 @@ export const EXTENSIONS = [
 		default: true,
 	},
 	{
+		name: "tool-metadata",
+		get label() {
+			return `${icon("clock")} Tool Metadata — Add completion timestamps, durations, and context snapshots to tool results`;
+		},
+		default: true,
+	},
+	{
 		name: "compact-header",
 		get label() {
 			return `${icon("bolt")} Compact Header — Dense startup info replacing verbose output`;

--- a/packages/extensions/README.md
+++ b/packages/extensions/README.md
@@ -10,6 +10,7 @@ This package includes extensions such as:
 - git-guard
 - auto-session-name
 - custom-footer
+- tool-metadata
 - compact-header
 - external-editor / /external-editor
 - auto-update
@@ -34,7 +35,7 @@ npx @ifi/oh-pi
 ## What it provides
 
 These extensions add commands, tools, UI widgets, safety checks, background process handling,
-usage monitoring, adaptive model routing, scheduling features, external-editor integration, and runtime performance protection (`/watchdog`, `/safe-mode`) to pi.
+usage monitoring, adaptive model routing, scheduling features, tool execution metadata, external-editor integration, and runtime performance protection (`/watchdog`, `/safe-mode`) to pi.
 
 `git-guard` also blocks git bash invocations that are likely to open an interactive editor in agent environments (for example `git rebase --continue` without non-interactive editor overrides), preventing hangs before they happen.
 

--- a/packages/extensions/extensions/smoke.test.ts
+++ b/packages/extensions/extensions/smoke.test.ts
@@ -6,6 +6,7 @@ import btwExtension from "./btw.js";
 import externalEditorExtension from "./external-editor.js";
 import safeGuardExtension from "./safe-guard.js";
 import schedulerExtension from "./scheduler.js";
+import toolMetadataExtension from "./tool-metadata.js";
 import usageTrackerExtension from "./usage-tracker.js";
 
 describe("extensions runtime smoke tests", () => {
@@ -44,6 +45,23 @@ describe("extensions runtime smoke tests", () => {
 		expect(harness.commands.has("usage-refresh")).toBe(true);
 		expect(harness.tools.has("usage_report")).toBe(true);
 		expect(harness.shortcuts.has("ctrl+u")).toBe(true);
+	});
+
+	it("registers tool metadata hooks without crashing", async () => {
+		const harness = createExtensionHarness();
+		toolMetadataExtension(harness.pi as never);
+		const [patch] = await harness.emitAsync(
+			"tool_result",
+			{
+				toolCallId: "tool-1",
+				toolName: "read",
+				input: { path: "README.md" },
+				content: [{ type: "text", text: "ok" }],
+				details: {},
+			},
+			harness.ctx,
+		);
+		expect(patch.details.toolMetadata).toBeDefined();
 	});
 
 	it("registers auto-update startup hook without crashing", () => {

--- a/packages/extensions/extensions/tool-metadata.test.ts
+++ b/packages/extensions/extensions/tool-metadata.test.ts
@@ -1,0 +1,74 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import { createExtensionHarness } from "../../../test-utils/extension-runtime-harness.js";
+import toolMetadataExtension, {
+	buildToolMetadata,
+	formatDuration,
+	formatTimestamp,
+	formatToolMetadataText,
+} from "./tool-metadata.js";
+
+describe("tool-metadata extension", () => {
+	beforeEach(() => {
+		vi.useFakeTimers();
+		vi.setSystemTime(new Date("2026-04-15T09:12:13Z"));
+	});
+
+	afterEach(() => {
+		vi.useRealTimers();
+	});
+
+	it("formats timestamps and durations for human-readable tool metadata", () => {
+		expect(formatTimestamp(Date.UTC(2026, 3, 15, 9, 12, 13))).toMatch(/2026-04-15 \d{2}:12:13/);
+		expect(formatDuration(950)).toBe("950ms");
+		expect(formatDuration(2300)).toBe("2.3s");
+		expect(formatDuration(65_000)).toBe("1m5s");
+	});
+
+	it("builds visible completion metadata for tool results", async () => {
+		const harness = createExtensionHarness();
+		harness.ctx.getContextUsage = vi
+			.fn()
+			.mockReturnValueOnce({ percent: 12.5, tokens: 24_500, contextWindow: 200_000 })
+			.mockReturnValueOnce({ percent: 13.1, tokens: 26_200, contextWindow: 200_000 });
+		toolMetadataExtension(harness.pi as never);
+
+		await harness.emitAsync(
+			"tool_call",
+			{ toolCallId: "tool-1", toolName: "bash", input: { command: "pnpm test" } },
+			harness.ctx,
+		);
+		await vi.advanceTimersByTimeAsync(2300);
+
+		const [patch] = await harness.emitAsync(
+			"tool_result",
+			{
+				toolCallId: "tool-1",
+				toolName: "bash",
+				input: { command: "pnpm test" },
+				content: [{ type: "text", text: "tests passed" }],
+				details: {},
+			},
+			harness.ctx,
+		);
+
+		expect(patch.details.toolMetadata.durationMs).toBe(2300);
+		expect(patch.details.toolMetadata.approxContextTokens).toBeGreaterThan(0);
+		expect(patch.content.at(-1).text).toContain("[tool metadata] completed");
+		expect(patch.content.at(-1).text).toContain("duration 2.3s");
+		expect(patch.content.at(-1).text).toContain("session context 13%");
+	});
+
+	it("creates metadata even when a tool_result arrives without a matching tool_call", () => {
+		const metadata = buildToolMetadata(
+			"read",
+			Date.UTC(2026, 3, 15, 9, 12, 13),
+			Date.UTC(2026, 3, 15, 9, 12, 13),
+			{ path: "README.md" },
+			[{ type: "text", text: "hello" }],
+			{ getContextUsage: () => undefined } as never,
+		);
+
+		expect(metadata.durationMs).toBe(0);
+		expect(formatToolMetadataText(metadata)).toContain("tool context");
+	});
+});

--- a/packages/extensions/extensions/tool-metadata.ts
+++ b/packages/extensions/extensions/tool-metadata.ts
@@ -1,0 +1,195 @@
+import type { ExtensionAPI, ExtensionContext } from "@mariozechner/pi-coding-agent";
+
+type ContextUsageSnapshot = {
+	tokens: number | null;
+	percent: number | null;
+	contextWindow: number | null;
+};
+
+export type ToolExecutionMetadata = {
+	toolName: string;
+	startedAt: number;
+	startedAtLabel: string;
+	completedAt: number;
+	completedAtLabel: string;
+	durationMs: number;
+	durationLabel: string;
+	approxContextTokens: number;
+	inputChars: number;
+	outputChars: number;
+	contextAtCompletion: ContextUsageSnapshot | null;
+};
+
+type PendingToolCall = {
+	startedAt: number;
+};
+
+const APPROX_TOKEN_CHARS = 4;
+const TOOL_METADATA_KEY = "toolMetadata";
+
+function pad(value: number): string {
+	return `${value}`.padStart(2, "0");
+}
+
+export function formatTimestamp(timestamp: number): string {
+	const date = new Date(timestamp);
+	return `${date.getFullYear()}-${pad(date.getMonth() + 1)}-${pad(date.getDate())} ${pad(date.getHours())}:${pad(date.getMinutes())}:${pad(date.getSeconds())}`;
+}
+
+export function formatDuration(durationMs: number): string {
+	if (durationMs < 1000) {
+		return `${durationMs}ms`;
+	}
+
+	const seconds = durationMs / 1000;
+	if (seconds < 60) {
+		return `${seconds.toFixed(seconds < 10 ? 1 : 0)}s`;
+	}
+
+	const minutes = Math.floor(seconds / 60);
+	const remainingSeconds = seconds % 60;
+	if (minutes < 60) {
+		return `${minutes}m${remainingSeconds > 0 ? `${Math.round(remainingSeconds)}s` : ""}`;
+	}
+
+	const hours = Math.floor(minutes / 60);
+	const remainingMinutes = minutes % 60;
+	return `${hours}h${remainingMinutes > 0 ? `${remainingMinutes}m` : ""}`;
+}
+
+function snapshotContextUsage(ctx: Pick<ExtensionContext, "getContextUsage">): ContextUsageSnapshot | null {
+	const usage = ctx.getContextUsage?.();
+	if (!usage) {
+		return null;
+	}
+
+	return {
+		tokens: typeof usage.tokens === "number" ? usage.tokens : null,
+		percent: typeof usage.percent === "number" ? usage.percent : null,
+		contextWindow: typeof usage.contextWindow === "number" ? usage.contextWindow : null,
+	};
+}
+
+function collectTextContentChars(content: unknown): number {
+	if (!Array.isArray(content)) {
+		return 0;
+	}
+
+	let total = 0;
+	for (const item of content) {
+		if (!item || typeof item !== "object") {
+			continue;
+		}
+		const text =
+			(item as { type?: unknown; text?: unknown }).type === "text" ? (item as { text?: unknown }).text : undefined;
+		if (typeof text === "string") {
+			total += text.length;
+		}
+	}
+	return total;
+}
+
+function estimateTokens(chars: number): number {
+	if (chars <= 0) {
+		return 0;
+	}
+	return Math.ceil(chars / APPROX_TOKEN_CHARS);
+}
+
+function formatCount(value: number): string {
+	if (value >= 1000) {
+		return `${(value / 1000).toFixed(1)}k`;
+	}
+	return `${value}`;
+}
+
+export function buildToolMetadata(
+	toolName: string,
+	startedAt: number,
+	completedAt: number,
+	input: unknown,
+	content: unknown,
+	ctx: Pick<ExtensionContext, "getContextUsage">,
+): ToolExecutionMetadata {
+	const inputChars = JSON.stringify(input ?? {}).length;
+	const outputChars = collectTextContentChars(content);
+	const approxContextTokens = estimateTokens(inputChars + outputChars);
+	const durationMs = Math.max(0, completedAt - startedAt);
+
+	return {
+		toolName,
+		startedAt,
+		startedAtLabel: formatTimestamp(startedAt),
+		completedAt,
+		completedAtLabel: formatTimestamp(completedAt),
+		durationMs,
+		durationLabel: formatDuration(durationMs),
+		approxContextTokens,
+		inputChars,
+		outputChars,
+		contextAtCompletion: snapshotContextUsage(ctx),
+	};
+}
+
+export function formatToolMetadataText(metadata: ToolExecutionMetadata): string {
+	const parts = [
+		`[tool metadata] completed ${metadata.completedAtLabel}`,
+		`duration ${metadata.durationLabel}`,
+		`tool context ~${formatCount(metadata.approxContextTokens)} tok`,
+	];
+
+	const context = metadata.contextAtCompletion;
+	if (context?.percent != null) {
+		const tokens = context.tokens == null ? "?" : formatCount(context.tokens);
+		const window = context.contextWindow == null ? "?" : formatCount(context.contextWindow);
+		parts.push(`session context ${context.percent.toFixed(0)}% (${tokens}/${window})`);
+	}
+
+	return parts.join(" · ");
+}
+
+export default function toolMetadataExtension(pi: ExtensionAPI): void {
+	const pending = new Map<string, PendingToolCall>();
+
+	pi.on("tool_call", (event) => {
+		pending.set(event.toolCallId, {
+			startedAt: Date.now(),
+		});
+	});
+
+	pi.on("tool_result", (event, ctx) => {
+		const started = pending.get(event.toolCallId);
+		pending.delete(event.toolCallId);
+
+		const completedAt = Date.now();
+		const metadata = buildToolMetadata(
+			event.toolName,
+			started?.startedAt ?? completedAt,
+			completedAt,
+			event.input,
+			event.content,
+			ctx,
+		);
+		if (!started) {
+			metadata.startedAtLabel = metadata.completedAtLabel;
+		}
+
+		const details =
+			event.details && typeof event.details === "object"
+				? ({ ...(event.details as Record<string, unknown>) } satisfies Record<string, unknown>)
+				: {};
+		details[TOOL_METADATA_KEY] = metadata;
+
+		return {
+			content: [...event.content, { type: "text" as const, text: formatToolMetadataText(metadata) }],
+			details,
+		};
+	});
+
+	const clearPending = () => {
+		pending.clear();
+	};
+
+	pi.on("session_switch", clearPending);
+	pi.on("session_shutdown", clearPending);
+}

--- a/packages/extensions/package.json
+++ b/packages/extensions/package.json
@@ -18,6 +18,7 @@
       "./extensions/git-guard.ts",
       "./extensions/safe-guard.ts",
       "./extensions/scheduler.ts",
+      "./extensions/tool-metadata.ts",
       "./extensions/usage-tracker.ts",
       "./extensions/watchdog.ts"
     ]


### PR DESCRIPTION
## Summary
- add a default-on `tool-metadata` extension
- append completion time, elapsed runtime, approximate tool-context size, and session context snapshot to tool results
- register the extension in manifests/registry and cover it with tests

## Validation
- pnpm typecheck
- pnpm exec biome check packages/extensions/extensions/tool-metadata.ts packages/extensions/extensions/tool-metadata.test.ts packages/extensions/extensions/smoke.test.ts packages/extensions/package.json packages/core/src/registry.ts packages/core/src/registry.test.ts packages/extensions/README.md package.json
- pnpm exec vitest run packages/extensions/extensions/tool-metadata.test.ts packages/extensions/extensions/smoke.test.ts packages/core/src/registry.test.ts
- pnpm exec vitest run packages/extensions/extensions/package-manifest.test.ts