### PR TITLE
fix: lazy-load ant-colony storage config

### DIFF
--- a/.changeset/ant-colony-storage-lazy.md
+++ b/.changeset/ant-colony-storage-lazy.md
@@ -1,0 +1,5 @@
+---
+default: patch
+---
+
+fix: lazily resolve ant-colony storage options

--- a/packages/ant-colony/extensions/ant-colony/index.ts
+++ b/packages/ant-colony/extensions/ant-colony/index.ts
@@ -86,7 +86,11 @@ interface BackgroundColony {
 }
 
 export default function antColonyExtension(pi: ExtensionAPI) {
-	const storageOptions = resolveColonyStorageOptions();
+	let storageOptions: ReturnType<typeof resolveColonyStorageOptions> | null = null;
+	const getStorageOptions = () => {
+		storageOptions ??= resolveColonyStorageOptions();
+		return storageOptions;
+	};
 	/** All running background colonies, keyed by short ID. */
 	const colonies = new Map<string, BackgroundColony>();
 	/** Auto-incrementing colony counter for generating IDs. */
@@ -345,6 +349,7 @@ export default function antColonyExtension(pi: ExtensionAPI) {
 		},
 		signal?: AbortSignal | null,
 	) {
+		const storageOptions = getStorageOptions();
 		if (shouldManageProjectGitignore(storageOptions)) {
 			ensureGitignore(params.cwd);
 		}
@@ -410,6 +415,7 @@ export default function antColonyExtension(pi: ExtensionAPI) {
 		},
 		options?: { resume?: boolean; stableIdHint?: string; workspaceHint?: ColonyWorkspace | null },
 	): { id: string; workspace: ColonyWorkspace } {
+		const storageOptions = getStorageOptions();
 		const resume = options?.resume ?? false;
 		const colonyId = nextColonyId();
 		const abortController = new AbortController();
@@ -1415,7 +1421,7 @@ export default function antColonyExtension(pi: ExtensionAPI) {
 	pi.registerCommand("colony-resume", {
 		description: "Resume colonies from their last checkpoint (resumes all resumable by default)",
 		async handler(args, ctx) {
-			const all = Nest.findAllResumable(ctx.cwd, storageOptions);
+			const all = Nest.findAllResumable(ctx.cwd, getStorageOptions());
 			if (all.length === 0) {
 				ctx.ui.notify("No resumable colonies found.", "info");
 				return;

--- a/packages/ant-colony/tests/index.test.ts
+++ b/packages/ant-colony/tests/index.test.ts
@@ -92,11 +92,31 @@ const runColonyMock = queenMocks.runColonyMock;
 const resumeColonyMock = queenMocks.resumeColonyMock;
 const createUsageLimitsTrackerMock = queenMocks.createUsageLimitsTrackerMock;
 
+const storageMocks = vi.hoisted(() => ({
+	resolveColonyStorageOptionsMock: vi.fn(),
+	shouldManageProjectGitignoreMock: vi.fn(),
+}));
+
 vi.mock("../extensions/ant-colony/queen.js", () => ({
 	runColony: queenMocks.runColonyMock,
 	resumeColony: queenMocks.resumeColonyMock,
 	createUsageLimitsTracker: queenMocks.createUsageLimitsTrackerMock,
 }));
+
+vi.mock("../extensions/ant-colony/storage.js", async (importActual) => {
+	const actual = await importActual<typeof import("../extensions/ant-colony/storage.js")>();
+	storageMocks.resolveColonyStorageOptionsMock.mockImplementation((options?: any) =>
+		actual.resolveColonyStorageOptions(options),
+	);
+	storageMocks.shouldManageProjectGitignoreMock.mockImplementation((options?: any) =>
+		actual.shouldManageProjectGitignore(options),
+	);
+	return {
+		...actual,
+		resolveColonyStorageOptions: storageMocks.resolveColonyStorageOptionsMock,
+		shouldManageProjectGitignore: storageMocks.shouldManageProjectGitignoreMock,
+	};
+});
 
 vi.mock("../extensions/ant-colony/worktree.js", async (importActual) => {
 	const actual = await importActual<typeof import("../extensions/ant-colony/worktree.js")>();
@@ -385,11 +405,20 @@ describe("index-level telemetry propagation", () => {
 	let restoreStorageEnv: (() => void) | undefined;
 
 	beforeEach(() => {
+		storageMocks.resolveColonyStorageOptionsMock.mockClear();
+		storageMocks.shouldManageProjectGitignoreMock.mockClear();
 		restoreStorageEnv = withSharedStorageEnv();
 	});
 
 	afterEach(() => {
 		restoreStorageEnv?.();
+	});
+
+	it("does not resolve colony storage options during extension registration", () => {
+		const pi = createMockPi();
+		antColonyExtension(pi as any);
+
+		expect(storageMocks.resolveColonyStorageOptionsMock).not.toHaveBeenCalled();
 	});
 
 	it("passes eventBus into ant_colony runtime tool execution", async () => {
@@ -409,6 +438,7 @@ describe("index-level telemetry propagation", () => {
 
 		const executePromise = antColonyTool.execute("id", { goal: "test telemetry" }, undefined, undefined, ctx);
 
+		expect(storageMocks.resolveColonyStorageOptionsMock).toHaveBeenCalledTimes(1);
 		expect(runInvocations).toHaveLength(1);
 		expect(runInvocations[0].opts.eventBus).toBe(pi.events);
 


### PR DESCRIPTION
## Summary
- avoid reading ant-colony storage config during extension registration
- resolve storage options lazily only when a colony command/tool flow actually needs them
- add coverage that registration stays lazy while runtime execution still resolves storage once

## Testing
- `pnpm exec vitest run packages/ant-colony/tests/index.test.ts`
- `pnpm lint`
- `pnpm typecheck`