### PR TITLE
fix: defer worktree status refresh on startup

### DIFF
--- a/.changeset/worktree-status-startup-defer.md
+++ b/.changeset/worktree-status-startup-defer.md
@@ -1,0 +1,5 @@
+---
+default: patch
+---
+
+fix: defer worktree status refresh on session startup

--- a/packages/extensions/extensions/worktree.test.ts
+++ b/packages/extensions/extensions/worktree.test.ts
@@ -64,6 +64,25 @@ describe("worktree extension", () => {
 		expect(harness.commands.has("wt")).toBe(true);
 	});
 
+	it("defers status refresh on session start so startup avoids immediate git work", async () => {
+		vi.useFakeTimers();
+		try {
+			const harness = createExtensionHarness();
+			harness.ctx.cwd = "/repo";
+			worktreeShared.getRepoWorktreeSnapshot.mockReturnValue(makeSnapshot());
+
+			worktreeExtension(harness.pi as never);
+			harness.emit("session_start", {}, harness.ctx);
+			expect(worktreeShared.getRepoWorktreeSnapshot).not.toHaveBeenCalled();
+
+			await vi.advanceTimersByTimeAsync(500);
+			expect(worktreeShared.getRepoWorktreeSnapshot).toHaveBeenCalledWith("/repo");
+			expect(harness.statusMap.get("pi-worktree")).toContain("main checkout");
+		} finally {
+			vi.useRealTimers();
+		}
+	});
+
 	it("creates a pi-owned worktree and reports owner + purpose metadata", async () => {
 		const harness = createExtensionHarness();
 		harness.ctx.cwd = "/repo";

--- a/packages/extensions/extensions/worktree.ts
+++ b/packages/extensions/extensions/worktree.ts
@@ -17,6 +17,7 @@ import {
 
 const COMMAND = "worktree";
 const COMMAND_ALIASES = [COMMAND, "Worktree", "wt"] as const;
+const WORKTREE_STATUS_REFRESH_DELAY_MS = 250;
 const instanceId = buildPaiInstanceId();
 
 function relativeDisplayPath(root: string, target: string): string {
@@ -514,12 +515,40 @@ function buildCommandSpec(pi: ExtensionAPI) {
 }
 
 export default function worktreeExtension(pi: ExtensionAPI) {
+	let refreshTimer: ReturnType<typeof setTimeout> | null = null;
+
+	const scheduleStatusRefresh = (ctx: ExtensionContext, delayMs = WORKTREE_STATUS_REFRESH_DELAY_MS) => {
+		if (refreshTimer) {
+			clearTimeout(refreshTimer);
+		}
+
+		refreshTimer = setTimeout(
+			() => {
+				refreshTimer = null;
+				refreshStatus(ctx);
+			},
+			Math.max(0, delayMs),
+		);
+	};
+
+	const clearStatusRefresh = () => {
+		if (!refreshTimer) {
+			return;
+		}
+		clearTimeout(refreshTimer);
+		refreshTimer = null;
+	};
+
 	pi.on("session_start", (_event, ctx) => {
-		refreshStatus(ctx);
+		scheduleStatusRefresh(ctx);
 	});
 
 	pi.on("session_switch", (_event, ctx) => {
-		refreshStatus(ctx);
+		scheduleStatusRefresh(ctx);
+	});
+
+	pi.on("session_shutdown", () => {
+		clearStatusRefresh();
 	});
 
 	const spec = buildCommandSpec(pi);


### PR DESCRIPTION
## Summary
- defer the worktree status-bar refresh on session start and session switch
- keep direct worktree commands synchronous while moving non-critical startup status work off the hot path
- add a test that verifies startup does not query worktree state immediately

## Testing
- `pnpm exec vitest run packages/extensions/extensions/worktree.test.ts packages/extensions/extensions/smoke.test.ts`
- `pnpm lint`
- `pnpm typecheck`