### PR TITLE
fix(extensions): harden tool-output rendering against crash inputs

### DIFF
--- a/.changes/tool-output-ui-guard.md
+++ b/.changes/tool-output-ui-guard.md
@@ -1,0 +1,10 @@
+---
+default: patch
+---
+
+Harden tool result rendering against oversized or malformed text output.
+
+- sanitize tool-result text blocks before metadata rendering
+- split extremely long single lines into bounded chunks to avoid recursive line-wrap overflows
+- cap total rendered text size/line count and strip NUL bytes before UI fallback rendering
+- attach `outputGuard` details when truncation is applied

--- a/packages/extensions/README.md
+++ b/packages/extensions/README.md
@@ -153,9 +153,9 @@ recent subscription windows when a live provider probe is temporarily rate-limit
 
 Key usage-tracker surfaces:
 
-- widget above the editor for at-a-glance quotas and current-provider session totals
-- `/usage` to search/select a provider, then open that provider's dashboard
-- `Ctrl+U` as a shortcut for the current provider's dashboard
+- widget above the editor for at-a-glance quotas and session totals
+- `/usage` for the full dashboard overlay
+- `Ctrl+U` as a shortcut for the same overlay
 - `/usage-toggle` to show or hide the widget
 - `/usage-refresh` to force fresh provider probes
 - `usage_report` so the agent can answer quota and spend questions directly

--- a/packages/extensions/extensions/tool-metadata.test.ts
+++ b/packages/extensions/extensions/tool-metadata.test.ts
@@ -24,6 +24,35 @@ describe("tool-metadata extension", () => {
 		expect(formatDuration(65_000)).toBe("1m5s");
 	});
 
+	it("sanitizes oversized text output to avoid TUI rendering crashes", async () => {
+		const harness = createExtensionHarness();
+		toolMetadataExtension(harness.pi as never);
+
+		const longLine = "x".repeat(12_000);
+		const [patch] = await harness.emitAsync(
+			"tool_result",
+			{
+				toolCallId: "tool-big",
+				toolName: "bash",
+				input: { command: "printf huge" },
+				content: [{ type: "text", text: `${longLine}\u0000${longLine}` }],
+				details: {},
+			},
+			harness.ctx,
+		);
+
+		expect(patch.details.outputGuard).toEqual(
+			expect.objectContaining({
+				truncated: true,
+				maxChars: 120_000,
+				maxLineChars: 2_000,
+				maxLines: 2_000,
+			}),
+		);
+		expect(patch.content[0].text).toContain("[tool output truncated for UI safety]");
+		expect(patch.content[0].text).not.toContain("\u0000");
+	});
+
 	it("builds visible completion metadata for tool results", async () => {
 		const harness = createExtensionHarness();
 		harness.ctx.getContextUsage = vi

--- a/packages/extensions/extensions/tool-metadata.ts
+++ b/packages/extensions/extensions/tool-metadata.ts
@@ -26,6 +26,10 @@ type PendingToolCall = {
 
 const APPROX_TOKEN_CHARS = 4;
 const TOOL_METADATA_KEY = "toolMetadata";
+const MAX_TEXT_BLOCK_CHARS = 120_000;
+const MAX_TEXT_LINE_CHARS = 2_000;
+const MAX_TEXT_LINES = 2_000;
+const OUTPUT_GUARD_NOTE = "\n[tool output truncated for UI safety]";
 
 function pad(value: number): string {
 	return `${value}`.padStart(2, "0");
@@ -68,6 +72,80 @@ function snapshotContextUsage(ctx: Pick<ExtensionContext, "getContextUsage">): C
 		percent: typeof usage.percent === "number" ? usage.percent : null,
 		contextWindow: typeof usage.contextWindow === "number" ? usage.contextWindow : null,
 	};
+}
+
+function chunkLine(line: string, maxChars: number): string[] {
+	if (line.length <= maxChars) {
+		return [line];
+	}
+
+	const chunks: string[] = [];
+	for (let i = 0; i < line.length; i += maxChars) {
+		chunks.push(line.slice(i, i + maxChars));
+	}
+	return chunks;
+}
+
+function sanitizeTextBlock(text: string): { text: string; changed: boolean } {
+	if (!text) {
+		return { text, changed: false };
+	}
+
+	const cleaned = text.replaceAll("\u0000", "");
+	let changed = cleaned !== text;
+
+	const lines = cleaned.split("\n");
+	const boundedLines = lines.slice(0, MAX_TEXT_LINES);
+	if (boundedLines.length !== lines.length) {
+		changed = true;
+	}
+
+	const wrapped: string[] = [];
+	for (const line of boundedLines) {
+		const parts = chunkLine(line, MAX_TEXT_LINE_CHARS);
+		if (parts.length > 1) {
+			changed = true;
+		}
+		wrapped.push(...parts);
+		if (wrapped.length >= MAX_TEXT_LINES) {
+			changed = true;
+			break;
+		}
+	}
+
+	let normalized = wrapped.slice(0, MAX_TEXT_LINES).join("\n");
+	if (normalized.length > MAX_TEXT_BLOCK_CHARS) {
+		normalized = normalized.slice(0, MAX_TEXT_BLOCK_CHARS);
+		changed = true;
+	}
+	if (changed) {
+		normalized += OUTPUT_GUARD_NOTE;
+	}
+	return { text: normalized, changed };
+}
+
+function sanitizeContent(content: unknown): { content: unknown[]; changed: boolean } {
+	if (!Array.isArray(content)) {
+		return { content: [], changed: false };
+	}
+
+	let changed = false;
+	const normalized = content.map((item) => {
+		if (!(item && typeof item === "object" && (item as { type?: unknown }).type === "text")) {
+			return item;
+		}
+		const originalText = (item as { text?: unknown }).text;
+		if (typeof originalText !== "string") {
+			return item;
+		}
+		const safeText = sanitizeTextBlock(originalText);
+		if (!safeText.changed) {
+			return item;
+		}
+		changed = true;
+		return { ...(item as Record<string, unknown>), text: safeText.text };
+	});
+	return { content: normalized, changed };
 }
 
 function collectTextContentChars(content: unknown): number {
@@ -161,13 +239,14 @@ export default function toolMetadataExtension(pi: ExtensionAPI): void {
 		const started = pending.get(event.toolCallId);
 		pending.delete(event.toolCallId);
 
+		const { content: safeContent, changed } = sanitizeContent(event.content);
 		const completedAt = Date.now();
 		const metadata = buildToolMetadata(
 			event.toolName,
 			started?.startedAt ?? completedAt,
 			completedAt,
 			event.input,
-			event.content,
+			safeContent,
 			ctx,
 		);
 		if (!started) {
@@ -179,9 +258,17 @@ export default function toolMetadataExtension(pi: ExtensionAPI): void {
 				? ({ ...(event.details as Record<string, unknown>) } satisfies Record<string, unknown>)
 				: {};
 		details[TOOL_METADATA_KEY] = metadata;
+		if (changed) {
+			details.outputGuard = {
+				truncated: true,
+				maxChars: MAX_TEXT_BLOCK_CHARS,
+				maxLineChars: MAX_TEXT_LINE_CHARS,
+				maxLines: MAX_TEXT_LINES,
+			};
+		}
 
 		return {
-			content: [...event.content, { type: "text" as const, text: formatToolMetadataText(metadata) }],
+			content: [...safeContent, { type: "text" as const, text: formatToolMetadataText(metadata) }],
 			details,
 		};
 	});

--- a/packages/extensions/extensions/usage-tracker.ts
+++ b/packages/extensions/extensions/usage-tracker.ts
@@ -21,9 +21,9 @@ recent subscription windows when a live provider probe is temporarily rate-limit
 
 Key usage-tracker surfaces:
 
-- widget above the editor for at-a-glance quotas and current-provider session totals
-- `/usage` to search/select a provider, then open that provider's dashboard
-- `Ctrl+U` as a shortcut for the current provider's dashboard
+- widget above the editor for at-a-glance quotas and session totals
+- `/usage` for the full dashboard overlay
+- `Ctrl+U` as a shortcut for the same overlay
 - `/usage-toggle` to show or hide the widget
 - `/usage-refresh` to force fresh provider probes
 - `usage_report` so the agent can answer quota and spend questions directly


### PR DESCRIPTION
## What this fixes
This addresses urgent crash paths triggered by oversized or malformed tool text output in interactive mode, including stack overflows in line wrapping and shell sanitization failures.

## Changes
- sanitize text blocks in `tool-metadata` `tool_result` hook before rendering fallback paths
- split very long single lines into bounded chunks
- cap max output chars and line count for UI-safe rendering
- strip NUL bytes
- add `details.outputGuard` metadata when truncation is applied
- add tests for oversized output sanitization

## Validation
- pnpm test packages/extensions/extensions/tool-metadata.test.ts
- pnpm test packages/extensions/extensions/smoke.test.ts
- pnpm exec biome check packages/extensions/extensions/tool-metadata.ts packages/extensions/extensions/tool-metadata.test.ts
