### PR TITLE
fix(subagents): avoid blocking startup cleanup

### DIFF
--- a/.changeset/subagents-startup-cleanup-async.md
+++ b/.changeset/subagents-startup-cleanup-async.md
@@ -1,0 +1,5 @@
+---
+"default": patch
+---
+
+fix(subagents): run startup cleanup without blocking the event loop

--- a/packages/subagents/artifacts.ts
+++ b/packages/subagents/artifacts.ts
@@ -43,43 +43,59 @@ export function appendJsonl(filePath: string, line: string): void {
 	fs.appendFileSync(filePath, `${line}\n`);
 }
 
-export function cleanupOldArtifacts(dir: string, maxAgeDays: number): void {
-	if (!fs.existsSync(dir)) return;
+export async function cleanupOldArtifacts(dir: string, maxAgeDays: number): Promise<void> {
+	try {
+		await fs.promises.access(dir, fs.constants.F_OK);
+	} catch {
+		return;
+	}
 
 	const markerPath = path.join(dir, CLEANUP_MARKER_FILE);
 	const now = Date.now();
 
-	if (fs.existsSync(markerPath)) {
-		const stat = fs.statSync(markerPath);
-		if (now - stat.mtimeMs < 24 * 60 * 60 * 1000) return;
-	}
+	try {
+		const stat = await fs.promises.stat(markerPath);
+		if (now - stat.mtimeMs < 24 * 60 * 60 * 1000) {
+			return;
+		}
+	} catch {}
 
 	const maxAgeMs = maxAgeDays * 24 * 60 * 60 * 1000;
 	const cutoff = now - maxAgeMs;
 
-	for (const file of fs.readdirSync(dir)) {
-		if (file === CLEANUP_MARKER_FILE) continue;
+	let files: string[];
+	try {
+		files = await fs.promises.readdir(dir);
+	} catch {
+		return;
+	}
+
+	for (const file of files) {
+		if (file === CLEANUP_MARKER_FILE) {
+			continue;
+		}
+
 		const filePath = path.join(dir, file);
 		try {
-			const stat = fs.statSync(filePath);
+			const stat = await fs.promises.stat(filePath);
 			if (stat.mtimeMs < cutoff) {
-				fs.unlinkSync(filePath);
+				await fs.promises.unlink(filePath);
 			}
 		} catch {}
 	}
 
-	fs.writeFileSync(markerPath, String(now));
+	try {
+		await fs.promises.writeFile(markerPath, String(now));
+	} catch {}
 }
 
-export function cleanupAllArtifactDirs(maxAgeDays: number): void {
-	cleanupOldArtifacts(TEMP_ARTIFACTS_DIR, maxAgeDays);
+export async function cleanupAllArtifactDirs(maxAgeDays: number): Promise<void> {
+	await cleanupOldArtifacts(TEMP_ARTIFACTS_DIR, maxAgeDays);
 
 	const sessionsBase = getSessionsBaseDir();
-	if (!fs.existsSync(sessionsBase)) return;
-
 	let dirs: string[];
 	try {
-		dirs = fs.readdirSync(sessionsBase);
+		dirs = await fs.promises.readdir(sessionsBase);
 	} catch {
 		return;
 	}
@@ -87,7 +103,7 @@ export function cleanupAllArtifactDirs(maxAgeDays: number): void {
 	for (const dir of dirs) {
 		const artifactsDir = path.join(sessionsBase, dir, "subagent-artifacts");
 		try {
-			cleanupOldArtifacts(artifactsDir, maxAgeDays);
+			await cleanupOldArtifacts(artifactsDir, maxAgeDays);
 		} catch {}
 	}
 }

--- a/packages/subagents/index.ts
+++ b/packages/subagents/index.ts
@@ -1053,19 +1053,19 @@ MANAGEMENT (use action field — omit agent/task/chain/tasks):
 
 	let startupCleanupTimer: ReturnType<typeof setTimeout> | undefined;
 	let startupGlobalCleanupCompleted = false;
-	const runGlobalStartupCleanup = () => {
+	const runGlobalStartupCleanup = async (): Promise<void> => {
 		if (startupGlobalCleanupCompleted) {
 			return;
 		}
 		startupGlobalCleanupCompleted = true;
-		cleanupOldChainDirs();
-		cleanupAllArtifactDirs(DEFAULT_ARTIFACT_CONFIG.cleanupDays);
+		await cleanupOldChainDirs();
+		await cleanupAllArtifactDirs(DEFAULT_ARTIFACT_CONFIG.cleanupDays);
 	};
-	const cleanupSessionArtifacts = (ctx: ExtensionContext) => {
+	const cleanupSessionArtifacts = async (ctx: ExtensionContext): Promise<void> => {
 		try {
 			const sessionFile = ctx.sessionManager.getSessionFile();
 			if (sessionFile) {
-				cleanupOldArtifacts(getArtifactsDir(sessionFile), DEFAULT_ARTIFACT_CONFIG.cleanupDays);
+				await cleanupOldArtifacts(getArtifactsDir(sessionFile), DEFAULT_ARTIFACT_CONFIG.cleanupDays);
 			}
 		} catch {}
 	};
@@ -1080,8 +1080,10 @@ MANAGEMENT (use action field — omit agent/task/chain/tasks):
 		cancelStartupCleanup();
 		startupCleanupTimer = setTimeout(() => {
 			startupCleanupTimer = undefined;
-			runGlobalStartupCleanup();
-			cleanupSessionArtifacts(ctx);
+			void (async () => {
+				await runGlobalStartupCleanup();
+				await cleanupSessionArtifacts(ctx);
+			})();
 		}, STARTUP_CLEANUP_DELAY_MS);
 		startupCleanupTimer.unref?.();
 	};
@@ -1093,7 +1095,7 @@ MANAGEMENT (use action field — omit agent/task/chain/tasks):
 			scheduleStartupCleanup(ctx);
 		} else {
 			cancelStartupCleanup();
-			cleanupSessionArtifacts(ctx);
+			void cleanupSessionArtifacts(ctx);
 		}
 		for (const timer of cleanupTimers.values()) clearTimeout(timer);
 		cleanupTimers.clear();

--- a/packages/subagents/settings.ts
+++ b/packages/subagents/settings.ts
@@ -101,12 +101,11 @@ export function removeChainDir(chainDir: string): void {
 	} catch {}
 }
 
-export function cleanupOldChainDirs(): void {
-	if (!fs.existsSync(CHAIN_RUNS_DIR)) return;
+export async function cleanupOldChainDirs(): Promise<void> {
 	const now = Date.now();
 	let dirs: string[];
 	try {
-		dirs = fs.readdirSync(CHAIN_RUNS_DIR);
+		dirs = await fs.promises.readdir(CHAIN_RUNS_DIR);
 	} catch {
 		return;
 	}
@@ -114,9 +113,9 @@ export function cleanupOldChainDirs(): void {
 	for (const dir of dirs) {
 		try {
 			const dirPath = path.join(CHAIN_RUNS_DIR, dir);
-			const stat = fs.statSync(dirPath);
+			const stat = await fs.promises.stat(dirPath);
 			if (stat.isDirectory() && now - stat.mtimeMs > CHAIN_DIR_MAX_AGE_MS) {
-				fs.rmSync(dirPath, { recursive: true });
+				await fs.promises.rm(dirPath, { recursive: true });
 			}
 		} catch {
 			// Skip directories that can't be processed; continue with others


### PR DESCRIPTION
## Summary
- move subagent startup cleanup off synchronous filesystem APIs
- keep the same cleanup behavior for chain dirs and artifact dirs
- avoid event-loop stalls during the deferred startup cleanup window

## Testing
- pnpm exec vitest run packages/subagents/tests/session-churn.test.ts packages/subagents/tests/smoke.test.ts
- pnpm lint
- pnpm typecheck