### PR TITLE
fix: defer ollama local CLI refresh on startup

### DIFF
--- a/.changeset/ollama-cli-startup-defer.md
+++ b/.changeset/ollama-cli-startup-defer.md
@@ -1,0 +1,5 @@
+---
+default: patch
+---
+
+fix: defer ollama cli detection during session startup

--- a/packages/ollama/index.ts
+++ b/packages/ollama/index.ts
@@ -81,6 +81,7 @@ const cloudEnvDiscoveryState: RuntimeDiscoveryState = {
 
 const activeLocalPulls = new Map<string, Promise<boolean>>();
 const PULL_STATUS_KEY = "ollama.pull";
+const OLLAMA_STARTUP_CLI_REFRESH_DELAY_MS = 250;
 
 let ollamaCliStatus: OllamaCliStatus | null = null;
 let missingCliWarningShown = false;
@@ -234,10 +235,48 @@ function registerOllamaCommands(pi: ExtensionAPI): void {
 	});
 }
 
-function registerOllamaLifecycle(pi: ExtensionAPI): void {
+function registerOllamaLifecycle(pi: ExtensionAPI): { scheduleLocalBootstrapRefresh: (ctx?: CommandContextLike) => void } {
+	let startupCliRefreshTimer: ReturnType<typeof setTimeout> | null = null;
+	let pendingLocalBootstrapRefresh: Promise<void> | null = null;
+	let pendingStartupContext: CommandContextLike | null = null;
+
+	const notifyMissingCli = (ctx: CommandContextLike | null) => {
+		if (!ctx?.hasUI || missingCliWarningShown || ollamaCliStatus?.available !== false) {
+			return;
+		}
+
+		missingCliWarningShown = true;
+		ctx.ui.notify(
+			"Ollama CLI not found. Only ollama-cloud models are available right now because Ollama is not installed.",
+			"warning",
+		);
+	};
+
+	const scheduleLocalBootstrapRefresh = (ctx?: CommandContextLike) => {
+		if (ctx) {
+			pendingStartupContext = ctx;
+		}
+		if (pendingLocalBootstrapRefresh || startupCliRefreshTimer) {
+			return;
+		}
+
+		startupCliRefreshTimer = setTimeout(() => {
+			startupCliRefreshTimer = null;
+			pendingLocalBootstrapRefresh = refreshRegisteredLocalModels(pi)
+				.then(() => {
+					pendingStartupContext?.modelRegistry.refresh?.();
+					notifyMissingCli(pendingStartupContext);
+				})
+				.finally(() => {
+					pendingLocalBootstrapRefresh = null;
+					pendingStartupContext = null;
+				});
+		}, OLLAMA_STARTUP_CLI_REFRESH_DELAY_MS);
+	};
+
 	pi.on("session_start", async (_event, ctx) => {
-		ollamaCliStatus = await getOllamaCliStatus();
-		registerOllamaLocalProvider(pi);
+		scheduleLocalBootstrapRefresh(ctx);
+		notifyMissingCli(ctx);
 
 		try {
 			const credential = getStoredCloudCredentialFromContext(ctx);
@@ -247,14 +286,14 @@ function registerOllamaLifecycle(pi: ExtensionAPI): void {
 			// Auth storage can be unavailable during early startup depending on initialization order.
 			// Keep boot resilient and rely on manual /ollama refresh-models as fallback.
 		}
+	});
 
-		if (!ollamaCliStatus.available && ctx.hasUI && !missingCliWarningShown) {
-			missingCliWarningShown = true;
-			ctx.ui.notify(
-				"Ollama CLI not found. Only ollama-cloud models are available right now because Ollama is not installed.",
-				"warning",
-			);
+	pi.on("session_shutdown", () => {
+		if (startupCliRefreshTimer) {
+			clearTimeout(startupCliRefreshTimer);
+			startupCliRefreshTimer = null;
 		}
+		pendingStartupContext = null;
 	});
 
 	pi.on("model_select", async (event, ctx) => {
@@ -302,6 +341,8 @@ function registerOllamaLifecycle(pi: ExtensionAPI): void {
 
 		await pullLocalModel(pi, ctx, event.model.id);
 	});
+
+	return { scheduleLocalBootstrapRefresh };
 }
 
 async function refreshCloudModels(pi: ExtensionAPI, ctx: CommandContextLike, credential: OllamaCloudCredentials | null): Promise<OllamaProviderModel[]> {
@@ -677,11 +718,11 @@ function createOllamaProcessEnv(): NodeJS.ProcessEnv {
 	return env;
 }
 
-function bootstrapOllamaProviders(pi: ExtensionAPI): void {
+function bootstrapOllamaProviders(pi: ExtensionAPI, scheduleLocalRefresh: () => void): void {
 	registerOllamaCloudProvider(pi);
 	registerOllamaLocalProvider(pi);
 	void refreshRegisteredCloudEnvModels(pi);
-	void refreshRegisteredLocalModels(pi);
+	scheduleLocalRefresh();
 }
 
 export {
@@ -696,7 +737,7 @@ export {
 export { toOllamaModel, toOllamaCloudModel, type OllamaCloudCredentials, type OllamaProviderModel } from "./models.js";
 
 export default function ollamaProviderExtension(pi: ExtensionAPI): void {
-	bootstrapOllamaProviders(pi);
+	const registerLifecycle = registerOllamaLifecycle(pi);
+	bootstrapOllamaProviders(pi, registerLifecycle.scheduleLocalBootstrapRefresh);
 	registerOllamaCommands(pi);
-	registerOllamaLifecycle(pi);
 }

--- a/packages/ollama/tests/download.test.ts
+++ b/packages/ollama/tests/download.test.ts
@@ -142,10 +142,15 @@ describe("ollama local downloads", () => {
 		const { default: ollamaProviderExtension } = await import("../index.js");
 		const harness = createExtensionHarness();
 		ollamaProviderExtension(harness.pi as never);
+		expect(execFileSyncMock).not.toHaveBeenCalled();
 
-		await harness.emitAsync("session_start", { type: "session_start" }, harness.ctx);
+		const sessionStart = harness.emitAsync("session_start", { type: "session_start" }, harness.ctx);
+		expect(execFileSyncMock).not.toHaveBeenCalled();
+		await sessionStart;
+
 		await waitFor(() => harness.notifications.some((item) => item.msg.includes("Only ollama-cloud models are available right now")));
 
+		expect(execFileSyncMock).toHaveBeenCalled();
 		expect(harness.notifications.some((item) => item.type === "warning")).toBe(true);
 		expect((harness.providers.get("ollama")?.models as Array<{ id: string }> | undefined) ?? []).toEqual([]);
 	});


### PR DESCRIPTION
## Summary
- defer local Ollama CLI/model refresh work instead of doing it immediately during provider bootstrap
- reuse the deferred refresh during session start so the missing-CLI warning still appears after startup settles
- add coverage that the deferred warning path no longer probes the CLI immediately

## Testing
- `pnpm --filter @ifi/pi-provider-ollama test:worktree`
- `pnpm lint`
- `pnpm typecheck`