### PR TITLE
fix(providers): page login picker

### DIFF
--- a/.changeset/fix-provider-login-pagination.md
+++ b/.changeset/fix-provider-login-pagination.md
@@ -1,0 +1,5 @@
+---
+default: patch
+---
+
+Reduce provider-catalog login clutter by switching to a paged `/providers login` flow that shows at most 10 providers at a time, lazily registers selected providers, and keeps persisted or env-configured providers available across sessions.

--- a/packages/providers/README.md
+++ b/packages/providers/README.md
@@ -4,10 +4,10 @@ Experimental multi-provider package for pi backed by the OpenCode `models.dev` c
 
 ## What it does
 
-- Registers a large set of API-key providers that OpenCode already catalogs
+- Registers configured API-key providers from the OpenCode catalog without flooding pi's global `/login` picker
 - Keeps provider model lists, context windows, reasoning flags, and vision support aligned with `models.dev`
 - Reuses live provider discovery when a provider exposes a model-list endpoint
-- Adds `/login <provider-id>` support for each registered provider through a simple API-key prompt flow
+- Adds a paged `/providers login` flow with 10 providers per page for lazy provider registration and API-key login
 - Adds `/providers ...` commands for status, listing, inspection, and catalog refreshes
 
 ## Install
@@ -22,7 +22,7 @@ This package is intentionally separate from `@ifi/oh-pi` for now.
 
 1. Install the package
 2. Run `/providers list` to see supported provider ids
-3. Run `/login <provider-id>` for any provider you want to use
+3. Run `/providers login` to browse providers 10 at a time, or `/providers login <provider-id>` if you already know the id
 4. Open `/model` and select one of the discovered models
 5. Run `/providers refresh-models <provider-id>` whenever you want to refresh the live catalog
 
@@ -32,6 +32,7 @@ You can also skip `/login` and set a supported provider env var directly when th
 
 - `/providers status` — summarize configured providers from this package
 - `/providers list [query]` — list supported provider ids and env vars
+- `/providers login [provider]` — page through providers 10 at a time, lazily register one, and prompt for its API key
 - `/providers info <provider>` — inspect a provider's API mode, URLs, env vars, and model count
 - `/providers models <provider>` — list the current or fallback model catalog for one provider
 - `/providers refresh-models [provider|all]` — refresh configured providers from live discovery when possible

--- a/packages/providers/index.ts
+++ b/packages/providers/index.ts
@@ -1,5 +1,10 @@
 import type { AuthCredential, ExtensionAPI } from "@mariozechner/pi-coding-agent";
-import { createApiKeyOAuthProvider, refreshProviderCredential, refreshProviderCredentialModels } from "./auth.js";
+import {
+	createApiKeyOAuthProvider,
+	loginProvider,
+	refreshProviderCredential,
+	refreshProviderCredentialModels,
+} from "./auth.js";
 import {
 	getCatalogModels,
 	getCredentialModels,
@@ -9,16 +14,51 @@ import {
 } from "./catalog.js";
 import { getEnvApiKey, resolveApiKeyConfig, SUPPORTED_PROVIDERS, type SupportedProviderDefinition } from "./config.js";
 
+type ProviderUi = {
+	notify: (message: string, level: "info" | "warning" | "error" | "success") => void;
+	select?: (title: string, options: string[]) => Promise<string | null>;
+	input?: (title: string, placeholder?: string) => Promise<string | null>;
+};
+
+type ProviderRegistryContext = {
+	modelRegistry: {
+		authStorage: {
+			get: (provider: string) => AuthCredential | undefined;
+			set: (provider: string, credential: AuthCredential) => void;
+		};
+		refresh?: () => void;
+	};
+};
+
+type ProviderCommandContext = ProviderRegistryContext & {
+	ui: ProviderUi;
+};
+
+type ProviderStatusContext = {
+	modelRegistry: {
+		authStorage: {
+			get: (provider: string) => unknown;
+		};
+	};
+};
+
 type RuntimeProviderState = {
 	models: Map<string, ProviderCatalogModel[]>;
 	lastRefresh: Map<string, number>;
 	lastError: Map<string, string | null>;
+	registered: Set<string>;
 };
+
+const PROVIDER_SELECTION_PAGE_SIZE = 10;
+const PROVIDER_PICKER_PREVIOUS = "← Previous 10";
+const PROVIDER_PICKER_NEXT = "Next 10 →";
+const PROVIDER_PICKER_SEARCH = "Search providers…";
 
 const runtimeState: RuntimeProviderState = {
 	models: new Map(),
 	lastRefresh: new Map(),
 	lastError: new Map(),
+	registered: new Set(),
 };
 
 function registerProvider(pi: ExtensionAPI, provider: SupportedProviderDefinition): void {
@@ -29,18 +69,28 @@ function registerProvider(pi: ExtensionAPI, provider: SupportedProviderDefinitio
 		oauth: createApiKeyOAuthProvider(provider),
 		models: toProviderModels(runtimeState.models.get(provider.id) ?? []),
 	});
+	runtimeState.registered.add(provider.id);
 }
 
 function registerProvidersCommand(pi: ExtensionAPI): void {
 	pi.registerCommand("providers", {
 		description:
-			"Inspect or refresh the OpenCode-backed multi-provider catalog: /providers [status|list [query]|info <provider>|models <provider>|refresh-models [provider|all]]",
+			"Inspect, log in to, or refresh the OpenCode-backed multi-provider catalog: /providers [status|list [query]|info <provider>|models <provider>|login [provider]|refresh-models [provider|all]]",
 		// biome-ignore lint/complexity/noExcessiveCognitiveComplexity: This explicit command router keeps each provider subcommand readable.
 		async handler(args, ctx) {
 			const trimmed = args.trim();
 			const [rawAction = "status", ...rest] = trimmed ? trimmed.split(/\s+/) : ["status"];
 			const action = rawAction.toLowerCase();
 			const query = rest.join(" ").trim();
+
+			if (action === "login") {
+				const provider = await resolveProviderSelection(query, ctx);
+				if (!provider) {
+					return;
+				}
+				await loginProviderFromCommand(pi, ctx, provider);
+				return;
+			}
 
 			if (action === "refresh-models") {
 				const providers = query && query.toLowerCase() !== "all" ? findProviders(query) : SUPPORTED_PROVIDERS;
@@ -94,15 +144,7 @@ function registerProvidersCommand(pi: ExtensionAPI): void {
 
 async function refreshProviders(
 	pi: ExtensionAPI,
-	ctx: {
-		modelRegistry: {
-			authStorage: {
-				get: (provider: string) => AuthCredential | undefined;
-				set: (provider: string, credential: AuthCredential) => void;
-			};
-			refresh?: () => void;
-		};
-	},
+	ctx: ProviderRegistryContext,
 	providers: readonly SupportedProviderDefinition[],
 ): Promise<
 	Array<{
@@ -128,6 +170,10 @@ async function refreshProviders(
 						? await refreshProviderCredential(provider, credential)
 						: await refreshProviderCredentialModels(provider, credential);
 				ctx.modelRegistry.authStorage.set(provider.id, { type: "oauth", ...refreshed });
+				runtimeState.models.set(provider.id, getCredentialModels(refreshed));
+				runtimeState.lastRefresh.set(provider.id, refreshed.lastModelRefresh);
+				runtimeState.lastError.set(provider.id, null);
+				registerProvider(pi, provider);
 				results.push({ provider, status: "refreshed", models: getCredentialModels(refreshed).length });
 				continue;
 			} catch (error) {
@@ -172,7 +218,7 @@ async function refreshProviders(
 	return results;
 }
 
-function renderStatus(ctx: { modelRegistry: { authStorage: { get: (provider: string) => unknown } } }): string {
+function renderStatus(ctx: ProviderStatusContext): string {
 	const configured = SUPPORTED_PROVIDERS.filter(
 		(provider) => hasStoredCredential(ctx, provider.id) || getEnvApiKey(provider),
 	);
@@ -180,9 +226,7 @@ function renderStatus(ctx: { modelRegistry: { authStorage: { get: (provider: str
 
 	if (configured.length === 0) {
 		lines.push("No provider from this package is configured yet.");
-		lines.push(
-			"Tip: run /login <provider-id> or set one of the advertised env vars, then use /providers refresh-models.",
-		);
+		lines.push("Tip: run /providers login to open the paged provider picker, then use /providers refresh-models.");
 		return lines.join("\n");
 	}
 
@@ -215,10 +259,7 @@ function renderProviderList(query: string): string {
 		.join("\n");
 }
 
-async function renderProviderInfo(
-	provider: SupportedProviderDefinition,
-	ctx: { modelRegistry: { authStorage: { get: (provider: string) => unknown } } },
-): Promise<string> {
+async function renderProviderInfo(provider: SupportedProviderDefinition, ctx: ProviderStatusContext): Promise<string> {
 	const credential = getStoredCredential(ctx, provider.id);
 	const currentModels = credential ? getCredentialModels(credential) : (runtimeState.models.get(provider.id) ?? []);
 	const catalogModels = currentModels.length > 0 ? currentModels : await getCatalogModels(provider).catch(() => []);
@@ -240,7 +281,7 @@ async function renderProviderInfo(
 
 async function renderProviderModels(
 	provider: SupportedProviderDefinition,
-	ctx: { modelRegistry: { authStorage: { get: (provider: string) => unknown } } },
+	ctx: ProviderStatusContext,
 ): Promise<string> {
 	const credential = getStoredCredential(ctx, provider.id);
 	const currentModels = credential ? getCredentialModels(credential) : (runtimeState.models.get(provider.id) ?? []);
@@ -287,17 +328,11 @@ function renderRefreshSummary(
 	return lines.join("\n");
 }
 
-function hasStoredCredential(
-	ctx: { modelRegistry: { authStorage: { get: (provider: string) => unknown } } },
-	providerId: string,
-): boolean {
+function hasStoredCredential(ctx: ProviderStatusContext, providerId: string): boolean {
 	return getStoredCredential(ctx, providerId) !== null;
 }
 
-function getStoredCredential(
-	ctx: { modelRegistry: { authStorage: { get: (provider: string) => unknown } } },
-	providerId: string,
-): ProviderCatalogCredentials | null {
+function getStoredCredential(ctx: ProviderStatusContext, providerId: string): ProviderCatalogCredentials | null {
 	const credential = ctx.modelRegistry.authStorage.get(providerId);
 	return credential && typeof credential === "object" && (credential as { type?: string }).type === "oauth"
 		? (credential as ProviderCatalogCredentials)
@@ -320,6 +355,139 @@ function findProviders(query: string): SupportedProviderDefinition[] {
 	return SUPPORTED_PROVIDERS.filter(
 		(provider) => provider.id.toLowerCase().includes(normalized) || provider.name.toLowerCase().includes(normalized),
 	);
+}
+
+async function resolveProviderSelection(
+	query: string,
+	ctx: ProviderCommandContext,
+): Promise<SupportedProviderDefinition | null> {
+	const matchedProviders = query ? findProviders(query) : SUPPORTED_PROVIDERS;
+	if (matchedProviders.length === 0) {
+		ctx.ui.notify(`No provider matched "${query}". Run /providers list first.`, "warning");
+		return null;
+	}
+
+	if (matchedProviders.length === 1) {
+		return matchedProviders[0] ?? null;
+	}
+
+	return await selectProviderPage(ctx, matchedProviders);
+}
+
+// biome-ignore lint/complexity/noExcessiveCognitiveComplexity: Provider picker coordinates pagination, search, and selection in one loop.
+async function selectProviderPage(
+	ctx: ProviderCommandContext,
+	providers: readonly SupportedProviderDefinition[],
+): Promise<SupportedProviderDefinition | null> {
+	if (providers.length === 0) {
+		return null;
+	}
+	if (providers.length === 1 || typeof ctx.ui.select !== "function") {
+		return providers[0] ?? null;
+	}
+
+	let visibleProviders = [...providers];
+	let page = 0;
+
+	while (visibleProviders.length > 0) {
+		const pageCount = Math.max(1, Math.ceil(visibleProviders.length / PROVIDER_SELECTION_PAGE_SIZE));
+		page = Math.min(page, pageCount - 1);
+		const start = page * PROVIDER_SELECTION_PAGE_SIZE;
+		const pageProviders = visibleProviders.slice(start, start + PROVIDER_SELECTION_PAGE_SIZE);
+		const optionToProvider = new Map<string, SupportedProviderDefinition>();
+		const options = pageProviders.map((provider) => {
+			const option = formatProviderPickerOption(provider, ctx);
+			optionToProvider.set(option, provider);
+			return option;
+		});
+
+		if (page > 0) {
+			options.push(PROVIDER_PICKER_PREVIOUS);
+		}
+		if (page < pageCount - 1) {
+			options.push(PROVIDER_PICKER_NEXT);
+		}
+		if (typeof ctx.ui.input === "function") {
+			options.push(PROVIDER_PICKER_SEARCH);
+		}
+
+		const selection = await ctx.ui.select(
+			[
+				`Select provider to log in (${visibleProviders.length} total)`,
+				`Page ${page + 1}/${pageCount} · max ${PROVIDER_SELECTION_PAGE_SIZE} providers per page`,
+			].join("\n"),
+			options,
+		);
+		if (!selection) {
+			return null;
+		}
+
+		if (selection === PROVIDER_PICKER_PREVIOUS) {
+			page = Math.max(0, page - 1);
+			continue;
+		}
+		if (selection === PROVIDER_PICKER_NEXT) {
+			page = Math.min(pageCount - 1, page + 1);
+			continue;
+		}
+		if (selection === PROVIDER_PICKER_SEARCH) {
+			const search = (await ctx.ui.input("Provider search", "Type a provider id or name"))?.trim() ?? "";
+			const nextProviders = search ? findProviders(search) : [...providers];
+			if (nextProviders.length === 0) {
+				ctx.ui.notify(`No provider matched "${search}".`, "warning");
+				continue;
+			}
+			visibleProviders = nextProviders;
+			page = 0;
+			continue;
+		}
+
+		return optionToProvider.get(selection) ?? null;
+	}
+
+	return null;
+}
+
+function formatProviderPickerOption(provider: SupportedProviderDefinition, ctx: ProviderStatusContext): string {
+	const state = hasStoredCredential(ctx, provider.id) ? "✓ logged in" : getEnvApiKey(provider) ? "env key" : "login";
+	return `${provider.name} — ${provider.id} · ${state}`;
+}
+
+async function loginProviderFromCommand(
+	pi: ExtensionAPI,
+	ctx: ProviderCommandContext,
+	provider: SupportedProviderDefinition,
+): Promise<void> {
+	try {
+		registerProvider(pi, provider);
+		const credential = await loginProvider(provider, {
+			onAuth(params) {
+				ctx.ui.notify(`${params.instructions}\n${params.url}`, "info");
+			},
+			onProgress(message) {
+				if (message) {
+					ctx.ui.notify(message, "info");
+				}
+			},
+			async onPrompt(params) {
+				return (await ctx.ui.input(`Log in to ${provider.name}`, `${params.message}\n${provider.authUrl}`)) ?? "";
+			},
+		});
+		ctx.modelRegistry.authStorage.set(provider.id, { type: "oauth", ...credential });
+		runtimeState.models.set(provider.id, getCredentialModels(credential));
+		runtimeState.lastRefresh.set(provider.id, credential.lastModelRefresh);
+		runtimeState.lastError.set(provider.id, null);
+		registerProvider(pi, provider);
+		ctx.modelRegistry.refresh?.();
+		ctx.ui.notify(
+			`Logged in to ${provider.name}. ${getCredentialModels(credential).length} model${getCredentialModels(credential).length === 1 ? "" : "s"} available.`,
+			"success",
+		);
+	} catch (error) {
+		const message = error instanceof Error ? error.message : String(error);
+		runtimeState.lastError.set(provider.id, message);
+		ctx.ui.notify(`Failed to log in to ${provider.name}: ${message}`, "error");
+	}
 }
 
 function toProviderModels(models: readonly ProviderCatalogModel[]): ProviderCatalogModel[] {
@@ -354,7 +522,7 @@ function formatRefreshAge(timestamp: number | null | undefined): string {
 }
 
 function bootstrapProviders(pi: ExtensionAPI): void {
-	for (const provider of SUPPORTED_PROVIDERS) {
+	for (const provider of SUPPORTED_PROVIDERS.filter((candidate) => Boolean(getEnvApiKey(candidate)))) {
 		registerProvider(pi, provider);
 	}
 
@@ -372,6 +540,23 @@ function bootstrapProviders(pi: ExtensionAPI): void {
 	);
 }
 
+function registerPersistedProviders(pi: ExtensionAPI): void {
+	pi.on("session_start", (_event, ctx: ProviderRegistryContext) => {
+		let changed = false;
+		for (const provider of SUPPORTED_PROVIDERS) {
+			if (!(hasStoredCredential(ctx, provider.id) || getEnvApiKey(provider))) {
+				continue;
+			}
+			const wasRegistered = runtimeState.registered.has(provider.id);
+			registerProvider(pi, provider);
+			changed ||= !wasRegistered;
+		}
+		if (changed) {
+			ctx.modelRegistry.refresh?.();
+		}
+	});
+}
+
 export type { ProviderCatalogCredentials, ProviderCatalogModel } from "./catalog.js";
 export { SUPPORTED_PROVIDERS } from "./config.js";
 export {
@@ -383,7 +568,15 @@ export {
 	resolveProviderModels,
 };
 
+export function resetProviderCatalogRuntimeStateForTests(): void {
+	runtimeState.models.clear();
+	runtimeState.lastRefresh.clear();
+	runtimeState.lastError.clear();
+	runtimeState.registered.clear();
+}
+
 export default function providerCatalogExtension(pi: ExtensionAPI): void {
 	bootstrapProviders(pi);
+	registerPersistedProviders(pi);
 	registerProvidersCommand(pi);
 }

--- a/packages/providers/tests/index.test.ts
+++ b/packages/providers/tests/index.test.ts
@@ -1,0 +1,162 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import { createExtensionHarness } from "../../../test-utils/extension-runtime-harness.js";
+import { clearModelsDevCatalogCache } from "../catalog.js";
+import { getSupportedProvider } from "../config.js";
+import providerCatalogExtension, { resetProviderCatalogRuntimeStateForTests, SUPPORTED_PROVIDERS } from "../index.js";
+
+const envSnapshot = { ...process.env };
+const PROVIDER_PICKER_PREVIOUS = "← Previous 10";
+const PROVIDER_PICKER_NEXT = "Next 10 →";
+const PROVIDER_PICKER_SEARCH = "Search providers…";
+
+function jsonResponse(body: unknown): Response {
+	return new Response(JSON.stringify(body), {
+		status: 200,
+		headers: { "Content-Type": "application/json" },
+	});
+}
+
+beforeEach(() => {
+	clearModelsDevCatalogCache();
+	resetProviderCatalogRuntimeStateForTests();
+	for (const provider of SUPPORTED_PROVIDERS) {
+		for (const envName of provider.env) {
+			delete process.env[envName];
+		}
+	}
+	vi.restoreAllMocks();
+});
+
+afterEach(() => {
+	for (const key of Object.keys(process.env)) {
+		if (!(key in envSnapshot)) {
+			delete process.env[key];
+		}
+	}
+	Object.assign(process.env, envSnapshot);
+	vi.restoreAllMocks();
+});
+
+describe("provider catalog extension", () => {
+	it("does not eagerly register the full provider catalog on startup", () => {
+		const harness = createExtensionHarness();
+		providerCatalogExtension(harness.pi as never);
+
+		expect(harness.commands.has("providers")).toBe(true);
+		expect(harness.providers.size).toBe(0);
+	});
+
+	it("registers env-configured providers during bootstrap", async () => {
+		const provider = getSupportedProvider("moonshotai");
+		process.env[provider.env[0] ?? "MOONSHOTAI_API_KEY"] = "moonshot-env-key";
+		vi.stubGlobal(
+			"fetch",
+			vi
+				.fn<() => Promise<Response>>()
+				.mockImplementationOnce(async () => jsonResponse({ moonshotai: { models: {} } }))
+				.mockImplementationOnce(async () => jsonResponse({ data: [] })),
+		);
+
+		const harness = createExtensionHarness();
+		providerCatalogExtension(harness.pi as never);
+		await Promise.resolve();
+
+		expect(harness.providers.has(provider.id)).toBe(true);
+	});
+
+	it("registers stored providers on session_start so existing logins still load", async () => {
+		const provider = getSupportedProvider("moonshotai");
+		const harness = createExtensionHarness();
+		const refresh = vi.fn();
+		harness.ctx.modelRegistry = {
+			authStorage: {
+				get: vi.fn((providerId: string) =>
+					providerId === provider.id
+						? {
+								type: "oauth",
+								refresh: "moonshot-key",
+								access: "moonshot-key",
+								expires: Date.now() + 60_000,
+								providerId: provider.id,
+								models: [],
+								lastModelRefresh: Date.now(),
+							}
+						: undefined,
+				),
+				set: vi.fn(),
+			},
+			refresh,
+		};
+
+		providerCatalogExtension(harness.pi as never);
+		await harness.emitAsync("session_start", { type: "session_start" }, harness.ctx);
+
+		expect(harness.providers.has(provider.id)).toBe(true);
+		expect(refresh).toHaveBeenCalledTimes(1);
+	});
+
+	it("pages provider login selections in groups of 10 and lazily registers the chosen provider", async () => {
+		const provider = SUPPORTED_PROVIDERS[10];
+		if (!provider) {
+			throw new Error("Expected at least 11 providers in the catalog.");
+		}
+		const sampleCatalog = {
+			[provider.id]: {
+				models: {
+					"demo-model": {
+						id: "demo-model",
+						name: "Demo Model",
+						reasoning: true,
+						attachment: true,
+						limit: { context: 262144, output: 32768 },
+						modalities: { input: ["text", "image"], output: ["text"] },
+					},
+				},
+			},
+		};
+		vi.stubGlobal(
+			"fetch",
+			vi
+				.fn<() => Promise<Response>>()
+				.mockImplementationOnce(async () => jsonResponse(sampleCatalog))
+				.mockImplementationOnce(async () => jsonResponse({ data: [{ id: "demo-model", max_output: 24576 }] })),
+		);
+
+		const harness = createExtensionHarness();
+		const stored = new Map<string, unknown>();
+		const refresh = vi.fn();
+		harness.ctx.modelRegistry = {
+			authStorage: {
+				get: vi.fn((providerId: string) => stored.get(providerId) as never),
+				set: vi.fn((providerId: string, credential: unknown) => {
+					stored.set(providerId, credential);
+				}),
+			},
+			refresh,
+		};
+
+		const pickerCalls: string[][] = [];
+		harness.ctx.ui.select = vi.fn((_title: string, options: string[]) => {
+			pickerCalls.push(options);
+			if (pickerCalls.length === 1) {
+				return Promise.resolve(PROVIDER_PICKER_NEXT);
+			}
+			return Promise.resolve(`${provider.name} — ${provider.id} · login`);
+		});
+		harness.ctx.ui.input = vi.fn(async () => "provider-api-key");
+
+		providerCatalogExtension(harness.pi as never);
+		const command = harness.commands.get("providers");
+		await command.handler("login", harness.ctx);
+
+		const providerOptions = (pickerCalls[0] ?? []).filter((option) => {
+			return (
+				option !== PROVIDER_PICKER_PREVIOUS && option !== PROVIDER_PICKER_NEXT && option !== PROVIDER_PICKER_SEARCH
+			);
+		});
+		expect(providerOptions).toHaveLength(10);
+		expect(harness.providers.has(provider.id)).toBe(true);
+		expect(stored.get(provider.id)).toMatchObject({ type: "oauth", providerId: provider.id });
+		expect(refresh).toHaveBeenCalledTimes(1);
+	});
+});

--- a/packages/providers/tests/smoke.test.ts
+++ b/packages/providers/tests/smoke.test.ts
@@ -3,14 +3,10 @@ import { createExtensionHarness } from "../../../test-utils/extension-runtime-ha
 import providerCatalogExtension from "../index.js";
 
 describe("provider catalog smoke tests", () => {
-	it("registers the multi-provider catalog extension without crashing", () => {
+	it("registers the catalog command without crashing", () => {
 		const harness = createExtensionHarness();
 		providerCatalogExtension(harness.pi as never);
 
 		expect(harness.commands.has("providers")).toBe(true);
-		expect(harness.providers.has("opencode")).toBe(true);
-		expect(harness.providers.has("opencode-go")).toBe(true);
-		expect(harness.providers.has("moonshotai")).toBe(true);
-		expect(harness.providers.has("xai")).toBe(true);
 	});
 });


### PR DESCRIPTION
## Summary
- switch provider catalog login to a paged `/providers login` flow with at most 10 providers per page
- lazily register selected providers instead of flooding the global login picker
- keep env-configured and persisted providers available across sessions

## Testing
- pnpm exec biome check packages/providers/index.ts packages/providers/README.md packages/providers/tests/index.test.ts packages/providers/tests/smoke.test.ts
- cd packages/providers && pnpm exec vitest run -c vitest.worktree.config.ts