### PR TITLE
fix(ollama): avoid startup watchdog stalls

### DIFF
--- a/.changeset/ollama-startup-watchdog-blocking.md
+++ b/.changeset/ollama-startup-watchdog-blocking.md
@@ -1,0 +1,5 @@
+---
+"default": patch
+---
+
+fix(ollama): keep startup refresh from blocking the watchdog

--- a/packages/ollama/index.ts
+++ b/packages/ollama/index.ts
@@ -82,6 +82,7 @@ const cloudEnvDiscoveryState: RuntimeDiscoveryState = {
 const activeLocalPulls = new Map<string, Promise<boolean>>();
 const PULL_STATUS_KEY = "ollama.pull";
 const OLLAMA_STARTUP_CLI_REFRESH_DELAY_MS = 250;
+const OLLAMA_STARTUP_CLOUD_REFRESH_DELAY_MS = 250;
 
 let ollamaCliStatus: OllamaCliStatus | null = null;
 let missingCliWarningShown = false;
@@ -235,9 +236,14 @@ function registerOllamaCommands(pi: ExtensionAPI): void {
 	});
 }
 
-function registerOllamaLifecycle(pi: ExtensionAPI): { scheduleLocalBootstrapRefresh: (ctx?: CommandContextLike) => void } {
+function registerOllamaLifecycle(pi: ExtensionAPI): {
+	scheduleCloudBootstrapRefresh: (ctx?: CommandContextLike) => void;
+	scheduleLocalBootstrapRefresh: (ctx?: CommandContextLike) => void;
+} {
 	let startupCliRefreshTimer: ReturnType<typeof setTimeout> | null = null;
+	let startupCloudRefreshTimer: ReturnType<typeof setTimeout> | null = null;
 	let pendingLocalBootstrapRefresh: Promise<void> | null = null;
+	let pendingCloudBootstrapRefresh: Promise<void> | null = null;
 	let pendingStartupContext: CommandContextLike | null = null;
 
 	const notifyMissingCli = (ctx: CommandContextLike | null) => {
@@ -252,10 +258,21 @@ function registerOllamaLifecycle(pi: ExtensionAPI): { scheduleLocalBootstrapRefr
 		);
 	};
 
-	const scheduleLocalBootstrapRefresh = (ctx?: CommandContextLike) => {
+	const updatePendingStartupContext = (ctx?: CommandContextLike) => {
 		if (ctx) {
 			pendingStartupContext = ctx;
 		}
+	};
+
+	const clearPendingStartupContext = () => {
+		if (startupCliRefreshTimer || startupCloudRefreshTimer || pendingLocalBootstrapRefresh || pendingCloudBootstrapRefresh) {
+			return;
+		}
+		pendingStartupContext = null;
+	};
+
+	const scheduleLocalBootstrapRefresh = (ctx?: CommandContextLike) => {
+		updatePendingStartupContext(ctx);
 		if (pendingLocalBootstrapRefresh || startupCliRefreshTimer) {
 			return;
 		}
@@ -269,29 +286,57 @@ function registerOllamaLifecycle(pi: ExtensionAPI): { scheduleLocalBootstrapRefr
 				})
 				.finally(() => {
 					pendingLocalBootstrapRefresh = null;
-					pendingStartupContext = null;
+					clearPendingStartupContext();
 				});
 		}, OLLAMA_STARTUP_CLI_REFRESH_DELAY_MS);
+		startupCliRefreshTimer.unref?.();
 	};
 
-	pi.on("session_start", async (_event, ctx) => {
+	const scheduleCloudBootstrapRefresh = (ctx?: CommandContextLike) => {
+		updatePendingStartupContext(ctx);
+		if (pendingCloudBootstrapRefresh || startupCloudRefreshTimer) {
+			return;
+		}
+
+		startupCloudRefreshTimer = setTimeout(() => {
+			startupCloudRefreshTimer = null;
+			pendingCloudBootstrapRefresh = (async () => {
+				const startupCtx = pendingStartupContext;
+				if (!startupCtx) {
+					await refreshRegisteredCloudEnvModels(pi);
+					return;
+				}
+
+				const credential = getStoredCloudCredentialFromContext(startupCtx);
+				await refreshCloudModels(pi, startupCtx, credential);
+				startupCtx.modelRegistry.refresh?.();
+			})()
+				.catch(() => {
+					// Auth storage can be unavailable during early startup depending on initialization order.
+					// Keep boot resilient and rely on manual /ollama refresh-models as fallback.
+				})
+				.finally(() => {
+					pendingCloudBootstrapRefresh = null;
+					clearPendingStartupContext();
+				});
+		}, OLLAMA_STARTUP_CLOUD_REFRESH_DELAY_MS);
+		startupCloudRefreshTimer.unref?.();
+	};
+
+	pi.on("session_start", (_event, ctx) => {
+		scheduleCloudBootstrapRefresh(ctx);
 		scheduleLocalBootstrapRefresh(ctx);
 		notifyMissingCli(ctx);
-
-		try {
-			const credential = getStoredCloudCredentialFromContext(ctx);
-			await refreshCloudModels(pi, ctx, credential);
-			ctx.modelRegistry.refresh?.();
-		} catch {
-			// Auth storage can be unavailable during early startup depending on initialization order.
-			// Keep boot resilient and rely on manual /ollama refresh-models as fallback.
-		}
 	});
 
 	pi.on("session_shutdown", () => {
 		if (startupCliRefreshTimer) {
 			clearTimeout(startupCliRefreshTimer);
 			startupCliRefreshTimer = null;
+		}
+		if (startupCloudRefreshTimer) {
+			clearTimeout(startupCloudRefreshTimer);
+			startupCloudRefreshTimer = null;
 		}
 		pendingStartupContext = null;
 	});
@@ -342,7 +387,7 @@ function registerOllamaLifecycle(pi: ExtensionAPI): { scheduleLocalBootstrapRefr
 		await pullLocalModel(pi, ctx, event.model.id);
 	});
 
-	return { scheduleLocalBootstrapRefresh };
+	return { scheduleCloudBootstrapRefresh, scheduleLocalBootstrapRefresh };
 }
 
 async function refreshCloudModels(pi: ExtensionAPI, ctx: CommandContextLike, credential: OllamaCloudCredentials | null): Promise<OllamaProviderModel[]> {
@@ -730,11 +775,14 @@ function createOllamaProcessEnv(): NodeJS.ProcessEnv {
 	return env;
 }
 
-function bootstrapOllamaProviders(pi: ExtensionAPI, scheduleLocalRefresh: () => void): void {
+function bootstrapOllamaProviders(
+	pi: ExtensionAPI,
+	scheduleRefreshes: { scheduleCloudBootstrapRefresh: () => void; scheduleLocalBootstrapRefresh: () => void },
+): void {
 	registerOllamaCloudProvider(pi);
 	registerOllamaLocalProvider(pi);
-	void refreshRegisteredCloudEnvModels(pi);
-	scheduleLocalRefresh();
+	scheduleRefreshes.scheduleCloudBootstrapRefresh();
+	scheduleRefreshes.scheduleLocalBootstrapRefresh();
 }
 
 export {
@@ -750,6 +798,6 @@ export { toOllamaModel, toOllamaCloudModel, type OllamaCloudCredentials, type Ol
 
 export default function ollamaProviderExtension(pi: ExtensionAPI): void {
 	const registerLifecycle = registerOllamaLifecycle(pi);
-	bootstrapOllamaProviders(pi, registerLifecycle.scheduleLocalBootstrapRefresh);
+	bootstrapOllamaProviders(pi, registerLifecycle);
 	registerOllamaCommands(pi);
 }

--- a/packages/ollama/local.ts
+++ b/packages/ollama/local.ts
@@ -1,4 +1,4 @@
-import { type ChildProcessByStdio, execFileSync, spawn } from "node:child_process";
+import { type ChildProcessByStdio, execFile, spawn } from "node:child_process";
 import process from "node:process";
 import type { Readable } from "node:stream";
 
@@ -24,7 +24,7 @@ export async function getOllamaCliStatus(options: { force?: boolean } = {}): Pro
 		return pendingCliStatus;
 	}
 
-	pendingCliStatus = Promise.resolve(detectOllamaCli()).finally(() => {
+	pendingCliStatus = detectOllamaCli().finally(() => {
 		pendingCliStatus = null;
 	});
 	cachedCliStatus = await pendingCliStatus;
@@ -93,23 +93,35 @@ export function clearOllamaCliStatusCache(): void {
 	cachedCliStatus = null;
 }
 
-function detectOllamaCli(): OllamaCliStatus {
+function execFileText(command: string, args: string[]): Promise<{ text: string | null; error: string | null }> {
+	return new Promise((resolve) => {
+		execFile(command, args, { encoding: "utf-8", shell: IS_WINDOWS }, (error, stdout, stderr) => {
+			if (error) {
+				resolve({
+					text: null,
+					error: stderr.trim() || error.message || `Failed to execute ${command} ${args.join(" ")}`,
+				});
+				return;
+			}
+
+			const text = stdout.trim();
+			resolve({ text: text || null, error: null });
+		});
+	});
+}
+
+async function detectOllamaCli(): Promise<OllamaCliStatus> {
 	let lastError = "Ollama CLI not found.";
 	for (const command of OLLAMA_COMMAND_CANDIDATES) {
-		try {
-			const output = execFileSync(command, ["--version"], {
-				encoding: "utf-8",
-				stdio: ["ignore", "pipe", "pipe"],
-				shell: IS_WINDOWS,
-			}).trim();
+		const result = await execFileText(command, ["--version"]);
+		if (result.text) {
 			return {
 				available: true,
 				command,
-				version: output || undefined,
+				version: result.text,
 			};
-		} catch (error) {
-			lastError = error instanceof Error ? error.message : String(error);
 		}
+		lastError = result.error ?? `Failed to execute ${command} --version.`;
 	}
 
 	return {

--- a/packages/ollama/tests/download.test.ts
+++ b/packages/ollama/tests/download.test.ts
@@ -4,19 +4,25 @@ import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 import { createExtensionHarness } from "../../../test-utils/extension-runtime-harness.js";
 import { createTestOllamaBackend, type TestOllamaBackend } from "./test-backend.js";
 
-const execFileSyncMock = vi.fn();
+const execFileMock = vi.fn();
 const spawnMock = vi.fn();
 const envSnapshot = { ...process.env };
 const backends: TestOllamaBackend[] = [];
 
 vi.mock("node:child_process", () => ({
-	execFileSync: execFileSyncMock,
+	execFile: execFileMock,
 	spawn: spawnMock,
 }));
 
 beforeEach(() => {
-	execFileSyncMock.mockReset();
+	execFileMock.mockReset();
 	spawnMock.mockReset();
+	execFileMock.mockImplementation((_command, _args, _options, callback) => {
+		queueMicrotask(() => {
+			callback(null, "ollama version 0.8.0", "");
+		});
+		return {};
+	});
 });
 
 afterEach(async () => {
@@ -35,7 +41,12 @@ afterEach(async () => {
 
 describe("ollama local downloads", () => {
 	it("registers downloadable local models with cloud context metadata when the CLI is available", async () => {
-		execFileSyncMock.mockReturnValue("ollama version 0.8.0");
+		execFileMock.mockImplementation((_command, _args, _options, callback) => {
+			queueMicrotask(() => {
+				callback(null, "ollama version 0.8.0", "");
+			});
+			return {};
+		});
 
 		const cloudBackend = await createTestOllamaBackend();
 		backends.push(cloudBackend);
@@ -68,7 +79,12 @@ describe("ollama local downloads", () => {
 	});
 
 	it("prompts to download a local model and refreshes the installed catalog", async () => {
-		execFileSyncMock.mockReturnValue("ollama version 0.8.0");
+		execFileMock.mockImplementation((_command, _args, _options, callback) => {
+			queueMicrotask(() => {
+				callback(null, "ollama version 0.8.0", "");
+			});
+			return {};
+		});
 
 		const cloudBackend = await createTestOllamaBackend();
 		backends.push(cloudBackend);
@@ -128,8 +144,11 @@ describe("ollama local downloads", () => {
 	});
 
 	it("warns on session start when the Ollama CLI is missing", async () => {
-		execFileSyncMock.mockImplementation(() => {
-			throw new Error("command not found");
+		execFileMock.mockImplementation((_command, _args, _options, callback) => {
+			queueMicrotask(() => {
+				callback(new Error("command not found"), "", "command not found");
+			});
+			return {};
 		});
 
 		const cloudBackend = await createTestOllamaBackend();
@@ -142,15 +161,16 @@ describe("ollama local downloads", () => {
 		const { default: ollamaProviderExtension } = await import("../index.js");
 		const harness = createExtensionHarness();
 		ollamaProviderExtension(harness.pi as never);
-		expect(execFileSyncMock).not.toHaveBeenCalled();
+		expect(execFileMock).not.toHaveBeenCalled();
 
 		const sessionStart = harness.emitAsync("session_start", { type: "session_start" }, harness.ctx);
-		expect(execFileSyncMock).not.toHaveBeenCalled();
+		expect(execFileMock).not.toHaveBeenCalled();
 		await sessionStart;
+		expect(execFileMock).not.toHaveBeenCalled();
 
 		await waitFor(() => harness.notifications.some((item) => item.msg.includes("Only ollama-cloud models are available right now")));
 
-		expect(execFileSyncMock).toHaveBeenCalled();
+		expect(execFileMock).toHaveBeenCalled();
 		expect(harness.notifications.some((item) => item.type === "warning")).toBe(true);
 		expect((harness.providers.get("ollama")?.models as Array<{ id: string }> | undefined) ?? []).toEqual([]);
 	});

--- a/packages/ollama/tests/smoke.test.ts
+++ b/packages/ollama/tests/smoke.test.ts
@@ -6,8 +6,11 @@ import ollamaProviderExtension from "../index.js";
 import { createTestOllamaBackend } from "./test-backend.js";
 
 const envSnapshot = { ...process.env };
+const harnesses: ReturnType<typeof createExtensionHarness>[] = [];
 
-async function createDelayedCloudBootstrapBackend(): Promise<{ apiUrl: string; origin: string; close: () => Promise<void> }> {
+async function createDelayedCloudBootstrapBackend(
+	delayMs = 50,
+): Promise<{ apiUrl: string; origin: string; close: () => Promise<void> }> {
 	const server = http.createServer((req, res) => {
 		const reply = () => {
 			if (req.url === "/v1/models" && req.method === "GET") {
@@ -43,7 +46,7 @@ async function createDelayedCloudBootstrapBackend(): Promise<{ apiUrl: string; o
 			res.end("not found");
 		};
 
-		setTimeout(reply, 50);
+		setTimeout(reply, delayMs);
 	});
 
 	await new Promise<void>((resolve) => server.listen(0, "127.0.0.1", resolve));
@@ -58,7 +61,11 @@ async function createDelayedCloudBootstrapBackend(): Promise<{ apiUrl: string; o
 	};
 }
 
-afterEach(() => {
+afterEach(async () => {
+	for (const harness of harnesses.splice(0)) {
+		await harness.emitAsync("session_shutdown", { type: "session_shutdown" }, harness.ctx);
+	}
+
 	for (const key of Object.keys(process.env)) {
 		if (!(key in envSnapshot)) {
 			delete process.env[key];
@@ -70,6 +77,7 @@ afterEach(() => {
 describe("ollama provider smoke tests", () => {
 	it("registers local + cloud ollama providers and commands without crashing", () => {
 		const harness = createExtensionHarness();
+		harnesses.push(harness);
 		ollamaProviderExtension(harness.pi as never);
 
 		expect(harness.commands.has("ollama")).toBe(true);
@@ -88,6 +96,7 @@ describe("ollama provider smoke tests", () => {
 		delete process.env.OLLAMA_API_KEY;
 
 		const harness = createExtensionHarness();
+		harnesses.push(harness);
 		(harness.ctx as any).modelRegistry = {
 			...(harness.ctx.modelRegistry as object),
 			authStorage: {
@@ -103,6 +112,24 @@ describe("ollama provider smoke tests", () => {
 		await backend.close();
 	});
 
+	it("returns from session_start before delayed cloud discovery finishes", async () => {
+		const backend = await createDelayedCloudBootstrapBackend(250);
+		process.env.PI_OLLAMA_CLOUD_API_URL = backend.apiUrl;
+		process.env.PI_OLLAMA_CLOUD_MODELS_URL = `${backend.apiUrl}/models`;
+		process.env.PI_OLLAMA_CLOUD_SHOW_URL = `${backend.origin}/api/show`;
+		delete process.env.OLLAMA_API_KEY;
+
+		const harness = createExtensionHarness();
+		harnesses.push(harness);
+		ollamaProviderExtension(harness.pi as never);
+
+		const startedAt = Date.now();
+		await expect(harness.emitAsync("session_start", { type: "session_start" }, harness.ctx)).resolves.toBeDefined();
+		expect(Date.now() - startedAt).toBeLessThan(150);
+
+		await backend.close();
+	});
+
 	it("exposes a cloud glm model immediately on startup", async () => {
 		const backend = await createDelayedCloudBootstrapBackend();
 		process.env.PI_OLLAMA_CLOUD_API_URL = backend.apiUrl;
@@ -111,6 +138,7 @@ describe("ollama provider smoke tests", () => {
 		delete process.env.OLLAMA_API_KEY;
 
 		const harness = createExtensionHarness();
+		harnesses.push(harness);
 		ollamaProviderExtension(harness.pi as never);
 
 		const initialModels = harness.providers.get("ollama-cloud")?.models as Array<{ id: string }> | undefined;
@@ -131,9 +159,10 @@ describe("ollama provider smoke tests", () => {
 		delete process.env.OLLAMA_API_KEY;
 
 		const harness = createExtensionHarness();
+		harnesses.push(harness);
 		ollamaProviderExtension(harness.pi as never);
 
-		for (let attempt = 0; attempt < 40; attempt += 1) {
+		for (let attempt = 0; attempt < 80; attempt += 1) {
 			const models = harness.providers.get("ollama-cloud")?.models as Array<{ id: string }> | undefined;
 			if (models?.length === 2) {
 				break;


### PR DESCRIPTION
## Summary
- stop the Ollama startup path from awaiting cloud discovery during session start
- replace synchronous local CLI detection with an async execFile probe
- keep model/provider refresh behavior while moving startup work off the watchdog-critical path

## Validation
- pnpm --filter @ifi/pi-provider-ollama test:worktree
- pnpm lint
- pnpm typecheck