### PR TITLE
fix: defer git-guard dirty repo checks on startup

### DIFF
--- a/.changeset/git-guard-startup-defer.md
+++ b/.changeset/git-guard-startup-defer.md
@@ -1,0 +1,5 @@
+---
+default: patch
+---
+
+fix: defer git-guard dirty-repo startup checks

--- a/packages/extensions/extensions/git-guard.test.ts
+++ b/packages/extensions/extensions/git-guard.test.ts
@@ -1,5 +1,6 @@
-import { describe, expect, it } from "vitest";
-import { detectInteractiveGitCommand, INTERACTIVE_GIT_WARNING_PREFIX } from "./git-guard.js";
+import { describe, expect, it, vi } from "vitest";
+import { createExtensionHarness } from "../../../test-utils/extension-runtime-harness.js";
+import gitGuardExtension, { detectInteractiveGitCommand, INTERACTIVE_GIT_WARNING_PREFIX } from "./git-guard.js";
 
 describe("detectInteractiveGitCommand", () => {
 	it("detects git rebase --continue without non-interactive editor overrides", () => {
@@ -42,5 +43,25 @@ describe("detectInteractiveGitCommand", () => {
 describe("INTERACTIVE_GIT_WARNING_PREFIX", () => {
 	it("stays stable for user-facing block messages", () => {
 		expect(INTERACTIVE_GIT_WARNING_PREFIX).toBe("Interactive git command blocked");
+	});
+});
+
+describe("git-guard extension", () => {
+	it("defers dirty-repo startup checks until after the initial startup window", async () => {
+		vi.useFakeTimers();
+		try {
+			const harness = createExtensionHarness();
+			harness.pi.exec = vi.fn(async () => ({ stdout: " M README.md\n?? notes.txt\n", exitCode: 0 }));
+
+			gitGuardExtension(harness.pi as never);
+			harness.emit("session_start", {}, harness.ctx);
+
+			expect(harness.pi.exec).not.toHaveBeenCalled();
+			await vi.advanceTimersByTimeAsync(500);
+			expect(harness.pi.exec).toHaveBeenCalledWith("git", ["status", "--porcelain"]);
+			expect(harness.notifications.at(-1)?.msg).toContain("Dirty repo: 2 uncommitted change(s)");
+		} finally {
+			vi.useRealTimers();
+		}
 	});
 });

--- a/packages/extensions/extensions/git-guard.ts
+++ b/packages/extensions/extensions/git-guard.ts
@@ -9,9 +9,10 @@
  *
  * Supports Kitty (OSC 99) and generic terminal (OSC 777) notification protocols.
  */
-import type { ExtensionAPI } from "@mariozechner/pi-coding-agent";
+import type { ExtensionAPI, ExtensionContext } from "@mariozechner/pi-coding-agent";
 
 export const INTERACTIVE_GIT_WARNING_PREFIX = "Interactive git command blocked";
+const DIRTY_REPO_CHECK_DELAY_MS = 250;
 
 interface InteractiveGitDetection {
 	reason: string;
@@ -130,6 +131,26 @@ function terminalNotify(title: string, body: string): void {
 export default function (pi: ExtensionAPI) {
 	/** Counts the number of agent turns for the checkpoint label. */
 	let turnCount = 0;
+	let dirtyRepoTimer: ReturnType<typeof setTimeout> | null = null;
+
+	const scheduleDirtyRepoCheck = (ctx: ExtensionContext) => {
+		if (dirtyRepoTimer) {
+			clearTimeout(dirtyRepoTimer);
+		}
+
+		dirtyRepoTimer = setTimeout(async () => {
+			dirtyRepoTimer = null;
+			try {
+				const { stdout } = await pi.exec("git", ["status", "--porcelain"]);
+				if (stdout.trim() && ctx.hasUI) {
+					const lines = stdout.trim().split("\n").length;
+					ctx.ui.notify(`Dirty repo: ${lines} uncommitted change(s)`, "warning");
+				}
+			} catch {
+				// Not a git repo — nothing to warn about
+			}
+		}, DIRTY_REPO_CHECK_DELAY_MS);
+	};
 
 	pi.on("tool_call", async (event) => {
 		if (event.toolName !== "bash") {
@@ -146,17 +167,9 @@ export default function (pi: ExtensionAPI) {
 		};
 	});
 
-	// Warn on dirty repo at session start
+	// Warn on dirty repo at session start, but defer it so startup avoids immediate git work.
 	pi.on("session_start", async (_event, ctx) => {
-		try {
-			const { stdout } = await pi.exec("git", ["status", "--porcelain"]);
-			if (stdout.trim() && ctx.hasUI) {
-				const lines = stdout.trim().split("\n").length;
-				ctx.ui.notify(`Dirty repo: ${lines} uncommitted change(s)`, "warning");
-			}
-		} catch {
-			// Not a git repo — nothing to warn about
-		}
+		scheduleDirtyRepoCheck(ctx);
 	});
 
 	// Stash checkpoint before each turn
@@ -173,5 +186,13 @@ export default function (pi: ExtensionAPI) {
 	pi.on("agent_end", () => {
 		terminalNotify("oh-pi", `Done after ${turnCount} turn(s). Ready for input.`);
 		turnCount = 0;
+	});
+
+	pi.on("session_shutdown", () => {
+		if (!dirtyRepoTimer) {
+			return;
+		}
+		clearTimeout(dirtyRepoTimer);
+		dirtyRepoTimer = null;
 	});
 }


### PR DESCRIPTION
## Summary
- defer the dirty-repo startup check so startup avoids immediate `git status --porcelain` work
- keep the warning behavior intact once the short startup delay elapses
- add a focused test for delayed dirty-repo detection

## Testing
- `pnpm exec vitest run packages/extensions/extensions/git-guard.test.ts packages/extensions/extensions/smoke.test.ts`
- `pnpm lint`
- `pnpm typecheck`