### PR TITLE
fix(extensions): defer usage tracker persisted loads

### DIFF
--- a/.changeset/usage-tracker-startup-persisted-loads.md
+++ b/.changeset/usage-tracker-startup-persisted-loads.md
@@ -1,0 +1,5 @@
+---
+"default": patch
+---
+
+fix(extensions): defer usage tracker persisted startup loads

--- a/packages/extensions/extensions/smoke.test.ts
+++ b/packages/extensions/extensions/smoke.test.ts
@@ -106,5 +106,4 @@ describe("extensions runtime smoke tests", () => {
 		worktreeExtension(harness.pi as never);
 		expect(harness.commands.has("worktree")).toBe(true);
 	});
-
 });

--- a/packages/extensions/extensions/usage-tracker.test.ts
+++ b/packages/extensions/extensions/usage-tracker.test.ts
@@ -10,6 +10,11 @@ import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 
 // ─── Mocks ──────────────────────────────────────────────────────────────────
 
+const { mockFsReadFile, mockFsAccess } = vi.hoisted(() => ({
+	mockFsReadFile: vi.fn().mockResolvedValue("{}"),
+	mockFsAccess: vi.fn().mockRejectedValue(new Error("missing")),
+}));
+
 vi.mock("node:fs", async (importOriginal) => {
 	const actual = await importOriginal<typeof import("node:fs")>();
 	return {
@@ -18,6 +23,11 @@ vi.mock("node:fs", async (importOriginal) => {
 		mkdirSync: vi.fn(),
 		readFileSync: vi.fn().mockReturnValue("{}"),
 		writeFileSync: vi.fn(),
+		promises: {
+			...actual.promises,
+			access: mockFsAccess,
+			readFile: mockFsReadFile,
+		},
 	};
 });
 
@@ -269,7 +279,7 @@ function stripAnsiForTest(text: string): string {
 
 // ─── Import ──────────────────────────────────────────────────────────────────
 
-import { existsSync, mkdirSync, readFileSync, writeFileSync } from "node:fs";
+import { existsSync, promises as fsPromises, mkdirSync, readFileSync, writeFileSync } from "node:fs";
 import usageTracker from "./usage-tracker.js";
 
 // ─── Tests ───────────────────────────────────────────────────────────────────
@@ -295,6 +305,8 @@ describe("usage-tracker extension", () => {
 		});
 		(mkdirSync as ReturnType<typeof vi.fn>).mockImplementation(() => undefined);
 		(writeFileSync as ReturnType<typeof vi.fn>).mockImplementation(() => undefined);
+		(mockFsAccess as ReturnType<typeof vi.fn>).mockRejectedValue(new Error("missing"));
+		(mockFsReadFile as ReturnType<typeof vi.fn>).mockResolvedValue("{}");
 		mockFetch.mockResolvedValue(
 			makeFetchResponse({
 				headers: {
@@ -342,6 +354,71 @@ describe("usage-tracker extension", () => {
 			usageTracker(pi as any);
 			expect(pi._shortcuts.has("ctrl+u")).toBe(true);
 			expect(pi._shortcuts.get("ctrl+u").description).toContain("rate limits");
+		});
+
+		it("does not load persisted history or rate-limit cache during registration", () => {
+			usageTracker(pi as any);
+
+			expect(fsPromises.readFile).not.toHaveBeenCalled();
+		});
+
+		it("defers persisted history and cache loading until after startup", async () => {
+			(mockFsReadFile as ReturnType<typeof vi.fn>).mockImplementation(async (path: string) => {
+				if (String(path).includes("usage-tracker-history.json")) {
+					return JSON.stringify({ version: 1, entries: [{ timestamp: Date.now() - 60_000, cost: 1.25 }] });
+				}
+				if (String(path).includes("usage-tracker-rate-limits.json")) {
+					return makeRateLimitCacheJson({ openai: makeOpenAiRateLimitCacheEntry() });
+				}
+				return "{}";
+			});
+
+			usageTracker(pi as any);
+			pi._emit("session_start", { type: "session_start" }, ctx);
+
+			expect(fsPromises.readFile).not.toHaveBeenCalled();
+
+			await vi.advanceTimersByTimeAsync(250);
+
+			expect(fsPromises.readFile).toHaveBeenCalledTimes(2);
+			expect((fsPromises.readFile as ReturnType<typeof vi.fn>).mock.calls[0]?.[0]).toContain(
+				"usage-tracker-history.json",
+			);
+			expect((fsPromises.readFile as ReturnType<typeof vi.fn>).mock.calls[1]?.[0]).toContain(
+				"usage-tracker-rate-limits.json",
+			);
+		});
+
+		it("loads persisted history on demand for usage_report before the startup timer fires", async () => {
+			const now = Date.now();
+			(mockFsReadFile as ReturnType<typeof vi.fn>).mockImplementation(async (path: string) => {
+				if (String(path).includes("usage-tracker-history.json")) {
+					return JSON.stringify({
+						version: 1,
+						entries: [{ timestamp: now - 60_000, cost: 1.23 }],
+					});
+				}
+				return "{}";
+			});
+
+			usageTracker(pi as any);
+			pi._emit("session_start", { type: "session_start" }, ctx);
+
+			const tool = pi._tools.get("usage_report");
+			const result = await runWithTimers(() => tool.execute("id", { format: "summary" }, undefined, undefined, ctx));
+
+			expect(fsPromises.readFile).toHaveBeenCalled();
+			expect(result.content[0].text).toContain("30d: $1.23");
+		});
+
+		it("cancels deferred persisted-state loading on session shutdown", async () => {
+			usageTracker(pi as any);
+			pi._emit("session_start", { type: "session_start" }, ctx);
+			pi._emit("session_shutdown", { type: "session_shutdown" }, ctx);
+
+			await vi.advanceTimersByTimeAsync(250);
+
+			expect(fsPromises.readFile).not.toHaveBeenCalled();
 		});
 	});
 
@@ -398,10 +475,7 @@ describe("usage-tracker extension", () => {
 	describe("rolling 30d totals", () => {
 		it("loads persisted 30d history from disk and shows it in summary", async () => {
 			const now = Date.now();
-			(existsSync as ReturnType<typeof vi.fn>).mockImplementation((path: string) =>
-				String(path).includes("usage-tracker-history.json"),
-			);
-			(readFileSync as ReturnType<typeof vi.fn>).mockImplementation((path: string) => {
+			(mockFsReadFile as ReturnType<typeof vi.fn>).mockImplementation(async (path: string) => {
 				if (String(path).includes("usage-tracker-history.json")) {
 					return JSON.stringify({
 						version: 1,
@@ -437,10 +511,7 @@ describe("usage-tracker extension", () => {
 
 		it("drops history older than 30 days", async () => {
 			const now = Date.now();
-			(existsSync as ReturnType<typeof vi.fn>).mockImplementation((path: string) =>
-				String(path).includes("usage-tracker-history.json"),
-			);
-			(readFileSync as ReturnType<typeof vi.fn>).mockImplementation((path: string) => {
+			(mockFsReadFile as ReturnType<typeof vi.fn>).mockImplementation(async (path: string) => {
 				if (String(path).includes("usage-tracker-history.json")) {
 					return JSON.stringify({
 						version: 1,
@@ -844,16 +915,14 @@ describe("usage-tracker extension", () => {
 		});
 
 		it("restores cached Anthropic windows across restarts when the live probe is rate-limited", async () => {
-			(existsSync as ReturnType<typeof vi.fn>).mockImplementation((path: string) => {
-				if (String(path) === AUTH_JSON_PATH || String(path) === RATE_LIMIT_CACHE_PATH) {
-					return true;
-				}
-				return false;
-			});
+			(existsSync as ReturnType<typeof vi.fn>).mockImplementation((path: string) => String(path) === AUTH_JSON_PATH);
 			(readFileSync as ReturnType<typeof vi.fn>).mockImplementation((path: string) => {
 				if (String(path) === AUTH_JSON_PATH) {
 					return makeAuthJson();
 				}
+				return "{}";
+			});
+			(mockFsReadFile as ReturnType<typeof vi.fn>).mockImplementation(async (path: string) => {
 				if (String(path) === RATE_LIMIT_CACHE_PATH) {
 					return makeRateLimitCacheJson();
 				}
@@ -1100,17 +1169,15 @@ describe("usage-tracker extension", () => {
 			expect(rendered).not.toContain("$0.050");
 		});
 
-		it("shows cached Anthropic windows in the widget when live probing is rate-limited", () => {
-			(existsSync as ReturnType<typeof vi.fn>).mockImplementation((path: string) => {
-				if (String(path) === AUTH_JSON_PATH || String(path) === RATE_LIMIT_CACHE_PATH) {
-					return true;
-				}
-				return false;
-			});
+		it("shows cached Anthropic windows in the widget when live probing is rate-limited", async () => {
+			(existsSync as ReturnType<typeof vi.fn>).mockImplementation((path: string) => String(path) === AUTH_JSON_PATH);
 			(readFileSync as ReturnType<typeof vi.fn>).mockImplementation((path: string) => {
 				if (String(path) === AUTH_JSON_PATH) {
 					return makeAuthJson();
 				}
+				return "{}";
+			});
+			(mockFsReadFile as ReturnType<typeof vi.fn>).mockImplementation(async (path: string) => {
 				if (String(path) === RATE_LIMIT_CACHE_PATH) {
 					return makeRateLimitCacheJson();
 				}
@@ -1120,6 +1187,7 @@ describe("usage-tracker extension", () => {
 
 			usageTracker(pi as any);
 			pi._emit("session_start", { type: "session_start" }, ctx);
+			await vi.advanceTimersByTimeAsync(250);
 
 			const widgetFactory = ctx._widgets.get("usage-tracker") as
 				| ((
@@ -1136,17 +1204,15 @@ describe("usage-tracker extension", () => {
 			expect(rendered).toContain("72%");
 		});
 
-		it("shows only the current provider in the widget when multiple providers have cached usage", () => {
-			(existsSync as ReturnType<typeof vi.fn>).mockImplementation((path: string) => {
-				if (String(path) === AUTH_JSON_PATH || String(path) === RATE_LIMIT_CACHE_PATH) {
-					return true;
-				}
-				return false;
-			});
+		it("shows only the current provider in the widget when multiple providers have cached usage", async () => {
+			(existsSync as ReturnType<typeof vi.fn>).mockImplementation((path: string) => String(path) === AUTH_JSON_PATH);
 			(readFileSync as ReturnType<typeof vi.fn>).mockImplementation((path: string) => {
 				if (String(path) === AUTH_JSON_PATH) {
 					return makeAuthJson();
 				}
+				return "{}";
+			});
+			(mockFsReadFile as ReturnType<typeof vi.fn>).mockImplementation(async (path: string) => {
 				if (String(path) === RATE_LIMIT_CACHE_PATH) {
 					return makeRateLimitCacheJson({ openai: makeOpenAiRateLimitCacheEntry() });
 				}
@@ -1157,6 +1223,7 @@ describe("usage-tracker extension", () => {
 
 			usageTracker(pi as any);
 			pi._emit("session_start", { type: "session_start" }, ctx);
+			await vi.advanceTimersByTimeAsync(250);
 
 			const widgetFactory = ctx._widgets.get("usage-tracker") as
 				| ((

--- a/packages/extensions/extensions/usage-tracker.ts
+++ b/packages/extensions/extensions/usage-tracker.ts
@@ -31,7 +31,7 @@ Key usage-tracker surfaces:
 <!-- {/extensionsUsageTrackerCommandsDocs} -->
 */
 
-import { existsSync, mkdirSync, readFileSync, writeFileSync } from "node:fs";
+import { existsSync, promises as fsp, mkdirSync, readFileSync, writeFileSync } from "node:fs";
 import { dirname, join } from "node:path";
 import type { AssistantMessage } from "@mariozechner/pi-ai";
 import { type ExtensionAPI, type ExtensionContext, getAgentDir } from "@mariozechner/pi-coding-agent";
@@ -81,6 +81,7 @@ import {
 const KEYBINDINGS_SYNC_DELAY_MS = 250;
 const STARTUP_REFRESH_DELAY_MS = 250;
 const STARTUP_DEFER_ENTRY_THRESHOLD = 250;
+const PERSISTED_STATE_LOAD_DELAY_MS = 250;
 
 /**
  * Ensure `ctrl+u` is unbound from the built-in `deleteToLineStart` action
@@ -148,7 +149,11 @@ function getRateLimitCachePath(): string {
 
 export default function usageTracker(pi: ExtensionAPI) {
 	let keybindingsSyncScheduled = false;
+	let persistedStateLoadPromise: Promise<void> | null = null;
+	let persistedStateLoadScheduled = false;
+	let persistedStateLoadTimer: ReturnType<typeof setTimeout> | null = null;
 	let startupRefreshTimer: ReturnType<typeof setTimeout> | null = null;
+	let requestWidgetRender: (() => void) | null = null;
 
 	const scheduleCtrlUUnbound = () => {
 		if (keybindingsSyncScheduled) {
@@ -215,12 +220,9 @@ export default function usageTracker(pi: ExtensionAPI) {
 		return total;
 	}
 
-	function loadRollingHistory(): void {
+	async function loadRollingHistory(): Promise<void> {
 		try {
-			if (!existsSync(usageHistoryPath)) {
-				return;
-			}
-			const raw = JSON.parse(readFileSync(usageHistoryPath, "utf-8")) as { entries?: unknown };
+			const raw = JSON.parse(await fsp.readFile(usageHistoryPath, "utf-8")) as { entries?: unknown };
 			if (!Array.isArray(raw.entries)) {
 				return;
 			}
@@ -315,12 +317,9 @@ export default function usageTracker(pi: ExtensionAPI) {
 		};
 	}
 
-	function loadRateLimitCache(): void {
+	async function loadRateLimitCache(): Promise<void> {
 		try {
-			if (!existsSync(rateLimitCachePath)) {
-				return;
-			}
-			const raw = JSON.parse(readFileSync(rateLimitCachePath, "utf-8")) as { providers?: unknown };
+			const raw = JSON.parse(await fsp.readFile(rateLimitCachePath, "utf-8")) as { providers?: unknown };
 			if (!raw.providers || typeof raw.providers !== "object") {
 				return;
 			}
@@ -329,7 +328,20 @@ export default function usageTracker(pi: ExtensionAPI) {
 				if (!providerRateLimits) {
 					continue;
 				}
-				rateLimits.set(providerRateLimits.provider, providerRateLimits);
+				const existing = rateLimits.get(providerRateLimits.provider);
+				if (existing && shouldPreserveStaleWindows(providerRateLimits, existing)) {
+					rateLimits.set(providerRateLimits.provider, {
+						...existing,
+						windows: providerRateLimits.windows.map((window) => ({ ...window })),
+						note: existing.note
+							? `${existing.note} Showing last known window values.`
+							: "Showing last known window values.",
+					});
+					continue;
+				}
+				if (!existing || existing.probedAt <= providerRateLimits.probedAt) {
+					rateLimits.set(providerRateLimits.provider, providerRateLimits);
+				}
 			}
 		} catch {
 			// Non-critical. The next live probe will repopulate provider data.
@@ -351,8 +363,43 @@ export default function usageTracker(pi: ExtensionAPI) {
 		}
 	}
 
-	loadRollingHistory();
-	loadRateLimitCache();
+	const loadPersistedState = async (): Promise<void> => {
+		if (persistedStateLoadPromise) {
+			await persistedStateLoadPromise;
+			return;
+		}
+
+		persistedStateLoadPromise = (async () => {
+			await Promise.all([loadRollingHistory(), loadRateLimitCache()]);
+			requestWidgetRender?.();
+			broadcastUsageData();
+		})();
+
+		await persistedStateLoadPromise;
+	};
+
+	const schedulePersistedStateLoad = () => {
+		if (persistedStateLoadPromise || persistedStateLoadScheduled) {
+			return;
+		}
+
+		persistedStateLoadScheduled = true;
+		persistedStateLoadTimer = setTimeout(() => {
+			persistedStateLoadScheduled = false;
+			persistedStateLoadTimer = null;
+			loadPersistedState().catch(() => undefined);
+		}, PERSISTED_STATE_LOAD_DELAY_MS);
+		persistedStateLoadTimer.unref?.();
+	};
+
+	const clearPersistedStateLoadTimer = () => {
+		if (!persistedStateLoadTimer) {
+			return;
+		}
+		clearTimeout(persistedStateLoadTimer);
+		persistedStateLoadTimer = null;
+		persistedStateLoadScheduled = false;
+	};
 
 	// ─── Data collection ──────────────────────────────────────────────────
 
@@ -1478,13 +1525,16 @@ export default function usageTracker(pi: ExtensionAPI) {
 
 	pi.on("session_start", (_event, ctx) => {
 		activeCtx = ctx;
+		schedulePersistedStateLoad();
 		refreshStartupState(ctx);
 
 		ctx.ui.setWidget("usage-tracker", (tui, theme) => {
+			requestWidgetRender = () => tui.requestRender();
 			const unsubSafeMode = subscribeSafeMode(() => tui.requestRender());
 			const timer = setInterval(() => tui.requestRender(), 15_000);
 			return {
 				dispose() {
+					requestWidgetRender = null;
 					unsubSafeMode();
 					clearInterval(timer);
 				},
@@ -1499,6 +1549,7 @@ export default function usageTracker(pi: ExtensionAPI) {
 
 	pi.on("session_switch", (_event, ctx) => {
 		activeCtx = ctx;
+		schedulePersistedStateLoad();
 		refreshStartupState(ctx);
 	});
 
@@ -1518,6 +1569,7 @@ export default function usageTracker(pi: ExtensionAPI) {
 	});
 
 	pi.on("session_shutdown", () => {
+		clearPersistedStateLoadTimer();
 		clearStartupRefreshTimer();
 	});
 
@@ -1526,6 +1578,7 @@ export default function usageTracker(pi: ExtensionAPI) {
 	pi.registerCommand("usage", {
 		description: "Pick a provider and show its usage dashboard",
 		async handler(args, ctx) {
+			await loadPersistedState();
 			triggerProbeAll(true);
 			await new Promise((resolve) => setTimeout(resolve, 500));
 
@@ -1574,6 +1627,7 @@ export default function usageTracker(pi: ExtensionAPI) {
 	pi.registerCommand("usage-refresh", {
 		description: "Force refresh rate limit data from provider APIs",
 		async handler(_args, ctx) {
+			await loadPersistedState();
 			// Clear cooldowns to force fresh probes
 			lastProbeTime.clear();
 			triggerProbeAll(true);
@@ -1597,6 +1651,7 @@ export default function usageTracker(pi: ExtensionAPI) {
 			),
 		}),
 		async execute(_toolCallId, params, _signal, _onUpdate, ctx) {
+			await loadPersistedState();
 			// Force a probe of all configured providers before reporting
 			triggerProbeAll(true);
 			await new Promise((resolve) => setTimeout(resolve, 1000));
@@ -1625,6 +1680,7 @@ export default function usageTracker(pi: ExtensionAPI) {
 	pi.registerShortcut("ctrl+u", {
 		description: "Show usage dashboard with current-provider rate limits and costs",
 		async handler(ctx) {
+			await loadPersistedState();
 			triggerProbeAll(true);
 			await new Promise((resolve) => setTimeout(resolve, 500));
 


### PR DESCRIPTION
## Summary
- remove registration-time persisted state reads from the usage tracker
- defer usage history and rate-limit cache loading until after startup settles
- preserve correctness by loading persisted data on demand for /usage, Ctrl+U, and usage_report
- restore stale cached windows even if a rate-limited live probe wins the race during startup

## Testing
- pnpm lint
- pnpm typecheck
- pnpm exec vitest run packages/extensions/extensions/usage-tracker.test.ts packages/extensions/extensions/smoke.test.ts