### PR TITLE
fix: defer heavy usage-tracker startup work

### DIFF
--- a/.changeset/usage-tracker-startup-defer.md
+++ b/.changeset/usage-tracker-startup-defer.md
@@ -1,0 +1,5 @@
+---
+default: patch
+---
+
+fix: defer expensive usage-tracker startup refresh work for large sessions

--- a/packages/extensions/extensions/usage-tracker.test.ts
+++ b/packages/extensions/extensions/usage-tracker.test.ts
@@ -484,6 +484,37 @@ describe("usage-tracker extension", () => {
 			expect(result.content[0].text).toContain("1.2k in"); // 500 + 700
 		});
 
+		it("defers startup hydration for large sessions so the widget can mount first", async () => {
+			const entries = Array.from({ length: 300 }, () =>
+				makeSessionEntry(makeAssistantMessage({ input: 10, output: 5, costTotal: 0.001 })),
+			);
+			ctx = createMockCtx(entries);
+			usageTracker(pi as any);
+			pi._emit("session_start", { type: "session_start" }, ctx);
+
+			const widgetFactory = ctx._widgets.get("usage-tracker") as
+				| ((
+						tui: { requestRender: () => void },
+						theme: { fg: (_color: string, text: string) => string },
+				  ) => { render: (width: number) => string[] })
+				| undefined;
+			expect(widgetFactory).toBeTypeOf("function");
+
+			const beforeStartupRefresh = widgetFactory?.(
+				{ requestRender: vi.fn() },
+				{ fg: (_color: string, text: string) => text },
+			).render(120);
+			expect(beforeStartupRefresh).toEqual([]);
+
+			await vi.advanceTimersByTimeAsync(500);
+
+			const afterStartupRefresh = widgetFactory?.(
+				{ requestRender: vi.fn() },
+				{ fg: (_color: string, text: string) => text },
+			).render(120);
+			expect(afterStartupRefresh?.join("\n")).toContain("$0.30");
+		});
+
 		it("resets state on session_switch", async () => {
 			usageTracker(pi as any);
 			pi._emit("session_start", { type: "session_start" }, ctx);
@@ -1508,9 +1539,10 @@ describe("usage-tracker extension", () => {
 	});
 
 	describe("keybinding auto-configuration", () => {
-		it("writes keybindings.json to unbind deleteToLineStart when file does not exist", () => {
+		it("writes keybindings.json to unbind deleteToLineStart when file does not exist", async () => {
 			(existsSync as ReturnType<typeof vi.fn>).mockReturnValue(false);
 			usageTracker(pi as any);
+			await vi.advanceTimersByTimeAsync(500);
 
 			expect(writeFileSync).toHaveBeenCalledWith(
 				expect.stringContaining("keybindings.json"),
@@ -1519,11 +1551,12 @@ describe("usage-tracker extension", () => {
 			);
 		});
 
-		it("writes keybindings.json when file exists but deleteToLineStart is not configured", () => {
+		it("writes keybindings.json when file exists but deleteToLineStart is not configured", async () => {
 			(existsSync as ReturnType<typeof vi.fn>).mockReturnValue(true);
 			(readFileSync as ReturnType<typeof vi.fn>).mockReturnValue('{"cursorUp": ["up"]}');
 
 			usageTracker(pi as any);
+			await vi.advanceTimersByTimeAsync(500);
 
 			expect(writeFileSync).toHaveBeenCalledWith(
 				expect.stringContaining("keybindings.json"),
@@ -1532,12 +1565,13 @@ describe("usage-tracker extension", () => {
 			);
 		});
 
-		it("does not overwrite keybindings.json when deleteToLineStart is configured without ctrl+u", () => {
+		it("does not overwrite keybindings.json when deleteToLineStart is configured without ctrl+u", async () => {
 			(existsSync as ReturnType<typeof vi.fn>).mockReturnValue(true);
 			(readFileSync as ReturnType<typeof vi.fn>).mockReturnValue('{"deleteToLineStart": ["ctrl+shift+u"]}');
 
 			(writeFileSync as ReturnType<typeof vi.fn>).mockClear();
 			usageTracker(pi as any);
+			await vi.advanceTimersByTimeAsync(500);
 
 			// writeFileSync should not be called for keybindings (may be called for other things)
 			const keybindingWrites = (writeFileSync as ReturnType<typeof vi.fn>).mock.calls.filter(
@@ -1546,13 +1580,14 @@ describe("usage-tracker extension", () => {
 			expect(keybindingWrites).toHaveLength(0);
 		});
 
-		it("removes ctrl+u from existing deleteToLineStart bindings", () => {
+		it("removes ctrl+u from existing deleteToLineStart bindings", async () => {
 			(existsSync as ReturnType<typeof vi.fn>).mockReturnValue(true);
 			(readFileSync as ReturnType<typeof vi.fn>).mockReturnValue(
 				'{"deleteToLineStart": ["ctrl+u", "ctrl+shift+u"], "cursorUp": ["up"]}',
 			);
 
 			usageTracker(pi as any);
+			await vi.advanceTimersByTimeAsync(500);
 
 			const writeCalls = (writeFileSync as ReturnType<typeof vi.fn>).mock.calls.filter(
 				(c: unknown[]) => typeof c[0] === "string" && (c[0] as string).includes("keybindings.json"),
@@ -1563,11 +1598,12 @@ describe("usage-tracker extension", () => {
 			expect(written.cursorUp).toEqual(["up"]);
 		});
 
-		it("preserves existing keybindings when adding deleteToLineStart", () => {
+		it("preserves existing keybindings when adding deleteToLineStart", async () => {
 			(existsSync as ReturnType<typeof vi.fn>).mockReturnValue(true);
 			(readFileSync as ReturnType<typeof vi.fn>).mockReturnValue('{"cursorUp": ["up", "ctrl+p"]}');
 
 			usageTracker(pi as any);
+			await vi.advanceTimersByTimeAsync(500);
 
 			const writeCalls = (writeFileSync as ReturnType<typeof vi.fn>).mock.calls.filter(
 				(c: unknown[]) => typeof c[0] === "string" && (c[0] as string).includes("keybindings.json"),

--- a/packages/extensions/extensions/usage-tracker.ts
+++ b/packages/extensions/extensions/usage-tracker.ts
@@ -78,6 +78,10 @@ import {
 
 // ─── Extension entry point ──────────────────────────────────────────────────
 
+const KEYBINDINGS_SYNC_DELAY_MS = 250;
+const STARTUP_REFRESH_DELAY_MS = 250;
+const STARTUP_DEFER_ENTRY_THRESHOLD = 250;
+
 /**
  * Ensure `ctrl+u` is unbound from the built-in `deleteToLineStart` action
  * so the usage-tracker shortcut takes priority without a conflict warning.
@@ -143,8 +147,23 @@ function getRateLimitCachePath(): string {
 }
 
 export default function usageTracker(pi: ExtensionAPI) {
-	// Unbind ctrl+u from deleteToLineStart so our shortcut wins cleanly
-	ensureCtrlUUnbound();
+	let keybindingsSyncScheduled = false;
+	let startupRefreshTimer: ReturnType<typeof setTimeout> | null = null;
+
+	const scheduleCtrlUUnbound = () => {
+		if (keybindingsSyncScheduled) {
+			return;
+		}
+
+		keybindingsSyncScheduled = true;
+		setTimeout(() => {
+			keybindingsSyncScheduled = false;
+			ensureCtrlUUnbound();
+		}, KEYBINDINGS_SYNC_DELAY_MS);
+	};
+
+	// Unbind ctrl+u from deleteToLineStart without doing sync fs work on extension load.
+	scheduleCtrlUUnbound();
 
 	/** Per-model accumulated usage. Key = model ID. */
 	const models = new Map<string, ModelUsage>();
@@ -776,13 +795,41 @@ export default function usageTracker(pi: ExtensionAPI) {
 		sessionStart = Date.now();
 	}
 
-	function hydrateFromSession(ctx: ExtensionContext): void {
+	function hydrateFromSessionEntries(entries: ReturnType<ExtensionContext["sessionManager"]["getBranch"]>): void {
 		reset();
-		for (const entry of ctx.sessionManager.getBranch()) {
+		for (const entry of entries) {
 			if (entry.type === "message" && entry.message.role === "assistant") {
 				recordUsage(entry.message as AssistantMessage, { persist: false });
 			}
 		}
+	}
+
+	function clearStartupRefreshTimer(): void {
+		if (!startupRefreshTimer) {
+			return;
+		}
+		clearTimeout(startupRefreshTimer);
+		startupRefreshTimer = null;
+	}
+
+	function refreshStartupState(ctx: ExtensionContext): void {
+		clearStartupRefreshTimer();
+		const entries = ctx.sessionManager.getBranch();
+		const refresh = () => {
+			hydrateFromSessionEntries(entries);
+			triggerProbe(ctx);
+			broadcastUsageData();
+		};
+
+		if (entries.length < STARTUP_DEFER_ENTRY_THRESHOLD) {
+			refresh();
+			return;
+		}
+
+		startupRefreshTimer = setTimeout(() => {
+			startupRefreshTimer = null;
+			refresh();
+		}, STARTUP_REFRESH_DELAY_MS);
 	}
 
 	// ─── Rate limit probing ───────────────────────────────────────────────
@@ -1431,8 +1478,7 @@ export default function usageTracker(pi: ExtensionAPI) {
 
 	pi.on("session_start", (_event, ctx) => {
 		activeCtx = ctx;
-		hydrateFromSession(ctx);
-		triggerProbe(ctx);
+		refreshStartupState(ctx);
 
 		ctx.ui.setWidget("usage-tracker", (tui, theme) => {
 			const unsubSafeMode = subscribeSafeMode(() => tui.requestRender());
@@ -1453,8 +1499,7 @@ export default function usageTracker(pi: ExtensionAPI) {
 
 	pi.on("session_switch", (_event, ctx) => {
 		activeCtx = ctx;
-		hydrateFromSession(ctx);
-		triggerProbe(ctx);
+		refreshStartupState(ctx);
 	});
 
 	pi.on("turn_end", (event, ctx) => {
@@ -1470,6 +1515,10 @@ export default function usageTracker(pi: ExtensionAPI) {
 	pi.on("model_select", (_event, ctx) => {
 		activeCtx = ctx;
 		triggerProbe(ctx); // Probe the new provider
+	});
+
+	pi.on("session_shutdown", () => {
+		clearStartupRefreshTimer();
 	});
 
 	// ─── /usage command ───────────────────────────────────────────────────


### PR DESCRIPTION
## Summary
- defer usage-tracker startup hydration and probing for large sessions so the widget can mount first
- schedule the ctrl+u keybinding cleanup instead of doing sync fs work during extension load
- add tests covering deferred startup refresh and delayed keybinding writes

## Testing
- `pnpm exec vitest run packages/extensions/extensions/usage-tracker.test.ts packages/extensions/extensions/smoke.test.ts`
- `pnpm lint`