### PR TITLE
fix(extensions): harden tool-result details against render crashes

### DIFF
--- a/.changes/tool-result-details-safety-guard.md
+++ b/.changes/tool-result-details-safety-guard.md
@@ -1,0 +1,10 @@
+---
+default: patch
+---
+
+Further harden interactive tool-result rendering against pathological payloads.
+
+- sanitize large string fields in tool-result `details` before renderer fallback paths consume them
+- strip NUL bytes and bound nested details depth/field counts to avoid shell/text sanitizer crashes
+- keep `outputGuard` metadata with a `detailsSanitized` flag when truncation is applied
+- add tests covering oversized nested `details.stdout/stderr` payloads

--- a/packages/extensions/extensions/tool-metadata.test.ts
+++ b/packages/extensions/extensions/tool-metadata.test.ts
@@ -53,6 +53,29 @@ describe("tool-metadata extension", () => {
 		expect(patch.content[0].text).not.toContain("\u0000");
 	});
 
+	it("sanitizes oversized details payloads used by fallback renderers", async () => {
+		const harness = createExtensionHarness();
+		toolMetadataExtension(harness.pi as never);
+
+		const huge = `${"y".repeat(50_000)}\u0000${"z".repeat(50_000)}`;
+		const [patch] = await harness.emitAsync(
+			"tool_result",
+			{
+				toolCallId: "tool-details",
+				toolName: "bash",
+				input: { command: "huge" },
+				content: [{ type: "text", text: "ok" }],
+				details: { stdout: huge, nested: { stderr: huge } },
+			},
+			harness.ctx,
+		);
+
+		expect((patch.details.stdout as string).length).toBeLessThan(130_000);
+		expect(patch.details.stdout).not.toContain("\u0000");
+		expect((patch.details.nested as { stderr: string }).stderr.length).toBeLessThan(130_000);
+		expect(patch.details.outputGuard).toEqual(expect.objectContaining({ detailsSanitized: true }));
+	});
+
 	it("builds visible completion metadata for tool results", async () => {
 		const harness = createExtensionHarness();
 		harness.ctx.getContextUsage = vi

--- a/packages/extensions/extensions/tool-metadata.ts
+++ b/packages/extensions/extensions/tool-metadata.ts
@@ -30,6 +30,8 @@ const MAX_TEXT_BLOCK_CHARS = 120_000;
 const MAX_TEXT_LINE_CHARS = 2_000;
 const MAX_TEXT_LINES = 2_000;
 const OUTPUT_GUARD_NOTE = "\n[tool output truncated for UI safety]";
+const MAX_DETAIL_FIELDS = 256;
+const MAX_DETAIL_DEPTH = 4;
 
 function pad(value: number): string {
 	return `${value}`.padStart(2, "0");
@@ -148,6 +150,70 @@ function sanitizeContent(content: unknown): { content: unknown[]; changed: boole
 	return { content: normalized, changed };
 }
 
+function sanitizeDetailsValue(
+	value: unknown,
+	depth = 0,
+	seen = new WeakSet<object>(),
+): { value: unknown; changed: boolean } {
+	if (typeof value === "string") {
+		const safe = sanitizeTextBlock(value);
+		return { value: safe.text, changed: safe.changed };
+	}
+	if (!(value && typeof value === "object")) {
+		return { value, changed: false };
+	}
+	if (seen.has(value)) {
+		return { value: "[circular]", changed: true };
+	}
+	if (depth >= MAX_DETAIL_DEPTH) {
+		return { value: "[depth-truncated]", changed: true };
+	}
+	seen.add(value);
+
+	if (Array.isArray(value)) {
+		let changed = false;
+		const limited = value.slice(0, MAX_DETAIL_FIELDS);
+		if (limited.length !== value.length) {
+			changed = true;
+		}
+		const next = limited.map((item) => {
+			const normalized = sanitizeDetailsValue(item, depth + 1, seen);
+			if (normalized.changed) {
+				changed = true;
+			}
+			return normalized.value;
+		});
+		return { value: next, changed };
+	}
+
+	let changed = false;
+	const nextEntries: Array<[string, unknown]> = [];
+	const entries = Object.entries(value as Record<string, unknown>).slice(0, MAX_DETAIL_FIELDS);
+	if (entries.length !== Object.keys(value as Record<string, unknown>).length) {
+		changed = true;
+	}
+	for (const [key, entryValue] of entries) {
+		const normalized = sanitizeDetailsValue(entryValue, depth + 1, seen);
+		if (normalized.changed) {
+			changed = true;
+		}
+		nextEntries.push([key, normalized.value]);
+	}
+
+	return { value: Object.fromEntries(nextEntries), changed };
+}
+
+function sanitizeDetails(details: unknown): { details: Record<string, unknown>; changed: boolean } {
+	if (!(details && typeof details === "object")) {
+		return { details: {}, changed: false };
+	}
+	const normalized = sanitizeDetailsValue(details);
+	if (normalized.value && typeof normalized.value === "object" && !Array.isArray(normalized.value)) {
+		return { details: normalized.value as Record<string, unknown>, changed: normalized.changed };
+	}
+	return { details: {}, changed: true };
+}
+
 function collectTextContentChars(content: unknown): number {
 	if (!Array.isArray(content)) {
 		return 0;
@@ -239,7 +305,8 @@ export default function toolMetadataExtension(pi: ExtensionAPI): void {
 		const started = pending.get(event.toolCallId);
 		pending.delete(event.toolCallId);
 
-		const { content: safeContent, changed } = sanitizeContent(event.content);
+		const { content: safeContent, changed: contentChanged } = sanitizeContent(event.content);
+		const { details: safeDetails, changed: detailsChanged } = sanitizeDetails(event.details);
 		const completedAt = Date.now();
 		const metadata = buildToolMetadata(
 			event.toolName,
@@ -253,17 +320,15 @@ export default function toolMetadataExtension(pi: ExtensionAPI): void {
 			metadata.startedAtLabel = metadata.completedAtLabel;
 		}
 
-		const details =
-			event.details && typeof event.details === "object"
-				? ({ ...(event.details as Record<string, unknown>) } satisfies Record<string, unknown>)
-				: {};
+		const details = safeDetails;
 		details[TOOL_METADATA_KEY] = metadata;
-		if (changed) {
+		if (contentChanged || detailsChanged) {
 			details.outputGuard = {
 				truncated: true,
 				maxChars: MAX_TEXT_BLOCK_CHARS,
 				maxLineChars: MAX_TEXT_LINE_CHARS,
 				maxLines: MAX_TEXT_LINES,
+				detailsSanitized: detailsChanged,
 			};
 		}
 


### PR DESCRIPTION
## Summary
- confirms the new stack trace is the same crash family (interactive fallback rendering on pathological output)
- sanitizes tool-result `details` strings (including nested fields) before fallback rendering
- strips NUL bytes, bounds recursion depth/field count, and truncates very large strings
- keeps `outputGuard.detailsSanitized` metadata for diagnostics
- adds tests for oversized nested details payloads

## Validation
- pnpm test packages/extensions/extensions/tool-metadata.test.ts packages/extensions/extensions/smoke.test.ts
- pnpm exec biome check packages/extensions/extensions/tool-metadata.ts packages/extensions/extensions/tool-metadata.test.ts
- pnpm mdt check
