### PR TITLE
fix: defer subagents global startup cleanup

### DIFF
--- a/.changeset/subagents-global-startup-cleanup-defer.md
+++ b/.changeset/subagents-global-startup-cleanup-defer.md
@@ -1,0 +1,5 @@
+---
+default: patch
+---
+
+fix: defer subagents global startup cleanup

--- a/packages/subagents/index.ts
+++ b/packages/subagents/index.ts
@@ -61,7 +61,7 @@ import { registerSubagentCommands } from "./command-registration.js";
 import { ensureAccessibleDir, expandTildePath, getSubagentSessionRoot, loadSubagentConfig } from "./bootstrap.js";
 import { createSubagentRuntimeMonitor } from "./runtime-monitor.js";
 
-const STARTUP_ARTIFACT_CLEANUP_DELAY_MS = 250;
+const STARTUP_CLEANUP_DELAY_MS = 250;
 
 // ExtensionConfig is now imported from ./types.js
 
@@ -69,14 +69,10 @@ export default function registerSubagentExtension(pi: ExtensionAPI): void {
 	ensureAccessibleDir(RESULTS_DIR);
 	ensureAccessibleDir(ASYNC_DIR);
 
-	// Cleanup old chain directories on startup (after 24h)
-	cleanupOldChainDirs();
-
 	const config = loadSubagentConfig();
 	const asyncByDefault = config.asyncByDefault === true;
 
 	const tempArtifactsDir = getArtifactsDir(null);
-	cleanupAllArtifactDirs(DEFAULT_ARTIFACT_CONFIG.cleanupDays);
 	let baseCwd = process.cwd();
 	let currentSessionId: string | null = null;
 	const asyncJobs = new Map<string, AsyncJobState>();
@@ -1051,6 +1047,15 @@ MANAGEMENT (use action field — omit agent/task/chain/tasks):
 	});
 
 	let startupCleanupTimer: ReturnType<typeof setTimeout> | undefined;
+	let startupGlobalCleanupCompleted = false;
+	const runGlobalStartupCleanup = () => {
+		if (startupGlobalCleanupCompleted) {
+			return;
+		}
+		startupGlobalCleanupCompleted = true;
+		cleanupOldChainDirs();
+		cleanupAllArtifactDirs(DEFAULT_ARTIFACT_CONFIG.cleanupDays);
+	};
 	const cleanupSessionArtifacts = (ctx: ExtensionContext) => {
 		try {
 			const sessionFile = ctx.sessionManager.getSessionFile();
@@ -1070,8 +1075,9 @@ MANAGEMENT (use action field — omit agent/task/chain/tasks):
 		cancelStartupCleanup();
 		startupCleanupTimer = setTimeout(() => {
 			startupCleanupTimer = undefined;
+			runGlobalStartupCleanup();
 			cleanupSessionArtifacts(ctx);
-		}, STARTUP_ARTIFACT_CLEANUP_DELAY_MS);
+		}, STARTUP_CLEANUP_DELAY_MS);
 		startupCleanupTimer.unref?.();
 	};
 	const resetSessionState = (ctx: ExtensionContext, options: { deferArtifactCleanup?: boolean } = {}) => {

--- a/packages/subagents/tests/session-churn.test.ts
+++ b/packages/subagents/tests/session-churn.test.ts
@@ -6,14 +6,18 @@ const {
 	mockWatcherClose,
 	mockCoalescerClear,
 	mockCoalescerSchedule,
+	mockCleanupAllArtifactDirs,
 	mockCleanupOldArtifacts,
+	mockCleanupOldChainDirs,
 } = vi.hoisted(() => ({
 	mockRenderWidget: vi.fn(),
 	mockReadStatus: vi.fn(() => null),
 	mockWatcherClose: vi.fn(),
 	mockCoalescerClear: vi.fn(),
 	mockCoalescerSchedule: vi.fn(),
+	mockCleanupAllArtifactDirs: vi.fn(),
 	mockCleanupOldArtifacts: vi.fn(),
+	mockCleanupOldChainDirs: vi.fn(),
 }));
 
 vi.mock("node:fs", () => ({
@@ -48,7 +52,7 @@ vi.mock("../agent-scope.js", () => ({
 	resolveExecutionAgentScope: () => "both",
 }));
 vi.mock("../settings.js", () => ({
-	cleanupOldChainDirs: vi.fn(),
+	cleanupOldChainDirs: mockCleanupOldChainDirs,
 	getStepAgents: vi.fn(() => []),
 	isParallelStep: vi.fn(() => false),
 	resolveStepBehavior: vi.fn(() => ({})),
@@ -57,7 +61,7 @@ vi.mock("../chain-clarify.js", () => ({
 	ChainClarifyComponent: class {},
 }));
 vi.mock("../artifacts.js", () => ({
-	cleanupAllArtifactDirs: vi.fn(),
+	cleanupAllArtifactDirs: mockCleanupAllArtifactDirs,
 	cleanupOldArtifacts: mockCleanupOldArtifacts,
 	getArtifactsDir: vi.fn(() => "/tmp/artifacts"),
 }));
@@ -194,7 +198,9 @@ beforeEach(() => {
 	mockWatcherClose.mockReset();
 	mockCoalescerClear.mockReset();
 	mockCoalescerSchedule.mockReset();
+	mockCleanupAllArtifactDirs.mockReset();
 	mockCleanupOldArtifacts.mockReset();
+	mockCleanupOldChainDirs.mockReset();
 });
 
 afterEach(() => {
@@ -203,15 +209,28 @@ afterEach(() => {
 });
 
 describe("subagent session churn", () => {
-	it("defers session_start artifact cleanup until after the startup window", async () => {
+	it("does not run global cleanup during extension registration", () => {
+		const pi = createMockPi();
+
+		registerSubagentExtension(pi as any);
+
+		expect(mockCleanupOldChainDirs).not.toHaveBeenCalled();
+		expect(mockCleanupAllArtifactDirs).not.toHaveBeenCalled();
+	});
+
+	it("defers startup cleanup until after the startup window", async () => {
 		const pi = createMockPi();
 		const ctx = createCtx();
 
 		registerSubagentExtension(pi as any);
 		await pi._emit("session_start", {}, ctx);
+		expect(mockCleanupOldChainDirs).not.toHaveBeenCalled();
+		expect(mockCleanupAllArtifactDirs).not.toHaveBeenCalled();
 		expect(mockCleanupOldArtifacts).not.toHaveBeenCalled();
 
 		await vi.advanceTimersByTimeAsync(250);
+		expect(mockCleanupOldChainDirs).toHaveBeenCalledTimes(1);
+		expect(mockCleanupAllArtifactDirs).toHaveBeenCalledWith(7);
 		expect(mockCleanupOldArtifacts).toHaveBeenCalledWith("/tmp/artifacts", 7);
 	});
 
@@ -224,6 +243,8 @@ describe("subagent session churn", () => {
 		await pi._emit("session_shutdown");
 		await vi.advanceTimersByTimeAsync(250);
 
+		expect(mockCleanupOldChainDirs).not.toHaveBeenCalled();
+		expect(mockCleanupAllArtifactDirs).not.toHaveBeenCalled();
 		expect(mockCleanupOldArtifacts).not.toHaveBeenCalled();
 	});
 


### PR DESCRIPTION
## Summary
- defer subagents global cleanup scans off the immediate extension startup path
- keep the cleanup work on the first session startup, alongside the existing delayed per-session cleanup
- add coverage that registration no longer runs the global cleanup eagerly and that shutdown cancels the deferred work

## Testing
- `pnpm exec vitest run packages/subagents/tests/session-churn.test.ts packages/subagents/tests/smoke.test.ts`
- `pnpm lint`
- `pnpm typecheck`