### PR TITLE
fix(ollama): avoid startup crash when auth storage is unavailable

### DIFF
--- a/.changes/ollama-auth-storage-startup-guard.md
+++ b/.changes/ollama-auth-storage-startup-guard.md
@@ -1,0 +1,9 @@
+---
+default: patch
+---
+
+Prevent Ollama extension startup crashes when auth storage is not ready yet.
+
+- guard `authStorage.get` and `authStorage.set` calls with safe wrappers
+- make cloud-model refresh on `session_start` best-effort to avoid aborting extension initialization
+- add smoke coverage for `session_start` with throwing auth storage access

--- a/packages/ollama/index.ts
+++ b/packages/ollama/index.ts
@@ -239,9 +239,14 @@ function registerOllamaLifecycle(pi: ExtensionAPI): void {
 		ollamaCliStatus = await getOllamaCliStatus();
 		registerOllamaLocalProvider(pi);
 
-		const credential = getStoredCloudCredentialFromContext(ctx);
-		await refreshCloudModels(pi, ctx, credential);
-		ctx.modelRegistry.refresh?.();
+		try {
+			const credential = getStoredCloudCredentialFromContext(ctx);
+			await refreshCloudModels(pi, ctx, credential);
+			ctx.modelRegistry.refresh?.();
+		} catch {
+			// Auth storage can be unavailable during early startup depending on initialization order.
+			// Keep boot resilient and rely on manual /ollama refresh-models as fallback.
+		}
 
 		if (!ollamaCliStatus.available && ctx.hasUI && !missingCliWarningShown) {
 			missingCliWarningShown = true;
@@ -304,7 +309,7 @@ async function refreshCloudModels(pi: ExtensionAPI, ctx: CommandContextLike, cre
 		const refreshed = credential.expires <= Date.now()
 			? await refreshOllamaCloudCredential(credential)
 			: await refreshOllamaCloudCredentialModels(credential);
-		ctx.modelRegistry.authStorage.set(OLLAMA_CLOUD_PROVIDER, { type: "oauth", ...refreshed });
+		setCloudCredentialInContext(ctx, refreshed);
 		cloudEnvDiscoveryState.models = getCredentialModels(refreshed);
 		cloudEnvDiscoveryState.lastRefresh = Date.now();
 		cloudEnvDiscoveryState.lastError = null;
@@ -642,10 +647,26 @@ function getStoredCloudCredentialFromContext(ctx: CommandContextLike): OllamaClo
 	if (typeof getter !== "function") {
 		return null;
 	}
-	const credential = getter(OLLAMA_CLOUD_PROVIDER);
-	return credential && typeof credential === "object" && (credential as { type?: string }).type === "oauth"
-		? (credential as OllamaCloudCredentials)
-		: null;
+	try {
+		const credential = getter(OLLAMA_CLOUD_PROVIDER);
+		return credential && typeof credential === "object" && (credential as { type?: string }).type === "oauth"
+			? (credential as OllamaCloudCredentials)
+			: null;
+	} catch {
+		return null;
+	}
+}
+
+function setCloudCredentialInContext(ctx: CommandContextLike, credential: OllamaCloudCredentials): void {
+	const setter = ctx.modelRegistry?.authStorage?.set;
+	if (typeof setter !== "function") {
+		return;
+	}
+	try {
+		setter(OLLAMA_CLOUD_PROVIDER, { type: "oauth", ...credential });
+	} catch {
+		// Ignore auth-storage races and keep runtime usable.
+	}
 }
 
 function createOllamaProcessEnv(): NodeJS.ProcessEnv {

--- a/packages/ollama/tests/smoke.test.ts
+++ b/packages/ollama/tests/smoke.test.ts
@@ -26,6 +26,22 @@ describe("ollama provider smoke tests", () => {
 		expect(typeof harness.providers.get("ollama-cloud")?.streamSimple).toBe("function");
 	});
 
+	it("does not crash on session_start when auth storage is not ready", async () => {
+		const harness = createExtensionHarness();
+		(harness.ctx as any).modelRegistry = {
+			...(harness.ctx.modelRegistry as object),
+			authStorage: {
+				get() {
+					throw new Error("auth storage not initialized");
+				},
+				set() {},
+			},
+		};
+		ollamaProviderExtension(harness.pi as never);
+
+		await expect(harness.emitAsync("session_start", { type: "session_start" }, harness.ctx)).resolves.toBeDefined();
+	});
+
 	it("bootstraps the public cloud catalog without an API key", async () => {
 		const backend = await createTestOllamaBackend();
 		backend.setModels([


### PR DESCRIPTION
## Summary
- guard ollama cloud authStorage get/set calls so startup does not crash if storage is not initialized yet
- make cloud model refresh during session_start best-effort
- add smoke test coverage for auth storage failures during session startup

## Validation
- pnpm --filter @ifi/pi-provider-ollama run typecheck
- pnpm --filter @ifi/pi-provider-ollama run test:worktree
