### PR TITLE
fix: defer subagent startup artifact cleanup

### DIFF
--- a/.changeset/subagents-startup-cleanup-defer.md
+++ b/.changeset/subagents-startup-cleanup-defer.md
@@ -1,0 +1,5 @@
+---
+default: patch
+---
+
+fix: defer subagent startup artifact cleanup

--- a/packages/subagents/index.ts
+++ b/packages/subagents/index.ts
@@ -61,6 +61,8 @@ import { registerSubagentCommands } from "./command-registration.js";
 import { ensureAccessibleDir, expandTildePath, getSubagentSessionRoot, loadSubagentConfig } from "./bootstrap.js";
 import { createSubagentRuntimeMonitor } from "./runtime-monitor.js";
 
+const STARTUP_ARTIFACT_CLEANUP_DELAY_MS = 250;
+
 // ExtensionConfig is now imported from ./types.js
 
 export default function registerSubagentExtension(pi: ExtensionAPI): void {
@@ -1048,6 +1050,7 @@ MANAGEMENT (use action field — omit agent/task/chain/tasks):
 		}
 	});
 
+	let startupCleanupTimer: ReturnType<typeof setTimeout> | undefined;
 	const cleanupSessionArtifacts = (ctx: ExtensionContext) => {
 		try {
 			const sessionFile = ctx.sessionManager.getSessionFile();
@@ -1056,50 +1059,52 @@ MANAGEMENT (use action field — omit agent/task/chain/tasks):
 			}
 		} catch {}
 	};
+	const cancelStartupCleanup = () => {
+		if (!startupCleanupTimer) {
+			return;
+		}
+		clearTimeout(startupCleanupTimer);
+		startupCleanupTimer = undefined;
+	};
+	const scheduleStartupCleanup = (ctx: ExtensionContext) => {
+		cancelStartupCleanup();
+		startupCleanupTimer = setTimeout(() => {
+			startupCleanupTimer = undefined;
+			cleanupSessionArtifacts(ctx);
+		}, STARTUP_ARTIFACT_CLEANUP_DELAY_MS);
+		startupCleanupTimer.unref?.();
+	};
+	const resetSessionState = (ctx: ExtensionContext, options: { deferArtifactCleanup?: boolean } = {}) => {
+		baseCwd = ctx.cwd;
+		currentSessionId =
+			ctx.sessionManager.getSessionFile() ?? `session-${Date.now()}-${Math.random().toString(36).slice(2, 8)}`;
+		if (options.deferArtifactCleanup) {
+			scheduleStartupCleanup(ctx);
+		} else {
+			cancelStartupCleanup();
+			cleanupSessionArtifacts(ctx);
+		}
+		for (const timer of cleanupTimers.values()) clearTimeout(timer);
+		cleanupTimers.clear();
+		asyncJobs.clear();
+		runtimeMonitor.clearResults();
+		if (ctx.hasUI) {
+			lastUiContext = ctx;
+			renderWidget(ctx, []);
+		}
+	};
 
 	pi.on("session_start", (_event, ctx) => {
-		baseCwd = ctx.cwd;
-		currentSessionId =
-			ctx.sessionManager.getSessionFile() ?? `session-${Date.now()}-${Math.random().toString(36).slice(2, 8)}`;
-		cleanupSessionArtifacts(ctx);
-		for (const timer of cleanupTimers.values()) clearTimeout(timer);
-		cleanupTimers.clear();
-		asyncJobs.clear();
-		runtimeMonitor.clearResults();
-		if (ctx.hasUI) {
-			lastUiContext = ctx;
-			renderWidget(ctx, []);
-		}
+		resetSessionState(ctx, { deferArtifactCleanup: true });
 	});
 	pi.on("session_switch", (_event, ctx) => {
-		baseCwd = ctx.cwd;
-		currentSessionId =
-			ctx.sessionManager.getSessionFile() ?? `session-${Date.now()}-${Math.random().toString(36).slice(2, 8)}`;
-		cleanupSessionArtifacts(ctx);
-		for (const timer of cleanupTimers.values()) clearTimeout(timer);
-		cleanupTimers.clear();
-		asyncJobs.clear();
-		runtimeMonitor.clearResults();
-		if (ctx.hasUI) {
-			lastUiContext = ctx;
-			renderWidget(ctx, []);
-		}
+		resetSessionState(ctx);
 	});
 	pi.on("session_branch", (_event, ctx) => {
-		baseCwd = ctx.cwd;
-		currentSessionId =
-			ctx.sessionManager.getSessionFile() ?? `session-${Date.now()}-${Math.random().toString(36).slice(2, 8)}`;
-		cleanupSessionArtifacts(ctx);
-		for (const timer of cleanupTimers.values()) clearTimeout(timer);
-		cleanupTimers.clear();
-		asyncJobs.clear();
-		runtimeMonitor.clearResults();
-		if (ctx.hasUI) {
-			lastUiContext = ctx;
-			renderWidget(ctx, []);
-		}
+		resetSessionState(ctx);
 	});
 	pi.on("session_shutdown", () => {
+		cancelStartupCleanup();
 		runtimeMonitor.stop();
 		// Clear all pending cleanup timers
 		for (const timer of cleanupTimers.values()) {

--- a/packages/subagents/tests/session-churn.test.ts
+++ b/packages/subagents/tests/session-churn.test.ts
@@ -1,14 +1,20 @@
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 
-const { mockRenderWidget, mockReadStatus, mockWatcherClose, mockCoalescerClear, mockCoalescerSchedule } = vi.hoisted(
-	() => ({
-		mockRenderWidget: vi.fn(),
-		mockReadStatus: vi.fn(() => null),
-		mockWatcherClose: vi.fn(),
-		mockCoalescerClear: vi.fn(),
-		mockCoalescerSchedule: vi.fn(),
-	}),
-);
+const {
+	mockRenderWidget,
+	mockReadStatus,
+	mockWatcherClose,
+	mockCoalescerClear,
+	mockCoalescerSchedule,
+	mockCleanupOldArtifacts,
+} = vi.hoisted(() => ({
+	mockRenderWidget: vi.fn(),
+	mockReadStatus: vi.fn(() => null),
+	mockWatcherClose: vi.fn(),
+	mockCoalescerClear: vi.fn(),
+	mockCoalescerSchedule: vi.fn(),
+	mockCleanupOldArtifacts: vi.fn(),
+}));
 
 vi.mock("node:fs", () => ({
 	constants: { R_OK: 4, W_OK: 2 },
@@ -52,7 +58,7 @@ vi.mock("../chain-clarify.js", () => ({
 }));
 vi.mock("../artifacts.js", () => ({
 	cleanupAllArtifactDirs: vi.fn(),
-	cleanupOldArtifacts: vi.fn(),
+	cleanupOldArtifacts: mockCleanupOldArtifacts,
 	getArtifactsDir: vi.fn(() => "/tmp/artifacts"),
 }));
 vi.mock("../types.js", () => ({
@@ -188,6 +194,7 @@ beforeEach(() => {
 	mockWatcherClose.mockReset();
 	mockCoalescerClear.mockReset();
 	mockCoalescerSchedule.mockReset();
+	mockCleanupOldArtifacts.mockReset();
 });
 
 afterEach(() => {
@@ -196,6 +203,30 @@ afterEach(() => {
 });
 
 describe("subagent session churn", () => {
+	it("defers session_start artifact cleanup until after the startup window", async () => {
+		const pi = createMockPi();
+		const ctx = createCtx();
+
+		registerSubagentExtension(pi as any);
+		await pi._emit("session_start", {}, ctx);
+		expect(mockCleanupOldArtifacts).not.toHaveBeenCalled();
+
+		await vi.advanceTimersByTimeAsync(250);
+		expect(mockCleanupOldArtifacts).toHaveBeenCalledWith("/tmp/artifacts", 7);
+	});
+
+	it("cancels deferred startup cleanup on session_shutdown", async () => {
+		const pi = createMockPi();
+		const ctx = createCtx();
+
+		registerSubagentExtension(pi as any);
+		await pi._emit("session_start", {}, ctx);
+		await pi._emit("session_shutdown");
+		await vi.advanceTimersByTimeAsync(250);
+
+		expect(mockCleanupOldArtifacts).not.toHaveBeenCalled();
+	});
+
 	it("keeps a single poller while many async jobs are added in one session", async () => {
 		const pi = createMockPi();
 		const ctx = createCtx();
@@ -239,8 +270,8 @@ describe("subagent session churn", () => {
 
 		expect(setIntervalSpy).toHaveBeenCalledTimes(10);
 		expect(clearIntervalSpy).toHaveBeenCalledTimes(10);
-		expect(setTimeoutSpy).toHaveBeenCalledTimes(30);
-		expect(clearTimeoutSpy).toHaveBeenCalledTimes(30);
+		expect(setTimeoutSpy).toHaveBeenCalledTimes(40);
+		expect(clearTimeoutSpy).toHaveBeenCalledTimes(40);
 		expect(mockCoalescerClear).toHaveBeenCalledTimes(20);
 	});
 });


### PR DESCRIPTION
## Summary
- defer per-session artifact cleanup off the immediate subagents startup path
- keep session switch/branch cleanup immediate so existing session transitions still reset state promptly
- cancel the delayed startup cleanup if the session shuts down first

## Testing
- `pnpm exec vitest run packages/subagents/tests/session-churn.test.ts packages/subagents/tests/smoke.test.ts`
- `pnpm lint`
- `pnpm typecheck`