### PR TITLE
fix(ollama): stabilize cloud model startup and streaming

### DIFF
--- a/.changes/ollama-cloud-registry-refresh.md
+++ b/.changes/ollama-cloud-registry-refresh.md
@@ -1,0 +1,10 @@
+---
+default: patch
+---
+
+Improve Ollama Cloud startup behavior and response reliability.
+
+- register `streamSimple` for the `ollama-cloud` provider explicitly
+- refresh cloud models on `session_start` using stored OAuth credentials when present
+- update runtime cloud discovery state from credential-backed model catalogs so scoped model matching is stable
+- add smoke coverage that validates `ollama-cloud` registers a stream handler

--- a/packages/ollama/index.ts
+++ b/packages/ollama/index.ts
@@ -102,7 +102,7 @@ function registerOllamaCloudProvider(pi: ExtensionAPI): void {
 		baseUrl: getOllamaCloudRuntimeConfig().apiUrl,
 		oauth: createOllamaCloudOAuthProvider(),
 		models: toProviderModels(cloudEnvDiscoveryState.models),
-		streamSimple: streamSimpleOpenAICompletions,
+		streamSimple: streamSimpleOllamaCloud,
 	});
 }
 
@@ -363,6 +363,10 @@ async function pullLocalModel(pi: ExtensionAPI, ctx: CommandContextLike, modelId
 
 	activeLocalPulls.set(modelId, run);
 	return run;
+}
+
+function streamSimpleOllamaCloud(model: Model<any>, context: Context, options?: SimpleStreamOptions): AssistantMessageEventStream {
+	return streamSimpleOpenAICompletions(model as Model<"openai-completions">, context, options);
 }
 
 function streamSimpleOllamaLocal(model: Model<any>, context: Context, options?: SimpleStreamOptions): AssistantMessageEventStream {

--- a/packages/ollama/index.ts
+++ b/packages/ollama/index.ts
@@ -102,6 +102,7 @@ function registerOllamaCloudProvider(pi: ExtensionAPI): void {
 		baseUrl: getOllamaCloudRuntimeConfig().apiUrl,
 		oauth: createOllamaCloudOAuthProvider(),
 		models: toProviderModels(cloudEnvDiscoveryState.models),
+		streamSimple: streamSimpleOpenAICompletions,
 	});
 }
 
@@ -238,6 +239,10 @@ function registerOllamaLifecycle(pi: ExtensionAPI): void {
 		ollamaCliStatus = await getOllamaCliStatus();
 		registerOllamaLocalProvider(pi);
 
+		const credential = getStoredCloudCredentialFromContext(ctx);
+		await refreshCloudModels(pi, ctx, credential);
+		ctx.modelRegistry.refresh?.();
+
 		if (!ollamaCliStatus.available && ctx.hasUI && !missingCliWarningShown) {
 			missingCliWarningShown = true;
 			ctx.ui.notify(
@@ -300,7 +305,12 @@ async function refreshCloudModels(pi: ExtensionAPI, ctx: CommandContextLike, cre
 			? await refreshOllamaCloudCredential(credential)
 			: await refreshOllamaCloudCredentialModels(credential);
 		ctx.modelRegistry.authStorage.set(OLLAMA_CLOUD_PROVIDER, { type: "oauth", ...refreshed });
-		return getCredentialModels(refreshed);
+		cloudEnvDiscoveryState.models = getCredentialModels(refreshed);
+		cloudEnvDiscoveryState.lastRefresh = Date.now();
+		cloudEnvDiscoveryState.lastError = null;
+		registerOllamaCloudProvider(pi);
+		registerOllamaLocalProvider(pi);
+		return cloudEnvDiscoveryState.models;
 	}
 	return refreshRegisteredCloudEnvModels(pi);
 }
@@ -618,6 +628,17 @@ function formatRefreshAge(timestamp: number | null | undefined): string {
 
 function getStoredCloudCredential(ctx: { modelRegistry: { authStorage: { get: (provider: string) => unknown } } }): OllamaCloudCredentials | null {
 	const credential = ctx.modelRegistry.authStorage.get(OLLAMA_CLOUD_PROVIDER);
+	return credential && typeof credential === "object" && (credential as { type?: string }).type === "oauth"
+		? (credential as OllamaCloudCredentials)
+		: null;
+}
+
+function getStoredCloudCredentialFromContext(ctx: CommandContextLike): OllamaCloudCredentials | null {
+	const getter = ctx.modelRegistry?.authStorage?.get;
+	if (typeof getter !== "function") {
+		return null;
+	}
+	const credential = getter(OLLAMA_CLOUD_PROVIDER);
 	return credential && typeof credential === "object" && (credential as { type?: string }).type === "oauth"
 		? (credential as OllamaCloudCredentials)
 		: null;

--- a/packages/ollama/tests/smoke.test.ts
+++ b/packages/ollama/tests/smoke.test.ts
@@ -23,6 +23,7 @@ describe("ollama provider smoke tests", () => {
 		expect(harness.commands.has("ollama-cloud")).toBe(true);
 		expect(harness.providers.has("ollama")).toBe(true);
 		expect(harness.providers.has("ollama-cloud")).toBe(true);
+		expect(typeof harness.providers.get("ollama-cloud")?.streamSimple).toBe("function");
 	});
 
 	it("bootstraps the public cloud catalog without an API key", async () => {


### PR DESCRIPTION
## Summary
- explicitly attach streamSimple for `ollama-cloud` provider registration
- refresh cloud models on `session_start` from stored oauth credentials when available
- synchronize runtime cloud model state with credential catalogs to avoid stale scoped-model mismatches
- add smoke assertion that cloud provider has a stream handler

## Validation
- pnpm --filter @ifi/pi-provider-ollama run test:worktree
