### PR TITLE
fix(extensions): make adaptive routing opt-in by default

### DIFF
--- a/.changes/adaptive-routing-default-off.md
+++ b/.changes/adaptive-routing-default-off.md
@@ -1,0 +1,9 @@
+---
+default: patch
+---
+
+Make adaptive routing opt-in by default.
+
+- change the default adaptive-routing mode from `shadow` to `off`
+- add regression coverage to ensure no route suggestions are emitted without explicit config
+- document that adaptive routing is off by default in the extensions README

--- a/packages/extensions/README.md
+++ b/packages/extensions/README.md
@@ -69,7 +69,7 @@ gets a stable namespace. Each managed worktree records which pi instance/session
 
 ## Adaptive routing
 
-Adaptive routing adds a user-friendly `/route` command set and an opt-in model-agnostic mode that can:
+Adaptive routing adds a user-friendly `/route` command set and an opt-in model-agnostic mode (off by default) that can:
 
 - classify prompts with a cheap router model
 - choose model and thinking level before a turn starts

--- a/packages/extensions/extensions/adaptive-routing/adaptive-routing.test.ts
+++ b/packages/extensions/extensions/adaptive-routing/adaptive-routing.test.ts
@@ -92,6 +92,29 @@ describe("adaptive routing extension", () => {
 		vi.clearAllMocks();
 	});
 
+	it("keeps adaptive routing disabled by default when no config exists", async () => {
+		const harness = createExtensionHarness();
+		harness.ctx.model = sampleModel("google", "gemini-2.5-flash", "Gemini 2.5 Flash") as never;
+		harness.ctx.modelRegistry = {
+			getAvailable: () => [
+				sampleModel("google", "gemini-2.5-flash", "Gemini 2.5 Flash"),
+				sampleModel("anthropic", "claude-opus-4.6", "Claude Opus 4.6"),
+			],
+			getApiKey: async () => "key",
+		} as never;
+
+		adaptiveRoutingExtension(harness.pi as never);
+		await harness.emitAsync(
+			"before_agent_start",
+			{ type: "before_agent_start", prompt: "Design a better settings page UI.", systemPrompt: "system" },
+			harness.ctx,
+		);
+
+		expect(harness.ctx.model).toMatchObject({ provider: "google", id: "gemini-2.5-flash" });
+		expect(harness.notifications.some((item) => item.msg.includes("Adaptive route suggestion"))).toBe(false);
+		expect(harness.statusMap.has("adaptive-routing")).toBe(false);
+	});
+
 	it("registers route commands and auto-applies a routed premium model", async () => {
 		writeFileSync(
 			join(tempAgentDir, "extensions", "adaptive-routing", "config.json"),

--- a/packages/extensions/extensions/adaptive-routing/defaults.ts
+++ b/packages/extensions/extensions/adaptive-routing/defaults.ts
@@ -83,7 +83,7 @@ export const DEFAULT_FALLBACK_GROUPS: Record<string, FallbackGroupPolicy> = {
 };
 
 export const DEFAULT_ADAPTIVE_ROUTING_CONFIG: AdaptiveRoutingConfig = {
-	mode: "shadow",
+	mode: "off",
 	routerModels: ["google/gemini-2.5-flash", "openai/gpt-5-mini"],
 	stickyTurns: 1,
 	telemetry: {


### PR DESCRIPTION
## Summary
- change adaptive-routing default mode from `shadow` to `off`
- add regression coverage to ensure no suggestions are emitted with default config
- clarify in extensions README that adaptive routing is off by default

## Validation
- pnpm exec vitest run packages/extensions/extensions/adaptive-routing/adaptive-routing.test.ts packages/extensions/extensions/adaptive-routing/schema.test.ts
- pnpm exec biome check packages/extensions/extensions/adaptive-routing/defaults.ts packages/extensions/extensions/adaptive-routing/adaptive-routing.test.ts packages/extensions/README.md .changes/adaptive-routing-default-off.md
