### PR TITLE
fix(ollama): align cloud glm reasoning compat

### DIFF
--- a/.changes/ollama-glm-zai-compat.md
+++ b/.changes/ollama-glm-zai-compat.md
@@ -1,0 +1,9 @@
+---
+default: patch
+---
+
+Align Ollama cloud GLM models with the z.ai request semantics used upstream.
+
+- normalize cloud `glm-*` models to use z.ai-compatible thinking flags and `tool_stream`
+- raise cloud GLM max token defaults so the provider can keep a 32k default output budget
+- add regression coverage for GLM request shaping and visible streamed text

--- a/packages/ollama/models.ts
+++ b/packages/ollama/models.ts
@@ -48,6 +48,8 @@ const DEFAULT_CONTEXT_WINDOW = 128_000;
 const DEFAULT_MAX_TOKENS = 16_384;
 const MAX_DISCOVERY_CONCURRENCY = 6;
 
+const OLLAMA_CLOUD_ZAI_REASONING_MAX_TOKENS = 131_072;
+
 const OLLAMA_OPENAI_COMPAT: NonNullable<OllamaProviderModel["compat"]> = {
 	supportsDeveloperRole: false,
 	supportsReasoningEffort: true,
@@ -59,6 +61,12 @@ const OLLAMA_OPENAI_COMPAT: NonNullable<OllamaProviderModel["compat"]> = {
 		xhigh: "high",
 	},
 	maxTokensField: "max_tokens",
+};
+
+const OLLAMA_CLOUD_ZAI_COMPAT: Partial<NonNullable<OllamaProviderModel["compat"]>> = {
+	supportsReasoningEffort: false,
+	thinkingFormat: "zai",
+	zaiToolStream: true,
 };
 
 const FALLBACK_OLLAMA_CLOUD_MODELS: OllamaProviderModel[] = [
@@ -195,7 +203,8 @@ export function mergeOllamaLocalCatalog(
 
 export function toOllamaModel(model: Partial<OllamaProviderModel> & Pick<OllamaProviderModel, "id">): OllamaProviderModel {
 	const contextWindow = normalizePositiveInteger(model.contextWindow, DEFAULT_CONTEXT_WINDOW);
-	const maxTokens = normalizePositiveInteger(model.maxTokens, inferMaxTokens(contextWindow));
+	const maxTokens = normalizeModelMaxTokens(model, contextWindow);
+	const compatDefaults = getOllamaCompatDefaults(model);
 	return {
 		id: model.id,
 		name: applySourceSuffix(model.name?.trim() || formatDisplayName(model.id), model.source),
@@ -204,7 +213,7 @@ export function toOllamaModel(model: Partial<OllamaProviderModel> & Pick<OllamaP
 		cost: model.cost ? { ...model.cost } : { input: 0, output: 0, cacheRead: 0, cacheWrite: 0 },
 		contextWindow,
 		maxTokens,
-		compat: { ...OLLAMA_OPENAI_COMPAT, ...(model.compat ?? {}) },
+		compat: { ...OLLAMA_OPENAI_COMPAT, ...compatDefaults, ...(model.compat ?? {}) },
 		source: model.source,
 		localAvailability: sanitizeLocalAvailability(model.localAvailability),
 		family: sanitizeOptionalString(model.family),
@@ -320,7 +329,14 @@ function sanitizeInput(input: OllamaProviderModel["input"] | undefined): ("text"
 	return [...next];
 }
 
-function inferMaxTokens(contextWindow: number): number {
+function inferMaxTokens(
+	contextWindow: number,
+	model: Partial<Pick<OllamaProviderModel, "id" | "source">> = {},
+): number {
+	if (isOllamaCloudZaiModel(model)) {
+		return OLLAMA_CLOUD_ZAI_REASONING_MAX_TOKENS;
+	}
+
 	if (contextWindow >= 1_000_000) {
 		return 65_536;
 	}
@@ -331,6 +347,34 @@ function inferMaxTokens(contextWindow: number): number {
 		return 20_480;
 	}
 	return DEFAULT_MAX_TOKENS;
+}
+
+function normalizeModelMaxTokens(
+	model: Partial<OllamaProviderModel> & Pick<OllamaProviderModel, "id">,
+	contextWindow: number,
+): number {
+	const inferred = inferMaxTokens(contextWindow, model);
+	const normalized = normalizePositiveInteger(model.maxTokens, inferred);
+
+	if (!isOllamaCloudZaiModel(model)) {
+		return normalized;
+	}
+
+	return Math.max(normalized, OLLAMA_CLOUD_ZAI_REASONING_MAX_TOKENS);
+}
+
+function getOllamaCompatDefaults(
+	model: Partial<Pick<OllamaProviderModel, "id" | "source">>,
+): Partial<NonNullable<OllamaProviderModel["compat"]>> {
+	if (isOllamaCloudZaiModel(model)) {
+		return OLLAMA_CLOUD_ZAI_COMPAT;
+	}
+
+	return {};
+}
+
+function isOllamaCloudZaiModel(model: Partial<Pick<OllamaProviderModel, "id" | "source">>): boolean {
+	return model.source === "cloud" && typeof model.id === "string" && model.id.trim().toLowerCase().startsWith("glm-");
 }
 
 function normalizePositiveInteger(value: number | undefined, fallback: number): number {

--- a/packages/ollama/tests/models.test.ts
+++ b/packages/ollama/tests/models.test.ts
@@ -36,6 +36,19 @@ describe("ollama models", () => {
 		expect(compat?.maxTokensField).toBe("max_tokens");
 	});
 
+	it("applies z.ai compat defaults to cloud glm models", () => {
+		const model = toOllamaModel({ id: "glm-5.1", source: "cloud", reasoning: true, input: ["text"], maxTokens: 25_344 });
+		const compat = model.compat as {
+			supportsReasoningEffort?: boolean;
+			thinkingFormat?: string;
+			zaiToolStream?: boolean;
+		} | undefined;
+		expect(model.maxTokens).toBe(131_072);
+		expect(compat?.supportsReasoningEffort).toBe(false);
+		expect(compat?.thinkingFormat).toBe("zai");
+		expect(compat?.zaiToolStream).toBe(true);
+	});
+
 	it("discovers cloud models with bearer auth", async () => {
 		const backend = await createTestOllamaBackend();
 		backend.setModels([
@@ -84,8 +97,17 @@ describe("ollama models", () => {
 		process.env.PI_OLLAMA_CLOUD_MODELS_URL = `${backend.apiUrl}/models`;
 		process.env.PI_OLLAMA_CLOUD_SHOW_URL = `${backend.origin}/api/show`;
 		const models = await discoverOllamaCloudModels();
+		const glmCompat = models?.[0]?.compat as {
+			supportsReasoningEffort?: boolean;
+			thinkingFormat?: string;
+			zaiToolStream?: boolean;
+		} | undefined;
 		expect(models?.map((model) => model.id)).toEqual(["glm-5.1", "kimi-k2.5"]);
 		expect(models?.[0]?.reasoning).toBe(true);
+		expect(models?.[0]?.maxTokens).toBe(131_072);
+		expect(glmCompat?.supportsReasoningEffort).toBe(false);
+		expect(glmCompat?.thinkingFormat).toBe("zai");
+		expect(glmCompat?.zaiToolStream).toBe(true);
 		expect(models?.[1]?.input).toEqual(["text", "image"]);
 		expect(backend.getAuthHeaders()).toEqual(["", "", ""]);
 		await backend.close();

--- a/packages/ollama/tests/stream.test.ts
+++ b/packages/ollama/tests/stream.test.ts
@@ -1,0 +1,172 @@
+import http from "node:http";
+import type { AddressInfo } from "node:net";
+import { streamSimpleOpenAICompletions, type Model } from "@mariozechner/pi-ai";
+import { describe, expect, it } from "vitest";
+import { toOllamaModel } from "../models.js";
+
+type ChatCompletionPayload = {
+	model?: string;
+	max_tokens?: number;
+	reasoning_effort?: string;
+	enable_thinking?: boolean;
+	stream?: boolean;
+};
+
+async function createReasoningAwareChatBackend(): Promise<{
+	apiUrl: string;
+	requests: ChatCompletionPayload[];
+	close: () => Promise<void>;
+}> {
+	const requests: ChatCompletionPayload[] = [];
+	const server = http.createServer((req, res) => {
+		if (req.url !== "/v1/chat/completions" || req.method !== "POST") {
+			res.writeHead(404, { "Content-Type": "text/plain" });
+			res.end("not found");
+			return;
+		}
+
+		let body = "";
+		req.on("data", (chunk) => {
+			body += String(chunk);
+		});
+		req.on("end", () => {
+			const payload = JSON.parse(body || "{}") as ChatCompletionPayload;
+			requests.push(payload);
+
+			const shouldReturnVisibleText =
+				typeof payload.max_tokens === "number" &&
+				payload.max_tokens >= 32_000 &&
+				payload.reasoning_effort === undefined &&
+				typeof payload.enable_thinking === "boolean";
+
+			res.writeHead(200, {
+				"Cache-Control": "no-cache",
+				Connection: "keep-alive",
+				"Content-Type": "text/event-stream",
+			});
+
+			if (payload.enable_thinking) {
+				writeSse(res, {
+					choices: [{ delta: { reasoning: "Plan the exact reply first." }, finish_reason: null }],
+				});
+			}
+
+			if (shouldReturnVisibleText) {
+				writeSse(res, {
+					choices: [{ delta: { content: "OK" }, finish_reason: null }],
+				});
+			} else {
+				writeSse(res, {
+					choices: [{ delta: { reasoning: "Spent the full budget reasoning." }, finish_reason: null }],
+				});
+			}
+
+			writeSse(res, {
+				choices: [{ delta: {}, finish_reason: "stop" }],
+				usage: {
+					prompt_tokens: 10,
+					completion_tokens: shouldReturnVisibleText ? 12 : 96,
+					prompt_tokens_details: { cached_tokens: 0 },
+					completion_tokens_details: { reasoning_tokens: shouldReturnVisibleText ? 4 : 96 },
+				},
+			});
+			writeSse(res, "[DONE]");
+			res.end();
+		});
+	});
+
+	await new Promise<void>((resolve) => server.listen(0, "127.0.0.1", resolve));
+	const port = (server.address() as AddressInfo).port;
+	const apiUrl = `http://127.0.0.1:${port}/v1`;
+
+	return {
+		apiUrl,
+		requests,
+		async close() {
+			await new Promise<void>((resolve, reject) => server.close((error) => (error ? reject(error) : resolve())));
+		},
+	};
+}
+
+function writeSse(res: http.ServerResponse, chunk: unknown): void {
+	const data = typeof chunk === "string" ? chunk : JSON.stringify(chunk);
+	res.write(`data: ${data}\n\n`);
+}
+
+function createCloudGlmModel(baseUrl: string): Model<"openai-completions"> {
+	return {
+		...toOllamaModel({ id: "glm-5.1", source: "cloud", reasoning: true, input: ["text"], maxTokens: 25_344 }),
+		api: "openai-completions",
+		provider: "ollama-cloud",
+		baseUrl,
+	};
+}
+
+function extractText(blocks: Array<{ type: string; text?: string }>): string {
+	return blocks.filter((block) => block.type === "text").map((block) => block.text ?? "").join("");
+}
+
+describe("ollama glm cloud streaming", () => {
+	it("uses z.ai thinking flags and a larger default token budget when reasoning is enabled", async () => {
+		const backend = await createReasoningAwareChatBackend();
+
+		try {
+			const payloads: ChatCompletionPayload[] = [];
+			const result = await streamSimpleOpenAICompletions(
+				createCloudGlmModel(backend.apiUrl),
+				{
+					messages: [{ role: "user", content: "Reply with exactly: OK", timestamp: Date.now() }],
+				},
+				{
+					apiKey: "test-key",
+					reasoning: "medium",
+					onPayload: (payload) => {
+						payloads.push(payload as ChatCompletionPayload);
+					},
+				},
+			).result();
+
+			expect(extractText(result.content as Array<{ type: string; text?: string }>)).toBe("OK");
+			expect(payloads[0]).toMatchObject({
+				enable_thinking: true,
+				max_tokens: 32_000,
+				model: "glm-5.1",
+			});
+			expect(payloads[0]?.reasoning_effort).toBeUndefined();
+			expect(backend.requests[0]).toMatchObject({ enable_thinking: true, max_tokens: 32_000 });
+		} finally {
+			await backend.close();
+		}
+	});
+
+	it("explicitly disables z.ai thinking by default so glm replies stay visible", async () => {
+		const backend = await createReasoningAwareChatBackend();
+
+		try {
+			const payloads: ChatCompletionPayload[] = [];
+			const result = await streamSimpleOpenAICompletions(
+				createCloudGlmModel(backend.apiUrl),
+				{
+					messages: [{ role: "user", content: "Reply with exactly: OK", timestamp: Date.now() }],
+				},
+				{
+					apiKey: "test-key",
+					onPayload: (payload) => {
+						payloads.push(payload as ChatCompletionPayload);
+					},
+				},
+			).result();
+
+			expect(extractText(result.content as Array<{ type: string; text?: string }>)).toBe("OK");
+			expect(payloads[0]).toMatchObject({
+				enable_thinking: false,
+				max_tokens: 32_000,
+				model: "glm-5.1",
+			});
+			expect(payloads[0]?.reasoning_effort).toBeUndefined();
+			expect(backend.requests[0]).toMatchObject({ enable_thinking: false, max_tokens: 32_000 });
+		} finally {
+			await backend.close();
+		}
+	});
+});


### PR DESCRIPTION
## Summary
- treat Ollama cloud `glm-*` models like z.ai reasoning models when normalizing compat metadata
- raise cloud GLM max token defaults so requests keep a 32k default output budget
- add regression coverage for GLM request shaping and visible streamed text

## Testing
- pnpm --filter @ifi/pi-provider-ollama run typecheck
- pnpm --filter @ifi/pi-provider-ollama run test:worktree