### PR TITLE
fix: detect pi command for published package switching

### DIFF
--- a/.changeset/fix-pi-published-command-detection.md
+++ b/.changeset/fix-pi-published-command-detection.md
@@ -1,0 +1,5 @@
+---
+default: patch
+---
+
+fix: detect the pi executable more reliably when switching oh-pi packages back to published sources

--- a/scripts/pi-source-switch.mts
+++ b/scripts/pi-source-switch.mts
@@ -1,6 +1,6 @@
 #!/usr/bin/env node
 
-import { execFileSync } from "node:child_process";
+import { execFileSync, spawnSync } from "node:child_process";
 import { existsSync, mkdirSync, readdirSync, readFileSync, realpathSync, writeFileSync } from "node:fs";
 import { homedir } from "node:os";
 import path from "node:path";
@@ -286,6 +286,90 @@ function parseArgs(argv: string[]): Options {
 	return options;
 }
 
+function normalizeBinDirs(prefix: string, platform: NodeJS.Platform): string[] {
+	const trimmed = prefix.trim();
+	if (!trimmed) {
+		return [];
+	}
+	if (path.basename(trimmed).toLowerCase() === "bin") {
+		return [trimmed];
+	}
+	return platform === "win32" ? [trimmed, path.join(trimmed, "bin")] : [path.join(trimmed, "bin"), trimmed];
+}
+
+export function buildPiExecutableCandidates(options?: {
+	env?: NodeJS.ProcessEnv;
+	homeDir?: string;
+	platform?: NodeJS.Platform;
+}): string[] {
+	const env = options?.env ?? process.env;
+	const homeDir = options?.homeDir ?? homedir();
+	const platform = options?.platform ?? process.platform;
+	const executableNames = platform === "win32" ? ["pi.cmd", "pi.exe", "pi"] : ["pi"];
+	const candidates: string[] = [];
+	const seen = new Set<string>();
+
+	const add = (candidate: string | undefined) => {
+		if (!candidate) {
+			return;
+		}
+		const normalized = path.normalize(candidate);
+		if (seen.has(normalized)) {
+			return;
+		}
+		seen.add(normalized);
+		candidates.push(candidate);
+	};
+
+	for (const executableName of executableNames) {
+		add(executableName);
+	}
+
+	const pathEntries = (env.PATH ?? "").split(path.delimiter).filter(Boolean);
+	for (const dir of pathEntries) {
+		for (const executableName of executableNames) {
+			add(path.join(dir, executableName));
+		}
+	}
+
+	const binDirs = [
+		env.PI_CODING_AGENT_BIN,
+		env.PNPM_HOME,
+		env.npm_config_prefix,
+		env.NPM_CONFIG_PREFIX,
+		...normalizeBinDirs(path.join(homeDir, ".pi", "agent", "bin"), platform),
+		...normalizeBinDirs(path.join(homeDir, "Library", "pnpm"), platform),
+		...normalizeBinDirs(path.join(homeDir, ".local", "share", "pnpm"), platform),
+		...normalizeBinDirs(path.join(homeDir, ".pnpm-global"), platform),
+		...normalizeBinDirs(path.join(homeDir, ".npm-global"), platform),
+		...normalizeBinDirs(path.join(homeDir, ".local"), platform),
+	];
+
+	if (platform === "win32") {
+		binDirs.push(env.APPDATA ? path.join(env.APPDATA, "pnpm") : undefined);
+		binDirs.push(env.APPDATA ? path.join(env.APPDATA, "npm") : undefined);
+	}
+
+	for (const rawDir of binDirs) {
+		for (const dir of normalizeBinDirs(rawDir ?? "", platform)) {
+			for (const executableName of executableNames) {
+				add(path.join(dir, executableName));
+			}
+		}
+	}
+
+	return candidates;
+}
+
+export function resolvePiCommand(candidates: readonly string[], probe: (candidate: string) => boolean): string | undefined {
+	for (const candidate of candidates) {
+		if (probe(candidate)) {
+			return candidate;
+		}
+	}
+	return undefined;
+}
+
 function printHelp() {
 	console.log(`
 oh-pi source switcher — toggle pi between local workspace packages and published npm packages
@@ -316,14 +400,22 @@ Notes:
 }
 
 function findPi(): string {
-	const candidates = IS_WINDOWS ? ["pi.cmd", "pi"] : ["pi"];
-	for (const candidate of candidates) {
-		try {
-			execFileSync(candidate, ["--version"], { stdio: "ignore", shell: IS_WINDOWS });
-			return candidate;
-		} catch {
-			// Try the next candidate.
+	const candidates = buildPiExecutableCandidates();
+	const resolved = resolvePiCommand(candidates, (candidate) => {
+		if (path.isAbsolute(candidate) && !existsSync(candidate)) {
+			return false;
 		}
+
+		const result = spawnSync(candidate, ["--version"], { stdio: "ignore", shell: IS_WINDOWS });
+		if (!result.error) {
+			return true;
+		}
+
+		return result.error.code !== "ENOENT";
+	});
+
+	if (resolved) {
+		return resolved;
 	}
 
 	throw new Error("'pi' command not found. Install pi-coding-agent first: npm install -g @mariozechner/pi-coding-agent");

--- a/scripts/pi-source-switch.test.ts
+++ b/scripts/pi-source-switch.test.ts
@@ -3,9 +3,11 @@ import { tmpdir } from "node:os";
 import path from "node:path";
 import { afterEach, describe, expect, it } from "vitest";
 import {
+	buildPiExecutableCandidates,
 	dedupeManagedPackageEntries,
 	parseNpmPackageName,
 	resolveManagedPackageNameFromSource,
+	resolvePiCommand,
 	resolveWorkspacePackageSources,
 	rewriteManagedPackageSources,
 } from "./pi-source-switch.mts";
@@ -102,5 +104,26 @@ describe("pi source switcher helpers", () => {
 		writeFileSync(path.join(packageDir, "package.json"), JSON.stringify({ name: "@ifi/oh-pi-themes" }));
 
 		expect(resolveManagedPackageNameFromSource(packageDir, repoDir)).toBe("@ifi/oh-pi-themes");
+	});
+
+	it("adds common global pnpm and pi bin directories when building pi candidates", () => {
+		const candidates = buildPiExecutableCandidates({
+			env: { PATH: "", PNPM_HOME: "/custom/pnpm-home" },
+			homeDir: "/Users/tester",
+			platform: "darwin",
+		});
+
+		expect(candidates).toContain("pi");
+		expect(candidates).toContain("/custom/pnpm-home/pi");
+		expect(candidates).toContain("/Users/tester/Library/pnpm/pi");
+		expect(candidates).toContain("/Users/tester/.pi/agent/bin/pi");
+	});
+
+	it("resolves pi from fallback candidates after PATH misses", () => {
+		const resolved = resolvePiCommand(["pi", "/Users/tester/Library/pnpm/pi"], (candidate) => {
+			return candidate === "/Users/tester/Library/pnpm/pi";
+		});
+
+		expect(resolved).toBe("/Users/tester/Library/pnpm/pi");
 	});
 });


### PR DESCRIPTION
## Summary\n- make the pi source switcher search common pnpm/global bin locations when resolving the pi executable\n- add reusable candidate-building and resolution helpers instead of relying only on PATH\n- cover the fallback lookup behavior with focused tests\n\n## Testing\n- PATH=/Users/ifiokjr/Developer/projects/aipi/oh-pi/node_modules/.bin:/Users/ifiokjr/.pi/agent/bin:/Users/ifiokjr/.config/carapace/bin:/Users/ifiokjr/.local/bin:/Users/ifiokjr/.cargo/bin:/Users/ifiokjr/.shorebird/bin:/Users/ifiokjr/Library/pnpm:/Users/ifiokjr/.local/share/solana/install/active_release/bin:/Users/ifiokjr/fvm/default/bin:/Users/ifiokjr/.deno/bin:/Users/ifiokjr/.nix-profile/bin:/etc/profiles/per-user/ifiokjr/bin:/run/current-system/sw/bin:/nix/var/nix/profiles/default/bin:/usr/bin:/bin:/usr/sbin:/sbin:/Applications/Ghostty.app/Contents/MacOS:/Users/ifiokjr/Library/Android/sdk/cmdline-tools/latest/bin:/Users/ifiokjr/Library/Android/sdk/platform-tools:/Applications/Android Studio.app/Contents/MacOS:/Users/ifiokjr/.pub-cache/bin:/usr/local/bin NODE_PATH=/Users/ifiokjr/Developer/projects/aipi/oh-pi/node_modules vitest run scripts/pi-source-switch.test.ts\n- PATH=/usr/bin:/bin /Users/ifiokjr/Library/pnpm/node --experimental-strip-types ./scripts/pi-source-switch.mts remote --dry-run