### PR TITLE
fix: defer plan state refresh on startup

### DIFF
--- a/.changeset/plan-startup-defer.md
+++ b/.changeset/plan-startup-defer.md
@@ -1,0 +1,5 @@
+---
+default: patch
+---
+
+fix: defer plan state refresh on startup

--- a/packages/plan/index.ts
+++ b/packages/plan/index.ts
@@ -1,7 +1,7 @@
 import { mkdir, writeFile } from "node:fs/promises";
 import path from "node:path";
 import type { AgentToolResult } from "@mariozechner/pi-agent-core";
-import { keyHint, type ExtensionAPI } from "@mariozechner/pi-coding-agent";
+import { keyHint, type ExtensionAPI, type ExtensionContext } from "@mariozechner/pi-coding-agent";
 import { Text } from "@mariozechner/pi-tui";
 import { registerPlanModeCommand } from "./flow";
 import { resolveActivePlanFilePath } from "./plan-files";
@@ -32,6 +32,7 @@ interface PlanModeExitDetails {
 }
 
 const PLAN_MODE_EXIT_ENTRY_TYPE = "pi-plan:exit";
+const STARTUP_REFRESH_DELAY_MS = 250;
 
 export default function (pi: ExtensionAPI) {
 	const stateManager = createPlanModeStateManager(pi);
@@ -181,19 +182,41 @@ export default function (pi: ExtensionAPI) {
 		};
 	});
 
-	pi.on("session_start", async (_event, ctx) => {
+	let startupRefreshTimer: ReturnType<typeof setTimeout> | undefined;
+	const cancelStartupRefresh = () => {
+		if (!startupRefreshTimer) {
+			return;
+		}
+		clearTimeout(startupRefreshTimer);
+		startupRefreshTimer = undefined;
+	};
+	const refreshState = (ctx: ExtensionContext) => {
+		cancelStartupRefresh();
 		stateManager.refresh(ctx);
+	};
+
+	pi.on("session_start", async (_event, ctx) => {
+		cancelStartupRefresh();
+		startupRefreshTimer = setTimeout(() => {
+			startupRefreshTimer = undefined;
+			stateManager.refresh(ctx);
+		}, STARTUP_REFRESH_DELAY_MS);
+		startupRefreshTimer.unref?.();
 	});
 
 	pi.on("session_switch", async (_event, ctx) => {
-		stateManager.refresh(ctx);
+		refreshState(ctx);
 	});
 
 	pi.on("session_tree", async (_event, ctx) => {
-		stateManager.refresh(ctx);
+		refreshState(ctx);
 	});
 
 	pi.on("session_fork", async (_event, ctx) => {
-		stateManager.refresh(ctx);
+		refreshState(ctx);
+	});
+
+	pi.on("session_shutdown", async () => {
+		cancelStartupRefresh();
 	});
 }

--- a/packages/plan/tests/startup.test.ts
+++ b/packages/plan/tests/startup.test.ts
@@ -1,0 +1,63 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import { createExtensionHarness } from "../../../test-utils/extension-runtime-harness.js";
+import planExtension from "../index.js";
+
+describe("plan extension startup refresh", () => {
+	beforeEach(() => {
+		vi.useFakeTimers();
+	});
+
+	afterEach(() => {
+		vi.useRealTimers();
+	});
+
+	it("defers session_start plan refresh until after the startup window", async () => {
+		const harness = createExtensionHarness();
+		harness.ctx.ui.setWidget = vi.fn();
+		harness.ctx.sessionManager.getEntries = () => [
+			{
+				type: "custom",
+				customType: "pi-plan:state",
+				data: {
+					version: 1,
+					active: true,
+					planFilePath: "/tmp/session.plan.md",
+				},
+			},
+		];
+
+		planExtension(harness.pi as never);
+		harness.emit("session_start", { type: "session_start" }, harness.ctx);
+		expect(harness.ctx.ui.setWidget).not.toHaveBeenCalled();
+
+		await vi.advanceTimersByTimeAsync(250);
+		expect(harness.ctx.ui.setWidget).toHaveBeenCalledWith(
+			"pi-plan-banner",
+			expect.any(Function),
+			expect.objectContaining({ placement: "aboveEditor" }),
+		);
+	});
+
+	it("cancels deferred session_start refresh on session_shutdown", async () => {
+		const harness = createExtensionHarness();
+		harness.ctx.ui.setWidget = vi.fn();
+		harness.ctx.sessionManager.getEntries = () => [
+			{
+				type: "custom",
+				customType: "pi-plan:state",
+				data: {
+					version: 1,
+					active: true,
+					planFilePath: "/tmp/session.plan.md",
+				},
+			},
+		];
+
+		planExtension(harness.pi as never);
+		harness.emit("session_start", { type: "session_start" }, harness.ctx);
+		harness.emit("session_shutdown", { type: "session_shutdown" }, harness.ctx);
+		await vi.advanceTimersByTimeAsync(250);
+
+		expect(harness.ctx.ui.setWidget).not.toHaveBeenCalled();
+	});
+});


### PR DESCRIPTION
## Summary
- defer plan state refresh off the immediate session startup path
- keep session switch/tree/fork refreshes immediate so plan-mode UI stays current after navigation
- cancel the delayed startup refresh if the session shuts down before it runs

## Testing
- `pnpm exec vitest run packages/plan/tests/startup.test.ts packages/plan/tests/state.test.ts`
- `pnpm lint`
- `pnpm typecheck`