### PR TITLE
fix(extensions): restore smoke test formatting

### DIFF
--- a/.changeset/fix-remove-safe-guard-lint-followup.md
+++ b/.changeset/fix-remove-safe-guard-lint-followup.md
@@ -1,0 +1,5 @@
+---
+default: patch
+---
+
+- Fix formatting in `packages/extensions/extensions/smoke.test.ts` after removing the `safe-guard` extension so CI lint passes cleanly.

--- a/packages/extensions/extensions/smoke.test.ts
+++ b/packages/extensions/extensions/smoke.test.ts
@@ -106,5 +106,4 @@ describe("extensions runtime smoke tests", () => {
 		worktreeExtension(harness.pi as never);
 		expect(harness.commands.has("worktree")).toBe(true);
 	});
-
 });


### PR DESCRIPTION
## Summary\n- fix Biome formatting in smoke.test.ts after the safe-guard removal\n- add a changeset for the CI-only follow-up\n\n## Validation\n- pnpm exec biome ci --error-on-warnings packages/extensions/extensions/smoke.test.ts\n- pnpm exec vitest run packages/extensions/extensions/smoke.test.ts