### PR TITLE
refactor(repo): apply readability cleanup across the repo

### DIFF
--- a/.changeset/extensions-style-breathing.md
+++ b/.changeset/extensions-style-breathing.md
@@ -1,0 +1,5 @@
+---
+default: patch
+---
+
+refactor: apply a repo-wide readability cleanup and stabilize a slow worktree test timeout

--- a/README.md
+++ b/README.md
@@ -97,6 +97,7 @@ oh-pi tracks upstream pi fairly closely and currently treats **pi `0.56.1` or ne
 minimum supported runtime baseline for packages that integrate directly with the pi SDK.
 
 Policy:
+
 - new oh-pi releases target the current pi runtime family first
 - compatibility with older pi builds is best-effort unless explicitly documented otherwise
 - peer dependency ranges on pi-facing packages express the minimum supported baseline more clearly

--- a/packages/agents/README.md
+++ b/packages/agents/README.md
@@ -3,6 +3,7 @@
 AGENTS.md templates for pi.
 
 This package contains reusable agent profile templates such as:
+
 - `general-developer`
 - `fullstack-developer`
 - `security-researcher`

--- a/packages/ant-colony/extensions/ant-colony/parser.ts
+++ b/packages/ant-colony/extensions/ant-colony/parser.ts
@@ -22,21 +22,27 @@ function normalizeCaste(v: unknown): AntCaste {
 	const raw = String(v ?? "worker")
 		.trim()
 		.toLowerCase();
+
 	if (VALID_CASTES.has(raw)) {
 		return raw as AntCaste;
 	}
+
 	if (raw.includes("scout")) {
 		return "scout";
 	}
+
 	if (raw.includes("worker")) {
 		return "worker";
 	}
+
 	if (raw.includes("review") || raw.includes("soldier")) {
 		return "soldier";
 	}
+
 	if (raw.includes("drone") || raw.includes("bash") || raw.includes("shell")) {
 		return "drone";
 	}
+
 	return "worker";
 }
 
@@ -66,12 +72,15 @@ function extractJsonTaskCandidates(parsed: unknown): Array<Record<string, unknow
 	if (Array.isArray(parsed)) {
 		return parsed.filter(isJsonTaskLike);
 	}
+
 	if (isRecord(parsed) && Array.isArray(parsed.tasks)) {
 		return parsed.tasks.filter(isJsonTaskLike);
 	}
+
 	if (isJsonTaskLike(parsed)) {
 		return [parsed];
 	}
+
 	return [];
 }
 
@@ -247,6 +256,7 @@ export function extractPheromones(
 			});
 		}
 	}
+
 	if (failed && files.length > 0) {
 		pheromones.push({
 			id: makePheromoneId(),

--- a/packages/ant-colony/extensions/ant-colony/prompts.ts
+++ b/packages/ant-colony/extensions/ant-colony/prompts.ts
@@ -85,27 +85,36 @@ export function buildPrompt(
 	budgetSection?: string,
 ): string {
 	let prompt = `${castePrompt}\n\n`;
+
 	if (maxTurns) {
 		prompt += `## ⚠️ Turn Limit\nYou have a MAXIMUM of ${maxTurns} turns. Plan accordingly — reserve your LAST turn to output the structured result format above. Do NOT waste turns on unnecessary exploration.\n\n`;
 	}
+
 	if (budgetSection) {
 		prompt += budgetSection;
 	}
+
 	if (pheromoneContext) {
 		prompt += `## Colony Pheromone Trail (intelligence from other ants)\n${pheromoneContext}\n\n`;
 	}
+
 	if (tandem?.parentResult) {
 		prompt += `## Tandem Context (from parent task)\n${tandem.parentResult.slice(0, 3000)}\n\n`;
 	}
+
 	if (tandem?.priorError) {
 		prompt += `## ⚠️ Prior Attempt Failed\nA previous ant failed on this task. Learn from their mistake:\n${tandem.priorError.slice(0, 1500)}\n\n`;
 	}
+
 	prompt += `## Your Assignment\n**Task:** ${task.title}\n**Description:** ${task.description}\n`;
+
 	if (task.files.length > 0) {
 		prompt += `**Files scope:** ${task.files.join(", ")}\n`;
 	}
+
 	if (task.context) {
 		prompt += `\n## Pre-loaded Context (from scout)\n${task.context}\n`;
 	}
+
 	return prompt;
 }

--- a/packages/ant-colony/tests/worktree.test.ts
+++ b/packages/ant-colony/tests/worktree.test.ts
@@ -84,5 +84,5 @@ describe("worktree workspace isolation", () => {
 		const resumed = resumeColonyWorkspace({ cwd: repo, runtimeId: "c4", savedWorkspace: initial, storageOptions });
 		expect(resumed.mode).toBe("worktree");
 		expect(resumed.executionCwd).toBe(initial.executionCwd);
-	});
+	}, 15_000);
 });

--- a/packages/ant-colony/tests/worktree.test.ts
+++ b/packages/ant-colony/tests/worktree.test.ts
@@ -71,7 +71,7 @@ describe("worktree workspace isolation", () => {
 			stdio: ["ignore", "pipe", "pipe"],
 		}).trim();
 		expect(branch).toBe(workspace.branch);
-	});
+	}, 15_000);
 
 	it("reuses saved worktree metadata on resume", () => {
 		const repo = mkTempDir("colony-resume-worktree-");

--- a/packages/cli/src/tui/config-wizard.ts
+++ b/packages/cli/src/tui/config-wizard.ts
@@ -100,17 +100,20 @@ export async function runConfigWizard(env: EnvInfo, initial: WizardBaseConfig): 
 			nextStep = "appearance";
 			continue;
 		}
+
 		if (step === "appearance") {
 			state.theme = await selectTheme(state.theme);
 			state.keybindings = await selectKeybindings(state.keybindings);
 			nextStep = "features";
 			continue;
 		}
+
 		if (step === "features") {
 			state.extensions = await selectExtensions(state.extensions);
 			nextStep = "agents";
 			continue;
 		}
+
 		if (step === "agents") {
 			state.agents = await selectAgents(state.agents);
 			nextStep = "finish";
@@ -140,16 +143,20 @@ export function summarizeProviders(setup: ProviderSetupResult | null): string {
 	if (!setup) {
 		return t("custom.providersUnset");
 	}
+
 	if (setup.providerStrategy === "keep") {
 		return t("confirm.providerStrategyKeep");
 	}
+
 	if (setup.providerStrategy === "add") {
 		return setup.providers.length > 0
 			? t("custom.providersAdd", { list: setup.providers.map((p) => p.name).join(", ") })
 			: t("confirm.providerStrategyAdd");
 	}
+
 	if (setup.providers.length === 0) {
 		return t("confirm.providerStrategyReplace");
 	}
+
 	return t("custom.providersReplace", { list: setup.providers.map((p) => p.name).join(", ") });
 }

--- a/packages/cli/src/tui/confirm-apply.ts
+++ b/packages/cli/src/tui/confirm-apply.ts
@@ -15,9 +15,11 @@ export function countExisting(env: EnvInfo, dir: string): number {
 }
 
 /**
- * Display the configuration summary, handle backup/overwrite of existing config, install pi if needed, and apply the final configuration.
- * @param config - the user's selected configuration
- * @param env - current environment info
+ * Display the configuration summary, handle backup or overwrite flows,
+ * install pi when needed, and apply the final configuration.
+ *
+ * @param config - The user's selected configuration
+ * @param env - Current environment info
  */
 // biome-ignore lint/complexity/noExcessiveCognitiveComplexity: Interactive wizard confirmation flow with many user branches.
 export async function confirmApply(config: OhPConfig, env: EnvInfo) {
@@ -99,8 +101,6 @@ export async function confirmApply(config: OhPConfig, env: EnvInfo) {
 			const backupDir = backupConfig();
 			s.stop(t("confirm.backedUp", { dir: chalk.dim(backupDir) }));
 		}
-	} else {
-		// New user — skip confirmation, apply directly
 	}
 
 	// ═══ Install pi if needed ═══

--- a/packages/cli/src/tui/provider-setup.ts
+++ b/packages/cli/src/tui/provider-setup.ts
@@ -29,33 +29,42 @@ export function isUnsafeUrl(urlStr: string): boolean {
 	try {
 		const u = new URL(urlStr);
 		const host = u.hostname;
+
 		// Allow localhost for local dev servers (Ollama, vLLM, etc.)
 		if (host === "localhost" || host === "127.0.0.1" || host === "::1") {
 			return false;
 		}
+
 		// Block private IP ranges
 		if (/^10\./.test(host)) {
 			return true;
 		}
+
 		if (/^172\.(1[6-9]|2\d|3[01])\./.test(host)) {
 			return true;
 		}
+
 		if (/^192\.168\./.test(host)) {
 			return true;
 		}
+
 		if (/^0\./.test(host) || host === "0.0.0.0") {
 			return true;
 		}
+
 		if (host.includes(":") || host.startsWith("[")) {
 			return true;
 		}
+
 		if (/^169\.254\./.test(host)) {
 			return true;
 		}
+
 		// Block non-https for remote hosts
 		if (u.protocol !== "https:") {
 			return true;
 		}
+
 		return false;
 	} catch {
 		return true;
@@ -244,9 +253,11 @@ export async function setupProviders(env?: EnvInfo): Promise<ProviderSetupResult
 			p.cancel(t("cancelled"));
 			process.exit(0);
 		}
+
 		if (action === "keep") {
 			return { providers: [], providerStrategy: "keep" };
 		}
+
 		providerStrategy = action;
 	}
 
@@ -375,6 +386,7 @@ async function setupProviderChoice(choice: string): Promise<ProviderConfig | nul
 		p.log.error(`Unknown provider: ${name}`);
 		return null;
 	}
+
 	const envVal = process.env[info.env];
 
 	const useCustomUrl = await p.confirm({
@@ -567,6 +579,7 @@ async function selectModelWithMeta(
 			p.cancel(t("cancelled"));
 			process.exit(0);
 		}
+
 		return { defaultModel: model, discoveredModels, api };
 	}
 

--- a/packages/cli/src/utils/writers.ts
+++ b/packages/cli/src/utils/writers.ts
@@ -40,6 +40,7 @@ function syncPackageRoot(src: string, dest: string, excludedEntries: string[]) {
 			copyFileSync(srcPath, destPath);
 		}
 	}
+
 	for (const entry of readdirSync(dest, { withFileTypes: true })) {
 		if (!allowedEntries.has(entry.name)) {
 			rmSync(join(dest, entry.name), { recursive: true, force: true });
@@ -103,9 +104,11 @@ export function writeProviderEnv(agentDir: string, config: OhPConfig) {
 		if (p.discoveredModels?.length) {
 			return p.discoveredModels.map((m) => m.id);
 		}
+
 		const info = PROVIDERS[p.name];
 		return info ? info.models : [];
 	});
+
 	if (strategy === "add") {
 		const current = Array.isArray(existingSettings.enabledModels) ? (existingSettings.enabledModels as string[]) : [];
 		const merged = [...new Set([...current, ...nextEnabledModels])];
@@ -135,6 +138,7 @@ export function writeModelConfig(agentDir: string, config: OhPConfig) {
 
 	const providers: Record<string, unknown> =
 		strategy === "add" ? (readJson<{ providers?: Record<string, unknown> }>(modelsPath)?.providers ?? {}) : {};
+
 	for (const cp of modelProviders) {
 		const isBuiltin = !!PROVIDERS[cp.name];
 		if (!cp.baseUrl && isBuiltin && cp.api) {
@@ -212,9 +216,11 @@ export function writeAgents(agentDir: string, config: OhPConfig) {
 			const lang = langNames[config.locale] ?? config.locale;
 			content = `## Language\nAlways respond in ${lang}. Use the user's language for all conversations and explanations. Code, commands, and technical terms can remain in English.\n\n${content}`;
 		}
+
 		if (config.extensions.includes("ant-colony") && config.agents !== "colony-operator") {
 			content = `${content.trimEnd()}\n\n${ANT_COLONY_AUTOTRIGGER_GUIDE}`;
 		}
+
 		writeFileSync(join(agentDir, "AGENTS.md"), content);
 	} catch {
 		/* template not found, skip */
@@ -261,14 +267,17 @@ export function writeExtensions(agentDir: string, config: OhPConfig) {
 			copyDedicatedExtension(extDir, "ant-colony", resources.antColonyDir());
 			continue;
 		}
+
 		if (ext === "plan") {
 			copyPlanExtension(extDir);
 			continue;
 		}
+
 		if (ext === "spec") {
 			copyDedicatedExtension(extDir, "spec", resources.specDir());
 			continue;
 		}
+
 		const dirSrc = resources.extension(ext);
 		const fileSrc = resources.extensionFile(ext);
 		if (existsSync(dirSrc) && statSync(dirSrc).isDirectory()) {
@@ -287,10 +296,11 @@ export function writeExtensions(agentDir: string, config: OhPConfig) {
 export function writePrompts(agentDir: string, config: OhPConfig) {
 	const promptDir = join(agentDir, "prompts");
 	ensureDir(promptDir);
-	for (const p of config.prompts) {
-		const src = resources.prompt(p);
+
+	for (const promptName of config.prompts) {
+		const src = resources.prompt(promptName);
 		try {
-			copyFileSync(src, join(promptDir, `${p}.md`));
+			copyFileSync(src, join(promptDir, `${promptName}.md`));
 		} catch {
 			/* skip */
 		}

--- a/packages/core/src/agent-paths.ts
+++ b/packages/core/src/agent-paths.ts
@@ -41,9 +41,11 @@ export function expandHomeDir(inputPath: string, options?: AgentPathOptions): st
 	if (inputPath === "~") {
 		return homeDir;
 	}
+
 	if (inputPath.startsWith("~/") || inputPath.startsWith(`~${path.sep}`)) {
 		return path.join(homeDir, inputPath.slice(2));
 	}
+
 	return inputPath;
 }
 
@@ -62,6 +64,7 @@ export function resolvePiAgentDir(options?: AgentPathOptions): string {
 	if (envPath) {
 		return path.resolve(expandHomeDir(envPath, options));
 	}
+
 	return path.join(defaultHomeDir(options), ".pi", "agent");
 }
 

--- a/packages/core/src/i18n.ts
+++ b/packages/core/src/i18n.ts
@@ -17,6 +17,7 @@ export function t(key: string, vars?: Record<string, string | number>): string {
 			text = text.replace(`{${k}}`, String(v));
 		}
 	}
+
 	return text;
 }
 
@@ -47,9 +48,11 @@ function detectLocale(): Locale | undefined {
 	if (lang.startsWith("fr")) {
 		return "fr";
 	}
+
 	if (lang.startsWith("en")) {
 		return "en";
 	}
+
 	return undefined;
 }
 
@@ -72,6 +75,7 @@ export async function selectLanguage(): Promise<Locale> {
 		p.cancel("Cancelled.");
 		process.exit(0);
 	}
+
 	setLocale(locale);
 	return locale;
 }

--- a/packages/core/src/worktree.ts
+++ b/packages/core/src/worktree.ts
@@ -442,6 +442,7 @@ export function createManagedWorktree(options: CreateManagedWorktreeOptions): Cr
 	if (!branch) {
 		throw new Error("Branch name is required.");
 	}
+
 	if (!purpose) {
 		throw new Error("Purpose is required.");
 	}
@@ -527,6 +528,7 @@ export function removeManagedWorktree(
 		if (fs.existsSync(worktreePath)) {
 			throw new Error(`Failed to remove worktree at ${worktreePath}.`);
 		}
+
 		note = "Worktree directory was already missing; removed stale pi registry entry.";
 	}
 
@@ -564,6 +566,7 @@ export function formatWorktreeKind(entry: Pick<GitWorktreeEntry, "isMain" | "isM
 	if (entry.isMain) {
 		return "main";
 	}
+
 	return entry.isManaged ? "pi-owned" : "external";
 }
 

--- a/packages/extensions/extensions/adaptive-routing/classifier.ts
+++ b/packages/extensions/extensions/adaptive-routing/classifier.ts
@@ -100,48 +100,62 @@ function detectIntent(text: string): RouteIntent {
 	if (/(design|ui|ux|layout|visual|styling|theme|color|aesthetic)/.test(text)) {
 		return "design";
 	}
+
 	if (/(architecture|system design|tradeoff|approach|deep refactor|cross-cutting)/.test(text)) {
 		return "architecture";
 	}
+
 	if (/(debug|failing|error|stack trace|why is|broken|fix)/.test(text)) {
 		return "debugging";
 	}
+
 	if (/(review|audit|look over|inspect this change|code review)/.test(text)) {
 		return "review";
 	}
+
 	if (/(refactor|clean up|restructure)/.test(text)) {
 		return "refactor";
 	}
+
 	if (/(plan|roadmap|spec|outline|break down|approach this)/.test(text)) {
 		return "planning";
 	}
+
 	if (/(research|investigate|compare|look up|search)/.test(text)) {
 		return "research";
 	}
+
 	if (/(autonomous|work through|handle all of|keep going until)/.test(text)) {
 		return "autonomous";
 	}
+
 	if (/(implement|build|add|create|wire up|integrate)/.test(text)) {
 		return "implementation";
 	}
+
 	return text.split(/\s+/).length < 18 ? "quick-qna" : "implementation";
 }
 
 function detectComplexity(text: string, intent: RouteIntent): 1 | 2 | 3 | 4 | 5 {
 	let score = 1;
 	const length = text.split(/\s+/).length;
+
 	if (length > 20) {
 		score += 1;
 	}
+
 	if (length > 50) {
 		score += 1;
 	}
+
 	if (/(multiple|across|migration|all of these|thoroughly|deeply|telemetry|fallback|quota|policy)/.test(text)) {
 		score += 1;
 	}
+
 	if (["architecture", "autonomous", "design"].includes(intent)) {
 		score += 1;
 	}
+
 	return Math.min(score, 5) as 1 | 2 | 3 | 4 | 5;
 }
 
@@ -149,25 +163,31 @@ function detectTier(intent: RouteIntent, complexity: number) {
 	if (intent === "quick-qna" && complexity <= 2) {
 		return "cheap" as const;
 	}
+
 	if ((intent === "design" || intent === "architecture" || intent === "autonomous") && complexity >= 4) {
 		return "peak" as const;
 	}
+
 	if (complexity >= 4 || intent === "debugging" || intent === "refactor") {
 		return "premium" as const;
 	}
+
 	return complexity <= 2 ? ("cheap" as const) : ("balanced" as const);
 }
 
-function detectThinking(tier: PromptRouteClassification["recommendedTier"], intent: RouteIntent): RouteThinkingLevel {
+function detectThinking(tier: PromptRouteClassification["recommendedTier"]): RouteThinkingLevel {
 	if (tier === "cheap") {
 		return "minimal";
 	}
+
 	if (tier === "balanced") {
 		return "medium";
 	}
+
 	if (tier === "premium") {
-		return intent === "design" ? "high" : "high";
+		return "high";
 	}
+
 	return "xhigh";
 }
 
@@ -195,9 +215,11 @@ async function resolveApiKey(
 	if (typeof registry.getApiKey === "function") {
 		return registry.getApiKey(model);
 	}
+
 	if (typeof registry.getApiKeyForProvider === "function") {
 		return registry.getApiKeyForProvider(model.provider);
 	}
+
 	if (typeof registry.authStorage?.getApiKey === "function") {
 		return registry.authStorage.getApiKey(model.provider);
 	}

--- a/packages/extensions/extensions/adaptive-routing/normalize.ts
+++ b/packages/extensions/extensions/adaptive-routing/normalize.ts
@@ -49,12 +49,15 @@ export function deriveCandidateTier(model: Model<Api>): RouteTier {
 	if (id.includes("gpt-5.4") || id.includes("opus-4.6") || id.includes("opus-4-6") || name.includes("ultra")) {
 		return "peak";
 	}
+
 	if (id.includes("opus") || id.includes("sonnet") || id.includes("pro") || id.includes("gpt-5")) {
 		return "premium";
 	}
+
 	if (id.includes("flash") || id.includes("mini")) {
 		return "cheap";
 	}
+
 	return "balanced";
 }
 
@@ -67,28 +70,36 @@ export function deriveCandidateTags(model: Model<Api>): string[] {
 
 	tags.add(provider);
 	tags.add(tier);
+
 	if (model.reasoning) {
 		tags.add("reasoning");
 	}
+
 	if (model.input.includes("image")) {
 		tags.add("multimodal");
 	}
+
 	if (tier === "premium" || tier === "peak") {
 		tags.add("premium");
 	}
+
 	if (tier === "cheap") {
 		tags.add("cheap");
 	}
+
 	if (provider === "anthropic" || name.includes("claude")) {
 		tags.add("design");
 	}
+
 	if (provider === "openai" || id.includes("gpt-5")) {
 		tags.add("architecture");
 	}
+
 	if (provider === "cursor-agent") {
 		tags.add("architecture");
 		tags.add("premium");
 	}
+
 	return Array.from(tags);
 }
 
@@ -99,15 +110,19 @@ export function deriveCandidateFamily(model: Model<Api>): string | undefined {
 	if (provider === "anthropic") {
 		return `anthropic-${tier}`;
 	}
+
 	if (provider === "openai") {
 		return `openai-${tier}`;
 	}
+
 	if (provider === "cursor-agent") {
 		return `cursor-${tier}`;
 	}
+
 	if (provider === "google") {
 		return `google-${tier}`;
 	}
+
 	return undefined;
 }
 
@@ -120,18 +135,22 @@ export function deriveFallbackGroups(model: Model<Api>): string[] {
 	if (tier === "cheap") {
 		groups.add("cheap-router");
 	}
+
 	if (
 		(provider === "anthropic" && (id.includes("opus") || id.includes("sonnet"))) ||
 		(provider === "openai" && id.includes("gpt-5.4"))
 	) {
 		groups.add("design-premium");
 	}
+
 	if ((provider === "anthropic" && id.includes("opus")) || (provider === "openai" && id.includes("gpt-5.4"))) {
 		groups.add("peak-reasoning");
 	}
+
 	if (provider === "cursor-agent") {
 		groups.add("peak-reasoning");
 	}
+
 	return Array.from(groups);
 }
 

--- a/packages/extensions/extensions/auto-session-name.ts
+++ b/packages/extensions/extensions/auto-session-name.ts
@@ -13,9 +13,11 @@ function toText(content: MessageLike["content"]): string {
 	if (!content) {
 		return "";
 	}
+
 	if (typeof content === "string") {
 		return content;
 	}
+
 	return content
 		.filter((block) => block?.type === "text" && typeof block.text === "string")
 		.map((block) => block.text?.trim() ?? "")
@@ -64,9 +66,11 @@ function isFocusShift(firstUserText: string, latestUserText: string): boolean {
 	if (!(firstUserText && latestUserText)) {
 		return false;
 	}
+
 	if (latestUserText.length < 12) {
 		return false;
 	}
+
 	return overlapRatio(firstUserText, latestUserText) < FOCUS_SHIFT_THRESHOLD;
 }
 

--- a/packages/extensions/extensions/custom-footer.test.ts
+++ b/packages/extensions/extensions/custom-footer.test.ts
@@ -177,7 +177,7 @@ describe("custom-footer extension", () => {
 		} finally {
 			vi.useRealTimers();
 		}
-	});
+	}, 15_000);
 
 	it("defers worktree snapshot refresh until after startup", async () => {
 		vi.useFakeTimers();

--- a/packages/extensions/extensions/usage-tracker-formatting.ts
+++ b/packages/extensions/extensions/usage-tracker-formatting.ts
@@ -4,9 +4,11 @@ export function fmtTokens(n: number): string {
 	if (n >= 1_000_000) {
 		return `${(n / 1_000_000).toFixed(1)}M`;
 	}
+
 	if (n >= 1_000) {
 		return `${(n / 1_000).toFixed(1)}k`;
 	}
+
 	return `${n}`;
 }
 
@@ -14,9 +16,11 @@ export function fmtCost(n: number): string {
 	if (n >= 1) {
 		return `$${n.toFixed(2)}`;
 	}
+
 	if (n >= 0.01) {
 		return `$${n.toFixed(3)}`;
 	}
+
 	return `$${n.toFixed(4)}`;
 }
 
@@ -46,9 +50,11 @@ export function pctColor(pct: number): string {
 	if (pct < 10) {
 		return "error";
 	}
+
 	if (pct < 25) {
 		return "warning";
 	}
+
 	return "success";
 }
 
@@ -180,9 +186,11 @@ export function formatPaceLeft(pace: WindowPace): string {
 	if (delta <= 2) {
 		return "On pace";
 	}
+
 	if (pace.deltaPercent > 0) {
 		return `${delta}% in deficit`;
 	}
+
 	return `${delta}% in reserve`;
 }
 
@@ -190,12 +198,15 @@ export function formatPaceRight(pace: WindowPace): string {
 	if (pace.willLastToReset) {
 		return "Lasts until reset";
 	}
+
 	if (pace.etaToExhaustionMs === null) {
 		return "";
 	}
+
 	if (pace.etaToExhaustionMs <= 0) {
 		return "Runs out now";
 	}
+
 	return `Runs out in ${fmtDuration(pace.etaToExhaustionMs)}`;
 }
 

--- a/packages/extensions/extensions/watchdog-runtime-diagnostics.ts
+++ b/packages/extensions/extensions/watchdog-runtime-diagnostics.ts
@@ -190,14 +190,17 @@ export function recordRuntimeSample(
 ): void {
 	const profile = ensureProfile(extensionId, source);
 	const sample: RuntimeSample = { name, durationMs: Math.max(0, durationMs), timestamp };
+
 	if (channel === "event") {
 		pushBounded(profile.eventSamples, sample);
 		return;
 	}
+
 	if (channel === "tool") {
 		pushBounded(profile.toolSamples, sample);
 		return;
 	}
+
 	pushBounded(profile.commandSamples, sample);
 }
 
@@ -257,21 +260,27 @@ export function getExtensionDiagnostics(now = Date.now()): ExtensionDiagnostic[]
 		if (recentHandlerMs > 0) {
 			reasons.push(`${Math.round(recentHandlerMs)}ms recent handler time`);
 		}
+
 		if (recentStatusUpdates > 0) {
 			reasons.push(`${recentStatusUpdates} status updates`);
 		}
+
 		if (recentNotifications > 0) {
 			reasons.push(`${recentNotifications} notifications`);
 		}
+
 		if (recentOverlays > 0) {
 			reasons.push(`${recentOverlays} overlays`);
 		}
+
 		if (pendingTasks > 0) {
 			reasons.push(`${pendingTasks} queued tasks`);
 		}
+
 		if (dueTasks > 0) {
 			reasons.push(`${dueTasks} due tasks`);
 		}
+
 		if (profile.metric.note) {
 			reasons.push(profile.metric.note);
 		}
@@ -303,6 +312,7 @@ function wrapContext<T>(ctx: T, extensionId: string, source: string): T {
 	if (!ctx || typeof ctx !== "object") {
 		return ctx;
 	}
+
 	const candidate = ctx as { ui?: Record<string, (...args: unknown[]) => unknown> };
 	if (!candidate.ui || typeof candidate.ui !== "object") {
 		return ctx;
@@ -436,10 +446,12 @@ export function installRuntimeDiagnostics(pi: ExtensionAPI): void {
 		if (!payload || typeof payload !== "object") {
 			return;
 		}
+
 		const extensionId = (payload as RuntimeDiagnosticsMetric).extensionId;
 		if (typeof extensionId !== "string" || extensionId.length === 0) {
 			return;
 		}
+
 		recordRuntimeMetric(payload as RuntimeDiagnosticsMetric);
 	});
 }

--- a/packages/extensions/extensions/worktree-shared.test.ts
+++ b/packages/extensions/extensions/worktree-shared.test.ts
@@ -89,7 +89,7 @@ describe("worktree-shared", () => {
 		const registry = loadWorktreeRegistry(repo, sharedRoot);
 		expect(registry.managedWorktrees).toHaveLength(1);
 		expect(registry.managedWorktrees[0]?.lastSeenAt).toBeTruthy();
-	}, 15_000);
+	}, 30_000);
 
 	it("removes only the targeted Pai-owned worktree and leaves external ones alone", () => {
 		const repo = mkTempDir("pi-worktree-cleanup-repo-");
@@ -118,5 +118,5 @@ describe("worktree-shared", () => {
 		expect(after?.worktrees.some((entry) => entry.path === managed.worktreePath)).toBe(false);
 		expect(after?.worktrees.some((entry) => entry.path === real(externalWorktreePath) && !entry.isManaged)).toBe(true);
 		expect(loadWorktreeRegistry(repo, sharedRoot).managedWorktrees).toHaveLength(0);
-	}, 15_000);
+	}, 30_000);
 });

--- a/packages/extensions/extensions/worktree-shared.test.ts
+++ b/packages/extensions/extensions/worktree-shared.test.ts
@@ -89,7 +89,7 @@ describe("worktree-shared", () => {
 		const registry = loadWorktreeRegistry(repo, sharedRoot);
 		expect(registry.managedWorktrees).toHaveLength(1);
 		expect(registry.managedWorktrees[0]?.lastSeenAt).toBeTruthy();
-	});
+	}, 15_000);
 
 	it("removes only the targeted Pai-owned worktree and leaves external ones alone", () => {
 		const repo = mkTempDir("pi-worktree-cleanup-repo-");
@@ -118,5 +118,5 @@ describe("worktree-shared", () => {
 		expect(after?.worktrees.some((entry) => entry.path === managed.worktreePath)).toBe(false);
 		expect(after?.worktrees.some((entry) => entry.path === real(externalWorktreePath) && !entry.isManaged)).toBe(true);
 		expect(loadWorktreeRegistry(repo, sharedRoot).managedWorktrees).toHaveLength(0);
-	});
+	}, 15_000);
 });

--- a/packages/plan/request-user-input.ts
+++ b/packages/plan/request-user-input.ts
@@ -55,6 +55,7 @@ export function buildRequestUserInputAnswer(
 		if (trimmed.length === 0) {
 			return { answers: [] };
 		}
+
 		return { answers: [`user_note: ${trimmed}`] };
 	}
 
@@ -62,6 +63,7 @@ export function buildRequestUserInputAnswer(
 		if (trimmed.length === 0) {
 			return { answers: [] };
 		}
+
 		return { answers: ["Other", `user_note: ${trimmed}`] };
 	}
 
@@ -69,6 +71,7 @@ export function buildRequestUserInputAnswer(
 	if (!label) {
 		return { answers: [] };
 	}
+
 	return { answers: [label] };
 }
 

--- a/packages/prompts/README.md
+++ b/packages/prompts/README.md
@@ -5,6 +5,7 @@ Prompt templates for pi.
 ## Included prompts
 
 This package contains reusable prompt templates such as:
+
 - review
 - fix
 - explain

--- a/packages/skills/README.md
+++ b/packages/skills/README.md
@@ -5,6 +5,7 @@ On-demand skill packs for pi.
 ## What this package includes
 
 This package bundles reusable skills for common workflows, including areas like:
+
 - web search and fetch
 - debugging
 - git workflow help

--- a/packages/spec/README.md
+++ b/packages/spec/README.md
@@ -282,7 +282,7 @@ That is important because the package should seed a workflow, not keep fighting 
 
 ## How to use it in practice
 
-## 1) Initialize the workflow
+### 1) Initialize the workflow
 
 ```bash
 /spec init
@@ -297,7 +297,7 @@ What happens:
 - constitution and pi-agent memory files are created if missing
 - a report is rendered in pi explaining what was created
 
-## 2) Define the project's constitution
+### 2) Define the project's constitution
 
 ```bash
 /spec constitution Security-first, testable, backwards-compatible changes by default
@@ -311,7 +311,7 @@ Typical outcomes:
 - related templates may be aligned with those rules
 - future workflow steps can refer back to the same governance file
 
-## 3) Create a feature spec
+### 3) Create a feature spec
 
 ```bash
 /spec specify Add SSO login for enterprise tenants
@@ -328,7 +328,7 @@ What happens:
 
 This is the key step that turns a vague idea into a concrete feature workspace.
 
-## 4) Clarify open questions
+### 4) Clarify open questions
 
 ```bash
 /spec clarify
@@ -342,7 +342,7 @@ or
 
 This step is meant to remove the highest-impact ambiguities before planning.
 
-## 5) Generate a requirement-quality checklist
+### 5) Generate a requirement-quality checklist
 
 ```bash
 /spec checklist Authentication quality gates
@@ -351,7 +351,7 @@ This step is meant to remove the highest-impact ambiguities before planning.
 This is not supposed to generate implementation TODOs. It is meant to verify that the spec is precise,
 complete, and testable.
 
-## 6) Build the implementation plan
+### 6) Build the implementation plan
 
 ```bash
 /spec plan Use TypeScript, Vitest, and existing auth services; avoid new infrastructure
@@ -363,7 +363,7 @@ What happens:
 - pi is instructed to use the local `plan` workflow template
 - `pi-agent.md` is treated as the pi-native context artifact instead of shell-generated agent files
 
-## 7) Generate tasks
+### 7) Generate tasks
 
 ```bash
 /spec tasks
@@ -377,7 +377,7 @@ or
 
 This step should produce a `tasks.md` with a strict checkbox-oriented execution plan.
 
-## 8) Analyze for contradictions
+### 8) Analyze for contradictions
 
 ```bash
 /spec analyze
@@ -386,7 +386,7 @@ This step should produce a `tasks.md` with a strict checkbox-oriented execution 
 This step is intentionally read-only. It is there to catch inconsistencies between the spec, plan,
 checklists, and tasks before coding begins.
 
-## 9) Implement
+### 9) Implement
 
 ```bash
 /spec implement
@@ -404,7 +404,7 @@ Behavior worth knowing:
 - if incomplete checklist items exist and the UI supports confirmation, pi asks whether you want to continue
 - the implementation prompt reminds pi to mark completed tasks as `[x]`
 
-## 10) Inspect progress any time
+### 10) Inspect progress any time
 
 ```bash
 /spec status

--- a/packages/spec/extension/prompts.ts
+++ b/packages/spec/extension/prompts.ts
@@ -35,30 +35,39 @@ export function buildWorkflowPrompt(context: WorkflowPromptContext): string {
 	if (context.paths.featureBranch) {
 		lines.push(`- Active feature branch/name: ${context.paths.featureBranch}`);
 	}
+
 	if (context.paths.featureDir) {
 		lines.push(`- Feature directory: ${context.paths.featureDir}`);
 	}
+
 	if (context.paths.featureSpec) {
 		lines.push(`- Feature spec: ${context.paths.featureSpec}`);
 	}
+
 	if (context.paths.planFile) {
 		lines.push(`- Implementation plan: ${context.paths.planFile}`);
 	}
+
 	if (context.paths.tasksFile) {
 		lines.push(`- Task list: ${context.paths.tasksFile}`);
 	}
+
 	if (context.paths.researchFile) {
 		lines.push(`- Research file: ${context.paths.researchFile}`);
 	}
+
 	if (context.paths.dataModelFile) {
 		lines.push(`- Data model: ${context.paths.dataModelFile}`);
 	}
+
 	if (context.paths.quickstartFile) {
 		lines.push(`- Quickstart: ${context.paths.quickstartFile}`);
 	}
+
 	if (context.paths.contractsDir) {
 		lines.push(`- Contracts directory: ${context.paths.contractsDir}`);
 	}
+
 	if (context.paths.checklistsDir) {
 		lines.push(`- Checklists directory: ${context.paths.checklistsDir}`);
 	}

--- a/packages/spec/extension/status.ts
+++ b/packages/spec/extension/status.ts
@@ -78,6 +78,7 @@ function nextStepsFor(paths: WorkflowPaths, initialized: boolean): string[] {
 
 	steps.push("/spec analyze");
 	steps.push(hasIncompleteChecklist ? "/spec implement (after checklist review)" : "/spec implement");
+
 	return steps;
 }
 
@@ -116,12 +117,15 @@ export function buildWorkflowStatus(options: {
 			exists: existsSync(options.paths.featureSpec),
 		});
 	}
+
 	if (options.paths.planFile) {
 		artifacts.push({ label: "plan.md", path: options.paths.planFile, exists: existsSync(options.paths.planFile) });
 	}
+
 	if (options.paths.tasksFile) {
 		artifacts.push({ label: "tasks.md", path: options.paths.tasksFile, exists: existsSync(options.paths.tasksFile) });
 	}
+
 	if (options.paths.researchFile) {
 		artifacts.push({
 			label: "research.md",
@@ -129,6 +133,7 @@ export function buildWorkflowStatus(options: {
 			exists: existsSync(options.paths.researchFile),
 		});
 	}
+
 	if (options.paths.dataModelFile) {
 		artifacts.push({
 			label: "data-model.md",
@@ -136,6 +141,7 @@ export function buildWorkflowStatus(options: {
 			exists: existsSync(options.paths.dataModelFile),
 		});
 	}
+
 	if (options.paths.quickstartFile) {
 		artifacts.push({
 			label: "quickstart.md",
@@ -143,6 +149,7 @@ export function buildWorkflowStatus(options: {
 			exists: existsSync(options.paths.quickstartFile),
 		});
 	}
+
 	if (options.paths.contractsDir) {
 		artifacts.push({
 			label: "contracts/",

--- a/packages/subagents/agent-manager-chain-detail.ts
+++ b/packages/subagents/agent-manager-chain-detail.ts
@@ -14,14 +14,22 @@ const CHAIN_DETAIL_VIEWPORT_HEIGHT = 12;
 export function buildDependencyMap(steps: ChainStepConfig[]): Map<number, number[]> {
 	const outputMap = new Map<string, number>();
 	const deps = new Map<number, number[]>();
+
 	for (let i = 0; i < steps.length; i++) {
 		const step = steps[i]!;
-		if (typeof step.output === "string" && step.output.length > 0) outputMap.set(step.output, i);
+
+		if (typeof step.output === "string" && step.output.length > 0) {
+			outputMap.set(step.output, i);
+		}
+
 		if (Array.isArray(step.reads) && step.reads.length > 0) {
 			const sources = step.reads.map((file) => outputMap.get(file)).filter((idx): idx is number => idx !== undefined);
-			if (sources.length > 0) deps.set(i, sources);
+			if (sources.length > 0) {
+				deps.set(i, sources);
+			}
 		}
 	}
+
 	return deps;
 }
 
@@ -72,25 +80,38 @@ function buildChainDetailLines(chain: ChainConfig, width: number): string[] {
 }
 
 export function handleChainDetailInput(state: ChainDetailState, data: string): ChainDetailAction | undefined {
-	if (matchesKey(data, "escape") || matchesKey(data, "ctrl+c")) return { type: "back" };
-	if (data === "l") return { type: "launch" };
-	if (data === "e") return { type: "edit" };
+	if (matchesKey(data, "escape") || matchesKey(data, "ctrl+c")) {
+		return { type: "back" };
+	}
+
+	if (data === "l") {
+		return { type: "launch" };
+	}
+
+	if (data === "e") {
+		return { type: "edit" };
+	}
+
 	if (matchesKey(data, "up")) {
 		state.scrollOffset--;
 		return;
 	}
+
 	if (matchesKey(data, "down")) {
 		state.scrollOffset++;
 		return;
 	}
+
 	if (matchesKey(data, "pageup") || matchesKey(data, "shift+up")) {
 		state.scrollOffset -= CHAIN_DETAIL_VIEWPORT_HEIGHT;
 		return;
 	}
+
 	if (matchesKey(data, "pagedown") || matchesKey(data, "shift+down")) {
 		state.scrollOffset += CHAIN_DETAIL_VIEWPORT_HEIGHT;
 		return;
 	}
+
 	return;
 }
 

--- a/packages/themes/README.md
+++ b/packages/themes/README.md
@@ -5,6 +5,7 @@ Color themes for pi.
 ## Included themes
 
 This package contains first-party themes such as:
+
 - Catppuccin Mocha
 - Cyberpunk
 - Gruvbox Dark

--- a/packages/web-client/README.md
+++ b/packages/web-client/README.md
@@ -6,6 +6,7 @@ Platform-agnostic TypeScript client for remote pi sessions.
 
 `@ifi/pi-web-client` is a lightweight client library for connecting to pi remote session servers.
 It is designed to work in:
+
 - browsers
 - Node.js
 - React Native

--- a/packages/web-client/src/client.ts
+++ b/packages/web-client/src/client.ts
@@ -101,12 +101,15 @@ export class PiWebClient {
 				// Handle RPC responses (correlated by id)
 				if (data.type === "response") {
 					const response = data as unknown as RpcResponse;
+
 					if (response.id && this._pendingRequests.has(response.id)) {
 						const pending = this._pendingRequests.get(response.id);
 						this._pendingRequests.delete(response.id);
+
 						if (!pending) {
 							return;
 						}
+
 						if (response.success) {
 							pending.resolve(response.data);
 						} else {
@@ -257,6 +260,7 @@ export class PiWebClient {
 
 	private _emit(event: string, data: unknown): void {
 		const handlers = this._listeners.get(event);
+
 		if (handlers) {
 			for (const handler of handlers) {
 				try {

--- a/packages/web-remote/README.md
+++ b/packages/web-remote/README.md
@@ -5,6 +5,7 @@ Pi extension that adds the `/remote` command for sharing sessions via a web UI.
 ## What it does
 
 This package registers a `/remote` command that can:
+
 - start remote access for the current pi session
 - expose a connection URL or tunnel-backed URL
 - show connection status

--- a/packages/web-remote/index.ts
+++ b/packages/web-remote/index.ts
@@ -49,6 +49,7 @@ export default function (pi: ExtensionAPI) {
 
 			// Try to start tunnel
 			const tunnelProvider = detectTunnelProvider();
+
 			if (tunnelProvider) {
 				try {
 					const port = Number.parseInt(result.url.match(/:(\d+)/)?.[1] ?? "3100", 10);
@@ -94,6 +95,7 @@ export default function (pi: ExtensionAPI) {
 
 function buildConnectUrl(server: PiWebServer): string {
 	const tunnelUrl = server.tunnelUrl;
+
 	if (tunnelUrl) {
 		return `${HOSTED_UI_URL}?host=${encodeURIComponent(tunnelUrl)}&t=${server.token}`;
 	}

--- a/packages/web-server/README.md
+++ b/packages/web-server/README.md
@@ -8,6 +8,7 @@ Embeddable HTTP + WebSocket server for remote pi session management.
 and WebSocket transports.
 
 It includes support for:
+
 - token-based access
 - LAN/tunnel-aware connection flows
 - remote session transport primitives

--- a/packages/web-server/src/bin/pi-web.ts
+++ b/packages/web-server/src/bin/pi-web.ts
@@ -38,8 +38,10 @@ async function main(): Promise<void> {
 
 	// Try to start tunnel
 	let tunnelUrl: string | undefined;
+
 	if (!noTunnel) {
 		const provider = detectTunnelProvider();
+
 		if (provider) {
 			try {
 				const tunnel = await startTunnel(resolvedPort, provider);
@@ -95,8 +97,10 @@ function parseFlags(args: string[]): Record<string, string> {
 	const flags: Record<string, string> = {};
 	for (let i = 0; i < args.length; i++) {
 		const arg = args[i];
+
 		if (arg.startsWith("--")) {
 			const key = arg.slice(2);
+
 			if (key === "no-tunnel") {
 				flags[key] = "true";
 			} else if (i + 1 < args.length && !args[i + 1].startsWith("--")) {

--- a/packages/web-server/src/lan.ts
+++ b/packages/web-server/src/lan.ts
@@ -4,9 +4,11 @@ export function getLanIp(): string | undefined {
 	const interfaces = networkInterfaces();
 	for (const name of Object.keys(interfaces)) {
 		const addrs = interfaces[name];
+
 		if (!addrs) {
 			continue;
 		}
+
 		for (const addr of addrs) {
 			if (addr.family === "IPv4" && !addr.internal) {
 				return addr.address;

--- a/packages/web-server/src/routes.ts
+++ b/packages/web-server/src/routes.ts
@@ -21,13 +21,17 @@ export function createRoutes(options: RoutesOptions): Hono {
 	// Auth middleware for all other /api routes
 	app.use("/api/*", async (c, next) => {
 		const auth = c.req.header("Authorization");
+
 		if (!auth?.startsWith("Bearer ")) {
 			return c.json({ error: "Authorization required" }, 401);
 		}
+
 		const provided = auth.slice(7);
+
 		if (!validateToken(provided, options.token)) {
 			return c.json({ error: "Invalid token" }, 401);
 		}
+
 		await next();
 	});
 
@@ -43,9 +47,11 @@ export function createRoutes(options: RoutesOptions): Hono {
 	// Session state
 	app.get("/api/session/state", (c) => {
 		const session = options.getSession();
+
 		if (!session) {
 			return c.json({ error: "No session attached" }, 503);
 		}
+
 		return c.json({
 			model: session.model,
 			thinkingLevel: session.thinkingLevel,
@@ -58,18 +64,22 @@ export function createRoutes(options: RoutesOptions): Hono {
 	// Session messages
 	app.get("/api/session/messages", (c) => {
 		const session = options.getSession();
+
 		if (!session) {
 			return c.json({ error: "No session attached" }, 503);
 		}
+
 		return c.json({ messages: session.messages });
 	});
 
 	// Session stats
 	app.get("/api/session/stats", (c) => {
 		const session = options.getSession();
+
 		if (!session) {
 			return c.json({ error: "No session attached" }, 503);
 		}
+
 		return c.json({
 			sessionId: session.sessionId,
 			messageCount: session.messages.length,
@@ -80,9 +90,11 @@ export function createRoutes(options: RoutesOptions): Hono {
 	// Available models
 	app.get("/api/models", (c) => {
 		const session = options.getSession();
+
 		if (!session) {
 			return c.json({ error: "No session attached" }, 503);
 		}
+
 		return c.json({
 			currentModel: session.model,
 			thinkingLevel: session.thinkingLevel,

--- a/packages/web-server/src/token.ts
+++ b/packages/web-server/src/token.ts
@@ -20,9 +20,11 @@ export function generateInstanceId(token: string): string {
 export function validateToken(provided: string, expected: string): boolean {
 	const a = Buffer.from(provided, "utf8");
 	const b = Buffer.from(expected, "utf8");
+
 	if (a.length !== b.length) {
 		return false;
 	}
+
 	return timingSafeEqual(a, b);
 }
 
@@ -36,6 +38,7 @@ export function loadOrCreateToken(filePath?: string): TokenInfo {
 	if (filePath) {
 		try {
 			const existing = readFileSync(filePath, "utf8").trim();
+
 			if (existing.length === 64) {
 				return { token: existing, instanceId: generateInstanceId(existing), isNew: false };
 			}

--- a/packages/web-server/src/tunnel.ts
+++ b/packages/web-server/src/tunnel.ts
@@ -26,6 +26,7 @@ export function detectTunnelProvider(): TunnelProvider | undefined {
 
 export function startTunnel(port: number, provider?: TunnelProvider): Promise<TunnelInfo> {
 	const resolved = provider ?? detectTunnelProvider();
+
 	if (!resolved) {
 		return Promise.reject(new Error("No tunnel provider found. Install cloudflared or tailscale."));
 	}
@@ -52,8 +53,10 @@ function startCloudflaredTunnel(port: number): Promise<TunnelInfo> {
 
 		const onData = (data: Buffer) => {
 			const text = data.toString();
+
 			// Cloudflared prints the URL to stderr
 			const match = text.match(/https:\/\/[a-zA-Z0-9-]+\.trycloudflare\.com/);
+
 			if (match && !resolved) {
 				resolved = true;
 				clearTimeout(timeout);
@@ -105,6 +108,7 @@ function startTailscaleTunnel(port: number): Promise<TunnelInfo> {
 		const onData = (data: Buffer) => {
 			const text = data.toString();
 			const match = text.match(/https:\/\/[^\s]+/);
+
 			if (match && !resolved) {
 				resolved = true;
 				clearTimeout(timeout);

--- a/packages/web-server/src/ws-handler.ts
+++ b/packages/web-server/src/ws-handler.ts
@@ -67,6 +67,7 @@ export function handleWebSocketConnection(ws: WebSocket, options: WsHandlerOptio
 
 					// Subscribe to agent events and relay to this client
 					const agentSession = options.getSession();
+
 					if (agentSession) {
 						unsubscribeEvents = agentSession.subscribe((event: unknown) => {
 							send(event);
@@ -99,6 +100,7 @@ export function handleWebSocketConnection(ws: WebSocket, options: WsHandlerOptio
 
 		// Authenticated — dispatch RPC commands
 		const agentSession = options.getSession();
+
 		if (!agentSession) {
 			send({ type: "response", command: msg.type, success: false, error: "No session attached", id: msg.id });
 			return;
@@ -143,6 +145,7 @@ async function dispatchCommand(
 		case "prompt": {
 			const message = msg.message as string;
 			const streamingBehavior = msg.streamingBehavior as "steer" | "followUp" | undefined;
+
 			if (agentSession.isStreaming && streamingBehavior) {
 				await agentSession.prompt(message, { streamingBehavior });
 			} else {


### PR DESCRIPTION
## Summary
- apply safe readability and spacing cleanups across TS and Markdown files
- keep runtime behavior unchanged while improving visual breathing room and grouping
- raise timeouts for a few slow worktree/footer tests so local and worktree runs stay green
- add the required changeset for the non-release repo change

## Verification
- pnpm format
- pnpm lint
- pnpm typecheck
- pnpm test
- pnpm security:check
- pnpm build