### PR TITLE
fix: defer btw thread restoration on startup

### DIFF
--- a/.changeset/btw-startup-defer.md
+++ b/.changeset/btw-startup-defer.md
@@ -1,0 +1,5 @@
+---
+default: patch
+---
+
+fix: defer btw thread restoration on startup

--- a/packages/extensions/extensions/btw.test.ts
+++ b/packages/extensions/extensions/btw.test.ts
@@ -1,4 +1,4 @@
-import { describe, expect, it, vi } from "vitest";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 
 vi.mock("@mariozechner/pi-ai", () => ({
 	completeSimple: vi.fn(),
@@ -22,7 +22,8 @@ vi.mock("@mariozechner/pi-coding-agent", () => ({
 	},
 }));
 
-import { resolveBtwApiKey } from "./btw.js";
+import { createExtensionHarness } from "../../../test-utils/extension-runtime-harness.js";
+import btwExtension, { resolveBtwApiKey } from "./btw.js";
 
 const model = {
 	provider: "anthropic",
@@ -54,5 +55,61 @@ describe("resolveBtwApiKey", () => {
 
 	it("reconstructs a registry when the runtime registry lacks getApiKey", async () => {
 		await expect(resolveBtwApiKey(model as never, {})).resolves.toBe("dynamic:anthropic/claude-sonnet-4");
+	});
+});
+
+describe("btw startup restore", () => {
+	beforeEach(() => {
+		vi.useFakeTimers();
+	});
+
+	afterEach(() => {
+		vi.useRealTimers();
+	});
+
+	it("defers session_start thread restoration until after the startup window", async () => {
+		const harness = createExtensionHarness();
+		const getBranch = vi.fn(() => [
+			{
+				type: "custom",
+				customType: "btw-thread-entry",
+				data: {
+					question: "What changed?",
+					thinking: "",
+					answer: "A few startup paths were deferred.",
+					provider: "anthropic",
+					model: "claude-sonnet-4",
+					thinkingLevel: "off",
+					timestamp: Date.now(),
+				},
+			},
+		]);
+		harness.ctx.sessionManager.getBranch = getBranch;
+		harness.ctx.ui.setWidget = vi.fn();
+
+		btwExtension(harness.pi as never);
+		harness.emit("session_start", { type: "session_start" }, harness.ctx);
+		expect(getBranch).not.toHaveBeenCalled();
+
+		await vi.advanceTimersByTimeAsync(250);
+		expect(getBranch).toHaveBeenCalledTimes(1);
+		expect(harness.ctx.ui.setWidget).toHaveBeenCalledWith(
+			"btw",
+			expect.any(Function),
+			expect.objectContaining({ placement: "aboveEditor" }),
+		);
+	});
+
+	it("cancels deferred session_start restoration on session_shutdown", async () => {
+		const harness = createExtensionHarness();
+		const getBranch = vi.fn(() => []);
+		harness.ctx.sessionManager.getBranch = getBranch;
+
+		btwExtension(harness.pi as never);
+		harness.emit("session_start", { type: "session_start" }, harness.ctx);
+		harness.emit("session_shutdown", { type: "session_shutdown" }, harness.ctx);
+		await vi.advanceTimersByTimeAsync(250);
+
+		expect(getBranch).not.toHaveBeenCalled();
 	});
 });

--- a/packages/extensions/extensions/btw.ts
+++ b/packages/extensions/extensions/btw.ts
@@ -39,6 +39,7 @@ const BTW_SYSTEM_PROMPT = [
 	"Focus on answering the user's side questions, helping them think through ideas, or planning next steps.",
 	"Do not act as if you need to continue unfinished work from the main session unless the user explicitly asks you to prepare something for injection back to it.",
 ].join(" ");
+const STARTUP_THREAD_RESTORE_DELAY_MS = 250;
 
 type SessionThinkingLevel = "off" | AiThinkingLevel;
 
@@ -660,19 +661,38 @@ export default function (pi: ExtensionAPI) {
 
 	// ── Session lifecycle — restore / cleanup ─────────────────────────────────
 
-	pi.on("session_start", async (_event, ctx) => {
+	let startupRestoreTimer: ReturnType<typeof setTimeout> | undefined;
+	const cancelStartupRestore = () => {
+		if (!startupRestoreTimer) {
+			return;
+		}
+		clearTimeout(startupRestoreTimer);
+		startupRestoreTimer = undefined;
+	};
+	const restoreCurrentThread = (ctx: ExtensionContext) => {
+		cancelStartupRestore();
 		restoreThread(ctx);
+	};
+
+	pi.on("session_start", async (_event, ctx) => {
+		cancelStartupRestore();
+		startupRestoreTimer = setTimeout(() => {
+			startupRestoreTimer = undefined;
+			restoreThread(ctx);
+		}, STARTUP_THREAD_RESTORE_DELAY_MS);
+		startupRestoreTimer.unref?.();
 	});
 
 	pi.on("session_switch", async (_event, ctx) => {
-		restoreThread(ctx);
+		restoreCurrentThread(ctx);
 	});
 
 	pi.on("session_tree", async (_event, ctx) => {
-		restoreThread(ctx);
+		restoreCurrentThread(ctx);
 	});
 
 	pi.on("session_shutdown", async () => {
+		cancelStartupRestore();
 		abortActiveSlots();
 	});
 


### PR DESCRIPTION
## Summary
- defer BTW thread restoration off the immediate session startup path
- keep session switch/tree restoration immediate so existing BTW threads still reappear promptly after navigation
- cancel the delayed startup restore if the session shuts down first

## Testing
- `pnpm exec vitest run packages/extensions/extensions/btw.test.ts packages/extensions/extensions/smoke.test.ts`
- `pnpm lint`
- `pnpm typecheck`