### PR TITLE
fix: approve the vitest coverage dependency

### DIFF
--- a/.changeset/approve-vitest-coverage-v8.md
+++ b/.changeset/approve-vitest-coverage-v8.md
@@ -1,0 +1,5 @@
+---
+default: patch
+---
+
+Approve `@vitest/coverage-v8` in the dependency allowlist so the new coverage workflow passes repository security checks.

--- a/security/dependency-allowlist.json
+++ b/security/dependency-allowlist.json
@@ -15,6 +15,7 @@
 		"@types/node",
 		"@types/ws",
 		"@typescript/native-preview",
+		"@vitest/coverage-v8",
 		"chalk",
 		"croner",
 		"hono",


### PR DESCRIPTION
## Summary
- add `@vitest/coverage-v8` to the dependency allowlist
- restore the Security Checks job after the coverage PR introduced the new dependency

## Validation
- pnpm lint
- pnpm security:check

## Context
Follow-up to PR #161, which merged before CI finished and then failed the dependency allowlist check.