### PR TITLE
fix: avoid blocking auto-update checks on startup

### DIFF
--- a/.changeset/auto-update-startup-nonblocking.md
+++ b/.changeset/auto-update-startup-nonblocking.md
@@ -1,0 +1,5 @@
+---
+default: patch
+---
+
+fix: make the auto-update extension check versions without blocking the event loop

--- a/packages/extensions/extensions/auto-update.test.ts
+++ b/packages/extensions/extensions/auto-update.test.ts
@@ -1,17 +1,90 @@
 import { describe, expect, it, vi } from "vitest";
+import { isNewer, runAutoUpdateCheck } from "./auto-update.js";
 
-vi.mock("@mariozechner/pi-coding-agent", () => ({
-	getAgentDir: () => "/mock-home/.pi/agent",
-}));
+describe("auto-update helpers", () => {
+	it("compares versions correctly", () => {
+		expect(isNewer("1.2.0", "1.1.9")).toBe(true);
+		expect(isNewer("1.1.9", "1.2.0")).toBe(false);
+		expect(isNewer("1.0.0", "1.0.0")).toBe(false);
+	});
 
-import { isNewer } from "./auto-update";
+	it("skips checks when the stamp is still fresh", async () => {
+		const getCurrentVersion = vi.fn(async () => "1.0.0");
+		const getLatestVersion = vi.fn(async () => "1.1.0");
+		const writeStamp = vi.fn();
 
-describe("isNewer", () => {
-	it("patch newer", () => expect(isNewer("1.0.1", "1.0.0")).toBe(true));
-	it("minor newer", () => expect(isNewer("1.1.0", "1.0.0")).toBe(true));
-	it("major newer", () => expect(isNewer("2.0.0", "1.9.9")).toBe(true));
-	it("equal", () => expect(isNewer("1.0.0", "1.0.0")).toBe(false));
-	it("older", () => expect(isNewer("1.0.0", "1.0.1")).toBe(false));
-	it("0.1.70 > 0.1.69", () => expect(isNewer("0.1.70", "0.1.69")).toBe(true));
-	it("0.1.69 < 0.1.70", () => expect(isNewer("0.1.69", "0.1.70")).toBe(false));
+		const result = await runAutoUpdateCheck({
+			now: () => 1_000,
+			readStamp: () => 900,
+			writeStamp,
+			getCurrentVersion,
+			getLatestVersion,
+		});
+
+		expect(result).toBeNull();
+		expect(writeStamp).not.toHaveBeenCalled();
+		expect(getCurrentVersion).not.toHaveBeenCalled();
+		expect(getLatestVersion).not.toHaveBeenCalled();
+	});
+
+	it("notifies when a newer version is available", async () => {
+		const notify = vi.fn();
+		const writeStamp = vi.fn();
+
+		const result = await runAutoUpdateCheck({
+			now: () => 24 * 60 * 60 * 1000 + 1,
+			readStamp: () => 0,
+			writeStamp,
+			getCurrentVersion: async () => "0.4.4",
+			getLatestVersion: async () => "0.4.5",
+			notify,
+		});
+
+		expect(result).toContain("0.4.5 available");
+		expect(writeStamp).toHaveBeenCalledTimes(1);
+		expect(notify).toHaveBeenCalledWith(expect.stringContaining("0.4.5 available"));
+	});
+
+	it("does not notify when the installed version is current", async () => {
+		const notify = vi.fn();
+
+		const result = await runAutoUpdateCheck({
+			now: () => 24 * 60 * 60 * 1000 + 1,
+			readStamp: () => 0,
+			writeStamp: vi.fn(),
+			getCurrentVersion: async () => "0.4.5",
+			getLatestVersion: async () => "0.4.5",
+			notify,
+		});
+
+		expect(result).toBeNull();
+		expect(notify).not.toHaveBeenCalled();
+	});
+
+	it("awaits async version lookups without blocking the call site contract", async () => {
+		const sequence: string[] = [];
+
+		const result = await runAutoUpdateCheck({
+			now: () => 24 * 60 * 60 * 1000 + 1,
+			readStamp: () => 0,
+			writeStamp: () => {
+				sequence.push("write-stamp");
+			},
+			getCurrentVersion: async () => {
+				sequence.push("current:start");
+				await Promise.resolve();
+				sequence.push("current:end");
+				return "0.4.4";
+			},
+			getLatestVersion: async () => {
+				sequence.push("latest:start");
+				await Promise.resolve();
+				sequence.push("latest:end");
+				return "0.4.5";
+			},
+		});
+
+		expect(result).toContain("0.4.5 available");
+		expect(sequence).toEqual(["write-stamp", "current:start", "latest:start", "current:end", "latest:end"]);
+	});
 });

--- a/packages/extensions/extensions/auto-update.ts
+++ b/packages/extensions/extensions/auto-update.ts
@@ -5,17 +5,29 @@
  * If a newer version is found, shows a toast notification with upgrade instructions.
  * The check runs in a `setTimeout` to avoid blocking session startup.
  */
-import { execSync } from "node:child_process";
+import { execFile } from "node:child_process";
 import { existsSync, readFileSync, writeFileSync } from "node:fs";
 import { dirname, join } from "node:path";
+import process from "node:process";
 import { fileURLToPath } from "node:url";
 import { type ExtensionAPI, getAgentDir } from "@mariozechner/pi-coding-agent";
+
+const IS_WINDOWS = process.platform === "win32";
 
 /** Minimum interval between version checks (24 hours). */
 const CHECK_INTERVAL = 24 * 60 * 60 * 1000;
 
 /** Stamp file path — stores the timestamp of the last version check. */
 const STAMP_FILE = join(getAgentDir(), ".update-check");
+
+export type AutoUpdateCheckDependencies = {
+	readStamp?: () => number;
+	writeStamp?: () => void;
+	getCurrentVersion?: () => Promise<string | null> | string | null;
+	getLatestVersion?: () => Promise<string | null> | string | null;
+	now?: () => number;
+	notify?: (message: string) => void;
+};
 
 /** Read the last-check timestamp from the stamp file. Returns 0 if missing or unreadable. */
 function readStamp(): number {
@@ -36,32 +48,56 @@ function writeStamp(): void {
 	}
 }
 
+function execFileText(command: string, args: string[], timeout = 8_000): Promise<string | null> {
+	return new Promise((resolve) => {
+		execFile(command, args, { encoding: "utf8", timeout, shell: IS_WINDOWS }, (error, stdout) => {
+			if (error) {
+				resolve(null);
+				return;
+			}
+
+			const text = stdout.trim();
+			resolve(text || null);
+		});
+	});
+}
+
 /** Query the npm registry for the latest published version of oh-pi. */
-function getLatestVersion(): string | null {
-	try {
-		return execSync("npm view oh-pi version", { encoding: "utf8", timeout: 8000 }).trim();
-	} catch {
-		return null;
-	}
+async function getLatestVersion(): Promise<string | null> {
+	return execFileText("npm", ["view", "oh-pi", "version"]);
 }
 
 /**
  * Determine the currently installed oh-pi version.
  * Tries reading the local package.json first, falls back to `npm list -g`.
  */
-function getCurrentVersion(): string | null {
+async function getCurrentVersion(): Promise<string | null> {
 	try {
 		const currentDir = dirname(fileURLToPath(import.meta.url));
 		const pkgPath = join(currentDir, "..", "..", "package.json");
 		if (existsSync(pkgPath)) {
-			return JSON.parse(readFileSync(pkgPath, "utf8")).version;
+			const pkg = JSON.parse(readFileSync(pkgPath, "utf8")) as { version?: unknown };
+			return typeof pkg.version === "string" ? pkg.version : null;
 		}
 	} catch {
 		// package.json not found at expected location
 	}
+
+	const output = await execFileText("npm", ["list", "-g", "oh-pi", "--json", "--depth=0"]);
+	if (!output) {
+		return null;
+	}
+
 	try {
-		const out = JSON.parse(execSync("npm list -g oh-pi --json --depth=0", { encoding: "utf8", timeout: 8000 }));
-		return out.dependencies?.["oh-pi"]?.version ?? null;
+		const parsed = JSON.parse(output) as {
+			dependencies?: {
+				"oh-pi"?: {
+					version?: unknown;
+				};
+			};
+		};
+		const version = parsed.dependencies?.["oh-pi"]?.version;
+		return typeof version === "string" ? version : null;
 	} catch {
 		return null;
 	}
@@ -91,6 +127,29 @@ export function isNewer(latest: string, current: string): boolean {
 	return false;
 }
 
+export async function runAutoUpdateCheck(deps: AutoUpdateCheckDependencies = {}): Promise<string | null> {
+	const now = deps.now ?? Date.now;
+	const read = deps.readStamp ?? readStamp;
+	const write = deps.writeStamp ?? writeStamp;
+	const resolveCurrentVersion = deps.getCurrentVersion ?? getCurrentVersion;
+	const resolveLatestVersion = deps.getLatestVersion ?? getLatestVersion;
+
+	if (now() - read() < CHECK_INTERVAL) {
+		return null;
+	}
+
+	write();
+
+	const [current, latest] = await Promise.all([resolveCurrentVersion(), resolveLatestVersion()]);
+	if (!(current && latest && isNewer(latest, current))) {
+		return null;
+	}
+
+	const message = `oh-pi ${latest} available (current: ${current}). Run: npx @ifi/oh-pi@latest`;
+	deps.notify?.(message);
+	return message;
+}
+
 /**
  * Extension entry point — registers a `session_start` hook that performs a
  * deferred, non-blocking version check and notifies the user if an update is available.
@@ -99,25 +158,11 @@ export default function (pi: ExtensionAPI) {
 	pi.on("session_start", (_event, ctx) => {
 		// Non-blocking: run check in background after a short delay
 		setTimeout(() => {
-			try {
-				if (Date.now() - readStamp() < CHECK_INTERVAL) {
-					return;
-				}
-				writeStamp();
-
-				const current = getCurrentVersion();
-				const latest = getLatestVersion();
-				if (!(current && latest && isNewer(latest, current))) {
-					return;
-				}
-
-				const msg = `oh-pi ${latest} available (current: ${current}). Run: npx @ifi/oh-pi@latest`;
-				if (ctx.hasUI) {
-					ctx.ui.notify(msg, "info");
-				}
-			} catch {
+			runAutoUpdateCheck({
+				notify: ctx.hasUI ? (message) => ctx.ui.notify(message, "info") : undefined,
+			}).catch(() => {
 				// Version check is best-effort — never crash the session
-			}
+			});
 		}, 2000);
 	});
 }


### PR DESCRIPTION
## Summary
- replace blocking `execSync` version probes with async child-process checks
- extract an async auto-update check helper so startup only schedules background work
- add focused tests for stamp gating and async version lookup behavior

## Testing
- `pnpm exec vitest run packages/extensions/extensions/auto-update.test.ts packages/extensions/extensions/smoke.test.ts`
- `pnpm lint`