### PR TITLE
fix: defer adaptive routing startup refresh

### DIFF
--- a/.changeset/adaptive-routing-startup-defer.md
+++ b/.changeset/adaptive-routing-startup-defer.md
@@ -1,0 +1,5 @@
+---
+default: patch
+---
+
+fix: defer adaptive routing startup refresh

--- a/packages/extensions/extensions/adaptive-routing/adaptive-routing.test.ts
+++ b/packages/extensions/extensions/adaptive-routing/adaptive-routing.test.ts
@@ -82,12 +82,14 @@ describe("adaptive routing extension", () => {
 	let tempAgentDir: string;
 
 	beforeEach(() => {
+		vi.useFakeTimers();
 		tempAgentDir = mkdtempSync(join(tmpdir(), "adaptive-routing-ext-"));
 		getAgentDir.mockReturnValue(tempAgentDir);
 		mkdirSync(join(tempAgentDir, "extensions", "adaptive-routing"), { recursive: true });
 	});
 
 	afterEach(() => {
+		vi.useRealTimers();
 		rmSync(tempAgentDir, { recursive: true, force: true });
 		vi.clearAllMocks();
 	});
@@ -112,6 +114,44 @@ describe("adaptive routing extension", () => {
 
 		expect(harness.ctx.model).toMatchObject({ provider: "google", id: "gemini-2.5-flash" });
 		expect(harness.notifications.some((item) => item.msg.includes("Adaptive route suggestion"))).toBe(false);
+		expect(harness.statusMap.has("adaptive-routing")).toBe(false);
+	});
+
+	it("defers session_start state refresh until after the startup window", async () => {
+		writeFileSync(
+			join(tempAgentDir, "extensions", "adaptive-routing", "config.json"),
+			`${JSON.stringify({ mode: "shadow" }, null, 2)}\n`,
+		);
+		writeFileSync(
+			join(tempAgentDir, "extensions", "adaptive-routing", "state.json"),
+			`${JSON.stringify({ mode: "shadow" }, null, 2)}\n`,
+		);
+		const harness = createExtensionHarness();
+
+		adaptiveRoutingExtension(harness.pi as never);
+		harness.emit("session_start", { type: "session_start" }, harness.ctx);
+		expect(harness.statusMap.has("adaptive-routing")).toBe(false);
+
+		await vi.advanceTimersByTimeAsync(250);
+		expect(harness.statusMap.get("adaptive-routing")).toContain("shadow");
+	});
+
+	it("cancels deferred session_start refresh on session_shutdown", async () => {
+		writeFileSync(
+			join(tempAgentDir, "extensions", "adaptive-routing", "config.json"),
+			`${JSON.stringify({ mode: "shadow" }, null, 2)}\n`,
+		);
+		writeFileSync(
+			join(tempAgentDir, "extensions", "adaptive-routing", "state.json"),
+			`${JSON.stringify({ mode: "shadow" }, null, 2)}\n`,
+		);
+		const harness = createExtensionHarness();
+
+		adaptiveRoutingExtension(harness.pi as never);
+		harness.emit("session_start", { type: "session_start" }, harness.ctx);
+		harness.emit("session_shutdown", { type: "session_shutdown" }, harness.ctx);
+		await vi.advanceTimersByTimeAsync(250);
+
 		expect(harness.statusMap.has("adaptive-routing")).toBe(false);
 	});
 

--- a/packages/extensions/extensions/adaptive-routing/index.ts
+++ b/packages/extensions/extensions/adaptive-routing/index.ts
@@ -28,6 +28,7 @@ import type {
 } from "./types.js";
 
 const STATUS_KEY = "adaptive-routing";
+const STARTUP_STATE_REFRESH_DELAY_MS = 250;
 
 type RuntimeState = {
 	state: AdaptiveRoutingState;
@@ -102,10 +103,32 @@ export default function adaptiveRoutingExtension(pi: ExtensionAPI) {
 		};
 	});
 
-	pi.on("session_start", async (_event, ctx) => {
+	let startupRefreshTimer: ReturnType<typeof setTimeout> | undefined;
+	const cancelStartupRefresh = () => {
+		if (!startupRefreshTimer) {
+			return;
+		}
+		clearTimeout(startupRefreshTimer);
+		startupRefreshTimer = undefined;
+	};
+	const refreshRuntimeState = (ctx: ExtensionContext) => {
+		cancelStartupRefresh();
 		runtime.state = readAdaptiveRoutingState();
 		refreshUsageSnapshot();
 		updateStatus(ctx);
+	};
+
+	pi.on("session_start", async (_event, ctx) => {
+		cancelStartupRefresh();
+		startupRefreshTimer = setTimeout(() => {
+			startupRefreshTimer = undefined;
+			refreshRuntimeState(ctx);
+		}, STARTUP_STATE_REFRESH_DELAY_MS);
+		startupRefreshTimer.unref?.();
+	});
+
+	pi.on("session_shutdown", async () => {
+		cancelStartupRefresh();
 	});
 
 	pi.on("model_select", async (event, ctx) => {


### PR DESCRIPTION
## Summary
- defer adaptive-routing state refresh and usage snapshot work off the immediate session startup path
- keep the delayed refresh behavior cancellable when the session shuts down early
- add focused tests for delayed startup refresh and shutdown cancellation

## Testing
- `pnpm exec vitest run packages/extensions/extensions/adaptive-routing/adaptive-routing.test.ts packages/extensions/extensions/smoke.test.ts`
- `pnpm lint`
- `pnpm typecheck`