### PR TITLE
fix: install missing packages during pi source switching

### DIFF
--- a/.changeset/pi-switch-installs-new-packages.md
+++ b/.changeset/pi-switch-installs-new-packages.md
@@ -1,0 +1,5 @@
+---
+default: patch
+---
+
+fix: make pi source switching install newly added packages and refresh local package manifests

--- a/README.md
+++ b/README.md
@@ -59,16 +59,17 @@ This is a monorepo. Install everything at once with `npx @ifi/oh-pi`, or pick in
 | [`@ifi/pi-plan`](./packages/plan)                         | Branch-aware planning mode extension        | `pi install npm:@ifi/pi-plan`               |
 | [`@ifi/pi-shared-qna`](./packages/shared-qna)             | Shared Q&A TUI helpers                      | (library, not installed directly)           |
 | [`@ifi/pi-spec`](./packages/spec)                         | Native spec-driven workflow with `/spec`    | `pi install npm:@ifi/pi-spec`               |
-| [`@ifi/pi-provider-cursor`](./packages/cursor)            | Experimental Cursor OAuth provider          | `pi install npm:@ifi/pi-provider-cursor`    |
-| [`@ifi/pi-provider-ollama`](./packages/ollama)            | Experimental Ollama local + cloud provider  | `pi install npm:@ifi/pi-provider-ollama`    |
+| [`@ifi/pi-provider-catalog`](./packages/providers)        | Experimental OpenCode-backed provider catalog | `pi install npm:@ifi/pi-provider-catalog` |
+| [`@ifi/pi-provider-cursor`](./packages/cursor)            | Experimental Cursor OAuth provider            | `pi install npm:@ifi/pi-provider-cursor`  |
+| [`@ifi/pi-provider-ollama`](./packages/ollama)            | Experimental Ollama local + cloud provider    | `pi install npm:@ifi/pi-provider-ollama`  |
 | [`@ifi/oh-pi-themes`](./packages/themes)                  | 6 color themes                              | `pi install npm:@ifi/oh-pi-themes`          |
 | [`@ifi/oh-pi-prompts`](./packages/prompts)                | 10 prompt templates                         | `pi install npm:@ifi/oh-pi-prompts`         |
 | [`@ifi/oh-pi-skills`](./packages/skills)                  | 12 skill packs                              | `pi install npm:@ifi/oh-pi-skills`          |
 | [`@ifi/oh-pi-agents`](./packages/agents)                  | 5 AGENTS.md templates                       | (used by CLI only)                          |
 
-`@ifi/pi-provider-cursor` and `@ifi/pi-provider-ollama` stay opt-in for now and are **not**
-installed by `npx @ifi/oh-pi`. They are intentionally shipped as separate experimental provider
-packages.
+`@ifi/pi-provider-catalog`, `@ifi/pi-provider-cursor`, and `@ifi/pi-provider-ollama` stay opt-in
+for now and are **not** installed by `npx @ifi/oh-pi`. They are intentionally shipped as separate
+experimental provider packages.
 
 ### Native `/spec` Workflow
 
@@ -583,9 +584,9 @@ pnpm pi:switch status                     # show the current managed package sou
 What it does:
 
 - rewrites only the managed oh-pi package sources in your pi settings
-- preserves package-specific config objects already in `settings.json`
-- runs `pi update` for each managed package so the switched source is ready to use
-- includes the experimental provider packages in addition to the main installer set
+- preserves package-specific config objects already in `settings.json`, while refreshing local package manifests so newly added extensions like `worktree` are picked up
+- runs `pi install` for newly added managed packages and `pi update` for packages you already had configured
+- includes the experimental provider packages in addition to the main installer set, including `@ifi/pi-provider-catalog`
 - lets you validate a branch or detached worktree before you publish
 
 After switching, fully restart `pi`. Do not rely on `/reload` for source switches because it can

--- a/packages/oh-pi/bin/package-list.mjs
+++ b/packages/oh-pi/bin/package-list.mjs
@@ -10,6 +10,10 @@ export const INSTALLER_PACKAGES = [
 	"@ifi/pi-web-remote",
 ];
 
-export const EXPERIMENTAL_PACKAGES = ["@ifi/pi-provider-cursor", "@ifi/pi-provider-ollama"];
+export const EXPERIMENTAL_PACKAGES = [
+	"@ifi/pi-provider-catalog",
+	"@ifi/pi-provider-cursor",
+	"@ifi/pi-provider-ollama",
+];
 
 export const SWITCHER_PACKAGES = [...INSTALLER_PACKAGES, ...EXPERIMENTAL_PACKAGES];

--- a/scripts/pi-source-switch.mts
+++ b/scripts/pi-source-switch.mts
@@ -32,6 +32,16 @@ type Change = {
 	nextSource: string;
 };
 
+type ManagedPackageManifest = Partial<Record<"extensions" | "prompts" | "skills" | "themes" | "agents", string[]>>;
+
+type PackageSyncAction = "install" | "update";
+
+type PackageSyncOperation = {
+	packageName: string;
+	source: string;
+	action: PackageSyncAction;
+};
+
 export function parseNpmPackageName(source: string): string | undefined {
 	if (!source.startsWith("npm:")) {
 		return undefined;
@@ -97,7 +107,7 @@ export function resolveManagedPackageNameFromSource(source: string, sourceBaseDi
 	return parseNpmPackageName(source) ?? resolvePathPackageName(source, sourceBaseDir);
 }
 
-export function resolveWorkspacePackageSources(repoPath: string, packageNames: readonly string[]): Map<string, string> {
+function collectWorkspacePackages(repoPath: string): Map<string, string> {
 	const packagesDir = path.join(repoPath, "packages");
 	const workspacePackages = new Map<string, string>();
 
@@ -113,6 +123,12 @@ export function resolveWorkspacePackageSources(repoPath: string, packageNames: r
 		}
 	}
 
+	return workspacePackages;
+}
+
+export function resolveWorkspacePackageSources(repoPath: string, packageNames: readonly string[]): Map<string, string> {
+	const workspacePackages = collectWorkspacePackages(repoPath);
+	const packagesDir = path.join(repoPath, "packages");
 	const missingPackages: string[] = [];
 	const resolvedSources = new Map<string, string>();
 	for (const packageName of packageNames) {
@@ -129,6 +145,52 @@ export function resolveWorkspacePackageSources(repoPath: string, packageNames: r
 	}
 
 	return resolvedSources;
+}
+
+function normalizeManifestPath(value: string): string {
+	return value.replace(/^\.\//, "");
+}
+
+export function resolveWorkspacePackageManifests(
+	repoPath: string,
+	packageNames: readonly string[],
+): Map<string, ManagedPackageManifest> {
+	const workspacePackages = collectWorkspacePackages(repoPath);
+	const manifests = new Map<string, ManagedPackageManifest>();
+
+	for (const packageName of packageNames) {
+		const packageDir = workspacePackages.get(packageName);
+		if (!packageDir) {
+			continue;
+		}
+
+		const pkgJson = readJsonFile<{
+			pi?: Partial<Record<"extensions" | "prompts" | "skills" | "themes" | "agents", unknown>>;
+		}>(path.join(packageDir, "package.json"));
+		const pi = pkgJson?.pi;
+		if (!(pi && typeof pi === "object")) {
+			continue;
+		}
+
+		const manifest: ManagedPackageManifest = {};
+		for (const key of ["extensions", "prompts", "skills", "themes", "agents"] as const) {
+			const raw = pi[key];
+			if (!Array.isArray(raw)) {
+				continue;
+			}
+
+			const entries = raw.filter((value): value is string => typeof value === "string").map(normalizeManifestPath);
+			if (entries.length > 0) {
+				manifest[key] = entries;
+			}
+		}
+
+		if (Object.keys(manifest).length > 0) {
+			manifests.set(packageName, manifest);
+		}
+	}
+
+	return manifests;
 }
 
 export function dedupeManagedPackageEntries(
@@ -185,10 +247,44 @@ export function dedupeManagedPackageEntries(
 	});
 }
 
+export function mergeManagedPackageManifest(
+	entry: PackageSetting,
+	manifest: ManagedPackageManifest | undefined,
+): PackageSetting {
+	if (typeof entry === "string" || !manifest) {
+		return entry;
+	}
+
+	const nextEntry: Record<string, unknown> = { ...entry };
+	for (const [key, manifestEntries] of Object.entries(manifest) as Array<[keyof ManagedPackageManifest, string[] | undefined]>) {
+		if (!(manifestEntries && manifestEntries.length > 0)) {
+			continue;
+		}
+
+		const current = Array.isArray(nextEntry[key])
+			? nextEntry[key].filter((value): value is string => typeof value === "string")
+			: undefined;
+		if (current?.length === 0) {
+			continue;
+		}
+
+		const merged = [...manifestEntries];
+		for (const value of current ?? []) {
+			if (!merged.includes(value)) {
+				merged.push(value);
+			}
+		}
+		nextEntry[key] = merged;
+	}
+
+	return nextEntry as PackageSetting;
+}
+
 export function rewriteManagedPackageSources(
 	entries: PackageSetting[],
 	desiredSources: ReadonlyMap<string, string>,
 	resolvePackageName: (source: string) => string | undefined,
+	options: { manifests?: ReadonlyMap<string, ManagedPackageManifest> } = {},
 ): PackageSetting[] {
 	const remainingPackages = new Set(desiredSources.keys());
 	const rewrittenEntries = entries.map((entry) => {
@@ -208,7 +304,8 @@ export function rewriteManagedPackageSources(
 		}
 
 		remainingPackages.delete(packageName);
-		return currentSource === nextSource ? entry : withPackageSource(entry, nextSource);
+		const nextEntry = currentSource === nextSource ? entry : withPackageSource(entry, nextSource);
+		return mergeManagedPackageManifest(nextEntry, options.manifests?.get(packageName));
 	});
 
 	for (const packageName of SWITCHER_PACKAGES) {
@@ -383,7 +480,7 @@ Options:
   --path <repo>       Repo checkout to use for local package paths (default: current directory)
   -v, --version <v>  Pin remote installs to a published version
   -l, --pi-local     Write to project .pi/settings.json instead of user settings
-  --dry-run          Show the changes without writing settings or running pi update
+  --dry-run          Show the changes without writing settings or running pi install/update
   -h, --help         Show this help
 
 Examples:
@@ -512,22 +609,43 @@ function printStatus(currentSources: ReadonlyMap<string, string>, settingsPath: 
 	}
 }
 
-function updatePiSources(pi: string, desiredSources: ReadonlyMap<string, string>) {
-	let failures = 0;
-	console.log("\nUpdating packages with pi...\n");
+export function planPackageSyncOperations(
+	currentSources: ReadonlyMap<string, string>,
+	desiredSources: ReadonlyMap<string, string>,
+): PackageSyncOperation[] {
+	const operations: PackageSyncOperation[] = [];
 	for (const packageName of SWITCHER_PACKAGES) {
 		const source = desiredSources.get(packageName);
 		if (!source) {
 			continue;
 		}
+		operations.push({
+			packageName,
+			source,
+			action: currentSources.has(packageName) ? "update" : "install",
+		});
+	}
+	return operations;
+}
 
-		process.stdout.write(`  ${packageName} ... `);
+function updatePiSources(pi: string, currentSources: ReadonlyMap<string, string>, desiredSources: ReadonlyMap<string, string>) {
+	let failures = 0;
+	console.log("\nSyncing packages with pi...\n");
+	for (const operation of planPackageSyncOperations(currentSources, desiredSources)) {
+		process.stdout.write(`  ${operation.packageName} (${operation.action}) ... `);
 		try {
-			execFileSync(pi, ["update", source], { stdio: "pipe", timeout: 120_000, shell: IS_WINDOWS });
+			execFileSync(pi, [operation.action, operation.source], { stdio: "pipe", timeout: 120_000, shell: IS_WINDOWS });
 			console.log("✓");
 		} catch (error) {
-			console.log("✗");
 			const stderr = error instanceof Error && "stderr" in error ? String(error.stderr ?? "").trim() : "";
+			if (
+				operation.action === "install" &&
+				(stderr.includes("already installed") || stderr.includes("already exists"))
+			) {
+				console.log("✓ (already installed)");
+				continue;
+			}
+			console.log("✗");
 			if (stderr) {
 				console.error(`    ${stderr.split("\n")[0]}`);
 			}
@@ -536,7 +654,7 @@ function updatePiSources(pi: string, desiredSources: ReadonlyMap<string, string>
 	}
 
 	if (failures > 0) {
-		throw new Error(`${failures} package(s) failed to update`);
+		throw new Error(`${failures} package(s) failed to sync`);
 	}
 }
 
@@ -555,20 +673,23 @@ function main() {
 	}
 
 	const desiredSources = buildDesiredSources(options);
-	const nextEntries = rewriteManagedPackageSources(currentEntries, desiredSources, resolvePackageName);
+	const localManifests = options.mode === "local" ? resolveWorkspacePackageManifests(options.repoPath, SWITCHER_PACKAGES) : undefined;
+	const nextEntries = rewriteManagedPackageSources(currentEntries, desiredSources, resolvePackageName, {
+		manifests: localManifests,
+	});
 	const changes = describeChanges(currentSources, desiredSources);
 	printChangeSummary(options.mode, changes, settingsPath, options.repoPath, options.piLocal);
 
 	const nextSettings: SettingsFile = { ...settings, packages: nextEntries };
 	if (options.dryRun) {
-		console.log("\nDry run only — settings were not written and pi update was not run.");
+		console.log("\nDry run only — settings were not written and pi install/update was not run.");
 		console.log("When you apply this switch, fully restart pi; /reload can keep old package modules alive.");
 		return;
 	}
 
 	writeSettings(settingsPath, nextSettings);
 	const pi = findPi();
-	updatePiSources(pi, desiredSources);
+	updatePiSources(pi, currentSources, desiredSources);
 	console.log("\n✅ Done. Fully restart pi to reload the switched packages.");
 	console.log("⚠️  Avoid /reload after switching sources; it can keep previously loaded package modules alive.");
 }

--- a/scripts/pi-source-switch.test.ts
+++ b/scripts/pi-source-switch.test.ts
@@ -5,9 +5,12 @@ import { afterEach, describe, expect, it } from "vitest";
 import {
 	buildPiExecutableCandidates,
 	dedupeManagedPackageEntries,
+	mergeManagedPackageManifest,
 	parseNpmPackageName,
+	planPackageSyncOperations,
 	resolveManagedPackageNameFromSource,
 	resolvePiCommand,
+	resolveWorkspacePackageManifests,
 	resolveWorkspacePackageSources,
 	rewriteManagedPackageSources,
 } from "./pi-source-switch.mts";
@@ -39,6 +42,7 @@ describe("pi source switcher helpers", () => {
 			new Map([
 				["@ifi/oh-pi-extensions", "/repo/packages/extensions"],
 				["@ifi/oh-pi-themes", "/repo/packages/themes"],
+				["@ifi/pi-provider-catalog", "/repo/packages/providers"],
 				["@ifi/pi-provider-cursor", "/repo/packages/cursor"],
 			]),
 			(source) => parseNpmPackageName(source),
@@ -48,6 +52,7 @@ describe("pi source switcher helpers", () => {
 			"npm:@ifi/oh-pi",
 			{ source: "/repo/packages/extensions", extensions: ["-extensions/safe-guard.ts"] },
 			"/repo/packages/themes",
+			"/repo/packages/providers",
 			"/repo/packages/cursor",
 		]);
 	});
@@ -94,6 +99,63 @@ describe("pi source switcher helpers", () => {
 		const sources = resolveWorkspacePackageSources(repoDir, ["@ifi/oh-pi-extensions", "@ifi/oh-pi-themes"]);
 		expect(sources.get("@ifi/oh-pi-extensions")).toBe(path.join(repoDir, "packages", "extensions"));
 		expect(sources.get("@ifi/oh-pi-themes")).toBe(path.join(repoDir, "packages", "themes"));
+	});
+
+	it("merges local package manifests into object settings so new extensions are not missed", () => {
+		expect(
+			mergeManagedPackageManifest(
+				{ source: "/repo/packages/extensions", extensions: ["extensions/existing.ts", "-extensions/safe-guard.ts"] },
+				{ extensions: ["extensions/existing.ts", "extensions/worktree.ts"] },
+			),
+		).toEqual({
+			source: "/repo/packages/extensions",
+			extensions: ["extensions/existing.ts", "extensions/worktree.ts", "-extensions/safe-guard.ts"],
+		});
+	});
+
+	it("keeps explicit empty arrays when merging local package manifests", () => {
+		expect(
+			mergeManagedPackageManifest(
+				{ source: "/repo/packages/extensions", extensions: [] },
+				{ extensions: ["extensions/worktree.ts"] },
+			),
+		).toEqual({ source: "/repo/packages/extensions", extensions: [] });
+	});
+
+	it("reads workspace pi manifests for managed packages", () => {
+		const repoDir = mkdtempSync(path.join(tmpdir(), "oh-pi-switcher-manifest-"));
+		tempDirs.push(repoDir);
+		const packageDir = path.join(repoDir, "packages", "extensions");
+		mkdirSync(packageDir, { recursive: true });
+		writeFileSync(
+			path.join(packageDir, "package.json"),
+			JSON.stringify({
+				name: "@ifi/oh-pi-extensions",
+				pi: { extensions: ["./extensions/custom-footer.ts", "./extensions/worktree.ts"] },
+			}),
+		);
+
+		const manifests = resolveWorkspacePackageManifests(repoDir, ["@ifi/oh-pi-extensions"]);
+		expect(manifests.get("@ifi/oh-pi-extensions")).toEqual({
+			extensions: ["extensions/custom-footer.ts", "extensions/worktree.ts"],
+		});
+	});
+
+	it("installs newly added managed packages while updating existing ones", () => {
+		const operations = planPackageSyncOperations(
+			new Map([["@ifi/oh-pi-extensions", "npm:@ifi/oh-pi-extensions"]]),
+			new Map([
+				["@ifi/oh-pi-extensions", "/repo/packages/extensions"],
+				["@ifi/pi-provider-catalog", "/repo/packages/providers"],
+			]),
+		);
+
+		expect(operations).toEqual(
+			expect.arrayContaining([
+				{ packageName: "@ifi/oh-pi-extensions", source: "/repo/packages/extensions", action: "update" },
+				{ packageName: "@ifi/pi-provider-catalog", source: "/repo/packages/providers", action: "install" },
+			]),
+		);
 	});
 
 	it("resolves local path sources back to workspace package names", () => {


### PR DESCRIPTION
## Summary
- add `@ifi/pi-provider-catalog` to the packages managed by `pi:switch`
- install newly added managed packages during source switching instead of only updating existing ones
- refresh local package manifests when switching to local sources so new entries like `worktree` are picked up

## Testing
- `pnpm lint`
- `PATH=/Users/ifiokjr/Developer/projects/aipi/oh-pi/node_modules/.bin:$PATH NODE_PATH=/Users/ifiokjr/Developer/projects/aipi/oh-pi/node_modules vitest run scripts/pi-source-switch.test.ts`
- `PATH=/usr/bin:/bin /Users/ifiokjr/Library/pnpm/node --experimental-strip-types ./scripts/pi-source-switch.mts local --dry-run | rg '@ifi/pi-provider-catalog|Dry run|Switching oh-pi packages'