### PR TITLE
fix(ollama): route cloud requests by provider

### DIFF
--- a/.changes/ollama-openai-completions-dispatch.md
+++ b/.changes/ollama-openai-completions-dispatch.md
@@ -1,0 +1,10 @@
+---
+default: patch
+---
+
+Fix Ollama startup and request routing so cloud models can be selected and answered reliably.
+
+- seed fallback Ollama cloud models immediately so startup model scoping can resolve known cloud IDs before async refresh finishes
+- route Ollama `openai-completions` requests by `model.provider` instead of assuming one handler per provider registration
+- keep non-Ollama `openai-completions` models on pi's built-in OpenAI-compatible stream path
+- add regression coverage for both startup fallback models and cloud dispatch when the local provider registers last

--- a/packages/ollama/index.ts
+++ b/packages/ollama/index.ts
@@ -74,7 +74,7 @@ const localDiscoveryState: RuntimeDiscoveryState = {
 };
 
 const cloudEnvDiscoveryState: RuntimeDiscoveryState = {
-	models: [],
+	models: getFallbackOllamaCloudModels(),
 	lastRefresh: null,
 	lastError: null,
 };
@@ -92,7 +92,7 @@ function registerOllamaLocalProvider(pi: ExtensionAPI): void {
 		apiKey: OLLAMA_LOCAL_API_KEY_LITERAL,
 		baseUrl: getOllamaLocalRuntimeConfig().apiUrl,
 		models: toProviderModels(getRegisteredLocalModels()),
-		streamSimple: streamSimpleOllamaLocal,
+		streamSimple: streamSimpleOllama,
 	});
 }
 
@@ -103,7 +103,7 @@ function registerOllamaCloudProvider(pi: ExtensionAPI): void {
 		baseUrl: getOllamaCloudRuntimeConfig().apiUrl,
 		oauth: createOllamaCloudOAuthProvider(),
 		models: toProviderModels(cloudEnvDiscoveryState.models),
-		streamSimple: streamSimpleOllamaCloud,
+		streamSimple: streamSimpleOllama,
 	});
 }
 
@@ -409,6 +409,18 @@ async function pullLocalModel(pi: ExtensionAPI, ctx: CommandContextLike, modelId
 
 	activeLocalPulls.set(modelId, run);
 	return run;
+}
+
+function streamSimpleOllama(model: Model<any>, context: Context, options?: SimpleStreamOptions): AssistantMessageEventStream {
+	if (model.provider === OLLAMA_LOCAL_PROVIDER) {
+		return streamSimpleOllamaLocal(model, context, options);
+	}
+
+	if (model.provider === OLLAMA_CLOUD_PROVIDER) {
+		return streamSimpleOllamaCloud(model, context, options);
+	}
+
+	return streamSimpleOpenAICompletions(model as Model<"openai-completions">, context, options);
 }
 
 function streamSimpleOllamaCloud(model: Model<any>, context: Context, options?: SimpleStreamOptions): AssistantMessageEventStream {

--- a/packages/ollama/tests/smoke.test.ts
+++ b/packages/ollama/tests/smoke.test.ts
@@ -42,6 +42,27 @@ describe("ollama provider smoke tests", () => {
 		await expect(harness.emitAsync("session_start", { type: "session_start" }, harness.ctx)).resolves.toBeDefined();
 	});
 
+	it("seeds cloud fallback models before async discovery finishes", async () => {
+		const backend = await createTestOllamaBackend();
+		backend.setModels([
+			{ id: "glm-5.1", capabilities: ["completion", "tools", "thinking"], contextWindow: 202752 },
+			{ id: "kimi-k2.5", capabilities: ["completion", "tools", "thinking", "vision"], contextWindow: 262144 },
+		]);
+		process.env.PI_OLLAMA_CLOUD_API_URL = backend.apiUrl;
+		process.env.PI_OLLAMA_CLOUD_MODELS_URL = `${backend.apiUrl}/models`;
+		process.env.PI_OLLAMA_CLOUD_SHOW_URL = `${backend.origin}/api/show`;
+		delete process.env.OLLAMA_API_KEY;
+
+		const harness = createExtensionHarness();
+		ollamaProviderExtension(harness.pi as never);
+
+		const initialModels = harness.providers.get("ollama-cloud")?.models as Array<{ id: string }> | undefined;
+		expect(initialModels?.some((model) => model.id === "glm-5.1")).toBe(true);
+		expect((initialModels?.length ?? 0) > 2).toBe(true);
+
+		await backend.close();
+	});
+
 	it("bootstraps the public cloud catalog without an API key", async () => {
 		const backend = await createTestOllamaBackend();
 		backend.setModels([

--- a/packages/ollama/tests/smoke.test.ts
+++ b/packages/ollama/tests/smoke.test.ts
@@ -1,9 +1,62 @@
+import http from "node:http";
+import type { AddressInfo } from "node:net";
 import { afterEach, describe, expect, it } from "vitest";
 import { createExtensionHarness } from "../../../test-utils/extension-runtime-harness.js";
 import ollamaProviderExtension from "../index.js";
 import { createTestOllamaBackend } from "./test-backend.js";
 
 const envSnapshot = { ...process.env };
+
+async function createDelayedCloudBootstrapBackend(): Promise<{ apiUrl: string; origin: string; close: () => Promise<void> }> {
+	const server = http.createServer((req, res) => {
+		const reply = () => {
+			if (req.url === "/v1/models" && req.method === "GET") {
+				res.writeHead(200, { "Content-Type": "application/json" });
+				res.end(JSON.stringify({ data: [{ id: "glm-5.1", object: "model" }, { id: "kimi-k2.5", object: "model" }] }));
+				return;
+			}
+
+			if (req.url === "/api/show" && req.method === "POST") {
+				let body = "";
+				req.on("data", (chunk) => {
+					body += String(chunk);
+				});
+				req.on("end", () => {
+					const parsed = JSON.parse(body || "{}") as { model?: string };
+					const contextWindow = parsed.model === "kimi-k2.5" ? 262144 : 202752;
+					const capabilities = parsed.model === "kimi-k2.5"
+						? ["completion", "tools", "thinking", "vision"]
+						: ["completion", "tools", "thinking"];
+					res.writeHead(200, { "Content-Type": "application/json" });
+					res.end(
+						JSON.stringify({
+							capabilities,
+							model_info: { [`${(parsed.model ?? "glm").split(/[:.-]/)[0]}.context_length`]: contextWindow },
+							details: {},
+						}),
+					);
+				});
+				return;
+			}
+
+			res.writeHead(404, { "Content-Type": "text/plain" });
+			res.end("not found");
+		};
+
+		setTimeout(reply, 50);
+	});
+
+	await new Promise<void>((resolve) => server.listen(0, "127.0.0.1", resolve));
+	const port = (server.address() as AddressInfo).port;
+	const origin = `http://127.0.0.1:${port}`;
+	return {
+		apiUrl: `${origin}/v1`,
+		origin,
+		async close() {
+			await new Promise<void>((resolve, reject) => server.close((error) => (error ? reject(error) : resolve())));
+		},
+	};
+}
 
 afterEach(() => {
 	for (const key of Object.keys(process.env)) {
@@ -27,6 +80,13 @@ describe("ollama provider smoke tests", () => {
 	});
 
 	it("does not crash on session_start when auth storage is not ready", async () => {
+		const backend = await createTestOllamaBackend();
+		backend.setModels([{ id: "glm-5.1", capabilities: ["completion", "tools", "thinking"], contextWindow: 202752 }]);
+		process.env.PI_OLLAMA_CLOUD_API_URL = backend.apiUrl;
+		process.env.PI_OLLAMA_CLOUD_MODELS_URL = `${backend.apiUrl}/models`;
+		process.env.PI_OLLAMA_CLOUD_SHOW_URL = `${backend.origin}/api/show`;
+		delete process.env.OLLAMA_API_KEY;
+
 		const harness = createExtensionHarness();
 		(harness.ctx as any).modelRegistry = {
 			...(harness.ctx.modelRegistry as object),
@@ -40,14 +100,11 @@ describe("ollama provider smoke tests", () => {
 		ollamaProviderExtension(harness.pi as never);
 
 		await expect(harness.emitAsync("session_start", { type: "session_start" }, harness.ctx)).resolves.toBeDefined();
+		await backend.close();
 	});
 
-	it("seeds cloud fallback models before async discovery finishes", async () => {
-		const backend = await createTestOllamaBackend();
-		backend.setModels([
-			{ id: "glm-5.1", capabilities: ["completion", "tools", "thinking"], contextWindow: 202752 },
-			{ id: "kimi-k2.5", capabilities: ["completion", "tools", "thinking", "vision"], contextWindow: 262144 },
-		]);
+	it("exposes a cloud glm model immediately on startup", async () => {
+		const backend = await createDelayedCloudBootstrapBackend();
 		process.env.PI_OLLAMA_CLOUD_API_URL = backend.apiUrl;
 		process.env.PI_OLLAMA_CLOUD_MODELS_URL = `${backend.apiUrl}/models`;
 		process.env.PI_OLLAMA_CLOUD_SHOW_URL = `${backend.origin}/api/show`;
@@ -58,7 +115,6 @@ describe("ollama provider smoke tests", () => {
 
 		const initialModels = harness.providers.get("ollama-cloud")?.models as Array<{ id: string }> | undefined;
 		expect(initialModels?.some((model) => model.id === "glm-5.1")).toBe(true);
-		expect((initialModels?.length ?? 0) > 2).toBe(true);
 
 		await backend.close();
 	});

--- a/packages/ollama/tests/stream.test.ts
+++ b/packages/ollama/tests/stream.test.ts
@@ -1,7 +1,10 @@
 import http from "node:http";
 import type { AddressInfo } from "node:net";
-import { streamSimpleOpenAICompletions, type Model } from "@mariozechner/pi-ai";
-import { describe, expect, it } from "vitest";
+import { registerApiProvider, resetApiProviders, streamSimple, streamSimpleOpenAICompletions, type Model } from "@mariozechner/pi-ai";
+import { afterEach, describe, expect, it } from "vitest";
+import { createExtensionHarness } from "../../../test-utils/extension-runtime-harness.js";
+import ollamaProviderExtension from "../index.js";
+import { OLLAMA_API } from "../config.js";
 import { toOllamaModel } from "../models.js";
 
 type ChatCompletionPayload = {
@@ -106,6 +109,10 @@ function extractText(blocks: Array<{ type: string; text?: string }>): string {
 	return blocks.filter((block) => block.type === "text").map((block) => block.text ?? "").join("");
 }
 
+afterEach(() => {
+	resetApiProviders();
+});
+
 describe("ollama glm cloud streaming", () => {
 	it("uses z.ai thinking flags and a larger default token budget when reasoning is enabled", async () => {
 		const backend = await createReasoningAwareChatBackend();
@@ -165,6 +172,50 @@ describe("ollama glm cloud streaming", () => {
 			});
 			expect(payloads[0]?.reasoning_effort).toBeUndefined();
 			expect(backend.requests[0]).toMatchObject({ enable_thinking: false, max_tokens: 32_000 });
+		} finally {
+			await backend.close();
+		}
+	});
+
+	it("keeps cloud glm requests on the cloud path even when the local provider registers last", async () => {
+		const backend = await createReasoningAwareChatBackend();
+		const harness = createExtensionHarness();
+		ollamaProviderExtension(harness.pi as never);
+
+		const cloudProvider = harness.providers.get("ollama-cloud");
+		const localProvider = harness.providers.get("ollama");
+		if (!cloudProvider || !localProvider) {
+			throw new Error("Expected ollama providers to be registered");
+		}
+
+		registerApiProvider(
+			{
+				api: OLLAMA_API,
+				stream: (model, context, options) => cloudProvider.streamSimple(model, context, options),
+				streamSimple: cloudProvider.streamSimple,
+			},
+			"test:ollama-cloud",
+		);
+		registerApiProvider(
+			{
+				api: OLLAMA_API,
+				stream: (model, context, options) => localProvider.streamSimple(model, context, options),
+				streamSimple: localProvider.streamSimple,
+			},
+			"test:ollama-local",
+		);
+
+		try {
+			const result = await streamSimple(
+				createCloudGlmModel(backend.apiUrl),
+				{
+					messages: [{ role: "user", content: "Reply with exactly: OK", timestamp: Date.now() }],
+				},
+				{ apiKey: "test-key" },
+			).result();
+
+			expect(extractText(result.content as Array<{ type: string; text?: string }>)).toBe("OK");
+			expect(backend.requests[0]).toMatchObject({ model: "glm-5.1", max_tokens: 32_000, enable_thinking: false });
 		} finally {
 			await backend.close();
 		}


### PR DESCRIPTION
## Summary
- seed fallback cloud models immediately so startup model scope can resolve `ollama-cloud/...` ids
- route Ollama requests by `model.provider` instead of assuming one handler per `openai-completions` API registration
- keep non-Ollama `openai-completions` models on pi's built-in path
- add regression coverage for startup seeding and cloud dispatch when the local provider registers last

## Validation
- pnpm --filter @ifi/pi-provider-ollama run typecheck
- pnpm --filter @ifi/pi-provider-ollama run test:worktree
- verified real pi CLI startup + print mode with a temporary PI_CODING_AGENT_DIR against this branch:
  - `pi --help` no longer warns about `ollama-cloud/glm-5.1`
  - `pi --no-session -p "Reply with exactly: OK"` returns `OK`
  - `pi --no-session -p --model ollama-cloud/glm-5.1 "Reply with exactly: OK"` returns `OK`