### PR TITLE
feat(tui): add scrollable provider and scheduler pickers

### DIFF
--- a/.changeset/scrollable-provider-schedule-pickers.md
+++ b/.changeset/scrollable-provider-schedule-pickers.md
@@ -1,0 +1,5 @@
+---
+default: patch
+---
+
+Improve the scheduler and provider pickers with scrollable overlays that stay within the current window height, and let provider model selection show the full model list instead of truncating it.

--- a/.npmrc
+++ b/.npmrc
@@ -1,0 +1,2 @@
+link-workspace-packages=true
+prefer-workspace-packages=true

--- a/.npmrc
+++ b/.npmrc
@@ -1,2 +1,0 @@
-link-workspace-packages=true
-prefer-workspace-packages=true

--- a/package.json
+++ b/package.json
@@ -32,8 +32,8 @@
 		"themes": ["./packages/themes/themes"]
 	},
 	"scripts": {
-		"build": "pnpm -r run build",
-		"build:fast": "pnpm -r run build:fast",
+		"build": "pnpm --filter @ifi/oh-pi-core build && pnpm -r --filter=!@ifi/oh-pi-core run build",
+		"build:fast": "pnpm --filter @ifi/oh-pi-core run build:fast && pnpm -r --filter=!@ifi/oh-pi-core run build:fast",
 		"typecheck": "pnpm --filter @ifi/oh-pi-core build && pnpm -r --filter @ifi/oh-pi-ant-colony --filter @ifi/oh-pi-core --filter @ifi/oh-pi-cli --filter @ifi/pi-spec --filter @ifi/pi-web-client --filter @ifi/pi-web-server run typecheck",
 		"verify:completion": "pnpm exec vitest run packages/ant-colony/tests/commands.test.ts",
 		"security:allowlist": "node ./scripts/security/check-dependency-allowlist.mjs",

--- a/packages/cli/src/tui/provider-setup.test.ts
+++ b/packages/cli/src/tui/provider-setup.test.ts
@@ -1,5 +1,6 @@
 import { describe, expect, it } from "vitest";
 import {
+	buildModelSelectionOptions,
 	isOpenAICompatibleApi,
 	isUnsafeUrl,
 	normalizeDiscoveryBaseUrl,
@@ -89,6 +90,18 @@ describe("normalizeDiscoveryBaseUrl", () => {
 
 	it("strips trailing /v1/ to avoid /v1/v1 probe", () => {
 		expect(normalizeDiscoveryBaseUrl("http://localhost:11434/v1/")).toBe("http://localhost:11434");
+	});
+});
+
+describe("buildModelSelectionOptions", () => {
+	it("keeps the full discovered model list instead of truncating at 50 entries", () => {
+		const modelIds = Array.from({ length: 75 }, (_, index) => `model-${index + 1}`);
+
+		const options = buildModelSelectionOptions(modelIds);
+
+		expect(options).toHaveLength(75);
+		expect(options[0]).toEqual({ value: "model-1", label: "model-1" });
+		expect(options[74]).toEqual({ value: "model-75", label: "model-75" });
 	});
 });
 

--- a/packages/cli/src/tui/provider-setup.ts
+++ b/packages/cli/src/tui/provider-setup.ts
@@ -533,6 +533,10 @@ interface SelectResult {
 	api?: string;
 }
 
+export function buildModelSelectionOptions(modelIds: readonly string[]) {
+	return modelIds.map((modelId) => ({ value: modelId, label: modelId }));
+}
+
 /**
  * Select a default model by dynamically fetching available models, falling back to a static list or manual input.
  * @param provider - Provider name
@@ -589,7 +593,7 @@ async function selectModelWithMeta(
 
 	const model = await p.select({
 		message: t("provider.selectModel", { label }),
-		options: modelIds.slice(0, 50).map((m) => ({ value: m, label: m })),
+		options: buildModelSelectionOptions(modelIds),
 	});
 	if (p.isCancel(model)) {
 		p.cancel(t("cancelled"));

--- a/packages/extensions/extensions/scheduler-overlay.test.ts
+++ b/packages/extensions/extensions/scheduler-overlay.test.ts
@@ -1,0 +1,106 @@
+import { describe, expect, it, vi } from "vitest";
+import { createExtensionHarness } from "../../../test-utils/extension-runtime-harness.js";
+import schedulerExtension from "./scheduler.js";
+
+describe("scheduler overlay picker", () => {
+	it("uses a scrollable overlay capped at 75% height for the task manager", async () => {
+		const harness = createExtensionHarness();
+		schedulerExtension(harness.pi as never);
+
+		await harness.commands.get("loop").handler("5m check api health", harness.ctx);
+		await harness.commands.get("loop").handler("10m check worker backlog", harness.ctx);
+
+		let pickerFactory: any;
+		harness.ctx.ui.custom = vi.fn(async (factory: any) => {
+			pickerFactory = factory;
+			return { kind: "close" };
+		}) as never;
+
+		await harness.commands.get("schedule").handler("", harness.ctx);
+
+		expect(harness.ctx.ui.custom).toHaveBeenCalledWith(expect.any(Function), {
+			overlay: true,
+			overlayOptions: {
+				anchor: "center",
+				width: "80%",
+				maxHeight: "75%",
+			},
+		});
+
+		const picker = pickerFactory(
+			{ requestRender: vi.fn() },
+			{ fg: (_color: string, text: string) => text, bold: (text: string) => text },
+			{},
+			() => undefined,
+		);
+		const rendered = picker.render(140).join("\n");
+		expect(rendered).toContain("Scheduled tasks for");
+		expect(rendered).toContain("Enter manages the selected task");
+		expect(rendered).toContain("🗑 Clear all");
+		expect(rendered).toContain("+ Close");
+	});
+
+	it("opens task actions after selecting a task from the overlay", async () => {
+		const harness = createExtensionHarness();
+		schedulerExtension(harness.pi as never);
+
+		const prompt = "check the full deployment pipeline and report every failing stage";
+		await harness.commands.get("loop").handler(`5m ${prompt}`, harness.ctx);
+
+		harness.ctx.ui.custom = vi
+			.fn()
+			.mockImplementationOnce(async () => {
+				const listResult = await harness.tools.get("schedule_prompt").execute("id", { action: "list" });
+				return { kind: "task", taskId: listResult.details.tasks[0].id };
+			})
+			.mockResolvedValueOnce({ kind: "close" }) as never;
+		harness.ctx.ui.select = vi.fn(async () => "↩ Back") as never;
+
+		await harness.commands.get("schedule").handler("", harness.ctx);
+
+		expect(harness.ctx.ui.select).toHaveBeenCalledWith(
+			expect.stringContaining(`Prompt: ${prompt}`),
+			expect.arrayContaining(["↩ Back"]),
+		);
+	});
+
+	it("can clear all tasks through the overlay picker result", async () => {
+		const harness = createExtensionHarness();
+		schedulerExtension(harness.pi as never);
+
+		await harness.commands.get("loop").handler("5m check api health", harness.ctx);
+		await harness.commands.get("loop").handler("10m check worker backlog", harness.ctx);
+
+		harness.ctx.ui.custom = vi.fn(async () => ({ kind: "clear-all" })) as never;
+		harness.ctx.ui.confirm = vi.fn(async () => true) as never;
+
+		await harness.commands.get("schedule").handler("", harness.ctx);
+
+		expect(harness.notifications.some((item) => item.msg.includes("Cleared 2 scheduled tasks."))).toBe(true);
+	});
+
+	it("can clear tasks not created here through the overlay picker result", async () => {
+		const harness = createExtensionHarness();
+		schedulerExtension(harness.pi as never);
+
+		await harness.commands.get("loop").handler("5m check local queue", harness.ctx);
+		await harness.commands.get("loop").handler("10m check foreign queue", harness.ctx);
+
+		const listResult = await harness.tools.get("schedule_prompt").execute("id", { action: "list" });
+		const foreignTask = listResult.details.tasks.find((task: any) => task.prompt.includes("foreign queue"));
+		foreignTask.creatorInstanceId = "foreign-instance";
+		foreignTask.creatorSessionId = "/mock-home/.pi/agent/sessions/foreign.jsonl";
+
+		harness.ctx.ui.custom = vi
+			.fn()
+			.mockResolvedValueOnce({ kind: "clear-other" })
+			.mockResolvedValueOnce({ kind: "close" }) as never;
+		harness.ctx.ui.confirm = vi.fn(async () => true) as never;
+
+		await harness.commands.get("schedule").handler("", harness.ctx);
+
+		expect(
+			harness.notifications.some((item) => item.msg.includes("Cleared 1 scheduled task not created in this instance.")),
+		).toBe(true);
+	});
+});

--- a/packages/extensions/extensions/scheduler.ts
+++ b/packages/extensions/extensions/scheduler.ts
@@ -26,6 +26,7 @@ instance changes in the same repository.
 import { randomUUID } from "node:crypto";
 import * as fs from "node:fs";
 import * as path from "node:path";
+import { openScrollableSelect, type ScrollSelectOption } from "@ifi/pi-shared-qna";
 import type { ExtensionAPI, ExtensionContext } from "@mariozechner/pi-coding-agent";
 import {
 	computeNextCronRunAt,
@@ -127,6 +128,12 @@ type CompletionOptions = {
 	retryIntervalMs?: number;
 	maxAttempts?: number;
 };
+
+type TaskManagerSelection =
+	| { kind: "task"; taskId: string }
+	| { kind: "clear-other" }
+	| { kind: "clear-all" }
+	| { kind: "close" };
 
 // ── Runtime ─────────────────────────────────────────────────────────────────
 
@@ -845,11 +852,15 @@ export class SchedulerRuntime {
 			}
 
 			const otherTasks = this.getTasksNotCreatedHere();
-			const clearOtherLabel =
-				otherTasks.length > 0 ? `🧹 Clear tasks not created here (${otherTasks.length})` : undefined;
-			const options = this.buildTaskManagerOptions(list, clearOtherLabel);
-			const selected = await ctx.ui.select(`Scheduled tasks for ${this.getWorkspaceLabel(ctx)} (select one)`, options);
-			const selection = await this.handleTaskManagerSelection(ctx, selected, list, otherTasks, clearOtherLabel);
+			const selected = await openScrollableSelect(ctx.ui, {
+				title: `Scheduled tasks for ${this.getWorkspaceLabel(ctx)} (select one)`,
+				options: this.buildTaskManagerOptions(list, otherTasks),
+				footerHint: "Enter manages the selected task",
+				maxVisibleOptions: 12,
+				overlayWidth: "80%",
+				overlayMaxHeight: "75%",
+			});
+			const selection = await this.handleTaskManagerSelection(ctx, selected, list, otherTasks);
 			if (selection === "close") {
 				return;
 			}
@@ -857,8 +868,7 @@ export class SchedulerRuntime {
 				continue;
 			}
 
-			const taskId = selected.slice(0, 8);
-			const task = this.tasks.get(taskId);
+			const task = this.tasks.get(selected.taskId);
 			if (!task) {
 				ctx.ui.notify("Task no longer exists. Refreshing list...", "warning");
 				continue;
@@ -871,28 +881,38 @@ export class SchedulerRuntime {
 		}
 	}
 
-	private buildTaskManagerOptions(list: ScheduleTask[], clearOtherLabel?: string): string[] {
-		const options = list.map((task) => this.taskOptionLabel(task));
-		if (clearOtherLabel) {
-			options.push(clearOtherLabel);
+	private buildTaskManagerOptions(
+		list: ScheduleTask[],
+		otherTasks: ScheduleTask[],
+	): ScrollSelectOption<TaskManagerSelection>[] {
+		const options = list.map((task) => ({
+			value: { kind: "task", taskId: task.id } as const,
+			label: this.taskOptionLabel(task),
+		}));
+
+		if (otherTasks.length > 0) {
+			options.push({
+				value: { kind: "clear-other" },
+				label: `🧹 Clear tasks not created here (${otherTasks.length})`,
+			});
 		}
-		options.push("🗑 Clear all");
-		options.push("+ Close");
+
+		options.push({ value: { kind: "clear-all" }, label: "🗑 Clear all" });
+		options.push({ value: { kind: "close" }, label: "+ Close" });
 		return options;
 	}
 
 	private async handleTaskManagerSelection(
 		ctx: ExtensionContext,
-		selected: string | null,
+		selected: TaskManagerSelection | null,
 		list: ScheduleTask[],
 		otherTasks: ScheduleTask[],
-		clearOtherLabel?: string,
-	): Promise<"open-task" | "refresh" | "close"> {
-		if (!selected || selected === "+ Close") {
+	): Promise<{ kind: "task"; taskId: string } | "refresh" | "close"> {
+		if (!selected || selected.kind === "close") {
 			return "close";
 		}
 
-		if (clearOtherLabel && selected === clearOtherLabel) {
+		if (selected.kind === "clear-other") {
 			const ok = await ctx.ui.confirm(
 				"Clear tasks not created here?",
 				this.describeExternalCreatorClear(otherTasks, ctx),
@@ -908,7 +928,7 @@ export class SchedulerRuntime {
 			return "refresh";
 		}
 
-		if (selected === "🗑 Clear all") {
+		if (selected.kind === "clear-all") {
 			const count = list.length;
 			const ok = await ctx.ui.confirm(
 				"Clear all scheduled tasks?",
@@ -922,7 +942,7 @@ export class SchedulerRuntime {
 			return "close";
 		}
 
-		return "open-task";
+		return selected;
 	}
 
 	// biome-ignore lint/complexity/noExcessiveCognitiveComplexity: TUI flow with multiple interactive branches.

--- a/packages/extensions/package.json
+++ b/packages/extensions/package.json
@@ -30,7 +30,7 @@
   ],
   "license": "MIT",
   "dependencies": {
-    "@ifi/pi-shared-qna": "workspace:*",
+    "@ifi/pi-shared-qna": "0.4.4",
     "croner": "^10.0.1"
   },
   "peerDependencies": {

--- a/packages/extensions/package.json
+++ b/packages/extensions/package.json
@@ -30,6 +30,7 @@
   ],
   "license": "MIT",
   "dependencies": {
+    "@ifi/pi-shared-qna": "workspace:*",
     "croner": "^10.0.1"
   },
   "peerDependencies": {

--- a/packages/providers/README.md
+++ b/packages/providers/README.md
@@ -7,7 +7,7 @@ Experimental multi-provider package for pi backed by the OpenCode `models.dev` c
 - Registers configured API-key providers from the OpenCode catalog without flooding pi's global `/login` picker
 - Keeps provider model lists, context windows, reasoning flags, and vision support aligned with `models.dev`
 - Reuses live provider discovery when a provider exposes a model-list endpoint
-- Adds a paged `/providers login` flow with 10 providers per page for lazy provider registration and API-key login
+- Adds a scrollable `/providers login` picker with in-place search for lazy provider registration and API-key login
 - Adds `/providers ...` commands for status, listing, inspection, and catalog refreshes
 
 ## Install
@@ -22,7 +22,7 @@ This package is intentionally separate from `@ifi/oh-pi` for now.
 
 1. Install the package
 2. Run `/providers list` to see supported provider ids
-3. Run `/providers login` to browse providers 10 at a time, or `/providers login <provider-id>` if you already know the id
+3. Run `/providers login` to browse the full provider list in a scrollable picker, or `/providers login <provider-id>` if you already know the id
 4. Open `/model` and select one of the discovered models
 5. Run `/providers refresh-models <provider-id>` whenever you want to refresh the live catalog
 
@@ -32,7 +32,7 @@ You can also skip `/login` and set a supported provider env var directly when th
 
 - `/providers status` — summarize configured providers from this package
 - `/providers list [query]` — list supported provider ids and env vars
-- `/providers login [provider]` — page through providers 10 at a time, lazily register one, and prompt for its API key
+- `/providers login [provider]` — scroll through the full provider list, search in place, lazily register one, and prompt for its API key
 - `/providers info <provider>` — inspect a provider's API mode, URLs, env vars, and model count
 - `/providers models <provider>` — list the current or fallback model catalog for one provider
 - `/providers refresh-models [provider|all]` — refresh configured providers from live discovery when possible

--- a/packages/providers/index.ts
+++ b/packages/providers/index.ts
@@ -1,3 +1,4 @@
+import { openScrollableSelect, type ScrollSelectOption } from "@ifi/pi-shared-qna";
 import type { ExtensionAPI, ExtensionCommandContext, ExtensionContext } from "@mariozechner/pi-coding-agent";
 import {
 	createApiKeyOAuthProvider,
@@ -43,11 +44,6 @@ type RuntimeProviderState = {
 	lastError: Map<string, string | null>;
 	registered: Set<string>;
 };
-
-const PROVIDER_SELECTION_PAGE_SIZE = 10;
-const PROVIDER_PICKER_PREVIOUS = "← Previous 10";
-const PROVIDER_PICKER_NEXT = "Next 10 →";
-const PROVIDER_PICKER_SEARCH = "Search providers…";
 
 const runtimeState: RuntimeProviderState = {
 	models: new Map(),
@@ -367,82 +363,49 @@ async function resolveProviderSelection(
 		return matchedProviders[0] ?? null;
 	}
 
-	return await selectProviderPage(ctx, matchedProviders);
+	return await selectProviderFromOverlay(ctx, matchedProviders);
 }
 
-// biome-ignore lint/complexity/noExcessiveCognitiveComplexity: Provider picker coordinates pagination, search, and selection in one loop.
-async function selectProviderPage(
+async function selectProviderFromOverlay(
 	ctx: ProviderCommandContext,
 	providers: readonly SupportedProviderDefinition[],
 ): Promise<SupportedProviderDefinition | null> {
-	if (providers.length === 0) {
-		return null;
-	}
-	const select = ctx.ui.select;
-	if (providers.length === 1 || typeof select !== "function") {
-		return providers[0] ?? null;
-	}
+	const options = buildProviderPickerOptions(providers, ctx);
+	return await openScrollableSelect(ctx.ui, {
+		title: `Select provider to log in (${providers.length} total)`,
+		options,
+		footerHint: typeof ctx.ui.input === "function" ? "type / to search" : undefined,
+		search:
+			typeof ctx.ui.input === "function"
+				? {
+						title: "Provider search",
+						placeholder: "Type a provider id or name",
+						getOptions(query) {
+							if (!query) {
+								return options;
+							}
 
-	let visibleProviders = [...providers];
-	let page = 0;
+							return buildProviderPickerOptions(findProviders(query), ctx);
+						},
+						emptyMessage(query) {
+							return `No provider matched "${query}".`;
+						},
+					}
+				: undefined,
+		maxVisibleOptions: 12,
+		overlayWidth: "80%",
+		overlayMaxHeight: "75%",
+	});
+}
 
-	while (visibleProviders.length > 0) {
-		const pageCount = Math.max(1, Math.ceil(visibleProviders.length / PROVIDER_SELECTION_PAGE_SIZE));
-		page = Math.min(page, pageCount - 1);
-		const start = page * PROVIDER_SELECTION_PAGE_SIZE;
-		const pageProviders = visibleProviders.slice(start, start + PROVIDER_SELECTION_PAGE_SIZE);
-		const optionToProvider = new Map<string, SupportedProviderDefinition>();
-		const options = pageProviders.map((provider) => {
-			const option = formatProviderPickerOption(provider, ctx);
-			optionToProvider.set(option, provider);
-			return option;
-		});
-
-		if (page > 0) {
-			options.push(PROVIDER_PICKER_PREVIOUS);
-		}
-		if (page < pageCount - 1) {
-			options.push(PROVIDER_PICKER_NEXT);
-		}
-		if (typeof ctx.ui.input === "function") {
-			options.push(PROVIDER_PICKER_SEARCH);
-		}
-
-		const selection = await select(
-			[
-				`Select provider to log in (${visibleProviders.length} total)`,
-				`Page ${page + 1}/${pageCount} · max ${PROVIDER_SELECTION_PAGE_SIZE} providers per page`,
-			].join("\n"),
-			options,
-		);
-		if (!selection) {
-			return null;
-		}
-
-		if (selection === PROVIDER_PICKER_PREVIOUS) {
-			page = Math.max(0, page - 1);
-			continue;
-		}
-		if (selection === PROVIDER_PICKER_NEXT) {
-			page = Math.min(pageCount - 1, page + 1);
-			continue;
-		}
-		if (selection === PROVIDER_PICKER_SEARCH) {
-			const search = (await promptProviderInput(ctx, "Provider search", "Type a provider id or name")).trim();
-			const nextProviders = search ? findProviders(search) : [...providers];
-			if (nextProviders.length === 0) {
-				ctx.ui.notify(`No provider matched "${search}".`, "warning");
-				continue;
-			}
-			visibleProviders = nextProviders;
-			page = 0;
-			continue;
-		}
-
-		return optionToProvider.get(selection) ?? null;
-	}
-
-	return null;
+function buildProviderPickerOptions(
+	providers: readonly SupportedProviderDefinition[],
+	ctx: ProviderStatusContext,
+): ScrollSelectOption<SupportedProviderDefinition>[] {
+	return providers.map((provider) => ({
+		value: provider,
+		label: formatProviderPickerOption(provider, ctx),
+	}));
 }
 
 function formatProviderPickerOption(provider: SupportedProviderDefinition, ctx: ProviderStatusContext): string {

--- a/packages/providers/package.json
+++ b/packages/providers/package.json
@@ -33,6 +33,9 @@
 	"bugs": {
 		"url": "https://github.com/ifiokjr/oh-pi/issues"
 	},
+	"dependencies": {
+		"@ifi/pi-shared-qna": "workspace:*"
+	},
 	"scripts": {
 		"build": "pnpm run typecheck && pnpm run test:worktree",
 		"typecheck": "tsgo --project ./tsconfig.json --noEmit",

--- a/packages/providers/package.json
+++ b/packages/providers/package.json
@@ -34,7 +34,7 @@
 		"url": "https://github.com/ifiokjr/oh-pi/issues"
 	},
 	"dependencies": {
-		"@ifi/pi-shared-qna": "workspace:*"
+		"@ifi/pi-shared-qna": "0.4.4"
 	},
 	"scripts": {
 		"build": "pnpm run typecheck && pnpm run test:worktree",

--- a/packages/providers/tests/index.test.ts
+++ b/packages/providers/tests/index.test.ts
@@ -5,9 +5,6 @@ import { getSupportedProvider } from "../config.js";
 import providerCatalogExtension, { resetProviderCatalogRuntimeStateForTests, SUPPORTED_PROVIDERS } from "../index.js";
 
 const envSnapshot = { ...process.env };
-const PROVIDER_PICKER_PREVIOUS = "← Previous 10";
-const PROVIDER_PICKER_NEXT = "Next 10 →";
-const PROVIDER_PICKER_SEARCH = "Search providers…";
 
 function jsonResponse(body: unknown): Response {
 	return new Response(JSON.stringify(body), {
@@ -95,7 +92,7 @@ describe("provider catalog extension", () => {
 		expect(refresh).toHaveBeenCalledTimes(1);
 	});
 
-	it("pages provider login selections in groups of 10 and lazily registers the chosen provider", async () => {
+	it("shows a scrollable provider login picker and lazily registers the chosen provider", async () => {
 		const provider = SUPPORTED_PROVIDERS[10];
 		if (!provider) {
 			throw new Error("Expected at least 11 providers in the catalog.");
@@ -135,13 +132,11 @@ describe("provider catalog extension", () => {
 			refresh,
 		} as never;
 
-		const pickerCalls: string[][] = [];
-		harness.ctx.ui.select = vi.fn((_title: string, options: string[]) => {
-			pickerCalls.push(options);
-			if (pickerCalls.length === 1) {
-				return Promise.resolve(PROVIDER_PICKER_NEXT);
-			}
-			return Promise.resolve(`${provider.name} — ${provider.id} · login`);
+		let pickerFactory: any;
+		harness.ctx.ui.select = vi.fn(async () => null) as never;
+		harness.ctx.ui.custom = vi.fn((factory: any) => {
+			pickerFactory = factory;
+			return Promise.resolve(provider);
 		}) as never;
 		harness.ctx.ui.input = vi.fn(async () => "provider-api-key") as never;
 
@@ -149,12 +144,28 @@ describe("provider catalog extension", () => {
 		const command = harness.commands.get("providers");
 		await command.handler("login", harness.ctx);
 
-		const providerOptions = (pickerCalls[0] ?? []).filter((option) => {
-			return (
-				option !== PROVIDER_PICKER_PREVIOUS && option !== PROVIDER_PICKER_NEXT && option !== PROVIDER_PICKER_SEARCH
-			);
+		expect(harness.ctx.ui.select).not.toHaveBeenCalled();
+		expect(harness.ctx.ui.custom).toHaveBeenCalledWith(expect.any(Function), {
+			overlay: true,
+			overlayOptions: {
+				anchor: "center",
+				width: "80%",
+				maxHeight: "75%",
+			},
 		});
-		expect(providerOptions).toHaveLength(10);
+
+		const component = pickerFactory(
+			{ requestRender: vi.fn() },
+			{ fg: (_color: string, text: string) => text, bold: (text: string) => text },
+			{},
+			() => undefined,
+		);
+		const rendered = component.render(120).join("\n");
+		expect(rendered).toContain("Select provider to log in");
+		expect(rendered).toContain("type / to search");
+		expect(rendered).not.toContain("Next 10");
+		expect(rendered).not.toContain("Previous 10");
+
 		expect(harness.providers.has(provider.id)).toBe(true);
 		expect(stored.get(provider.id)).toMatchObject({ type: "oauth", providerId: provider.id });
 		expect(refresh).toHaveBeenCalledTimes(1);

--- a/packages/shared-qna/index.ts
+++ b/packages/shared-qna/index.ts
@@ -1,2 +1,3 @@
 export * from "./pi-tui-loader.js";
 export * from "./qna-tui.js";
+export * from "./scroll-select.js";

--- a/packages/shared-qna/scroll-select.ts
+++ b/packages/shared-qna/scroll-select.ts
@@ -1,0 +1,325 @@
+import { requirePiTuiModule } from "./pi-tui-loader.js";
+
+let cachedPiTui:
+	| {
+			Key: {
+				enter: string;
+				escape: string;
+				up: string;
+				down: string;
+				ctrl: (key: string) => string;
+			};
+			matchesKey: (input: string, key: string) => boolean;
+			truncateToWidth: (text: string, width: number) => string;
+			visibleWidth: (text: string) => number;
+			wrapTextWithAnsi: (text: string, width: number) => string[];
+		}
+	| undefined;
+
+function getPiTui() {
+	if (cachedPiTui) {
+		return cachedPiTui;
+	}
+
+	cachedPiTui = requirePiTuiModule() as {
+		Key: {
+			enter: string;
+			escape: string;
+			up: string;
+			down: string;
+			ctrl: (key: string) => string;
+		};
+		matchesKey: (input: string, key: string) => boolean;
+		truncateToWidth: (text: string, width: number) => string;
+		visibleWidth: (text: string) => number;
+		wrapTextWithAnsi: (text: string, width: number) => string[];
+	};
+	return cachedPiTui;
+}
+
+export interface ScrollSelectOption<T> {
+	value: T;
+	label: string;
+}
+
+export interface ScrollSelectSearchConfig<T> {
+	title: string;
+	placeholder?: string;
+	getOptions: (query: string) => Promise<ScrollSelectOption<T>[]> | ScrollSelectOption<T>[];
+	emptyMessage?: (query: string) => string;
+}
+
+export interface ScrollSelectConfig<T> {
+	title: string;
+	options: ScrollSelectOption<T>[];
+	footerHint?: string;
+	emptyMessage?: string;
+	initialValue?: T;
+	maxVisibleOptions?: number;
+	overlayWidth?: number | string;
+	overlayMaxHeight?: number | string;
+	search?: ScrollSelectSearchConfig<T>;
+}
+
+type ScrollSelectUi = {
+	custom?: <T>(
+		factory: (tui: { requestRender: () => void }, theme: ScrollSelectTheme, keybindings: unknown, done: (value: T) => void) => {
+			render: (width: number) => string[];
+			handleInput: (data: string) => void;
+			dispose?: () => void;
+		},
+		options?: unknown,
+	) => Promise<T>;
+	select?: (title: string, options: string[]) => Promise<string | null | undefined>;
+	input?: (title: string, placeholder?: string) => Promise<string | null | undefined>;
+	notify?: (message: string, type?: "error" | "info" | "warning") => void;
+};
+
+type ScrollSelectTheme = {
+	fg: (color: string, text: string) => string;
+	bold: (text: string) => string;
+};
+
+class ScrollSelectComponent<T> {
+	private readonly tui: { requestRender: () => void };
+	private readonly theme: ScrollSelectTheme;
+	private readonly done: (value: T | null) => void;
+	private readonly input: ScrollSelectUi["input"];
+	private readonly notify: ScrollSelectUi["notify"];
+	private readonly baseOptions: ScrollSelectOption<T>[];
+	private readonly title: string;
+	private readonly footerHint: string;
+	private readonly emptyMessage: string;
+	private readonly maxVisibleOptions: number;
+	private readonly search?: ScrollSelectSearchConfig<T>;
+
+	private options: ScrollSelectOption<T>[];
+	private cursorIndex: number;
+	private searchQuery = "";
+	private searching = false;
+
+	constructor(
+		config: ScrollSelectConfig<T>,
+		dependencies: {
+			tui: { requestRender: () => void };
+			theme: ScrollSelectTheme;
+			done: (value: T | null) => void;
+			input: ScrollSelectUi["input"];
+			notify: ScrollSelectUi["notify"];
+		},
+	) {
+		this.tui = dependencies.tui;
+		this.theme = dependencies.theme;
+		this.done = dependencies.done;
+		this.input = dependencies.input;
+		this.notify = dependencies.notify;
+		this.baseOptions = [...config.options];
+		this.options = [...config.options];
+		this.title = config.title;
+		this.footerHint = config.footerHint ?? "";
+		this.emptyMessage = config.emptyMessage ?? "No options available.";
+		this.maxVisibleOptions = Math.max(4, config.maxVisibleOptions ?? 10);
+		this.search = config.search;
+		this.cursorIndex = this.getInitialCursorIndex(config.initialValue);
+	}
+
+	render(width: number): string[] {
+		const { truncateToWidth, visibleWidth, wrapTextWithAnsi } = getPiTui();
+		const safeWidth = Math.max(20, width);
+		const lines: string[] = [];
+		const bodyWidth = Math.max(12, safeWidth - 2);
+
+		for (const line of this.title.split("\n")) {
+			for (const wrapped of wrapTextWithAnsi(line, bodyWidth)) {
+				lines.push(truncateToWidth(wrapped, bodyWidth));
+			}
+		}
+
+		lines.push("");
+
+		if (this.search) {
+			const filterText = this.searchQuery.trim().length > 0 ? `Filter: ${this.searchQuery}` : "Filter: all";
+			lines.push(truncateToWidth(this.theme.fg("dim", filterText), bodyWidth));
+			lines.push("");
+		}
+
+		if (this.options.length === 0) {
+			lines.push(truncateToWidth(this.theme.fg("dim", this.emptyMessage), bodyWidth));
+		} else {
+			const { start, end } = this.getVisibleRange();
+
+			if (start > 0) {
+				lines.push(truncateToWidth(this.theme.fg("dim", `↑ ${start} more`), bodyWidth));
+			}
+
+			for (let index = start; index < end; index++) {
+				const option = this.options[index];
+				if (!option) {
+					continue;
+				}
+
+				const prefix = index === this.cursorIndex ? this.theme.fg("accent", "→ ") : "  ";
+				const availableWidth = Math.max(4, bodyWidth - visibleWidth(prefix));
+				const label = truncateToWidth(option.label, availableWidth);
+				const line = `${prefix}${index === this.cursorIndex ? this.theme.fg("accent", label) : label}`;
+				lines.push(truncateToWidth(line, bodyWidth));
+			}
+
+			const hiddenBelow = this.options.length - end;
+			if (hiddenBelow > 0) {
+				lines.push(truncateToWidth(this.theme.fg("dim", `↓ ${hiddenBelow} more`), bodyWidth));
+			}
+		}
+
+		lines.push("");
+		lines.push(truncateToWidth(this.footerText(), bodyWidth));
+		return lines;
+	}
+
+	handleInput(data: string): void {
+		const { Key, matchesKey } = getPiTui();
+
+		if (matchesKey(data, Key.escape) || data === "q") {
+			this.done(null);
+			return;
+		}
+
+		if (matchesKey(data, Key.enter) || data === "\r") {
+			this.done(this.options[this.cursorIndex]?.value ?? null);
+			return;
+		}
+
+		if (matchesKey(data, Key.up) || data === "k" || matchesKey(data, Key.ctrl("p"))) {
+			this.moveCursor(-1);
+			return;
+		}
+
+		if (matchesKey(data, Key.down) || data === "j" || matchesKey(data, Key.ctrl("n"))) {
+			this.moveCursor(1);
+			return;
+		}
+
+		if (this.search && (data === "/" || data === "s")) {
+			void this.promptSearch();
+		}
+	}
+
+	dispose(): void {}
+
+	private footerText(): string {
+		const parts = ["[↑↓/j/k] scroll", "[enter] select", "[esc] cancel"];
+		if (this.search) {
+			parts.push("[/] search");
+		}
+		if (this.footerHint.trim().length > 0) {
+			parts.push(this.footerHint.trim());
+		}
+		return this.theme.fg("dim", parts.join(" • "));
+	}
+
+	private getInitialCursorIndex(initialValue: T | undefined): number {
+		if (initialValue === undefined) {
+			return 0;
+		}
+
+		const index = this.baseOptions.findIndex((option) => Object.is(option.value, initialValue));
+		return index >= 0 ? index : 0;
+	}
+
+	private getVisibleRange(): { start: number; end: number } {
+		const count = this.options.length;
+		const visible = Math.min(this.maxVisibleOptions, count);
+		if (count <= visible) {
+			return { start: 0, end: count };
+		}
+
+		let start = Math.max(0, this.cursorIndex - Math.floor(visible / 2));
+		start = Math.min(start, count - visible);
+		return { start, end: Math.min(count, start + visible) };
+	}
+
+	private moveCursor(delta: number): void {
+		if (this.options.length === 0) {
+			return;
+		}
+
+		this.cursorIndex = Math.max(0, Math.min(this.options.length - 1, this.cursorIndex + delta));
+		this.tui.requestRender();
+	}
+
+	private async promptSearch(): Promise<void> {
+		if (!this.search || typeof this.input !== "function" || this.searching) {
+			return;
+		}
+
+		this.searching = true;
+		try {
+			const raw = await this.input(this.search.title, this.searchQuery || this.search.placeholder);
+			if (raw === null || raw === undefined) {
+				return;
+			}
+
+			const query = raw.trim();
+			if (query === this.searchQuery) {
+				return;
+			}
+
+			const nextOptions = await this.search.getOptions(query);
+			if (nextOptions.length === 0) {
+				this.notify?.(
+					this.search.emptyMessage?.(query) ?? `No option matched ${query ? `"${query}"` : "the current filter"}.`,
+					"warning",
+				);
+				return;
+			}
+
+			this.searchQuery = query;
+			this.options = [...nextOptions];
+			this.cursorIndex = 0;
+			this.tui.requestRender();
+		} finally {
+			this.searching = false;
+		}
+	}
+}
+
+export async function openScrollableSelect<T>(ui: ScrollSelectUi, config: ScrollSelectConfig<T>): Promise<T | null> {
+	if (config.options.length === 0) {
+		return null;
+	}
+
+	if (config.options.length === 1) {
+		return config.options[0]?.value ?? null;
+	}
+
+	if (typeof ui.custom !== "function") {
+		if (typeof ui.select !== "function") {
+			return null;
+		}
+
+		const selected = await ui.select(
+			config.title,
+			config.options.map((option) => option.label),
+		);
+		return config.options.find((option) => option.label === selected)?.value ?? null;
+	}
+
+	return await ui.custom<T | null>(
+		(tui, theme, _keybindings, done) =>
+			new ScrollSelectComponent(config, {
+				tui,
+				theme,
+				done,
+				input: ui.input,
+				notify: ui.notify,
+			}),
+		{
+			overlay: true,
+			overlayOptions: {
+				anchor: "center",
+				width: config.overlayWidth ?? 84,
+				maxHeight: config.overlayMaxHeight ?? "75%",
+			},
+		},
+	);
+}

--- a/packages/shared-qna/tests/scroll-select.test.ts
+++ b/packages/shared-qna/tests/scroll-select.test.ts
@@ -1,0 +1,266 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+vi.mock("../pi-tui-loader.js", () => ({
+	requirePiTuiModule: () => ({
+		Key: {
+			enter: "<enter>",
+			escape: "<escape>",
+			up: "<up>",
+			down: "<down>",
+			ctrl: (key: string) => `<ctrl-${key}>`,
+		},
+		matchesKey: (input: string, key: string) => input === key,
+		truncateToWidth: (text: string, width: number) => (text.length <= width ? text : text.slice(0, width)),
+		visibleWidth: (text: string) => text.length,
+		wrapTextWithAnsi: (text: string, _width: number) => [text],
+	}),
+}));
+
+import { openScrollableSelect, type ScrollSelectConfig } from "../scroll-select.js";
+
+type CustomFactory = (...args: any[]) => { render: (width: number) => string[]; handleInput: (data: string) => void };
+
+function createTheme() {
+	return {
+		fg: (_color: string, text: string) => text,
+		bold: (text: string) => text,
+	};
+}
+
+function createFactoryRunner() {
+	let factory: CustomFactory | undefined;
+	const ui = {
+		custom: vi.fn(((nextFactory: CustomFactory) => {
+			factory = nextFactory;
+			return Promise.resolve(null);
+		}) as NonNullable<Parameters<typeof openScrollableSelect<string>>[0]["custom"]>),
+		input: vi.fn(async () => null),
+		notify: vi.fn(),
+	};
+
+	function buildComponent(done = vi.fn()) {
+		if (!factory) {
+			throw new Error("Expected custom factory to be captured.");
+		}
+		return factory({ requestRender: vi.fn() }, createTheme(), {}, done);
+	}
+
+	return { ui, buildComponent };
+}
+
+describe("openScrollableSelect", () => {
+	beforeEach(() => {
+		vi.clearAllMocks();
+	});
+
+	it("returns null when there are no options", async () => {
+		const result = await openScrollableSelect({ custom: vi.fn() }, { title: "Empty", options: [] });
+
+		expect(result).toBeNull();
+	});
+
+	it("returns the only option without opening any UI", async () => {
+		const custom = vi.fn();
+		const result = await openScrollableSelect(
+			{ custom },
+			{ title: "Single", options: [{ value: "only", label: "Only" }] },
+		);
+
+		expect(result).toBe("only");
+		expect(custom).not.toHaveBeenCalled();
+	});
+
+	it("falls back to ui.select when custom overlays are unavailable", async () => {
+		const select = vi.fn(async () => "Beta");
+		const result = await openScrollableSelect(
+			{ select },
+			{
+				title: "Fallback",
+				options: [
+					{ value: "alpha", label: "Alpha" },
+					{ value: "beta", label: "Beta" },
+				],
+			},
+		);
+
+		expect(result).toBe("beta");
+		expect(select).toHaveBeenCalledWith("Fallback", ["Alpha", "Beta"]);
+	});
+
+	it("returns null when neither custom overlays nor ui.select are available", async () => {
+		const result = await openScrollableSelect(
+			{},
+			{
+				title: "Unavailable",
+				options: [
+					{ value: "alpha", label: "Alpha" },
+					{ value: "beta", label: "Beta" },
+				],
+			},
+		);
+
+		expect(result).toBeNull();
+	});
+
+	it("uses a centered overlay capped at 75% height", async () => {
+		const { ui } = createFactoryRunner();
+		const config: ScrollSelectConfig<string> = {
+			title: "Pick one",
+			options: [
+				{ value: "a", label: "Alpha" },
+				{ value: "b", label: "Beta" },
+			],
+		};
+
+		await openScrollableSelect(ui, config);
+
+		expect(ui.custom).toHaveBeenCalledWith(expect.any(Function), {
+			overlay: true,
+			overlayOptions: {
+				anchor: "center",
+				width: 84,
+				maxHeight: "75%",
+			},
+		});
+	});
+
+	it("renders a scrollable window and reveals later items as the cursor moves", async () => {
+		const { ui, buildComponent } = createFactoryRunner();
+		await openScrollableSelect(ui, {
+			title: "Providers",
+			options: Array.from({ length: 14 }, (_, index) => ({
+				value: `value-${index + 1}`,
+				label: `Option ${index + 1}`,
+			})),
+			maxVisibleOptions: 5,
+		});
+
+		const component = buildComponent();
+		const initial = component.render(60).join("\n");
+		expect(initial).toContain("Option 1");
+		expect(initial).toContain("Option 5");
+		expect(initial).not.toContain("Option 10");
+		expect(initial).toContain("↓ 9 more");
+
+		for (let index = 0; index < 9; index++) {
+			component.handleInput("<down>");
+		}
+
+		const later = component.render(60).join("\n");
+		expect(later).toContain("Option 10");
+		expect(later).toContain("↑ 7 more");
+	});
+
+	it("supports in-picker search without pager actions", async () => {
+		const { ui, buildComponent } = createFactoryRunner();
+		ui.input.mockResolvedValueOnce("beta");
+
+		await openScrollableSelect(ui, {
+			title: "Provider login",
+			options: [
+				{ value: "alpha", label: "Alpha" },
+				{ value: "beta", label: "Beta" },
+				{ value: "gamma", label: "Gamma" },
+			],
+			search: {
+				title: "Provider search",
+				placeholder: "Type a provider id or name",
+				getOptions(query) {
+					const all = [
+						{ value: "alpha", label: "Alpha" },
+						{ value: "beta", label: "Beta" },
+						{ value: "gamma", label: "Gamma" },
+					];
+					return all.filter((option) => option.label.toLowerCase().includes(query.toLowerCase()));
+				},
+			},
+		});
+
+		const component = buildComponent();
+		component.handleInput("/");
+		await Promise.resolve();
+		await Promise.resolve();
+		const rendered = component.render(60).join("\n");
+		expect(rendered).toContain("Filter: beta");
+		expect(rendered).toContain("Beta");
+		expect(rendered).not.toContain("Next 10");
+		expect(rendered).not.toContain("Previous 10");
+	});
+
+	it("keeps the current list and notifies when a search has no matches", async () => {
+		const { ui, buildComponent } = createFactoryRunner();
+		ui.input.mockResolvedValueOnce("zzz");
+
+		await openScrollableSelect(ui, {
+			title: "Provider login",
+			options: [
+				{ value: "alpha", label: "Alpha" },
+				{ value: "beta", label: "Beta" },
+			],
+			search: {
+				title: "Provider search",
+				getOptions: () => [],
+				emptyMessage: (query) => `No provider matched "${query}".`,
+			},
+		});
+
+		const component = buildComponent();
+		component.handleInput("/");
+		await Promise.resolve();
+		await Promise.resolve();
+
+		expect(ui.notify).toHaveBeenCalledWith('No provider matched "zzz".', "warning");
+		const rendered = component.render(60).join("\n");
+		expect(rendered).toContain("Alpha");
+		expect(rendered).toContain("Beta");
+	});
+
+	it("does not re-run search work when the query is unchanged", async () => {
+		const { ui, buildComponent } = createFactoryRunner();
+		const getOptions = vi.fn(() => [{ value: "beta", label: "Beta" }]);
+		ui.input.mockResolvedValueOnce("beta").mockResolvedValueOnce("beta");
+
+		await openScrollableSelect(ui, {
+			title: "Provider login",
+			options: [
+				{ value: "alpha", label: "Alpha" },
+				{ value: "beta", label: "Beta" },
+			],
+			search: {
+				title: "Provider search",
+				getOptions,
+			},
+		});
+
+		const component = buildComponent();
+		component.handleInput("/");
+		await Promise.resolve();
+		await Promise.resolve();
+		component.handleInput("/");
+		await Promise.resolve();
+		await Promise.resolve();
+
+		expect(getOptions).toHaveBeenCalledTimes(1);
+	});
+
+	it("handles enter and escape shortcuts", async () => {
+		const { ui, buildComponent } = createFactoryRunner();
+		await openScrollableSelect(ui, {
+			title: "Pick one",
+			options: [
+				{ value: "alpha", label: "Alpha" },
+				{ value: "beta", label: "Beta" },
+			],
+		});
+
+		const done = vi.fn();
+		const component = buildComponent(done);
+		component.handleInput("<enter>");
+		expect(done).toHaveBeenCalledWith("alpha");
+
+		const cancel = vi.fn();
+		const cancelComponent = buildComponent(cancel);
+		cancelComponent.handleInput("<escape>");
+		expect(cancel).toHaveBeenCalledWith(null);
+	});
+});

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -64,7 +64,7 @@ importers:
     dependencies:
       '@ifi/oh-pi-core':
         specifier: 0.4.4
-        version: 0.4.4
+        version: link:../core
       '@mariozechner/pi-agent-core':
         specifier: '>=0.56.1'
         version: 0.56.1(ws@8.19.0)(zod@3.25.76)
@@ -88,37 +88,37 @@ importers:
         version: 1.1.0
       '@ifi/oh-pi-agents':
         specifier: 0.4.4
-        version: 0.4.4
+        version: link:../agents
       '@ifi/oh-pi-ant-colony':
         specifier: 0.4.4
-        version: 0.4.4(@mariozechner/pi-agent-core@0.56.1(ws@8.19.0)(zod@3.25.76))(@mariozechner/pi-ai@0.56.1(ws@8.19.0)(zod@3.25.76))(@mariozechner/pi-coding-agent@0.56.1(ws@8.19.0)(zod@3.25.76))(@mariozechner/pi-tui@0.56.1)(@sinclair/typebox@0.34.48)
+        version: link:../ant-colony
       '@ifi/oh-pi-core':
         specifier: 0.4.4
-        version: 0.4.4
+        version: link:../core
       '@ifi/oh-pi-extensions':
         specifier: 0.4.4
-        version: 0.4.4(@mariozechner/pi-agent-core@0.56.1(ws@8.19.0)(zod@3.25.76))(@mariozechner/pi-ai@0.56.1(ws@8.19.0)(zod@3.25.76))(@mariozechner/pi-coding-agent@0.56.1(ws@8.19.0)(zod@3.25.76))(@mariozechner/pi-tui@0.56.1)(@sinclair/typebox@0.34.48)
+        version: link:../extensions
       '@ifi/oh-pi-prompts':
         specifier: 0.4.4
-        version: 0.4.4
+        version: link:../prompts
       '@ifi/oh-pi-skills':
         specifier: 0.4.4
-        version: 0.4.4
+        version: link:../skills
       '@ifi/oh-pi-themes':
         specifier: 0.4.4
-        version: 0.4.4
+        version: link:../themes
       '@ifi/pi-extension-subagents':
         specifier: 0.4.4
-        version: 0.4.4(@mariozechner/pi-agent-core@0.56.1(ws@8.19.0)(zod@3.25.76))(@mariozechner/pi-ai@0.56.1(ws@8.19.0)(zod@3.25.76))(@mariozechner/pi-coding-agent@0.56.1(ws@8.19.0)(zod@3.25.76))(@mariozechner/pi-tui@0.56.1)(@sinclair/typebox@0.34.48)
+        version: link:../subagents
       '@ifi/pi-plan':
         specifier: 0.4.4
-        version: 0.4.4(@mariozechner/pi-agent-core@0.56.1(ws@8.19.0)(zod@3.25.76))(@mariozechner/pi-ai@0.56.1(ws@8.19.0)(zod@3.25.76))(@mariozechner/pi-coding-agent@0.56.1(ws@8.19.0)(zod@3.25.76))(@mariozechner/pi-tui@0.56.1)(@sinclair/typebox@0.34.48)
+        version: link:../plan
       '@ifi/pi-shared-qna':
         specifier: 0.4.4
-        version: 0.4.4(@mariozechner/pi-tui@0.56.1)
+        version: link:../shared-qna
       '@ifi/pi-spec':
         specifier: 0.4.4
-        version: 0.4.4(@mariozechner/pi-agent-core@0.56.1(ws@8.19.0)(zod@3.25.76))(@mariozechner/pi-ai@0.56.1(ws@8.19.0)(zod@3.25.76))(@mariozechner/pi-coding-agent@0.56.1(ws@8.19.0)(zod@3.25.76))(@mariozechner/pi-tui@0.56.1)(@sinclair/typebox@0.34.48)
+        version: link:../spec
       chalk:
         specifier: ^5.6.2
         version: 5.6.2
@@ -157,7 +157,7 @@ importers:
     dependencies:
       '@ifi/pi-shared-qna':
         specifier: 0.4.4
-        version: 0.4.4(@mariozechner/pi-tui@0.56.1)
+        version: link:../shared-qna
       '@mariozechner/pi-agent-core':
         specifier: '>=0.56.1'
         version: 0.56.1(ws@8.19.0)(zod@3.25.76)
@@ -181,31 +181,31 @@ importers:
     dependencies:
       '@ifi/oh-pi-agents':
         specifier: 0.4.4
-        version: 0.4.4
+        version: link:../agents
       '@ifi/oh-pi-ant-colony':
         specifier: 0.4.4
-        version: 0.4.4(@mariozechner/pi-agent-core@0.56.1(ws@8.19.0)(zod@3.25.76))(@mariozechner/pi-ai@0.56.1(ws@8.19.0)(zod@3.25.76))(@mariozechner/pi-coding-agent@0.56.1(ws@8.19.0)(zod@3.25.76))(@mariozechner/pi-tui@0.56.1)(@sinclair/typebox@0.34.48)
+        version: link:../ant-colony
       '@ifi/oh-pi-extensions':
         specifier: 0.4.4
-        version: 0.4.4(@mariozechner/pi-agent-core@0.56.1(ws@8.19.0)(zod@3.25.76))(@mariozechner/pi-ai@0.56.1(ws@8.19.0)(zod@3.25.76))(@mariozechner/pi-coding-agent@0.56.1(ws@8.19.0)(zod@3.25.76))(@mariozechner/pi-tui@0.56.1)(@sinclair/typebox@0.34.48)
+        version: link:../extensions
       '@ifi/oh-pi-prompts':
         specifier: 0.4.4
-        version: 0.4.4
+        version: link:../prompts
       '@ifi/oh-pi-skills':
         specifier: 0.4.4
-        version: 0.4.4
+        version: link:../skills
       '@ifi/oh-pi-themes':
         specifier: 0.4.4
-        version: 0.4.4
+        version: link:../themes
       '@ifi/pi-extension-subagents':
         specifier: 0.4.4
-        version: 0.4.4(@mariozechner/pi-agent-core@0.56.1(ws@8.19.0)(zod@3.25.76))(@mariozechner/pi-ai@0.56.1(ws@8.19.0)(zod@3.25.76))(@mariozechner/pi-coding-agent@0.56.1(ws@8.19.0)(zod@3.25.76))(@mariozechner/pi-tui@0.56.1)(@sinclair/typebox@0.34.48)
+        version: link:../subagents
       '@ifi/pi-plan':
         specifier: 0.4.4
-        version: 0.4.4(@mariozechner/pi-agent-core@0.56.1(ws@8.19.0)(zod@3.25.76))(@mariozechner/pi-ai@0.56.1(ws@8.19.0)(zod@3.25.76))(@mariozechner/pi-coding-agent@0.56.1(ws@8.19.0)(zod@3.25.76))(@mariozechner/pi-tui@0.56.1)(@sinclair/typebox@0.34.48)
+        version: link:../plan
       '@ifi/pi-spec':
         specifier: 0.4.4
-        version: 0.4.4(@mariozechner/pi-agent-core@0.56.1(ws@8.19.0)(zod@3.25.76))(@mariozechner/pi-ai@0.56.1(ws@8.19.0)(zod@3.25.76))(@mariozechner/pi-coding-agent@0.56.1(ws@8.19.0)(zod@3.25.76))(@mariozechner/pi-tui@0.56.1)(@sinclair/typebox@0.34.48)
+        version: link:../spec
 
   packages/ollama:
     dependencies:
@@ -229,10 +229,10 @@ importers:
     dependencies:
       '@ifi/pi-extension-subagents':
         specifier: 0.4.4
-        version: 0.4.4(@mariozechner/pi-agent-core@0.56.1(ws@8.19.0)(zod@3.25.76))(@mariozechner/pi-ai@0.56.1(ws@8.19.0)(zod@3.25.76))(@mariozechner/pi-coding-agent@0.56.1(ws@8.19.0)(zod@3.25.76))(@mariozechner/pi-tui@0.56.1)(@sinclair/typebox@0.34.48)
+        version: link:../subagents
       '@ifi/pi-shared-qna':
         specifier: 0.4.4
-        version: 0.4.4(@mariozechner/pi-tui@0.56.1)
+        version: link:../shared-qna
       '@mariozechner/pi-agent-core':
         specifier: '>=0.56.1'
         version: 0.56.1(ws@8.19.0)(zod@3.25.76)
@@ -255,7 +255,7 @@ importers:
     dependencies:
       '@ifi/pi-shared-qna':
         specifier: 0.4.4
-        version: 0.4.4(@mariozechner/pi-tui@0.56.1)
+        version: link:../shared-qna
       '@mariozechner/pi-agent-core':
         specifier: '>=0.56.1'
         version: 0.56.1(ws@8.19.0)(zod@3.25.76)
@@ -302,7 +302,7 @@ importers:
     dependencies:
       '@ifi/oh-pi-core':
         specifier: 0.4.4
-        version: 0.4.4
+        version: link:../core
       '@mariozechner/pi-agent-core':
         specifier: '>=0.56.1'
         version: 0.56.1(ws@8.19.0)(zod@3.25.76)
@@ -327,7 +327,7 @@ importers:
     dependencies:
       '@ifi/pi-web-server':
         specifier: 0.4.4
-        version: 0.4.4(@mariozechner/pi-coding-agent@0.56.1(ws@8.19.0)(zod@3.25.76))
+        version: link:../web-server
       '@mariozechner/pi-coding-agent':
         specifier: '>=0.56.1'
         version: 0.56.1(ws@8.19.0)(zod@3.25.76)
@@ -815,81 +815,6 @@ packages:
     resolution: {integrity: sha512-kQQo4xPUdnvPNXvfaPXBcy+1yFxv1LhjM8vGaUGlq4BOy2wyD4QcXrKDReqcUJbk6Yg5lNffxrbKLKrnB11djw==}
     engines: {node: '>=18'}
     hasBin: true
-
-  '@ifi/oh-pi-agents@0.4.4':
-    resolution: {integrity: sha512-lrBL1EzuWhZxQ/YX7LZrJLQBfCt0qRxTkNr1s8Y2o8/lQiUiEAsH6V80XnFXtkDZw/Yp8wCwolLuSbTR8O9KTQ==}
-
-  '@ifi/oh-pi-ant-colony@0.4.4':
-    resolution: {integrity: sha512-nio0C6uT7w22nK4IUr7LCUnnaaYrb1fd0RTFD0KcjdDccxVmQQA5Se3owvzGxf28uT6dj3S5nyhK/fy7/96+cg==}
-    peerDependencies:
-      '@mariozechner/pi-agent-core': '>=0.56.1'
-      '@mariozechner/pi-ai': '>=0.56.1'
-      '@mariozechner/pi-coding-agent': '>=0.56.1'
-      '@mariozechner/pi-tui': '>=0.56.1'
-      '@sinclair/typebox': '*'
-
-  '@ifi/oh-pi-core@0.4.4':
-    resolution: {integrity: sha512-i9yh+P++mYV75LWl31MukT6tASHYbi7Qhnhv1lMMBZLazK/A7e5OJNh3uUlw0fykSVTiFXGpvOnqMc2pwvRZEw==}
-    engines: {node: '>=20.0.0'}
-
-  '@ifi/oh-pi-extensions@0.4.4':
-    resolution: {integrity: sha512-tx97zKymuK47oGisEzRh9VkY/bkBec76BVomM+dO4ty/tqX8wCDUmP1RJVkVk9szITucPHpnGFTRC6lPaZEjkQ==}
-    peerDependencies:
-      '@mariozechner/pi-agent-core': '>=0.56.1'
-      '@mariozechner/pi-ai': '>=0.56.1'
-      '@mariozechner/pi-coding-agent': '>=0.56.1'
-      '@mariozechner/pi-tui': '>=0.56.1'
-      '@sinclair/typebox': '*'
-
-  '@ifi/oh-pi-prompts@0.4.4':
-    resolution: {integrity: sha512-bMhN9ltlLkz1DwD6Dk37s+7Mvp+4X1BTIs57xWLq0Ljr4O7NqJou3j5M7p+aRjmoWpz6BLfk19vdC1jQY4rqyQ==}
-
-  '@ifi/oh-pi-skills@0.4.4':
-    resolution: {integrity: sha512-TGDMYvAf8IxcPQBO+8GeBv+Po2FgRpRO7GfLG++qzyr+W6TVb1IIXaTuFA3aPTfO1apg0YQl4uQFiUnQxrg8XA==}
-
-  '@ifi/oh-pi-themes@0.4.4':
-    resolution: {integrity: sha512-pm/JKFqnr0I/NJrfT0KVkg1C/rEtHx+HSiDhKG5BQAyaX+1gbY2Doh9kLUijABWpeNgkuRwzpCm6F2+Lv8QYzA==}
-
-  '@ifi/pi-extension-subagents@0.4.4':
-    resolution: {integrity: sha512-uGpzhZxWyPseT5srhT14h9fXBPe9l/wmExg8ufr4PTi+vJx9PW8lqvlhUxIWsqw/5PORRuZiD1ZtzK3MTHCKdg==}
-    hasBin: true
-    peerDependencies:
-      '@mariozechner/pi-agent-core': '>=0.56.1'
-      '@mariozechner/pi-ai': '>=0.56.1'
-      '@mariozechner/pi-coding-agent': '>=0.56.1'
-      '@mariozechner/pi-tui': '>=0.56.1'
-      '@sinclair/typebox': '*'
-
-  '@ifi/pi-plan@0.4.4':
-    resolution: {integrity: sha512-m8VqVod1bp3s3KyLZU/DE5fDuO03dVUdyMxQoB9dY8YLUYH1cspJVxpa6K4dO1evYB6B/6pI41U2IrEm6f65/g==}
-    hasBin: true
-    peerDependencies:
-      '@mariozechner/pi-agent-core': '>=0.56.1'
-      '@mariozechner/pi-ai': '>=0.56.1'
-      '@mariozechner/pi-coding-agent': '>=0.56.1'
-      '@mariozechner/pi-tui': '>=0.56.1'
-      '@sinclair/typebox': '*'
-
-  '@ifi/pi-shared-qna@0.4.4':
-    resolution: {integrity: sha512-zNHh5LMlim57x6h/31N3FakERggY2QzwTBnCEo9DloPh57PjHJ9z+9lk+8nM3ktOP0wZkcY8OHr2a2f8jNgV4w==}
-    peerDependencies:
-      '@mariozechner/pi-tui': '*'
-
-  '@ifi/pi-spec@0.4.4':
-    resolution: {integrity: sha512-BOSklndS4VOdBcf33n4jHbIygia0oe3V2w4L8TCh0LEBnOqCzUJzYC/6L/xr4qXyGK5w0RdJxa/qMm0l7RGFmg==}
-    peerDependencies:
-      '@mariozechner/pi-agent-core': '>=0.56.1'
-      '@mariozechner/pi-ai': '>=0.56.1'
-      '@mariozechner/pi-coding-agent': '>=0.56.1'
-      '@mariozechner/pi-tui': '>=0.56.1'
-      '@sinclair/typebox': '*'
-
-  '@ifi/pi-web-server@0.4.4':
-    resolution: {integrity: sha512-BxyDz6gE8hJdp4Z4SIhRoh88dlI14XDzR3k/732lsH0frqUT14VUoYrktF9BHor5XCIH9zopvGFFVV8Qd0WUzw==}
-    engines: {node: '>=20.0.0'}
-    hasBin: true
-    peerDependencies:
-      '@mariozechner/pi-coding-agent': '>=0.56.1'
 
   '@isaacs/cliui@8.0.2':
     resolution: {integrity: sha512-O8jcjabXaleOG9DQ0+ARXWZBTfnP4WNAqzuiJK7ll44AmxGKv/J2M4TPjxjY3znBCfvBXFzucm1twdyFybFqEA==}
@@ -2938,78 +2863,6 @@ snapshots:
       '@ifi/mdt-linux-x64-musl': 0.7.0
       '@ifi/mdt-win32-arm64-msvc': 0.7.0
       '@ifi/mdt-win32-x64-msvc': 0.7.0
-
-  '@ifi/oh-pi-agents@0.4.4': {}
-
-  '@ifi/oh-pi-ant-colony@0.4.4(@mariozechner/pi-agent-core@0.56.1(ws@8.19.0)(zod@3.25.76))(@mariozechner/pi-ai@0.56.1(ws@8.19.0)(zod@3.25.76))(@mariozechner/pi-coding-agent@0.56.1(ws@8.19.0)(zod@3.25.76))(@mariozechner/pi-tui@0.56.1)(@sinclair/typebox@0.34.48)':
-    dependencies:
-      '@ifi/oh-pi-core': 0.4.4
-      '@mariozechner/pi-agent-core': 0.56.1(ws@8.19.0)(zod@3.25.76)
-      '@mariozechner/pi-ai': 0.56.1(ws@8.19.0)(zod@3.25.76)
-      '@mariozechner/pi-coding-agent': 0.56.1(ws@8.19.0)(zod@3.25.76)
-      '@mariozechner/pi-tui': 0.56.1
-      '@sinclair/typebox': 0.34.48
-
-  '@ifi/oh-pi-core@0.4.4':
-    dependencies:
-      '@clack/prompts': 1.1.0
-      chalk: 5.6.2
-
-  '@ifi/oh-pi-extensions@0.4.4(@mariozechner/pi-agent-core@0.56.1(ws@8.19.0)(zod@3.25.76))(@mariozechner/pi-ai@0.56.1(ws@8.19.0)(zod@3.25.76))(@mariozechner/pi-coding-agent@0.56.1(ws@8.19.0)(zod@3.25.76))(@mariozechner/pi-tui@0.56.1)(@sinclair/typebox@0.34.48)':
-    dependencies:
-      '@mariozechner/pi-agent-core': 0.56.1(ws@8.19.0)(zod@3.25.76)
-      '@mariozechner/pi-ai': 0.56.1(ws@8.19.0)(zod@3.25.76)
-      '@mariozechner/pi-coding-agent': 0.56.1(ws@8.19.0)(zod@3.25.76)
-      '@mariozechner/pi-tui': 0.56.1
-      '@sinclair/typebox': 0.34.48
-      croner: 10.0.1
-
-  '@ifi/oh-pi-prompts@0.4.4': {}
-
-  '@ifi/oh-pi-skills@0.4.4': {}
-
-  '@ifi/oh-pi-themes@0.4.4': {}
-
-  '@ifi/pi-extension-subagents@0.4.4(@mariozechner/pi-agent-core@0.56.1(ws@8.19.0)(zod@3.25.76))(@mariozechner/pi-ai@0.56.1(ws@8.19.0)(zod@3.25.76))(@mariozechner/pi-coding-agent@0.56.1(ws@8.19.0)(zod@3.25.76))(@mariozechner/pi-tui@0.56.1)(@sinclair/typebox@0.34.48)':
-    dependencies:
-      '@ifi/oh-pi-core': 0.4.4
-      '@mariozechner/pi-agent-core': 0.56.1(ws@8.19.0)(zod@3.25.76)
-      '@mariozechner/pi-ai': 0.56.1(ws@8.19.0)(zod@3.25.76)
-      '@mariozechner/pi-coding-agent': 0.56.1(ws@8.19.0)(zod@3.25.76)
-      '@mariozechner/pi-tui': 0.56.1
-      '@sinclair/typebox': 0.34.48
-
-  '@ifi/pi-plan@0.4.4(@mariozechner/pi-agent-core@0.56.1(ws@8.19.0)(zod@3.25.76))(@mariozechner/pi-ai@0.56.1(ws@8.19.0)(zod@3.25.76))(@mariozechner/pi-coding-agent@0.56.1(ws@8.19.0)(zod@3.25.76))(@mariozechner/pi-tui@0.56.1)(@sinclair/typebox@0.34.48)':
-    dependencies:
-      '@ifi/pi-extension-subagents': 0.4.4(@mariozechner/pi-agent-core@0.56.1(ws@8.19.0)(zod@3.25.76))(@mariozechner/pi-ai@0.56.1(ws@8.19.0)(zod@3.25.76))(@mariozechner/pi-coding-agent@0.56.1(ws@8.19.0)(zod@3.25.76))(@mariozechner/pi-tui@0.56.1)(@sinclair/typebox@0.34.48)
-      '@ifi/pi-shared-qna': 0.4.4(@mariozechner/pi-tui@0.56.1)
-      '@mariozechner/pi-agent-core': 0.56.1(ws@8.19.0)(zod@3.25.76)
-      '@mariozechner/pi-ai': 0.56.1(ws@8.19.0)(zod@3.25.76)
-      '@mariozechner/pi-coding-agent': 0.56.1(ws@8.19.0)(zod@3.25.76)
-      '@mariozechner/pi-tui': 0.56.1
-      '@sinclair/typebox': 0.34.48
-
-  '@ifi/pi-shared-qna@0.4.4(@mariozechner/pi-tui@0.56.1)':
-    dependencies:
-      '@mariozechner/pi-tui': 0.56.1
-
-  '@ifi/pi-spec@0.4.4(@mariozechner/pi-agent-core@0.56.1(ws@8.19.0)(zod@3.25.76))(@mariozechner/pi-ai@0.56.1(ws@8.19.0)(zod@3.25.76))(@mariozechner/pi-coding-agent@0.56.1(ws@8.19.0)(zod@3.25.76))(@mariozechner/pi-tui@0.56.1)(@sinclair/typebox@0.34.48)':
-    dependencies:
-      '@mariozechner/pi-agent-core': 0.56.1(ws@8.19.0)(zod@3.25.76)
-      '@mariozechner/pi-ai': 0.56.1(ws@8.19.0)(zod@3.25.76)
-      '@mariozechner/pi-coding-agent': 0.56.1(ws@8.19.0)(zod@3.25.76)
-      '@mariozechner/pi-tui': 0.56.1
-      '@sinclair/typebox': 0.34.48
-
-  '@ifi/pi-web-server@0.4.4(@mariozechner/pi-coding-agent@0.56.1(ws@8.19.0)(zod@3.25.76))':
-    dependencies:
-      '@hono/node-server': 1.19.13(hono@4.12.12)
-      '@mariozechner/pi-coding-agent': 0.56.1(ws@8.19.0)(zod@3.25.76)
-      hono: 4.12.12
-      ws: 8.19.0
-    transitivePeerDependencies:
-      - bufferutil
-      - utf-8-validate
 
   '@isaacs/cliui@8.0.2':
     dependencies:

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -156,8 +156,8 @@ importers:
   packages/extensions:
     dependencies:
       '@ifi/pi-shared-qna':
-        specifier: workspace:*
-        version: link:../shared-qna
+        specifier: 0.4.4
+        version: 0.4.4(@mariozechner/pi-tui@0.56.1)
       '@mariozechner/pi-agent-core':
         specifier: '>=0.56.1'
         version: 0.56.1(ws@8.19.0)(zod@3.25.76)
@@ -254,8 +254,8 @@ importers:
   packages/providers:
     dependencies:
       '@ifi/pi-shared-qna':
-        specifier: workspace:*
-        version: link:../shared-qna
+        specifier: 0.4.4
+        version: 0.4.4(@mariozechner/pi-tui@0.56.1)
       '@mariozechner/pi-agent-core':
         specifier: '>=0.56.1'
         version: 0.56.1(ws@8.19.0)(zod@3.25.76)

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -155,6 +155,9 @@ importers:
 
   packages/extensions:
     dependencies:
+      '@ifi/pi-shared-qna':
+        specifier: workspace:*
+        version: link:../shared-qna
       '@mariozechner/pi-agent-core':
         specifier: '>=0.56.1'
         version: 0.56.1(ws@8.19.0)(zod@3.25.76)
@@ -250,6 +253,9 @@ importers:
 
   packages/providers:
     dependencies:
+      '@ifi/pi-shared-qna':
+        specifier: workspace:*
+        version: link:../shared-qna
       '@mariozechner/pi-agent-core':
         specifier: '>=0.56.1'
         version: 0.56.1(ws@8.19.0)(zod@3.25.76)

--- a/vitest.config.ts
+++ b/vitest.config.ts
@@ -1,4 +1,8 @@
+import { fileURLToPath } from "node:url";
 import { defineConfig } from "vitest/config";
+
+const coreEntry = fileURLToPath(new URL("./packages/core/src/index.ts", import.meta.url));
+const sharedQnaEntry = fileURLToPath(new URL("./packages/shared-qna/index.ts", import.meta.url));
 
 const coverageInclude = ["scripts/**/*.{ts,mts,mjs}", "packages/**/*.{ts,tsx,mts,mjs}"];
 const coverageExclude = [
@@ -13,6 +17,12 @@ const coverageExclude = [
 ];
 
 export default defineConfig({
+	resolve: {
+		alias: {
+			"@ifi/oh-pi-core": coreEntry,
+			"@ifi/pi-shared-qna": sharedQnaEntry,
+		},
+	},
 	test: {
 		include: [
 			"benchmarks/**/*.test.ts",

--- a/vitest.config.ts
+++ b/vitest.config.ts
@@ -3,6 +3,7 @@ import { defineConfig } from "vitest/config";
 
 const coreEntry = fileURLToPath(new URL("./packages/core/src/index.ts", import.meta.url));
 const sharedQnaEntry = fileURLToPath(new URL("./packages/shared-qna/index.ts", import.meta.url));
+const webServerEntry = fileURLToPath(new URL("./packages/web-server/src/index.ts", import.meta.url));
 
 const coverageInclude = ["scripts/**/*.{ts,mts,mjs}", "packages/**/*.{ts,tsx,mts,mjs}"];
 const coverageExclude = [
@@ -21,6 +22,7 @@ export default defineConfig({
 		alias: {
 			"@ifi/oh-pi-core": coreEntry,
 			"@ifi/pi-shared-qna": sharedQnaEntry,
+			"@ifi/pi-web-server": webServerEntry,
 		},
 	},
 	test: {


### PR DESCRIPTION
## Summary
- add a shared scrollable overlay picker in `@ifi/pi-shared-qna`
- switch `/providers login` and `/schedule` to the shared picker capped at 75% height
- stop truncating provider model selection to 50 models and cover the new picker/model-selection behavior with focused tests

## Performance
- keep rendering bounded to a visible window instead of the full list
- cache the shared `pi-tui` module lookup in the picker
- reuse the prebuilt provider option list when clearing the search filter

## Coverage
- add focused tests for the new scroll-select component and overlay flows
- add a regression test that keeps the full provider model list instead of truncating to 50 entries

## Validation
- `pnpm lint`
- `pnpm build`
- `pnpm exec vitest run packages/extensions/extensions/scheduler-overlay.test.ts packages/shared-qna/tests/scroll-select.test.ts packages/providers/tests/index.test.ts packages/cli/src/tui/provider-setup.test.ts packages/shared-qna/tests/pi-tui-loader.test.ts packages/shared-qna/tests/qna-tui.test.ts`
- `pnpm exec vitest run packages/extensions/extensions/scheduler-overlay.test.ts packages/shared-qna/tests/scroll-select.test.ts packages/providers/tests/index.test.ts packages/cli/src/tui/provider-setup.test.ts --coverage.enabled --coverage.reporter=text --coverage.include=packages/shared-qna/scroll-select.ts --coverage.include=packages/providers/index.ts --coverage.include=packages/extensions/extensions/scheduler.ts --coverage.include=packages/cli/src/tui/provider-setup.ts`
