### PR TITLE
fix(ollama): seed cloud models before startup refresh

### DIFF
--- a/.changes/ollama-cloud-startup-fallback-models.md
+++ b/.changes/ollama-cloud-startup-fallback-models.md
@@ -1,0 +1,9 @@
+---
+default: patch
+---
+
+Seed Ollama cloud fallback models during startup so scoped model filters can resolve known cloud models before async discovery completes.
+
+- register fallback cloud models immediately on startup
+- keep async public/authenticated discovery replacing the startup seed afterward
+- add smoke coverage for the initial fallback model list

--- a/packages/ollama/index.ts
+++ b/packages/ollama/index.ts
@@ -74,7 +74,7 @@ const localDiscoveryState: RuntimeDiscoveryState = {
 };
 
 const cloudEnvDiscoveryState: RuntimeDiscoveryState = {
-	models: [],
+	models: getFallbackOllamaCloudModels(),
 	lastRefresh: null,
 	lastError: null,
 };

--- a/packages/ollama/tests/smoke.test.ts
+++ b/packages/ollama/tests/smoke.test.ts
@@ -42,6 +42,27 @@ describe("ollama provider smoke tests", () => {
 		await expect(harness.emitAsync("session_start", { type: "session_start" }, harness.ctx)).resolves.toBeDefined();
 	});
 
+	it("seeds cloud fallback models before async discovery finishes", async () => {
+		const backend = await createTestOllamaBackend();
+		backend.setModels([
+			{ id: "glm-5.1", capabilities: ["completion", "tools", "thinking"], contextWindow: 202752 },
+			{ id: "kimi-k2.5", capabilities: ["completion", "tools", "thinking", "vision"], contextWindow: 262144 },
+		]);
+		process.env.PI_OLLAMA_CLOUD_API_URL = backend.apiUrl;
+		process.env.PI_OLLAMA_CLOUD_MODELS_URL = `${backend.apiUrl}/models`;
+		process.env.PI_OLLAMA_CLOUD_SHOW_URL = `${backend.origin}/api/show`;
+		delete process.env.OLLAMA_API_KEY;
+
+		const harness = createExtensionHarness();
+		ollamaProviderExtension(harness.pi as never);
+
+		const initialModels = harness.providers.get("ollama-cloud")?.models as Array<{ id: string }> | undefined;
+		expect(initialModels?.some((model) => model.id === "glm-5.1")).toBe(true);
+		expect((initialModels?.length ?? 0) > 2).toBe(true);
+
+		await backend.close();
+	});
+
 	it("bootstraps the public cloud catalog without an API key", async () => {
 		const backend = await createTestOllamaBackend();
 		backend.setModels([


### PR DESCRIPTION
## Summary
- seed Ollama cloud fallback models immediately during provider registration
- keep async discovery replacing the startup seed once public/authenticated refresh completes
- add smoke coverage for the initial fallback model list

## Testing
- pnpm --filter @ifi/pi-provider-ollama run typecheck
- pnpm --filter @ifi/pi-provider-ollama run test:worktree