### PR TITLE
fix(extensions): use canonical session ids in resume hints

### DIFF
--- a/.changeset/fix-session-resume-hint-id.md
+++ b/.changeset/fix-session-resume-hint-id.md
@@ -1,0 +1,5 @@
+---
+default: patch
+---
+
+fix: use the canonical session id in resume hints and drop the broken `pi resume` alias

--- a/packages/extensions/README.md
+++ b/packages/extensions/README.md
@@ -241,5 +241,5 @@ This package ships raw `.ts` extensions for pi to load directly.
 ## Auto session naming and compaction continuity
 
 `auto-session-name` now keeps session titles fresh as work focus changes, triggers a
-`continue` follow-up after compaction, and emits resume hints (including `pi --session <id>`
-and `pi resume <id>` alias path guidance) whenever you switch sessions or exit.
+`continue` follow-up after compaction, and emits canonical resume hints with
+`pi --session <session-id>` whenever you switch sessions or exit.

--- a/packages/extensions/extensions/auto-session-name.test.ts
+++ b/packages/extensions/extensions/auto-session-name.test.ts
@@ -60,19 +60,23 @@ describe("auto-session-name extension", () => {
 		expect(harness.userMessages.at(-1)).toBe("continue");
 	});
 
-	it("emits resume hints on session switch and shutdown", () => {
+	it("emits resume hints with the real session id on session switch and shutdown", () => {
 		const harness = createExtensionHarness();
-		harness.ctx.sessionManager.getSessionFile = () => "/tmp/sessions/test-session.jsonl";
+		harness.ctx.sessionManager.getSessionFile = () =>
+			"/tmp/sessions/2026-04-15T06-39-22-866Z_019d8fdd-acf2-760d-a215-05659dd89ced.jsonl";
+		harness.ctx.sessionManager.getSessionId = () => "019d8fdd-acf2-760d-a215-05659dd89ced";
 		autoSessionNameExtension(harness.pi as never);
 
 		harness.emit("session_switch", { type: "session_switch" }, harness.ctx);
 		expect(harness.messages.at(-1)?.content).toContain("Session switched");
-		expect(harness.messages.at(-1)?.content).toContain("pi --session test-session");
-		expect(harness.messages.at(-1)?.content).toContain("pi resume test-session");
+		expect(harness.messages.at(-1)?.content).toContain("pi --session 019d8fdd-acf2-760d-a215-05659dd89ced");
+		expect(harness.messages.at(-1)?.content).not.toContain("pi resume");
+		expect(harness.messages.at(-1)?.content).not.toContain("2026-04-15T06-39-22-866Z_");
 
 		harness.emit("session_shutdown", { type: "session_shutdown" }, harness.ctx);
 		expect(harness.messages.at(-1)?.content).toContain("Session saved");
-		expect(harness.messages.at(-1)?.content).toContain("pi --session test-session");
-		expect(harness.messages.at(-1)?.content).toContain("pi resume test-session");
+		expect(harness.messages.at(-1)?.content).toContain("pi --session 019d8fdd-acf2-760d-a215-05659dd89ced");
+		expect(harness.messages.at(-1)?.content).not.toContain("pi resume");
+		expect(harness.messages.at(-1)?.content).not.toContain("2026-04-15T06-39-22-866Z_");
 	});
 });

--- a/packages/extensions/extensions/auto-session-name.ts
+++ b/packages/extensions/extensions/auto-session-name.ts
@@ -1,4 +1,3 @@
-import * as path from "node:path";
 import type { ExtensionAPI } from "@mariozechner/pi-coding-agent";
 
 const MAX_NAME_LEN = 72;
@@ -52,19 +51,13 @@ function overlapRatio(a: string, b: string): number {
 	return shared / Math.max(left.size, right.size);
 }
 
-function deriveSessionId(sessionFile: string | undefined): string | undefined {
-	if (!sessionFile) {
-		return undefined;
-	}
-	return path.basename(sessionFile).replace(/\.jsonl$/i, "") || undefined;
+function normalizeSessionId(sessionId: string | undefined): string | undefined {
+	const normalized = sessionId?.trim();
+	return normalized || undefined;
 }
 
 function buildResumeCommandHint(sessionId: string): string {
-	return [
-		`Session id: ${sessionId}`,
-		`Resume now: pi --session ${sessionId}`,
-		`Alias path (if your shell forwards it): pi resume ${sessionId}`,
-	].join("\n");
+	return [`Session id: ${sessionId}`, `Resume now: pi --session ${sessionId}`].join("\n");
 }
 
 function isFocusShift(firstUserText: string, latestUserText: string): boolean {
@@ -110,16 +103,16 @@ export default function autoSessionNameExtension(pi: ExtensionAPI) {
 	let lastAutoName = "";
 	let compactContinuationQueued = false;
 
-	const emitResumeHint = (reason: "shutdown" | "switch", sessionFile: string | undefined) => {
-		const sessionId = deriveSessionId(sessionFile);
-		if (!sessionId) {
+	const emitResumeHint = (reason: "shutdown" | "switch", sessionId: string | undefined) => {
+		const normalizedSessionId = normalizeSessionId(sessionId);
+		if (!normalizedSessionId) {
 			return;
 		}
 
 		const prefix = reason === "shutdown" ? "Session saved." : "Session switched.";
 		pi.sendMessage({
 			customType: "session-resume-hint",
-			content: `${prefix}\n${buildResumeCommandHint(sessionId)}`,
+			content: `${prefix}\n${buildResumeCommandHint(normalizedSessionId)}`,
 			display: true,
 		});
 	};
@@ -160,10 +153,10 @@ export default function autoSessionNameExtension(pi: ExtensionAPI) {
 	});
 
 	pi.on("session_switch", (_event, ctx) => {
-		emitResumeHint("switch", ctx.sessionManager?.getSessionFile?.());
+		emitResumeHint("switch", ctx.sessionManager?.getSessionId?.());
 	});
 
 	pi.on("session_shutdown", (_event, ctx) => {
-		emitResumeHint("shutdown", ctx.sessionManager?.getSessionFile?.());
+		emitResumeHint("shutdown", ctx.sessionManager?.getSessionId?.());
 	});
 }

--- a/test-utils/extension-runtime-harness.js
+++ b/test-utils/extension-runtime-harness.js
@@ -98,6 +98,7 @@ export function createExtensionHarness() {
 			getEntries: () => [],
 			getBranch: () => [],
 			getLeafId: () => "leaf-1",
+			getSessionId: () => undefined,
 			getSessionFile: () => undefined,
 		},
 		isIdle: () => true,

--- a/test-utils/extension-runtime-harness.ts
+++ b/test-utils/extension-runtime-harness.ts
@@ -98,6 +98,7 @@ export function createExtensionHarness() {
 			getEntries: () => [],
 			getBranch: () => [],
 			getLeafId: () => "leaf-1",
+			getSessionId: () => undefined,
 			getSessionFile: () => undefined,
 		},
 		isIdle: () => true,


### PR DESCRIPTION
## Summary
- use the canonical session header id for resume hints instead of deriving an id from the session filename
- remove the broken `pi resume <id>` alias from the resume hint output and docs
- add coverage for canonical session ids in the auto-session-name tests

## Testing
- pnpm exec vitest run packages/extensions/extensions/auto-session-name.test.ts
- pnpm exec biome check --error-on-warnings packages/extensions/extensions/auto-session-name.ts packages/extensions/extensions/auto-session-name.test.ts test-utils/extension-runtime-harness.ts test-utils/extension-runtime-harness.js packages/extensions/README.md