### PR TITLE
fix: defer compact-header settings sync on startup

### DIFF
--- a/.changeset/compact-header-settings-defer.md
+++ b/.changeset/compact-header-settings-defer.md
@@ -1,0 +1,5 @@
+---
+default: patch
+---
+
+fix: defer compact header settings sync on startup

--- a/packages/extensions/extensions/compact-header.test.ts
+++ b/packages/extensions/extensions/compact-header.test.ts
@@ -1,0 +1,81 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import { createExtensionHarness } from "../../../test-utils/extension-runtime-harness.js";
+
+const { readFileSyncMock, getAgentDirMock } = vi.hoisted(() => ({
+	readFileSyncMock: vi.fn(),
+	getAgentDirMock: vi.fn(() => "/mock-home/.pi/agent"),
+}));
+
+vi.mock("node:fs", async (importOriginal) => {
+	const actual = await importOriginal<typeof import("node:fs")>();
+	return {
+		...actual,
+		readFileSync: readFileSyncMock,
+	};
+});
+
+vi.mock("@mariozechner/pi-coding-agent", async () => {
+	const actual = await vi.importActual<typeof import("@mariozechner/pi-coding-agent")>("@mariozechner/pi-coding-agent");
+	return {
+		...actual,
+		getAgentDir: getAgentDirMock,
+	};
+});
+
+import compactHeaderExtension from "./compact-header.js";
+
+describe("compact-header plain-icons bootstrap", () => {
+	beforeEach(() => {
+		vi.useFakeTimers();
+		readFileSyncMock.mockReset();
+		getAgentDirMock.mockReset();
+		getAgentDirMock.mockReturnValue("/mock-home/.pi/agent");
+		process.env.OH_PI_PLAIN_ICONS = "";
+	});
+
+	afterEach(() => {
+		vi.useRealTimers();
+		process.env.OH_PI_PLAIN_ICONS = "";
+	});
+
+	it("defers settings.json plain-icons reads until after the startup window", async () => {
+		readFileSyncMock.mockReturnValue('{"plainIcons": true}');
+		const harness = createExtensionHarness();
+		(harness.ctx.ui as { setHeader: ReturnType<typeof vi.fn> }).setHeader = vi.fn();
+
+		compactHeaderExtension(harness.pi as never);
+		expect(readFileSyncMock).not.toHaveBeenCalled();
+
+		harness.emit("session_start", { type: "session_start" }, harness.ctx);
+		expect(readFileSyncMock).not.toHaveBeenCalled();
+		expect(process.env.OH_PI_PLAIN_ICONS).toBe("");
+
+		await vi.advanceTimersByTimeAsync(250);
+		expect(readFileSyncMock).toHaveBeenCalled();
+		expect(process.env.OH_PI_PLAIN_ICONS).toBe("1");
+	});
+
+	it("cancels deferred plain-icons sync on session_shutdown", async () => {
+		readFileSyncMock.mockReturnValue('{"plainIcons": true}');
+		const harness = createExtensionHarness();
+		(harness.ctx.ui as { setHeader: ReturnType<typeof vi.fn> }).setHeader = vi.fn();
+
+		compactHeaderExtension(harness.pi as never);
+		harness.emit("session_start", { type: "session_start" }, harness.ctx);
+		harness.emit("session_shutdown", { type: "session_shutdown" }, harness.ctx);
+		await vi.advanceTimersByTimeAsync(250);
+
+		expect(readFileSyncMock).not.toHaveBeenCalled();
+		expect(process.env.OH_PI_PLAIN_ICONS).toBe("");
+	});
+
+	it("still honors the --plain-icons flag immediately", () => {
+		const harness = createExtensionHarness();
+		harness.pi.getFlag = vi.fn((name: string) => (name === "plain-icons" ? true : undefined));
+		(harness.ctx.ui as { setHeader: ReturnType<typeof vi.fn> }).setHeader = vi.fn();
+
+		compactHeaderExtension(harness.pi as never);
+		expect(process.env.OH_PI_PLAIN_ICONS).toBe("1");
+		expect(readFileSyncMock).not.toHaveBeenCalled();
+	});
+});

--- a/packages/extensions/extensions/compact-header.ts
+++ b/packages/extensions/extensions/compact-header.ts
@@ -13,6 +13,8 @@ import { truncateToWidth, visibleWidth } from "@mariozechner/pi-tui";
 import { getSafeModeState, subscribeSafeMode } from "./runtime-mode";
 
 /** Read `plainIcons` from settings.json (global or project-local). */
+const STARTUP_PLAIN_ICONS_SYNC_DELAY_MS = 250;
+
 function loadPlainIconsSetting(): boolean {
 	for (const dir of [join(process.cwd(), ".pi"), getAgentDir()]) {
 		try {
@@ -29,6 +31,22 @@ function loadPlainIconsSetting(): boolean {
 }
 
 export default function (pi: ExtensionAPI) {
+	let plainIconsSyncTimer: ReturnType<typeof setTimeout> | undefined;
+	const cancelPlainIconsSync = () => {
+		if (!plainIconsSyncTimer) {
+			return;
+		}
+		clearTimeout(plainIconsSyncTimer);
+		plainIconsSyncTimer = undefined;
+	};
+	const syncPlainIconsSetting = () => {
+		if (process.env.OH_PI_PLAIN_ICONS) {
+			return;
+		}
+		if (loadPlainIconsSetting()) {
+			process.env.OH_PI_PLAIN_ICONS = "1";
+		}
+	};
 	// Register --plain-icons CLI flag
 	pi.registerFlag("plain-icons", {
 		description: "Use ASCII-safe icons instead of emoji (same as OH_PI_PLAIN_ICONS=1 or plainIcons in settings.json)",
@@ -38,15 +56,17 @@ export default function (pi: ExtensionAPI) {
 
 	// Bridge settings.json and --plain-icons flag to the env var
 	// (env var takes precedence, then flag, then settings.json)
-	if (!process.env.OH_PI_PLAIN_ICONS) {
-		const fromFlag = pi.getFlag("plain-icons");
-		if (fromFlag === true) {
-			process.env.OH_PI_PLAIN_ICONS = "1";
-		} else if (loadPlainIconsSetting()) {
-			process.env.OH_PI_PLAIN_ICONS = "1";
-		}
+	if (!process.env.OH_PI_PLAIN_ICONS && pi.getFlag("plain-icons") === true) {
+		process.env.OH_PI_PLAIN_ICONS = "1";
 	}
 	pi.on("session_start", async (_event, ctx) => {
+		cancelPlainIconsSync();
+		plainIconsSyncTimer = setTimeout(() => {
+			plainIconsSyncTimer = undefined;
+			syncPlainIconsSetting();
+		}, STARTUP_PLAIN_ICONS_SYNC_DELAY_MS);
+		plainIconsSyncTimer.unref?.();
+
 		if (!ctx.hasUI) {
 			return;
 		}
@@ -130,5 +150,9 @@ export default function (pi: ExtensionAPI) {
 				invalidate() {},
 			};
 		});
+	});
+
+	pi.on("session_shutdown", async () => {
+		cancelPlainIconsSync();
 	});
 }


### PR DESCRIPTION
## Summary
- defer compact-header settings.json plain-icons sync off the immediate startup path
- keep `--plain-icons` immediate while still allowing settings-based plain icons shortly after startup
- cancel the delayed sync if the session shuts down first

## Testing
- `pnpm exec vitest run packages/extensions/extensions/compact-header.test.ts packages/extensions/extensions/smoke.test.ts`
- `pnpm lint`
- `pnpm typecheck`