### PR TITLE
feat(diagnostics): add standalone prompt diagnostics package

### DIFF
--- a/.changeset/prompt-diagnostics-extension.md
+++ b/.changeset/prompt-diagnostics-extension.md
@@ -1,0 +1,5 @@
+---
+default: minor
+---
+
+feat: add a diagnostics extension that logs prompt completion timestamps, durations, and per-turn timing details

--- a/README.md
+++ b/README.md
@@ -55,6 +55,7 @@ This is a monorepo. Install everything at once with `npx @ifi/oh-pi`, or pick in
 | [`@ifi/oh-pi-extensions`](./packages/extensions)          | Core extension pack (see below)             | `pi install npm:@ifi/oh-pi-extensions`      |
 | [`@ifi/pi-extension-adaptive-routing`](./packages/adaptive-routing) | Optional adaptive + delegated routing       | `pi install npm:@ifi/pi-extension-adaptive-routing` |
 | [`@ifi/oh-pi-ant-colony`](./packages/ant-colony)          | Multi-agent swarm extension                 | `pi install npm:@ifi/oh-pi-ant-colony`      |
+| [`@ifi/pi-diagnostics`](./packages/diagnostics)           | Prompt completion timing extension          | `pi install npm:@ifi/pi-diagnostics`         |
 | [`@ifi/pi-extension-subagents`](./packages/subagents)     | Full-featured subagent delegation extension | `pi install npm:@ifi/pi-extension-subagents` |
 | [`@ifi/pi-plan`](./packages/plan)                         | Branch-aware planning mode extension        | `pi install npm:@ifi/pi-plan`               |
 | [`@ifi/pi-shared-qna`](./packages/shared-qna)             | Shared Q&A TUI helpers                      | (library, not installed directly)           |
@@ -224,6 +225,22 @@ window %, elapsed time, working directory, git branch, and repo/worktree context
 **How it works:** Uses `ctx.ui.setFooter()` with a component that reads
 `ctx.sessionManager.getBranch()` for token/cost data and `footerData.getGitBranch()` for git info.
 Auto-refreshes every 30s.
+
+### ⏱ Diagnostics (`diagnostics`) — **default: on**
+
+Adds prompt-level completion diagnostics so you can see when a prompt started, when it finished,
+how long it took, and how each assistant turn progressed.
+
+**Surfaces:**
+
+- widget below the editor showing the active prompt or the last completed prompt
+- session log entry after each prompt finishes with human-readable start/end timestamps
+- expanded per-turn timing details for prompts that needed multiple assistant turns
+- `Ctrl+Shift+D` shortcut and `/diagnostics [status|toggle|on|off]`
+
+**How it works:** Reuses the same timestamp/duration formatting as `tool-metadata`, tracks
+`before_agent_start`, `turn_end`, and `agent_end`, then emits a custom diagnostic message when the
+agent goes idle for that prompt.
 
 ### ⚡ Compact Header (`compact-header`) — **default: on**
 

--- a/knope.toml
+++ b/knope.toml
@@ -11,6 +11,7 @@ versioned_files = [
   "packages/cli/package.json",
   "packages/extensions/package.json",
   "packages/ant-colony/package.json",
+  "packages/diagnostics/package.json",
   "packages/themes/package.json",
   "packages/prompts/package.json",
   "packages/skills/package.json",

--- a/package.json
+++ b/package.json
@@ -18,6 +18,7 @@
 			"./packages/extensions/extensions/usage-tracker.ts",
 			"./packages/extensions/extensions/worktree.ts",
 			"./packages/ant-colony/extensions/ant-colony/index.ts",
+			"./packages/diagnostics/index.ts",
 			"./packages/subagents/index.ts",
 			"./packages/subagents/notify.ts",
 			"./packages/plan/index.ts",

--- a/packages/cli/src/index.test.ts
+++ b/packages/cli/src/index.test.ts
@@ -1,0 +1,49 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+const getLocale = vi.fn(() => "en");
+const selectLanguage = vi.fn(async () => undefined);
+const confirmApply = vi.fn(async () => undefined);
+const selectMode = vi.fn(async () => "quick");
+const setupProviders = vi.fn(async () => ({ providers: [{ name: "openai", apiKey: "set" }], providerMode: "custom" }));
+const setupAdaptiveRouting = vi.fn(async () => ({ enabled: false }));
+const welcome = vi.fn();
+const detectEnv = vi.fn(async () => ({ existingProviders: ["anthropic"] }));
+
+vi.mock("@ifi/oh-pi-core", () => ({
+	EXTENSIONS: [],
+	getLocale,
+	selectLanguage,
+}));
+vi.mock("./tui/config-wizard.js", () => ({ runConfigWizard: vi.fn() }));
+vi.mock("./tui/confirm-apply.js", () => ({ confirmApply }));
+vi.mock("./tui/mode-select.js", () => ({ selectMode }));
+vi.mock("./tui/preset-select.js", () => ({ selectPreset: vi.fn() }));
+vi.mock("./tui/provider-setup.js", () => ({ setupProviders }));
+vi.mock("./tui/routing-setup.js", () => ({ setupAdaptiveRouting }));
+vi.mock("./tui/welcome.js", () => ({ welcome }));
+vi.mock("./utils/detect.js", () => ({ detectEnv }));
+
+describe("cli quick flow", () => {
+	beforeEach(() => {
+		vi.clearAllMocks();
+	});
+
+	it("includes diagnostics in the quick preset defaults", async () => {
+		const { run } = await import("./index.js");
+		await run();
+
+		expect(setupAdaptiveRouting).toHaveBeenCalledWith([
+			{ name: "anthropic", apiKey: "none" },
+			{ name: "openai", apiKey: "set" },
+		]);
+		expect(confirmApply).toHaveBeenCalledWith(
+			expect.objectContaining({
+				locale: "en",
+				extensions: expect.arrayContaining(["diagnostics"]),
+			}),
+			expect.objectContaining({ existingProviders: ["anthropic"] }),
+		);
+		expect(welcome).toHaveBeenCalled();
+		expect(selectLanguage).toHaveBeenCalled();
+	});
+});

--- a/packages/cli/src/index.ts
+++ b/packages/cli/src/index.ts
@@ -49,7 +49,7 @@ async function quickFlow(env: EnvInfo): Promise<OhPConfigWithRouting> {
 		adaptiveRouting,
 		theme: "dark",
 		keybindings: "default",
-		extensions: ["git-guard", "auto-session-name", "custom-footer", "compact-header", "auto-update"],
+		extensions: ["git-guard", "auto-session-name", "custom-footer", "diagnostics", "compact-header", "auto-update"],
 		prompts: ["review", "fix", "explain", "commit", "test"],
 		agents: "general-developer",
 		thinking: "medium",

--- a/packages/cli/src/utils/resources.test.ts
+++ b/packages/cli/src/utils/resources.test.ts
@@ -20,6 +20,12 @@ describe("resources", () => {
 		expect(p.startsWith("/")).toBe(true);
 	});
 
+	it("diagnosticsDir returns correct path", () => {
+		const p = resources.diagnosticsDir();
+		expect(/(?:packages\/diagnostics|node_modules\/@ifi\/pi-diagnostics)(?:\/|$)/.test(p)).toBe(true);
+		expect(p.startsWith("/")).toBe(true);
+	});
+
 	it("planDir returns correct path", () => {
 		const p = resources.planDir();
 		expect(/(?:packages\/plan|node_modules\/@ifi\/pi-plan)(?:\/|$)/.test(p)).toBe(true);

--- a/packages/cli/src/utils/resources.ts
+++ b/packages/cli/src/utils/resources.ts
@@ -5,9 +5,11 @@
  * in development (workspace:* links) and after publishing (real npm installs).
  */
 import { createRequire } from "node:module";
-import { dirname, join } from "node:path";
+import { dirname, join, resolve } from "node:path";
+import { fileURLToPath } from "node:url";
 
 const require = createRequire(import.meta.url);
+const resourcesDir = dirname(fileURLToPath(import.meta.url));
 
 /**
  * Resolve a subpath within an installed npm package.
@@ -20,12 +22,21 @@ function resolvePackagePath(pkg: string, subpath: string): string {
 	return join(dirname(pkgJson), subpath);
 }
 
+function resolvePackagePathWithFallback(pkg: string, subpath: string, fallbackRelativePath: string): string {
+	try {
+		return resolvePackagePath(pkg, subpath);
+	} catch {
+		return resolve(resourcesDir, fallbackRelativePath, subpath);
+	}
+}
+
 /** Resource path mapping — resolves paths into installed workspace packages. */
 export const resources = {
 	agent: (name: string) => join(resolvePackagePath("@ifi/oh-pi-agents", "agents"), `${name}.md`),
 	extension: (name: string) => join(resolvePackagePath("@ifi/oh-pi-extensions", "extensions"), name),
 	extensionFile: (name: string) => join(resolvePackagePath("@ifi/oh-pi-extensions", "extensions"), `${name}.ts`),
 	antColonyDir: () => resolvePackagePath("@ifi/oh-pi-ant-colony", "extensions/ant-colony"),
+	diagnosticsDir: () => resolvePackagePathWithFallback("@ifi/pi-diagnostics", ".", "../../../diagnostics"),
 	planDir: () => resolvePackagePath("@ifi/pi-plan", "."),
 	subagentsDir: () => resolvePackagePath("@ifi/pi-extension-subagents", "."),
 	sharedQnaDir: () => resolvePackagePath("@ifi/pi-shared-qna", "."),

--- a/packages/cli/src/utils/writers.test.ts
+++ b/packages/cli/src/utils/writers.test.ts
@@ -68,6 +68,19 @@ describe("writeExtensions", () => {
 		expect(existsSync(join(dir, "extensions", "spec", "index.ts"))).toBe(true);
 		expect(existsSync(join(dir, "extensions", "spec", "assets", "templates", "spec-template.md"))).toBe(true);
 	});
+
+	it("copies the dedicated diagnostics package into the local extensions directory", () => {
+		const dir = makeTempDir();
+		writeExtensions(
+			dir,
+			makeConfig({
+				extensions: ["diagnostics"],
+			}),
+		);
+
+		expect(existsSync(join(dir, "extensions", "diagnostics", "index.ts"))).toBe(true);
+		expect(existsSync(join(dir, "extensions", "diagnostics", "diagnostics-shared.ts"))).toBe(true);
+	});
 });
 
 describe("writeAdaptiveRoutingConfig", () => {

--- a/packages/cli/src/utils/writers.ts
+++ b/packages/cli/src/utils/writers.ts
@@ -273,6 +273,11 @@ export function writeExtensions(agentDir: string, config: OhPConfigWithRouting) 
 			continue;
 		}
 
+		if (ext === "diagnostics") {
+			copyDedicatedExtension(extDir, "diagnostics", resources.diagnosticsDir());
+			continue;
+		}
+
 		if (ext === "spec") {
 			copyDedicatedExtension(extDir, "spec", resources.specDir());
 			continue;

--- a/packages/core/src/registry.ts
+++ b/packages/core/src/registry.ts
@@ -90,6 +90,13 @@ export const EXTENSIONS = [
 		default: true,
 	},
 	{
+		name: "diagnostics",
+		get label() {
+			return `${icon("chart")} Diagnostics — Log prompt completion timestamps, durations, and per-turn response timing`;
+		},
+		default: true,
+	},
+	{
 		name: "compact-header",
 		get label() {
 			return `${icon("bolt")} Compact Header — Dense startup info replacing verbose output`;

--- a/packages/diagnostics/README.md
+++ b/packages/diagnostics/README.md
@@ -1,0 +1,41 @@
+# @ifi/pi-diagnostics
+
+Prompt-completion diagnostics for pi.
+
+## Install
+
+```bash
+pi install npm:@ifi/pi-diagnostics
+```
+
+Or install the full default oh-pi bundle:
+
+```bash
+npx @ifi/oh-pi
+```
+
+## What it provides
+
+This extension adds prompt-level completion timing so you can tell exactly:
+
+- when a prompt started
+- when the agent finished responding
+- how long the full prompt took
+- how long each assistant turn took on multi-turn runs
+
+## Surfaces
+
+- widget below the editor showing the active prompt or most recent completion
+- session log entry after each prompt finishes with human-readable start/end timestamps
+- expanded per-turn timing details for prompts that needed multiple assistant turns
+- `/diagnostics [status|toggle|on|off]`
+- `Ctrl+Shift+D` to toggle diagnostics on and off quickly
+
+## Relationship to tool-metadata
+
+`@ifi/pi-diagnostics` also exports shared timestamp and duration helpers used by
+`tool-metadata`, so prompt-level and tool-level timing stay consistent.
+
+## Notes
+
+This package ships raw `.ts` sources for pi to load directly.

--- a/packages/diagnostics/diagnostics-shared.ts
+++ b/packages/diagnostics/diagnostics-shared.ts
@@ -1,0 +1,67 @@
+const DEFAULT_PREVIEW_LENGTH = 120;
+
+function pad(value: number): string {
+	return `${value}`.padStart(2, "0");
+}
+
+export function formatTimestamp(timestamp: number): string {
+	const date = new Date(timestamp);
+	return `${date.getFullYear()}-${pad(date.getMonth() + 1)}-${pad(date.getDate())} ${pad(date.getHours())}:${pad(date.getMinutes())}:${pad(date.getSeconds())}`;
+}
+
+export function formatDuration(durationMs: number): string {
+	if (durationMs < 1000) {
+		return `${durationMs}ms`;
+	}
+
+	const seconds = durationMs / 1000;
+	if (seconds < 60) {
+		return `${seconds.toFixed(seconds < 10 ? 1 : 0)}s`;
+	}
+
+	const minutes = Math.floor(seconds / 60);
+	const remainingSeconds = seconds % 60;
+	if (minutes < 60) {
+		return `${minutes}m${remainingSeconds > 0 ? `${Math.round(remainingSeconds)}s` : ""}`;
+	}
+
+	const hours = Math.floor(minutes / 60);
+	const remainingMinutes = minutes % 60;
+	return `${hours}h${remainingMinutes > 0 ? `${remainingMinutes}m` : ""}`;
+}
+
+export function extractTextContent(content: unknown): string {
+	if (typeof content === "string") {
+		return content;
+	}
+
+	if (!Array.isArray(content)) {
+		return "";
+	}
+
+	return content
+		.filter((item) => item && typeof item === "object" && (item as { type?: unknown }).type === "text")
+		.map((item) => {
+			const text = (item as { text?: unknown }).text;
+			return typeof text === "string" ? text : "";
+		})
+		.join(" ")
+		.trim();
+}
+
+export function summarizeText(text: string, maxLength = DEFAULT_PREVIEW_LENGTH): string {
+	const singleLine = text.replaceAll(/\s+/g, " ").trim();
+	if (!singleLine) {
+		return "";
+	}
+
+	if (singleLine.length <= maxLength) {
+		return singleLine;
+	}
+
+	return `${singleLine.slice(0, maxLength - 1).trimEnd()}…`;
+}
+
+export function summarizeContent(content: unknown, maxLength = DEFAULT_PREVIEW_LENGTH): string {
+	return summarizeText(extractTextContent(content), maxLength);
+}

--- a/packages/diagnostics/index.ts
+++ b/packages/diagnostics/index.ts
@@ -1,0 +1,557 @@
+import type { ExtensionAPI, ExtensionCommandContext, ExtensionContext, Theme } from "@mariozechner/pi-coding-agent";
+import { Text, truncateToWidth } from "@mariozechner/pi-tui";
+import { formatDuration, formatTimestamp, summarizeContent, summarizeText } from "./diagnostics-shared.js";
+
+type PromptTurnDiagnostics = {
+	turnIndex: number;
+	completedAt: number;
+	completedAtLabel: string;
+	elapsedMs: number;
+	elapsedLabel: string;
+	toolCount: number;
+	stopReason: string | null;
+	responsePreview: string;
+};
+
+export type PromptCompletionDiagnostics = {
+	promptPreview: string;
+	startedAt: number;
+	startedAtLabel: string;
+	completedAt: number;
+	completedAtLabel: string;
+	durationMs: number;
+	durationLabel: string;
+	turnCount: number;
+	toolCount: number;
+	status: "completed" | "aborted" | "error" | "unknown";
+	statusLabel: string;
+	stopReason: string | null;
+	turns: PromptTurnDiagnostics[];
+};
+
+type DiagnosticsStateEntry = {
+	enabled?: boolean;
+	updatedAt?: number;
+};
+
+type ActivePromptRun = {
+	promptPreview: string;
+	startedAt: number;
+	startedAtLabel: string;
+	turns: PromptTurnDiagnostics[];
+};
+
+type SessionEntryLike = {
+	type?: string;
+	customType?: string;
+	data?: unknown;
+	details?: unknown;
+	message?: {
+		role?: string;
+		customType?: string;
+		details?: unknown;
+	};
+};
+
+type AgentMessageLike = {
+	role?: string;
+	content?: unknown;
+	stopReason?: string;
+};
+
+type ThemeLike = Theme;
+
+const COMMAND = "diagnostics";
+const SHORTCUT = "ctrl+shift+d";
+const DIAGNOSTICS_MESSAGE_TYPE = "pi-diagnostics:prompt";
+const DIAGNOSTICS_STATE_TYPE = "pi-diagnostics:state";
+const WIDGET_KEY = "diagnostics";
+const WIDGET_REFRESH_MS = 1000;
+const PROMPT_PREVIEW_MAX_LENGTH = 96;
+const RESPONSE_PREVIEW_MAX_LENGTH = 88;
+
+function pluralize(count: number, noun: string): string {
+	return `${count} ${noun}${count === 1 ? "" : "s"}`;
+}
+
+function classifyStopReason(stopReason: string | null | undefined): {
+	status: PromptCompletionDiagnostics["status"];
+	statusLabel: string;
+	color: "success" | "warning" | "error" | "muted";
+} {
+	if (stopReason === "aborted") {
+		return { status: "aborted", statusLabel: "aborted", color: "warning" };
+	}
+
+	if (stopReason === "error") {
+		return { status: "error", statusLabel: "errored", color: "error" };
+	}
+
+	if (stopReason === "stop" || stopReason === "length") {
+		return { status: "completed", statusLabel: "completed", color: "success" };
+	}
+
+	return { status: "unknown", statusLabel: "finished", color: "muted" };
+}
+
+function isPromptCompletionDiagnostics(value: unknown): value is PromptCompletionDiagnostics {
+	return !!value && typeof value === "object" && typeof (value as { completedAt?: unknown }).completedAt === "number";
+}
+
+function isDiagnosticsStateEntry(value: unknown): value is DiagnosticsStateEntry {
+	return !!value && typeof value === "object" && typeof (value as { enabled?: unknown }).enabled === "boolean";
+}
+
+function getMessageDetails(entry: SessionEntryLike): unknown {
+	if (entry.type === "custom_message") {
+		return entry.details;
+	}
+
+	if (entry.type === "message" && entry.message?.role === "custom") {
+		return entry.message.details;
+	}
+
+	return undefined;
+}
+
+function getMessageCustomType(entry: SessionEntryLike): string | undefined {
+	if (entry.type === "custom_message") {
+		return entry.customType;
+	}
+
+	if (entry.type === "message" && entry.message?.role === "custom") {
+		return entry.message.customType;
+	}
+
+	return undefined;
+}
+
+function summarizePrompt(prompt: string | undefined, images: unknown): string {
+	const promptPreview = summarizeText(prompt ?? "", PROMPT_PREVIEW_MAX_LENGTH);
+	if (promptPreview) {
+		return promptPreview;
+	}
+
+	const imageCount = Array.isArray(images) ? images.length : 0;
+	if (imageCount > 0) {
+		return imageCount === 1 ? "1 image prompt" : `${imageCount} image prompt`;
+	}
+
+	return "(empty prompt)";
+}
+
+function countToolResults(toolResults: unknown): number {
+	return Array.isArray(toolResults) ? toolResults.length : 0;
+}
+
+function summarizeResponsePreview(content: unknown, toolCount: number, stopReason: string | null): string {
+	const preview = summarizeContent(content, RESPONSE_PREVIEW_MAX_LENGTH);
+	if (preview) {
+		return preview;
+	}
+
+	if (toolCount > 0) {
+		return `Used ${pluralize(toolCount, "tool")}`;
+	}
+
+	if (stopReason) {
+		return `stop reason: ${stopReason}`;
+	}
+
+	return "(no visible response text)";
+}
+
+function findLastAssistantMessage(messages: unknown): AgentMessageLike | null {
+	if (!Array.isArray(messages)) {
+		return null;
+	}
+
+	for (let index = messages.length - 1; index >= 0; index -= 1) {
+		const message = messages[index] as AgentMessageLike | undefined;
+		if (message?.role === "assistant") {
+			return message;
+		}
+	}
+
+	return null;
+}
+
+function findPromptPreviewFromMessages(messages: unknown): string {
+	if (!Array.isArray(messages)) {
+		return "(empty prompt)";
+	}
+
+	for (const message of messages) {
+		const candidate = message as AgentMessageLike | undefined;
+		if (candidate?.role !== "user") {
+			continue;
+		}
+
+		const preview = summarizeContent(candidate.content, PROMPT_PREVIEW_MAX_LENGTH);
+		if (preview) {
+			return preview;
+		}
+	}
+
+	return "(empty prompt)";
+}
+
+function buildPromptSummaryText(details: PromptCompletionDiagnostics): string {
+	const timing = [
+		`${details.statusLabel} ${details.completedAtLabel}`,
+		`started ${details.startedAtLabel}`,
+		`duration ${details.durationLabel}`,
+		pluralize(details.turnCount, "turn"),
+		pluralize(details.toolCount, "tool"),
+	].join(" · ");
+
+	return `Prompt ${timing}\n${details.promptPreview}`;
+}
+
+function buildPromptCompletion(
+	run: ActivePromptRun,
+	messages: unknown,
+	completedAt: number,
+): PromptCompletionDiagnostics {
+	const lastAssistant = findLastAssistantMessage(messages);
+	const classification = classifyStopReason(lastAssistant?.stopReason ?? null);
+	const toolCount = run.turns.reduce((sum, turn) => sum + turn.toolCount, 0);
+	const durationMs = Math.max(0, completedAt - run.startedAt);
+
+	return {
+		promptPreview: run.promptPreview,
+		startedAt: run.startedAt,
+		startedAtLabel: run.startedAtLabel,
+		completedAt,
+		completedAtLabel: formatTimestamp(completedAt),
+		durationMs,
+		durationLabel: formatDuration(durationMs),
+		turnCount: run.turns.length,
+		toolCount,
+		status: classification.status,
+		statusLabel: classification.statusLabel,
+		stopReason: lastAssistant?.stopReason ?? null,
+		turns: [...run.turns],
+	};
+}
+
+function renderPromptCompletionMessage(
+	message: { content?: unknown; details?: unknown },
+	expanded: boolean,
+	theme: ThemeLike,
+) {
+	const details = isPromptCompletionDiagnostics(message.details) ? message.details : undefined;
+	const classification = classifyStopReason(details?.stopReason);
+	const render = (text: string) => new Text(text, 1, 0, (segment: string) => theme.bg("customMessageBg", segment));
+
+	if (!details) {
+		return render(String(message.content ?? "Prompt diagnostics"));
+	}
+
+	const lines = [
+		`${theme.fg(classification.color, theme.bold(`⏱ Prompt ${details.statusLabel}`))}`,
+		`${theme.fg("muted", "Prompt")}: ${details.promptPreview}`,
+		`${theme.fg("muted", "Started")}: ${details.startedAtLabel}`,
+		`${theme.fg("muted", "Completed")}: ${details.completedAtLabel}`,
+		`${theme.fg("muted", "Duration")}: ${details.durationLabel} · ${pluralize(details.turnCount, "turn")} · ${pluralize(details.toolCount, "tool")}`,
+	];
+
+	if (!expanded) {
+		if (details.turns.length > 0) {
+			lines.push(theme.fg("dim", "Expand to inspect per-turn completion timestamps."));
+		}
+		return render(lines.join("\n"));
+	}
+
+	if (details.turns.length === 0) {
+		lines.push("");
+		lines.push(theme.fg("dim", "No assistant turns were recorded for this prompt."));
+		return render(lines.join("\n"));
+	}
+
+	lines.push("");
+	lines.push(theme.fg("accent", theme.bold("Turn completions")));
+	for (const turn of details.turns) {
+		const stopReasonSuffix = turn.stopReason ? ` · ${turn.stopReason}` : "";
+		lines.push(
+			`${theme.fg("dim", `#${turn.turnIndex + 1}`)} ${turn.completedAtLabel} · ${turn.elapsedLabel} · ${pluralize(turn.toolCount, "tool")}${stopReasonSuffix}`,
+		);
+		lines.push(`  ${theme.fg("muted", turn.responsePreview)}`);
+	}
+
+	return render(lines.join("\n"));
+}
+
+function getBranchEntries(ctx: ExtensionContext): SessionEntryLike[] {
+	const entries = ctx.sessionManager?.getBranch?.();
+	return Array.isArray(entries) ? (entries as SessionEntryLike[]) : [];
+}
+
+function restoreEnabledState(entries: SessionEntryLike[]): boolean | undefined {
+	let next: boolean | undefined;
+	for (const entry of entries) {
+		if (entry.type !== "custom" || entry.customType !== DIAGNOSTICS_STATE_TYPE) {
+			continue;
+		}
+		if (isDiagnosticsStateEntry(entry.data)) {
+			next = entry.data.enabled;
+		}
+	}
+	return next;
+}
+
+function restoreLastCompletion(entries: SessionEntryLike[]): PromptCompletionDiagnostics | null {
+	let last: PromptCompletionDiagnostics | null = null;
+	for (const entry of entries) {
+		if (getMessageCustomType(entry) !== DIAGNOSTICS_MESSAGE_TYPE) {
+			continue;
+		}
+		const details = getMessageDetails(entry);
+		if (isPromptCompletionDiagnostics(details)) {
+			last = details;
+		}
+	}
+	return last;
+}
+
+export default function diagnosticsExtension(pi: ExtensionAPI): void {
+	let enabled = true;
+	let activeCtx: ExtensionContext | null = null;
+	let currentPrompt: ActivePromptRun | null = null;
+	let lastCompletion: PromptCompletionDiagnostics | null = null;
+	let requestWidgetRender: (() => void) | null = null;
+
+	const persistEnabledState = () => {
+		pi.appendEntry(DIAGNOSTICS_STATE_TYPE, {
+			enabled,
+			updatedAt: Date.now(),
+		});
+	};
+
+	const renderWidgetLines = (theme: ThemeLike): string[] => {
+		if (currentPrompt) {
+			return [
+				`${theme.fg("accent", theme.bold("⏱ Diagnostics"))} ${theme.fg("success", "running")} · ${currentPrompt.startedAtLabel} · ${formatDuration(Date.now() - currentPrompt.startedAt)} elapsed`,
+				`${theme.fg("muted", currentPrompt.promptPreview)} · ${pluralize(currentPrompt.turns.length, "turn")} recorded`,
+			];
+		}
+
+		if (lastCompletion) {
+			const classification = classifyStopReason(lastCompletion.stopReason);
+			return [
+				`${theme.fg("accent", theme.bold("⏱ Diagnostics"))} ${theme.fg(classification.color, lastCompletion.statusLabel)} · ${lastCompletion.completedAtLabel} · ${lastCompletion.durationLabel}`,
+				`${theme.fg("muted", lastCompletion.promptPreview)} · ${pluralize(lastCompletion.turnCount, "turn")} · ${pluralize(lastCompletion.toolCount, "tool")}`,
+			];
+		}
+
+		return [
+			`${theme.fg("accent", theme.bold("⏱ Diagnostics"))} ${theme.fg("muted", "on")} · waiting for next prompt`,
+			`${theme.fg("dim", `Use /${COMMAND} or ${SHORTCUT} to toggle logging.`)}`,
+		];
+	};
+
+	const clearWidget = () => {
+		activeCtx?.ui.setWidget(WIDGET_KEY, undefined);
+		requestWidgetRender = null;
+	};
+
+	const syncWidget = (ctx: ExtensionContext) => {
+		activeCtx = ctx;
+		if (!enabled) {
+			clearWidget();
+			return;
+		}
+
+		ctx.ui.setWidget(
+			WIDGET_KEY,
+			(tui, theme) => {
+				requestWidgetRender = () => tui.requestRender();
+				const timer = setInterval(() => tui.requestRender(), WIDGET_REFRESH_MS);
+				return {
+					dispose() {
+						if (requestWidgetRender) {
+							requestWidgetRender = null;
+						}
+						clearInterval(timer);
+					},
+					// biome-ignore lint/suspicious/noEmptyBlockStatements: Required by the widget component interface.
+					invalidate() {},
+					render(width: number) {
+						return renderWidgetLines(theme).map((line) => truncateToWidth(line, width));
+					},
+				};
+			},
+			{ placement: "belowEditor" },
+		);
+	};
+
+	const restoreSessionState = (ctx: ExtensionContext) => {
+		const entries = getBranchEntries(ctx);
+		const restoredEnabled = restoreEnabledState(entries);
+		if (typeof restoredEnabled === "boolean") {
+			enabled = restoredEnabled;
+		}
+		lastCompletion = restoreLastCompletion(entries);
+		currentPrompt = null;
+		syncWidget(ctx);
+		requestWidgetRender?.();
+	};
+
+	const applyToggle = (ctx: ExtensionContext, nextEnabled: boolean, source: "command" | "shortcut") => {
+		enabled = nextEnabled;
+		persistEnabledState();
+		syncWidget(ctx);
+		requestWidgetRender?.();
+		const origin = source === "shortcut" ? ` via ${SHORTCUT}` : "";
+		ctx.ui.notify(`Diagnostics ${enabled ? "enabled" : "disabled"}${origin}.`, "info");
+	};
+
+	const showStatus = (ctx: ExtensionCommandContext) => {
+		const currentStatus = enabled ? "on" : "off";
+		const currentPromptLine = currentPrompt
+			? `Running: ${currentPrompt.promptPreview} · ${formatDuration(Date.now() - currentPrompt.startedAt)} elapsed`
+			: "Running: none";
+		const lastLine = lastCompletion
+			? `Last ${lastCompletion.statusLabel}: ${lastCompletion.completedAtLabel} · ${lastCompletion.durationLabel} · ${lastCompletion.promptPreview}`
+			: "Last completion: none";
+		ctx.ui.notify(`Diagnostics ${currentStatus}. ${currentPromptLine}. ${lastLine}.`, "info");
+	};
+
+	pi.registerMessageRenderer(DIAGNOSTICS_MESSAGE_TYPE, (message, { expanded }, theme) =>
+		renderPromptCompletionMessage(message, expanded, theme),
+	);
+
+	pi.on("session_start", (_event, ctx) => {
+		restoreSessionState(ctx);
+	});
+
+	pi.on("session_switch", (_event, ctx) => {
+		restoreSessionState(ctx);
+	});
+
+	pi.on("session_tree", (_event, ctx) => {
+		restoreSessionState(ctx);
+	});
+
+	pi.on("session_fork", (_event, ctx) => {
+		restoreSessionState(ctx);
+	});
+
+	pi.on("before_agent_start", (event, ctx) => {
+		activeCtx = ctx;
+		if (!enabled) {
+			return;
+		}
+
+		currentPrompt = {
+			promptPreview: summarizePrompt(event.prompt, event.images),
+			startedAt: Date.now(),
+			startedAtLabel: formatTimestamp(Date.now()),
+			turns: [],
+		};
+		requestWidgetRender?.();
+	});
+
+	pi.on("turn_end", (event, ctx) => {
+		activeCtx = ctx;
+		if (!(enabled && currentPrompt && event.message?.role === "assistant")) {
+			return;
+		}
+
+		const completedAt = Date.now();
+		const stopReason = typeof event.message.stopReason === "string" ? event.message.stopReason : null;
+		const toolCount = countToolResults(event.toolResults);
+		const elapsedMs = Math.max(0, completedAt - currentPrompt.startedAt);
+		currentPrompt.turns.push({
+			turnIndex: typeof event.turnIndex === "number" ? event.turnIndex : currentPrompt.turns.length,
+			completedAt,
+			completedAtLabel: formatTimestamp(completedAt),
+			elapsedMs,
+			elapsedLabel: formatDuration(elapsedMs),
+			toolCount,
+			stopReason,
+			responsePreview: summarizeResponsePreview(event.message.content, toolCount, stopReason),
+		});
+		requestWidgetRender?.();
+	});
+
+	pi.on("agent_end", (event, ctx) => {
+		activeCtx = ctx;
+		if (!enabled) {
+			currentPrompt = null;
+			requestWidgetRender?.();
+			return;
+		}
+
+		const completedAt = Date.now();
+		const run = currentPrompt ?? {
+			promptPreview: findPromptPreviewFromMessages(event.messages),
+			startedAt: completedAt,
+			startedAtLabel: formatTimestamp(completedAt),
+			turns: [],
+		};
+		const completion = buildPromptCompletion(run, event.messages, completedAt);
+		lastCompletion = completion;
+		currentPrompt = null;
+		requestWidgetRender?.();
+		pi.sendMessage({
+			customType: DIAGNOSTICS_MESSAGE_TYPE,
+			content: buildPromptSummaryText(completion),
+			display: true,
+			details: completion,
+		});
+	});
+
+	pi.on("session_shutdown", () => {
+		currentPrompt = null;
+		requestWidgetRender = null;
+	});
+
+	pi.registerCommand(COMMAND, {
+		description: "Toggle prompt-completion diagnostics logging and widget output.",
+		getArgumentCompletions(prefix) {
+			const options = [
+				{ value: "status", label: "status", description: "Show the current diagnostics state" },
+				{ value: "toggle", label: "toggle", description: "Toggle diagnostics logging on or off" },
+				{ value: "on", label: "on", description: "Enable diagnostics logging and widget output" },
+				{ value: "off", label: "off", description: "Disable diagnostics logging and widget output" },
+			];
+			const filtered = options.filter((option) => option.value.startsWith(prefix.trim()));
+			return filtered.length > 0 ? filtered : null;
+		},
+		handler: async (args, ctx) => {
+			const action = (args.trim().toLowerCase() || "status") as "status" | "toggle" | "on" | "off";
+			if (action === "status") {
+				showStatus(ctx);
+				return;
+			}
+
+			if (action === "on") {
+				if (enabled) {
+					ctx.ui.notify("Diagnostics are already enabled.", "info");
+				} else {
+					applyToggle(ctx, true, "command");
+				}
+				return;
+			}
+
+			if (action === "off") {
+				if (enabled) {
+					applyToggle(ctx, false, "command");
+				} else {
+					ctx.ui.notify("Diagnostics are already disabled.", "info");
+				}
+				return;
+			}
+
+			applyToggle(ctx, !enabled, "command");
+		},
+	});
+
+	pi.registerShortcut(SHORTCUT, {
+		description: "Toggle prompt diagnostics logging and widget output",
+		handler: async (ctx) => {
+			applyToggle(ctx as ExtensionContext, !enabled, "shortcut");
+		},
+	});
+}

--- a/packages/diagnostics/index.ts
+++ b/packages/diagnostics/index.ts
@@ -555,3 +555,22 @@ export default function diagnosticsExtension(pi: ExtensionAPI): void {
 		},
 	});
 }
+
+export const diagnosticsInternals = {
+	classifyStopReason,
+	isPromptCompletionDiagnostics,
+	isDiagnosticsStateEntry,
+	getMessageDetails,
+	getMessageCustomType,
+	summarizePrompt,
+	countToolResults,
+	summarizeResponsePreview,
+	findLastAssistantMessage,
+	findPromptPreviewFromMessages,
+	buildPromptSummaryText,
+	buildPromptCompletion,
+	renderPromptCompletionMessage,
+	getBranchEntries,
+	restoreEnabledState,
+	restoreLastCompletion,
+};

--- a/packages/diagnostics/install.mjs
+++ b/packages/diagnostics/install.mjs
@@ -1,10 +1,11 @@
 #!/usr/bin/env node
 
 import { execFileSync } from "node:child_process";
+import { fileURLToPath } from "node:url";
 
-const PACKAGE_NAME = "@ifi/pi-diagnostics";
+export const PACKAGE_NAME = "@ifi/pi-diagnostics";
 
-function parseArgs(argv) {
+export function parseArgs(argv) {
 	const args = argv.slice(2);
 	let local = false;
 	let remove = false;
@@ -18,16 +19,15 @@ function parseArgs(argv) {
 		} else if (arg === "--help" || arg === "-h") {
 			help = true;
 		} else {
-			console.error(`Unknown argument: ${arg}`);
-			process.exit(1);
+			throw new Error(`Unknown argument: ${arg}`);
 		}
 	}
 
 	return { local, remove, help };
 }
 
-function printHelp() {
-	console.log(`
+export function printHelp(log = console.log) {
+	log(`
 pi-diagnostics — install the @ifi diagnostics extension into pi
 
 Usage:
@@ -45,23 +45,21 @@ Direct install:
 `.trim());
 }
 
-function findPi() {
+export function findPi(execute = execFileSync) {
 	try {
-		execFileSync("pi", ["--version"], { stdio: "ignore" });
+		execute("pi", ["--version"], { stdio: "ignore" });
 		return "pi";
 	} catch {
-		console.error("Error: 'pi' command not found. Install pi-coding-agent first:");
-		console.error("  npm install -g @mariozechner/pi-coding-agent");
-		process.exit(1);
+		return null;
 	}
 }
 
-function run(pi, command, args) {
+export function run(pi, command, args, execute = execFileSync, error = console.error) {
 	try {
-		execFileSync(pi, [command, ...args], { stdio: "pipe", timeout: 60_000 });
+		execute(pi, [command, ...args], { stdio: "pipe", timeout: 60_000 });
 		return { ok: true, status: "ok" };
-	} catch (error) {
-		const stderr = error?.stderr?.toString?.().trim?.() ?? "";
+	} catch (caughtError) {
+		const stderr = caughtError?.stderr?.toString?.().trim?.() ?? "";
 		if (stderr.includes("already installed") || stderr.includes("already exists")) {
 			return { ok: true, status: "already-installed" };
 		}
@@ -69,37 +67,65 @@ function run(pi, command, args) {
 			return { ok: true, status: "already-removed" };
 		}
 		if (stderr) {
-			console.error(stderr.split("\n")[0]);
+			error(stderr.split("\n")[0]);
 		}
 		return { ok: false, status: "error" };
 	}
 }
 
-const opts = parseArgs(process.argv);
-if (opts.help) {
-	printHelp();
-	process.exit(0);
+export function main(
+	argv = process.argv,
+	{ execute = execFileSync, log = console.log, error = console.error } = {},
+) {
+	let opts;
+	try {
+		opts = parseArgs(argv);
+	} catch (caughtError) {
+		error(caughtError instanceof Error ? caughtError.message : String(caughtError));
+		return 1;
+	}
+
+	if (opts.help) {
+		printHelp(log);
+		return 0;
+	}
+
+	const pi = findPi(execute);
+	if (!pi) {
+		error("Error: 'pi' command not found. Install pi-coding-agent first:");
+		error("  npm install -g @mariozechner/pi-coding-agent");
+		return 1;
+	}
+
+	const source = `npm:${PACKAGE_NAME}`;
+	const localFlag = opts.local ? ["-l"] : [];
+	const result = opts.remove
+		? run(pi, "remove", [source, ...localFlag], execute, error)
+		: run(pi, "install", [source, ...localFlag], execute, error);
+
+	if (!result.ok) {
+		return 1;
+	}
+
+	if (opts.remove) {
+		log(
+			result.status === "already-removed"
+				? "\n✅ @ifi/pi-diagnostics is already absent from pi."
+				: "\n✅ Removed @ifi/pi-diagnostics from pi.",
+		);
+	} else {
+		log(
+			result.status === "already-installed"
+				? "\n✅ @ifi/pi-diagnostics is already installed in pi."
+				: "\n✅ Installed @ifi/pi-diagnostics into pi. Restart pi to load it.",
+		);
+	}
+
+	return 0;
 }
 
-const pi = findPi();
-const source = `npm:${PACKAGE_NAME}`;
-const localFlag = opts.local ? ["-l"] : [];
-const result = opts.remove ? run(pi, "remove", [source, ...localFlag]) : run(pi, "install", [source, ...localFlag]);
+const isMain = process.argv[1] && fileURLToPath(import.meta.url) === process.argv[1];
 
-if (!result.ok) {
-	process.exit(1);
-}
-
-if (opts.remove) {
-	console.log(
-		result.status === "already-removed"
-			? "\n✅ @ifi/pi-diagnostics is already absent from pi."
-			: "\n✅ Removed @ifi/pi-diagnostics from pi.",
-	);
-} else {
-	console.log(
-		result.status === "already-installed"
-			? "\n✅ @ifi/pi-diagnostics is already installed in pi."
-			: "\n✅ Installed @ifi/pi-diagnostics into pi. Restart pi to load it.",
-	);
+if (isMain) {
+	process.exitCode = main();
 }

--- a/packages/diagnostics/install.mjs
+++ b/packages/diagnostics/install.mjs
@@ -1,0 +1,105 @@
+#!/usr/bin/env node
+
+import { execFileSync } from "node:child_process";
+
+const PACKAGE_NAME = "@ifi/pi-diagnostics";
+
+function parseArgs(argv) {
+	const args = argv.slice(2);
+	let local = false;
+	let remove = false;
+	let help = false;
+
+	for (const arg of args) {
+		if (arg === "--local" || arg === "-l") {
+			local = true;
+		} else if (arg === "--remove" || arg === "-r") {
+			remove = true;
+		} else if (arg === "--help" || arg === "-h") {
+			help = true;
+		} else {
+			console.error(`Unknown argument: ${arg}`);
+			process.exit(1);
+		}
+	}
+
+	return { local, remove, help };
+}
+
+function printHelp() {
+	console.log(`
+pi-diagnostics — install the @ifi diagnostics extension into pi
+
+Usage:
+  npx @ifi/pi-diagnostics            Install globally
+  npx @ifi/pi-diagnostics --local    Install into project .pi/settings.json
+  npx @ifi/pi-diagnostics --remove   Remove from pi
+
+Options:
+  -l, --local    Install project-locally instead of globally
+  -r, --remove   Remove the package from pi
+  -h, --help     Show this help
+
+Direct install:
+  pi install npm:${PACKAGE_NAME}
+`.trim());
+}
+
+function findPi() {
+	try {
+		execFileSync("pi", ["--version"], { stdio: "ignore" });
+		return "pi";
+	} catch {
+		console.error("Error: 'pi' command not found. Install pi-coding-agent first:");
+		console.error("  npm install -g @mariozechner/pi-coding-agent");
+		process.exit(1);
+	}
+}
+
+function run(pi, command, args) {
+	try {
+		execFileSync(pi, [command, ...args], { stdio: "pipe", timeout: 60_000 });
+		return { ok: true, status: "ok" };
+	} catch (error) {
+		const stderr = error?.stderr?.toString?.().trim?.() ?? "";
+		if (stderr.includes("already installed") || stderr.includes("already exists")) {
+			return { ok: true, status: "already-installed" };
+		}
+		if (stderr.includes("not installed") || stderr.includes("not found") || stderr.includes("No such")) {
+			return { ok: true, status: "already-removed" };
+		}
+		if (stderr) {
+			console.error(stderr.split("\n")[0]);
+		}
+		return { ok: false, status: "error" };
+	}
+}
+
+const opts = parseArgs(process.argv);
+if (opts.help) {
+	printHelp();
+	process.exit(0);
+}
+
+const pi = findPi();
+const source = `npm:${PACKAGE_NAME}`;
+const localFlag = opts.local ? ["-l"] : [];
+const result = opts.remove ? run(pi, "remove", [source, ...localFlag]) : run(pi, "install", [source, ...localFlag]);
+
+if (!result.ok) {
+	process.exit(1);
+}
+
+if (opts.remove) {
+	console.log(
+		result.status === "already-removed"
+			? "\n✅ @ifi/pi-diagnostics is already absent from pi."
+			: "\n✅ Removed @ifi/pi-diagnostics from pi.",
+	);
+} else {
+	console.log(
+		result.status === "already-installed"
+			? "\n✅ @ifi/pi-diagnostics is already installed in pi."
+			: "\n✅ Installed @ifi/pi-diagnostics into pi. Restart pi to load it.",
+	);
+}

--- a/packages/diagnostics/package.json
+++ b/packages/diagnostics/package.json
@@ -1,0 +1,52 @@
+{
+  "name": "@ifi/pi-diagnostics",
+  "version": "0.4.4",
+  "description": "Prompt-completion diagnostics extension for pi with timestamps, durations, per-turn timing, and a live widget.",
+  "type": "module",
+  "keywords": [
+    "pi-package",
+    "pi",
+    "pi-coding-agent",
+    "diagnostics",
+    "timing",
+    "timestamps",
+    "observability"
+  ],
+  "bin": {
+    "pi-diagnostics": "install.mjs"
+  },
+  "pi": {
+    "extensions": [
+      "./index.ts"
+    ]
+  },
+  "files": [
+    "*.ts",
+    "*.mjs",
+    "README.md",
+    "!**/*.test.ts",
+    "!tests/**"
+  ],
+  "license": "MIT",
+  "repository": {
+    "type": "git",
+    "url": "git+https://github.com/ifiokjr/oh-pi.git",
+    "directory": "packages/diagnostics"
+  },
+  "homepage": "https://github.com/ifiokjr/oh-pi/tree/main/packages/diagnostics",
+  "bugs": {
+    "url": "https://github.com/ifiokjr/oh-pi/issues"
+  },
+  "scripts": {
+    "build": "pnpm run typecheck && pnpm run test:worktree",
+    "typecheck": "tsgo --project ./tsconfig.json --noEmit",
+    "test:worktree": "vitest run --config ./vitest.worktree.config.ts"
+  },
+  "peerDependencies": {
+    "@mariozechner/pi-agent-core": ">=0.56.1",
+    "@mariozechner/pi-ai": ">=0.56.1",
+    "@mariozechner/pi-coding-agent": ">=0.56.1",
+    "@mariozechner/pi-tui": ">=0.56.1",
+    "@sinclair/typebox": "*"
+  }
+}

--- a/packages/diagnostics/tests/diagnostics-shared.test.ts
+++ b/packages/diagnostics/tests/diagnostics-shared.test.ts
@@ -1,0 +1,52 @@
+import { describe, expect, it } from "vitest";
+import {
+	extractTextContent,
+	formatDuration,
+	formatTimestamp,
+	summarizeContent,
+	summarizeText,
+} from "../diagnostics-shared.js";
+
+describe("diagnostics shared helpers", () => {
+	it("formats timestamps in local datetime form", () => {
+		expect(formatTimestamp(Date.UTC(2026, 3, 16, 11, 2, 3))).toMatch(/2026-04-16 \d{2}:02:03/);
+	});
+
+	it("formats durations across milliseconds, seconds, minutes, and hours", () => {
+		expect(formatDuration(250)).toBe("250ms");
+		expect(formatDuration(1_250)).toBe("1.3s");
+		expect(formatDuration(12_000)).toBe("12s");
+		expect(formatDuration(90_000)).toBe("1m30s");
+		expect(formatDuration(3_600_000)).toBe("1h");
+		expect(formatDuration(7_500_000)).toBe("2h5m");
+	});
+
+	it("extracts text content from strings and mixed content arrays", () => {
+		expect(extractTextContent("plain text")).toBe("plain text");
+		expect(extractTextContent(null)).toBe("");
+		expect(
+			extractTextContent([
+				{ type: "text", text: "hello" },
+				{ type: "image", url: "file://image.png" },
+				{ type: "text", text: "world" },
+				{ type: "text", text: 42 },
+			]),
+		).toBe("hello world");
+	});
+
+	it("summarizes text by trimming, normalizing whitespace, and truncating", () => {
+		expect(summarizeText("   hello\n\nworld   ")).toBe("hello world");
+		expect(summarizeText("   \n\t  ")).toBe("");
+		expect(summarizeText("abcdef", 5)).toBe("abcd…");
+	});
+
+	it("summarizes structured content via text extraction", () => {
+		expect(
+			summarizeContent([
+				{ type: "text", text: "First line" },
+				{ type: "text", text: "Second line" },
+			], 20),
+		).toBe("First line Second l…");
+		expect(summarizeContent([{ type: "image", url: "file://image.png" }])).toBe("");
+	});
+});

--- a/packages/diagnostics/tests/diagnostics.test.ts
+++ b/packages/diagnostics/tests/diagnostics.test.ts
@@ -1,0 +1,125 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import { createExtensionHarness } from "../../../test-utils/extension-runtime-harness.js";
+import diagnosticsExtension, { type PromptCompletionDiagnostics } from "../index.js";
+
+describe("diagnostics extension", () => {
+	beforeEach(() => {
+		vi.useFakeTimers();
+		vi.setSystemTime(new Date("2026-04-16T11:00:00Z"));
+	});
+
+	afterEach(() => {
+		vi.useRealTimers();
+	});
+
+	it("registers the diagnostics command, shortcut, and message renderer", () => {
+		const harness = createExtensionHarness();
+		diagnosticsExtension(harness.pi as never);
+
+		expect(harness.commands.has("diagnostics")).toBe(true);
+		expect(harness.shortcuts.has("ctrl+shift+d")).toBe(true);
+		expect(harness.messageRenderers.has("pi-diagnostics:prompt")).toBe(true);
+	});
+
+	it("logs prompt completion timing with per-turn timestamps", async () => {
+		const harness = createExtensionHarness();
+		harness.ctx.ui.setWidget = vi.fn();
+		diagnosticsExtension(harness.pi as never);
+
+		harness.emit("session_start", { type: "session_start" }, harness.ctx);
+		harness.emit(
+			"before_agent_start",
+			{ type: "before_agent_start", prompt: "Investigate the flaky test timeout in CI.", images: [] },
+			harness.ctx,
+		);
+		await vi.advanceTimersByTimeAsync(1250);
+
+		harness.emit(
+			"turn_end",
+			{
+				type: "turn_end",
+				turnIndex: 0,
+				message: {
+					role: "assistant",
+					stopReason: "toolUse",
+					content: [{ type: "text", text: "I’m checking the failing tests and CI logs now." }],
+				},
+				toolResults: [{ toolName: "read" }],
+			},
+			harness.ctx,
+		);
+		await vi.advanceTimersByTimeAsync(5000);
+
+		harness.emit(
+			"turn_end",
+			{
+				type: "turn_end",
+				turnIndex: 1,
+				message: {
+					role: "assistant",
+					stopReason: "stop",
+					content: [{ type: "text", text: "Done. The timeout came from an unmocked fetch call." }],
+				},
+				toolResults: [],
+			},
+			harness.ctx,
+		);
+		await vi.advanceTimersByTimeAsync(1000);
+
+		harness.emit(
+			"agent_end",
+			{
+				type: "agent_end",
+				messages: [
+					{ role: "user", content: [{ type: "text", text: "Investigate the flaky test timeout in CI." }] },
+					{ role: "assistant", stopReason: "stop", content: [{ type: "text", text: "Done." }] },
+				],
+			},
+			harness.ctx,
+		);
+
+		expect(harness.messages).toHaveLength(1);
+		const message = harness.messages[0] as {
+			customType: string;
+			details: PromptCompletionDiagnostics;
+			content: string;
+		};
+		expect(message.customType).toBe("pi-diagnostics:prompt");
+		expect(message.content).toContain("Prompt completed");
+		expect(message.content).toContain("duration 7.3s");
+		expect(message.details.promptPreview).toContain("Investigate the flaky test timeout");
+		expect(message.details.durationMs).toBe(7250);
+		expect(message.details.turnCount).toBe(2);
+		expect(message.details.toolCount).toBe(1);
+		expect(message.details.turns[0]?.completedAtLabel).toMatch(/2026-04-16 \d{2}:00:01/);
+		expect(message.details.turns[0]?.toolCount).toBe(1);
+		expect(message.details.turns[1]?.responsePreview).toContain("Done.");
+	});
+
+	it("stops logging after diagnostics is turned off", async () => {
+		const harness = createExtensionHarness();
+		harness.ctx.ui.setWidget = vi.fn();
+		diagnosticsExtension(harness.pi as never);
+		harness.emit("session_start", { type: "session_start" }, harness.ctx);
+
+		await harness.commands.get("diagnostics")?.handler("off", harness.ctx);
+		expect(harness.notifications.at(-1)?.msg).toContain("Diagnostics disabled");
+
+		harness.emit(
+			"before_agent_start",
+			{ type: "before_agent_start", prompt: "Summarize the release plan.", images: [] },
+			harness.ctx,
+		);
+		await vi.advanceTimersByTimeAsync(1200);
+		harness.emit(
+			"agent_end",
+			{
+				type: "agent_end",
+				messages: [{ role: "assistant", stopReason: "stop", content: [{ type: "text", text: "Done." }] }],
+			},
+			harness.ctx,
+		);
+
+		expect(harness.messages).toHaveLength(0);
+	});
+});

--- a/packages/diagnostics/tests/diagnostics.test.ts
+++ b/packages/diagnostics/tests/diagnostics.test.ts
@@ -1,6 +1,52 @@
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 import { createExtensionHarness } from "../../../test-utils/extension-runtime-harness.js";
-import diagnosticsExtension, { type PromptCompletionDiagnostics } from "../index.js";
+import diagnosticsExtension, { diagnosticsInternals, type PromptCompletionDiagnostics } from "../index.js";
+
+const theme = {
+	bg: (_color: string, text: string) => text,
+	fg: (_color: string, text: string) => text,
+	bold: (text: string) => text,
+} as const;
+
+function makeCompletion(overrides: Partial<PromptCompletionDiagnostics> = {}): PromptCompletionDiagnostics {
+	return {
+		promptPreview: "Investigate the flaky test timeout in CI.",
+		startedAt: Date.UTC(2026, 3, 16, 11, 0, 0),
+		startedAtLabel: "2026-04-16 11:00:00",
+		completedAt: Date.UTC(2026, 3, 16, 11, 0, 7),
+		completedAtLabel: "2026-04-16 11:00:07",
+		durationMs: 7_250,
+		durationLabel: "7.3s",
+		turnCount: 2,
+		toolCount: 1,
+		status: "completed",
+		statusLabel: "completed",
+		stopReason: "stop",
+		turns: [
+			{
+				turnIndex: 0,
+				completedAt: Date.UTC(2026, 3, 16, 11, 0, 1),
+				completedAtLabel: "2026-04-16 11:00:01",
+				elapsedMs: 1_250,
+				elapsedLabel: "1.3s",
+				toolCount: 1,
+				stopReason: "toolUse",
+				responsePreview: "Checking the failing tests.",
+			},
+			{
+				turnIndex: 1,
+				completedAt: Date.UTC(2026, 3, 16, 11, 0, 7),
+				completedAtLabel: "2026-04-16 11:00:07",
+				elapsedMs: 7_250,
+				elapsedLabel: "7.3s",
+				toolCount: 0,
+				stopReason: "stop",
+				responsePreview: "Done.",
+			},
+		],
+		...overrides,
+	};
+}
 
 describe("diagnostics extension", () => {
 	beforeEach(() => {
@@ -12,6 +58,157 @@ describe("diagnostics extension", () => {
 		vi.useRealTimers();
 	});
 
+	describe("internals", () => {
+		it("classifies stop reasons and prompt state entries", () => {
+			expect(diagnosticsInternals.classifyStopReason("aborted")).toMatchObject({ status: "aborted", color: "warning" });
+			expect(diagnosticsInternals.classifyStopReason("error")).toMatchObject({ status: "error", color: "error" });
+			expect(diagnosticsInternals.classifyStopReason("length")).toMatchObject({ status: "completed", color: "success" });
+			expect(diagnosticsInternals.classifyStopReason("toolUse")).toMatchObject({ status: "unknown", color: "muted" });
+			expect(diagnosticsInternals.isPromptCompletionDiagnostics(makeCompletion())).toBe(true);
+			expect(diagnosticsInternals.isPromptCompletionDiagnostics({ completedAt: "later" })).toBe(false);
+			expect(diagnosticsInternals.isDiagnosticsStateEntry({ enabled: true })).toBe(true);
+			expect(diagnosticsInternals.isDiagnosticsStateEntry({ enabled: "yes" })).toBe(false);
+		});
+
+		it("extracts message details and custom types from both session entry shapes", () => {
+			const customMessageEntry = {
+				type: "custom_message",
+				customType: "pi-diagnostics:prompt",
+				details: makeCompletion(),
+			};
+			const legacyMessageEntry = {
+				type: "message",
+				message: {
+					role: "custom",
+					customType: "pi-diagnostics:prompt",
+					details: makeCompletion({ promptPreview: "Restored from legacy entry" }),
+				},
+			};
+
+			expect(diagnosticsInternals.getMessageCustomType(customMessageEntry)).toBe("pi-diagnostics:prompt");
+			expect(diagnosticsInternals.getMessageDetails(customMessageEntry)).toMatchObject(makeCompletion());
+			expect(diagnosticsInternals.getMessageCustomType(legacyMessageEntry)).toBe("pi-diagnostics:prompt");
+			expect(diagnosticsInternals.getMessageDetails(legacyMessageEntry)).toMatchObject({
+				promptPreview: "Restored from legacy entry",
+			});
+			expect(diagnosticsInternals.getMessageCustomType({ type: "message" })).toBeUndefined();
+			expect(diagnosticsInternals.getMessageDetails({ type: "message" })).toBeUndefined();
+		});
+
+		it("summarizes prompts, responses, and messages", () => {
+			expect(diagnosticsInternals.summarizePrompt("  Ship it.  ", [])).toBe("Ship it.");
+			expect(diagnosticsInternals.summarizePrompt(undefined, ["img"])).toBe("1 image prompt");
+			expect(diagnosticsInternals.summarizePrompt(undefined, ["img1", "img2"])).toBe("2 image prompt");
+			expect(diagnosticsInternals.summarizePrompt(undefined, undefined)).toBe("(empty prompt)");
+
+			expect(diagnosticsInternals.countToolResults([{}, {}])).toBe(2);
+			expect(diagnosticsInternals.countToolResults(undefined)).toBe(0);
+
+			expect(
+				diagnosticsInternals.summarizeResponsePreview([{ type: "text", text: "Visible response" }], 0, null),
+			).toBe("Visible response");
+			expect(diagnosticsInternals.summarizeResponsePreview([], 2, null)).toBe("Used 2 tools");
+			expect(diagnosticsInternals.summarizeResponsePreview([], 0, "aborted")).toBe("stop reason: aborted");
+			expect(diagnosticsInternals.summarizeResponsePreview([], 0, null)).toBe("(no visible response text)");
+
+			expect(
+				diagnosticsInternals.findLastAssistantMessage([
+					{ role: "user", content: "Hi" },
+					{ role: "assistant", stopReason: "stop", content: "Done" },
+				]),
+			).toMatchObject({ role: "assistant", stopReason: "stop" });
+			expect(diagnosticsInternals.findLastAssistantMessage([{ role: "user", content: "Hi" }])).toBeNull();
+			expect(diagnosticsInternals.findLastAssistantMessage(undefined)).toBeNull();
+
+			expect(
+				diagnosticsInternals.findPromptPreviewFromMessages([
+					{ role: "assistant", content: "ignore" },
+					{ role: "user", content: [{ type: "text", text: "User prompt" }] },
+				]),
+			).toBe("User prompt");
+			expect(diagnosticsInternals.findPromptPreviewFromMessages([{ role: "assistant", content: "ignore" }])).toBe("(empty prompt)");
+			expect(diagnosticsInternals.findPromptPreviewFromMessages(undefined)).toBe("(empty prompt)");
+		});
+
+		it("builds summaries, completions, and restored session state", () => {
+			const run = {
+				promptPreview: "Investigate the flaky test timeout in CI.",
+				startedAt: Date.UTC(2026, 3, 16, 11, 0, 0),
+				startedAtLabel: "2026-04-16 11:00:00",
+				turns: makeCompletion().turns,
+			};
+			const completion = diagnosticsInternals.buildPromptCompletion(
+				run,
+				[
+					{ role: "user", content: [{ type: "text", text: "Investigate the flaky test timeout in CI." }] },
+					{ role: "assistant", stopReason: "error", content: [{ type: "text", text: "Failed." }] },
+				],
+				Date.UTC(2026, 3, 16, 11, 0, 7),
+			);
+			const fallbackCompletion = diagnosticsInternals.buildPromptCompletion(run, undefined, Date.UTC(2026, 3, 16, 11, 0, 8));
+
+			expect(completion).toMatchObject({
+				status: "error",
+				statusLabel: "errored",
+				toolCount: 1,
+				turnCount: 2,
+				stopReason: "error",
+			});
+			expect(diagnosticsInternals.buildPromptSummaryText(completion)).toContain("Prompt errored");
+			expect(fallbackCompletion.stopReason).toBeNull();
+			expect(diagnosticsInternals.getBranchEntries({ sessionManager: { getBranch: () => "invalid" } } as never)).toEqual([]);
+			expect(
+				diagnosticsInternals.restoreEnabledState([
+					{ type: "custom", customType: "pi-diagnostics:state", data: { enabled: false } },
+					{ type: "custom", customType: "pi-diagnostics:state", data: { enabled: true } },
+				]),
+			).toBe(true);
+			expect(diagnosticsInternals.restoreEnabledState([{ type: "message", customType: "other" }])).toBeUndefined();
+			expect(
+				diagnosticsInternals.restoreLastCompletion([
+					{ type: "custom_message", customType: "pi-diagnostics:prompt", details: makeCompletion() },
+					{
+						type: "message",
+						message: {
+							role: "custom",
+							customType: "pi-diagnostics:prompt",
+							details: makeCompletion({ promptPreview: "Most recent completion" }),
+						},
+					},
+				]),
+			).toMatchObject({ promptPreview: "Most recent completion" });
+			expect(diagnosticsInternals.restoreLastCompletion([])).toBeNull();
+		});
+
+		it("renders fallback, collapsed, and expanded completion messages", () => {
+			const fallback = diagnosticsInternals.renderPromptCompletionMessage({ content: "Prompt diagnostics" }, false, theme as never);
+			expect(fallback.text).toContain("Prompt diagnostics");
+
+			const collapsed = diagnosticsInternals.renderPromptCompletionMessage(
+				{ details: makeCompletion() },
+				false,
+				theme as never,
+			);
+			expect(collapsed.text).toContain("Expand to inspect per-turn completion timestamps.");
+
+			const expandedWithNoTurns = diagnosticsInternals.renderPromptCompletionMessage(
+				{ details: makeCompletion({ turnCount: 0, toolCount: 0, turns: [] }) },
+				true,
+				theme as never,
+			);
+			expect(expandedWithNoTurns.text).toContain("No assistant turns were recorded for this prompt.");
+
+			const expanded = diagnosticsInternals.renderPromptCompletionMessage(
+				{ details: makeCompletion() },
+				true,
+				theme as never,
+			);
+			expect(expanded.text).toContain("Turn completions");
+			expect(expanded.text).toContain("#1");
+			expect(expanded.text).toContain("toolUse");
+		});
+	});
+
 	it("registers the diagnostics command, shortcut, and message renderer", () => {
 		const harness = createExtensionHarness();
 		diagnosticsExtension(harness.pi as never);
@@ -19,21 +216,44 @@ describe("diagnostics extension", () => {
 		expect(harness.commands.has("diagnostics")).toBe(true);
 		expect(harness.shortcuts.has("ctrl+shift+d")).toBe(true);
 		expect(harness.messageRenderers.has("pi-diagnostics:prompt")).toBe(true);
+		const rendered = harness.messageRenderers
+			.get("pi-diagnostics:prompt")
+			?.({ details: makeCompletion() }, { expanded: false }, theme);
+		expect(rendered?.text).toContain("Prompt");
 	});
 
-	it("logs prompt completion timing with per-turn timestamps", async () => {
+	it("logs prompt completion timing with per-turn timestamps and updates the widget", async () => {
 		const harness = createExtensionHarness();
-		harness.ctx.ui.setWidget = vi.fn();
+		const setWidget = vi.fn();
+		const appendEntry = vi.fn();
+		harness.ctx.ui.setWidget = setWidget;
+		harness.pi.appendEntry = appendEntry;
 		diagnosticsExtension(harness.pi as never);
 
 		harness.emit("session_start", { type: "session_start" }, harness.ctx);
+		const widgetFactory = setWidget.mock.calls.at(-1)?.[1] as
+			| ((
+					tui: { requestRender: () => void },
+					theme: typeof theme,
+			  ) => { dispose: () => void; render: (width: number) => string[] })
+			| undefined;
+		expect(widgetFactory).toBeTypeOf("function");
+
+		const requestRender = vi.fn();
+		const widget = widgetFactory?.({ requestRender }, theme);
+		expect(widget?.render(200).join("\n")).toContain("waiting for next prompt");
+
 		harness.emit(
 			"before_agent_start",
 			{ type: "before_agent_start", prompt: "Investigate the flaky test timeout in CI.", images: [] },
 			harness.ctx,
 		);
-		await vi.advanceTimersByTimeAsync(1250);
+		expect(widget?.render(200).join("\n")).toContain("running");
 
+		await vi.advanceTimersByTimeAsync(1_000);
+		expect(requestRender).toHaveBeenCalled();
+
+		await vi.advanceTimersByTimeAsync(250);
 		harness.emit(
 			"turn_end",
 			{
@@ -48,7 +268,7 @@ describe("diagnostics extension", () => {
 			},
 			harness.ctx,
 		);
-		await vi.advanceTimersByTimeAsync(5000);
+		await vi.advanceTimersByTimeAsync(5_000);
 
 		harness.emit(
 			"turn_end",
@@ -64,7 +284,7 @@ describe("diagnostics extension", () => {
 			},
 			harness.ctx,
 		);
-		await vi.advanceTimersByTimeAsync(1000);
+		await vi.advanceTimersByTimeAsync(1_000);
 
 		harness.emit(
 			"agent_end",
@@ -88,29 +308,131 @@ describe("diagnostics extension", () => {
 		expect(message.content).toContain("Prompt completed");
 		expect(message.content).toContain("duration 7.3s");
 		expect(message.details.promptPreview).toContain("Investigate the flaky test timeout");
-		expect(message.details.durationMs).toBe(7250);
+		expect(message.details.durationMs).toBe(7_250);
 		expect(message.details.turnCount).toBe(2);
 		expect(message.details.toolCount).toBe(1);
 		expect(message.details.turns[0]?.completedAtLabel).toMatch(/2026-04-16 \d{2}:00:01/);
 		expect(message.details.turns[0]?.toolCount).toBe(1);
 		expect(message.details.turns[1]?.responsePreview).toContain("Done.");
+		expect(widget?.render(200).join("\n")).toContain("completed");
+
+		widget?.dispose();
+		expect(appendEntry).not.toHaveBeenCalled();
 	});
 
-	it("stops logging after diagnostics is turned off", async () => {
+	it("restores session state, handles command flows, and clears the widget when disabled", async () => {
+		const harness = createExtensionHarness();
+		const setWidget = vi.fn();
+		harness.ctx.ui.setWidget = setWidget;
+		harness.ctx.sessionManager.getBranch = () => [
+			{ type: "custom", customType: "pi-diagnostics:state", data: { enabled: true } },
+			{ type: "custom_message", customType: "pi-diagnostics:prompt", details: makeCompletion() },
+		];
+		harness.pi.appendEntry = vi.fn();
+		diagnosticsExtension(harness.pi as never);
+
+		harness.emit("session_start", { type: "session_start" }, harness.ctx);
+		harness.emit("session_switch", { type: "session_switch" }, harness.ctx);
+		harness.emit("session_tree", { type: "session_tree" }, harness.ctx);
+		harness.emit("session_fork", { type: "session_fork" }, harness.ctx);
+
+		const command = harness.commands.get("diagnostics");
+		expect(command.getArgumentCompletions("o")).toEqual(
+			expect.arrayContaining([
+				expect.objectContaining({ value: "on" }),
+				expect.objectContaining({ value: "off" }),
+			]),
+		);
+		expect(command.getArgumentCompletions("zzz")).toBeNull();
+
+		await command.handler("status", harness.ctx);
+		expect(harness.notifications.at(-1)?.msg).toContain("Last completed");
+
+		const freshHarness = createExtensionHarness();
+		freshHarness.ctx.ui.setWidget = vi.fn();
+		diagnosticsExtension(freshHarness.pi as never);
+		freshHarness.emit("session_start", { type: "session_start" }, freshHarness.ctx);
+		await freshHarness.commands.get("diagnostics")?.handler("status", freshHarness.ctx);
+		expect(freshHarness.notifications.at(-1)?.msg).toContain("Running: none");
+		expect(freshHarness.notifications.at(-1)?.msg).toContain("Last completion: none");
+
+		await command.handler("off", harness.ctx);
+		expect(harness.notifications.at(-1)?.msg).toContain("Diagnostics disabled");
+		expect(setWidget).toHaveBeenLastCalledWith("diagnostics", undefined);
+		harness.emit(
+			"before_agent_start",
+			{ type: "before_agent_start", prompt: "Should not start while disabled", images: [] },
+			harness.ctx,
+		);
+
+		await command.handler("off", harness.ctx);
+		expect(harness.notifications.at(-1)?.msg).toContain("already disabled");
+
+		await command.handler("on", harness.ctx);
+		expect(harness.notifications.at(-1)?.msg).toContain("Diagnostics enabled");
+
+		await command.handler("on", harness.ctx);
+		expect(harness.notifications.at(-1)?.msg).toContain("already enabled");
+
+		await command.handler("toggle", harness.ctx);
+		expect(harness.notifications.at(-1)?.msg).toContain("Diagnostics disabled");
+
+		await harness.shortcuts.get("ctrl+shift+d")?.handler(harness.ctx);
+		expect(harness.notifications.at(-1)?.msg).toContain("via ctrl+shift+d");
+		expect(harness.pi.appendEntry).toHaveBeenCalled();
+	});
+
+	it("builds a fallback completion when agent_end arrives without an active prompt", () => {
 		const harness = createExtensionHarness();
 		harness.ctx.ui.setWidget = vi.fn();
 		diagnosticsExtension(harness.pi as never);
 		harness.emit("session_start", { type: "session_start" }, harness.ctx);
 
-		await harness.commands.get("diagnostics")?.handler("off", harness.ctx);
-		expect(harness.notifications.at(-1)?.msg).toContain("Diagnostics disabled");
+		harness.emit(
+			"agent_end",
+			{
+				type: "agent_end",
+				messages: [
+					{ role: "user", content: [{ type: "text", text: "Summarize the release plan." }] },
+					{ role: "assistant", stopReason: "aborted", content: [] },
+				],
+			},
+			harness.ctx,
+		);
+
+		expect((harness.messages[0] as { details: PromptCompletionDiagnostics }).details).toMatchObject({
+			promptPreview: "Summarize the release plan.",
+			status: "aborted",
+			turnCount: 0,
+		});
+	});
+
+	it("ignores non-assistant turns and stops logging after diagnostics is turned off", async () => {
+		const harness = createExtensionHarness();
+		harness.ctx.ui.setWidget = vi.fn();
+		diagnosticsExtension(harness.pi as never);
+		harness.emit("session_start", { type: "session_start" }, harness.ctx);
 
 		harness.emit(
 			"before_agent_start",
-			{ type: "before_agent_start", prompt: "Summarize the release plan.", images: [] },
+			{ type: "before_agent_start", prompt: undefined, images: ["img"] },
 			harness.ctx,
 		);
-		await vi.advanceTimersByTimeAsync(1200);
+		await harness.commands.get("diagnostics")?.handler("status", harness.ctx);
+		expect(harness.notifications.at(-1)?.msg).toContain("Running: 1 image prompt");
+		harness.emit(
+			"turn_end",
+			{
+				type: "turn_end",
+				message: { role: "user", content: [{ type: "text", text: "Not an assistant turn." }] },
+				toolResults: [],
+			},
+			harness.ctx,
+		);
+
+		await harness.commands.get("diagnostics")?.handler("off", harness.ctx);
+		expect(harness.notifications.at(-1)?.msg).toContain("Diagnostics disabled");
+
 		harness.emit(
 			"agent_end",
 			{
@@ -119,6 +441,7 @@ describe("diagnostics extension", () => {
 			},
 			harness.ctx,
 		);
+		harness.emit("session_shutdown", { type: "session_shutdown" }, harness.ctx);
 
 		expect(harness.messages).toHaveLength(0);
 	});

--- a/packages/diagnostics/tests/diagnostics.test.ts
+++ b/packages/diagnostics/tests/diagnostics.test.ts
@@ -2,11 +2,21 @@ import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 import { createExtensionHarness } from "../../../test-utils/extension-runtime-harness.js";
 import diagnosticsExtension, { diagnosticsInternals, type PromptCompletionDiagnostics } from "../index.js";
 
-const theme = {
+type ThemeStub = {
+	bg: (_color: string, text: string) => string;
+	fg: (_color: string, text: string) => string;
+	bold: (text: string) => string;
+};
+
+const theme: ThemeStub = {
 	bg: (_color: string, text: string) => text,
 	fg: (_color: string, text: string) => text,
 	bold: (text: string) => text,
-} as const;
+};
+
+function renderText(component: { render: (width: number) => string[] }, width = 200): string {
+	return component.render(width).join("\n");
+}
 
 function makeCompletion(overrides: Partial<PromptCompletionDiagnostics> = {}): PromptCompletionDiagnostics {
 	return {
@@ -182,30 +192,31 @@ describe("diagnostics extension", () => {
 
 		it("renders fallback, collapsed, and expanded completion messages", () => {
 			const fallback = diagnosticsInternals.renderPromptCompletionMessage({ content: "Prompt diagnostics" }, false, theme as never);
-			expect(fallback.text).toContain("Prompt diagnostics");
+			expect(renderText(fallback)).toContain("Prompt diagnostics");
 
 			const collapsed = diagnosticsInternals.renderPromptCompletionMessage(
 				{ details: makeCompletion() },
 				false,
 				theme as never,
 			);
-			expect(collapsed.text).toContain("Expand to inspect per-turn completion timestamps.");
+			expect(renderText(collapsed)).toContain("Expand to inspect per-turn completion timestamps.");
 
 			const expandedWithNoTurns = diagnosticsInternals.renderPromptCompletionMessage(
 				{ details: makeCompletion({ turnCount: 0, toolCount: 0, turns: [] }) },
 				true,
 				theme as never,
 			);
-			expect(expandedWithNoTurns.text).toContain("No assistant turns were recorded for this prompt.");
+			expect(renderText(expandedWithNoTurns)).toContain("No assistant turns were recorded for this prompt.");
 
 			const expanded = diagnosticsInternals.renderPromptCompletionMessage(
 				{ details: makeCompletion() },
 				true,
 				theme as never,
 			);
-			expect(expanded.text).toContain("Turn completions");
-			expect(expanded.text).toContain("#1");
-			expect(expanded.text).toContain("toolUse");
+			const rendered = renderText(expanded);
+			expect(rendered).toContain("Turn completions");
+			expect(rendered).toContain("#1");
+			expect(rendered).toContain("toolUse");
 		});
 	});
 
@@ -219,7 +230,7 @@ describe("diagnostics extension", () => {
 		const rendered = harness.messageRenderers
 			.get("pi-diagnostics:prompt")
 			?.({ details: makeCompletion() }, { expanded: false }, theme);
-		expect(rendered?.text).toContain("Prompt");
+		expect(rendered ? renderText(rendered) : "").toContain("Prompt");
 	});
 
 	it("logs prompt completion timing with per-turn timestamps and updates the widget", async () => {
@@ -234,7 +245,7 @@ describe("diagnostics extension", () => {
 		const widgetFactory = setWidget.mock.calls.at(-1)?.[1] as
 			| ((
 					tui: { requestRender: () => void },
-					theme: typeof theme,
+					theme: ThemeStub,
 			  ) => { dispose: () => void; render: (width: number) => string[] })
 			| undefined;
 		expect(widgetFactory).toBeTypeOf("function");
@@ -324,10 +335,11 @@ describe("diagnostics extension", () => {
 		const harness = createExtensionHarness();
 		const setWidget = vi.fn();
 		harness.ctx.ui.setWidget = setWidget;
-		harness.ctx.sessionManager.getBranch = () => [
-			{ type: "custom", customType: "pi-diagnostics:state", data: { enabled: true } },
-			{ type: "custom_message", customType: "pi-diagnostics:prompt", details: makeCompletion() },
-		];
+		harness.ctx.sessionManager.getBranch = () =>
+			([
+				{ type: "custom", customType: "pi-diagnostics:state", data: { enabled: true } },
+				{ type: "custom_message", customType: "pi-diagnostics:prompt", details: makeCompletion() },
+			] as any);
 		harness.pi.appendEntry = vi.fn();
 		diagnosticsExtension(harness.pi as never);
 

--- a/packages/diagnostics/tests/install.test.ts
+++ b/packages/diagnostics/tests/install.test.ts
@@ -1,5 +1,6 @@
 import { fileURLToPath } from "node:url";
 import { describe, expect, it, vi } from "vitest";
+// @ts-ignore missing declaration file for runtime installer script
 import { PACKAGE_NAME, findPi, main, parseArgs, printHelp, run } from "../install.mjs";
 
 describe("diagnostics installer", () => {
@@ -131,6 +132,7 @@ describe("diagnostics installer", () => {
 
 		process.argv = ["node", scriptPath, "--help"];
 		process.exitCode = undefined;
+		// @ts-ignore missing declaration file for runtime installer script
 		await import("../install.mjs");
 
 		expect(process.exitCode).toBe(0);

--- a/packages/diagnostics/tests/install.test.ts
+++ b/packages/diagnostics/tests/install.test.ts
@@ -1,0 +1,144 @@
+import { fileURLToPath } from "node:url";
+import { describe, expect, it, vi } from "vitest";
+import { PACKAGE_NAME, findPi, main, parseArgs, printHelp, run } from "../install.mjs";
+
+describe("diagnostics installer", () => {
+	it("parses supported flags and rejects unknown ones", () => {
+		expect(parseArgs(["node", "install.mjs"])).toEqual({ help: false, local: false, remove: false });
+		expect(parseArgs(["node", "install.mjs", "--local", "--remove", "-h"])).toEqual({
+			help: true,
+			local: true,
+			remove: true,
+		});
+		expect(() => parseArgs(["node", "install.mjs", "--wat"])).toThrow("Unknown argument: --wat");
+	});
+
+	it("prints help text with the package source", () => {
+		const log = vi.fn();
+		printHelp(log);
+		expect(log).toHaveBeenCalledWith(expect.stringContaining(`pi install npm:${PACKAGE_NAME}`));
+	});
+
+	it("detects whether the pi binary is available", () => {
+		expect(findPi(vi.fn())).toBe("pi");
+		expect(findPi(vi.fn(() => {
+			throw new Error("missing");
+		}))).toBeNull();
+	});
+
+	it("normalizes install and removal command outcomes", () => {
+		const error = vi.fn();
+		expect(run("pi", "install", ["npm:@ifi/pi-diagnostics"], vi.fn(), error)).toEqual({ ok: true, status: "ok" });
+		expect(
+			run(
+				"pi",
+				"install",
+				["npm:@ifi/pi-diagnostics"],
+				vi.fn(() => {
+					throw { stderr: Buffer.from("already installed") };
+				}),
+				error,
+			),
+		).toEqual({ ok: true, status: "already-installed" });
+		expect(
+			run(
+				"pi",
+				"remove",
+				["npm:@ifi/pi-diagnostics"],
+				vi.fn(() => {
+					throw { stderr: Buffer.from("not installed") };
+				}),
+				error,
+			),
+		).toEqual({ ok: true, status: "already-removed" });
+		expect(
+			run(
+				"pi",
+				"install",
+				["npm:@ifi/pi-diagnostics"],
+				vi.fn(() => {
+					throw { stderr: Buffer.from("fatal problem\nsecond line") };
+				}),
+				error,
+			),
+		).toEqual({ ok: false, status: "error" });
+		expect(error).toHaveBeenLastCalledWith("fatal problem");
+	});
+
+	it("returns exit codes and messages for help, missing pi, installs, removals, and failures", () => {
+		const log = vi.fn();
+		const error = vi.fn();
+
+		expect(main(["node", "install.mjs", "--help"], { log, error, execute: vi.fn() })).toBe(0);
+		expect(log).toHaveBeenCalledWith(expect.stringContaining("Usage:"));
+
+		expect(main(["node", "install.mjs", "--wat"], { log, error, execute: vi.fn() })).toBe(1);
+		expect(error).toHaveBeenCalledWith("Unknown argument: --wat");
+
+		const missingPiExecute = vi.fn(() => {
+			throw new Error("missing");
+		});
+		expect(main(["node", "install.mjs"], { log, error, execute: missingPiExecute })).toBe(1);
+		expect(error).toHaveBeenCalledWith("Error: 'pi' command not found. Install pi-coding-agent first:");
+
+		const installExecute = vi.fn((command: string, args: string[]) => {
+			if (args[0] === "--version") {
+				return Buffer.from("0.1.0");
+			}
+			return Buffer.from("");
+		});
+		expect(main(["node", "install.mjs", "--local"], { log, error, execute: installExecute })).toBe(0);
+		expect(installExecute).toHaveBeenCalledWith("pi", ["install", `npm:${PACKAGE_NAME}`, "-l"], {
+			stdio: "pipe",
+			timeout: 60_000,
+		});
+		expect(log).toHaveBeenLastCalledWith("\n✅ Installed @ifi/pi-diagnostics into pi. Restart pi to load it.");
+
+		const alreadyRemovedExecute = vi.fn((command: string, args: string[]) => {
+			if (args[0] === "--version") {
+				return Buffer.from("0.1.0");
+			}
+			throw { stderr: Buffer.from("not found") };
+		});
+		expect(main(["node", "install.mjs", "--remove"], { log, error, execute: alreadyRemovedExecute })).toBe(0);
+		expect(log).toHaveBeenLastCalledWith("\n✅ @ifi/pi-diagnostics is already absent from pi.");
+
+		const alreadyInstalledExecute = vi.fn((command: string, args: string[]) => {
+			if (args[0] === "--version") {
+				return Buffer.from("0.1.0");
+			}
+			throw { stderr: Buffer.from("already exists") };
+		});
+		expect(main(["node", "install.mjs"], { log, error, execute: alreadyInstalledExecute })).toBe(0);
+		expect(log).toHaveBeenLastCalledWith("\n✅ @ifi/pi-diagnostics is already installed in pi.");
+
+		const failingExecute = vi.fn((command: string, args: string[]) => {
+			if (args[0] === "--version") {
+				return Buffer.from("0.1.0");
+			}
+			throw { stderr: Buffer.from("permission denied") };
+		});
+		expect(main(["node", "install.mjs"], { log, error, execute: failingExecute })).toBe(1);
+		expect(error).toHaveBeenLastCalledWith("permission denied");
+	});
+
+	it("executes the entrypoint when imported as the main module", async () => {
+		vi.resetModules();
+		const scriptPath = fileURLToPath(new URL("../install.mjs", import.meta.url));
+		const originalArgv = process.argv;
+		const originalExitCode = process.exitCode;
+		const log = vi.spyOn(console, "log").mockImplementation(() => undefined);
+
+		process.argv = ["node", scriptPath, "--help"];
+		process.exitCode = undefined;
+		await import("../install.mjs");
+
+		expect(process.exitCode).toBe(0);
+		expect(log).toHaveBeenCalledWith(expect.stringContaining("Usage:"));
+
+		log.mockRestore();
+		process.argv = originalArgv;
+		process.exitCode = originalExitCode;
+		vi.resetModules();
+	});
+});

--- a/packages/diagnostics/tests/smoke.test.ts
+++ b/packages/diagnostics/tests/smoke.test.ts
@@ -1,0 +1,14 @@
+import { describe, expect, it } from "vitest";
+import { createExtensionHarness } from "../../../test-utils/extension-runtime-harness.js";
+import diagnosticsExtension from "../index.js";
+
+describe("diagnostics runtime smoke tests", () => {
+	it("registers diagnostics surfaces without crashing", () => {
+		const harness = createExtensionHarness();
+		diagnosticsExtension(harness.pi as never);
+
+		expect(harness.commands.has("diagnostics")).toBe(true);
+		expect(harness.shortcuts.has("ctrl+shift+d")).toBe(true);
+		expect(harness.messageRenderers.has("pi-diagnostics:prompt")).toBe(true);
+	});
+});

--- a/packages/diagnostics/tsconfig.json
+++ b/packages/diagnostics/tsconfig.json
@@ -1,0 +1,7 @@
+{
+	"extends": "../../tsconfig.base.json",
+	"compilerOptions": {
+		"noEmit": true
+	},
+	"include": ["**/*.ts"]
+}

--- a/packages/diagnostics/vitest.worktree.config.ts
+++ b/packages/diagnostics/vitest.worktree.config.ts
@@ -1,0 +1,7 @@
+import { defineConfig } from "vitest/config";
+
+export default defineConfig({
+	test: {
+		include: ["tests/**/*.test.ts"],
+	},
+});

--- a/packages/extensions/extensions/package-manifest.test.ts
+++ b/packages/extensions/extensions/package-manifest.test.ts
@@ -24,6 +24,7 @@ describe("pi package extension entrypoints", () => {
 			"packages/adaptive-routing/package.json",
 			"packages/spec/package.json",
 			"packages/ant-colony/package.json",
+			"packages/diagnostics/package.json",
 			"packages/cursor/package.json",
 			"packages/ollama/package.json",
 		];

--- a/packages/oh-pi/README.md
+++ b/packages/oh-pi/README.md
@@ -26,6 +26,7 @@ npx @ifi/oh-pi --remove             # uninstall all oh-pi packages from pi
 | ----------------------- | ------------------------------------------------------------------------------------------- |
 | `@ifi/oh-pi-extensions`      | git-guard, auto-session, custom-footer, compact-header, external-editor, auto-update, bg-process, watchdog, worktree |
 | `@ifi/oh-pi-ant-colony`       | Multi-agent swarm extension (`/colony`, colony commands)                                     |
+| `@ifi/pi-diagnostics`         | Prompt completion timestamps, durations, per-turn timing, widget, and `/diagnostics`         |
 | `@ifi/pi-extension-subagents` | Subagent orchestration extension (`subagent`, `subagent_status`, `/run`, `/chain`, `/parallel`) |
 | `@ifi/pi-plan`                | Planning mode extension (`/plan`, `Alt+P`, `task_agents`, `set_plan`)                       |
 | `@ifi/pi-spec`                | Native spec-driven workflow package with `/spec` and local `.specify/` scaffolding          |

--- a/packages/oh-pi/bin/package-list.mjs
+++ b/packages/oh-pi/bin/package-list.mjs
@@ -1,6 +1,7 @@
 export const INSTALLER_PACKAGES = [
 	"@ifi/oh-pi-extensions",
 	"@ifi/oh-pi-ant-colony",
+	"@ifi/pi-diagnostics",
 	"@ifi/pi-extension-subagents",
 	"@ifi/pi-plan",
 	"@ifi/pi-spec",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -171,6 +171,24 @@ importers:
         specifier: '*'
         version: 0.34.48
 
+  packages/diagnostics:
+    dependencies:
+      '@mariozechner/pi-agent-core':
+        specifier: '>=0.56.1'
+        version: 0.56.1(ws@8.19.0)(zod@3.25.76)
+      '@mariozechner/pi-ai':
+        specifier: '>=0.56.1'
+        version: 0.56.1(ws@8.19.0)(zod@3.25.76)
+      '@mariozechner/pi-coding-agent':
+        specifier: '>=0.56.1'
+        version: 0.56.1(ws@8.19.0)(zod@3.25.76)
+      '@mariozechner/pi-tui':
+        specifier: '>=0.56.1'
+        version: 0.56.1
+      '@sinclair/typebox':
+        specifier: '*'
+        version: 0.34.48
+
   packages/extensions:
     dependencies:
       '@ifi/pi-shared-qna':

--- a/scripts/git-install-package.test.ts
+++ b/scripts/git-install-package.test.ts
@@ -37,6 +37,7 @@ describe("git-install package manifest", () => {
 		const extensionPackages = [
 			"packages/extensions/package.json",
 			"packages/ant-colony/package.json",
+			"packages/diagnostics/package.json",
 			"packages/subagents/package.json",
 			"packages/plan/package.json",
 			"packages/spec/package.json",

--- a/scripts/package-classes.mjs
+++ b/scripts/package-classes.mjs
@@ -9,6 +9,7 @@ export const publishedPackages = [
 	...compiledPackages,
 	{ name: "@ifi/oh-pi-extensions", dir: "packages/extensions" },
 	{ name: "@ifi/oh-pi-ant-colony", dir: "packages/ant-colony" },
+	{ name: "@ifi/pi-diagnostics", dir: "packages/diagnostics" },
 	{ name: "@ifi/oh-pi-themes", dir: "packages/themes" },
 	{ name: "@ifi/oh-pi-prompts", dir: "packages/prompts" },
 	{ name: "@ifi/oh-pi-skills", dir: "packages/skills" },

--- a/scripts/package-classes.test.ts
+++ b/scripts/package-classes.test.ts
@@ -1,0 +1,9 @@
+import { describe, expect, it } from "vitest";
+import { compiledPackages, publishedPackages } from "./package-classes.mjs";
+
+describe("package classes", () => {
+	it("lists diagnostics as a published package without changing compiled packages", () => {
+		expect(compiledPackages).not.toContainEqual(expect.objectContaining({ name: "@ifi/pi-diagnostics" }));
+		expect(publishedPackages).toContainEqual({ name: "@ifi/pi-diagnostics", dir: "packages/diagnostics" });
+	});
+});

--- a/scripts/verify-pi-compat.mjs
+++ b/scripts/verify-pi-compat.mjs
@@ -12,6 +12,7 @@ const PI_PACKAGES = [
 ];
 const SMOKE_TESTS = [
 	"packages/extensions/extensions/smoke.test.ts",
+	"packages/diagnostics/tests/smoke.test.ts",
 	"packages/ant-colony/tests/smoke.test.ts",
 	"packages/subagents/tests/smoke.test.ts",
 	"packages/spec/tests/smoke.test.ts",

--- a/scripts/verify-pi-compat.mjs
+++ b/scripts/verify-pi-compat.mjs
@@ -1,16 +1,17 @@
 #!/usr/bin/env node
 import { execFileSync } from "node:child_process";
 import { existsSync, readFileSync, writeFileSync } from "node:fs";
+import { fileURLToPath } from "node:url";
 
-const MIN_VERSION = "0.56.1";
-const CURRENT_VERSION = "0.64.0";
-const PI_PACKAGES = [
+export const MIN_VERSION = "0.56.1";
+export const CURRENT_VERSION = "0.64.0";
+export const PI_PACKAGES = [
 	"@mariozechner/pi-agent-core",
 	"@mariozechner/pi-ai",
 	"@mariozechner/pi-coding-agent",
 	"@mariozechner/pi-tui",
 ];
-const SMOKE_TESTS = [
+export const SMOKE_TESTS = [
 	"packages/extensions/extensions/smoke.test.ts",
 	"packages/diagnostics/tests/smoke.test.ts",
 	"packages/ant-colony/tests/smoke.test.ts",
@@ -20,8 +21,8 @@ const SMOKE_TESTS = [
 	"packages/ollama/tests/smoke.test.ts",
 ];
 
-function parseArgs(argv) {
-	const parsed = { version: process.env.PI_COMPAT_VERSION, restore: false };
+export function parseArgs(argv, env = process.env) {
+	const parsed = { version: env.PI_COMPAT_VERSION, restore: false };
 	for (let i = 0; i < argv.length; i++) {
 		const arg = argv[i];
 		if ((arg === "--version" || arg === "-v") && argv[i + 1]) {
@@ -38,7 +39,7 @@ function parseArgs(argv) {
 	return parsed;
 }
 
-function run(command, args, options = {}) {
+export function run(command, args, options = {}) {
 	console.log(`\n> ${command} ${args.join(" ")}`);
 	execFileSync(command, args, {
 		stdio: "inherit",
@@ -47,7 +48,7 @@ function run(command, args, options = {}) {
 	});
 }
 
-function patchRootManifest(version) {
+export function patchRootManifest(version) {
 	const manifestPath = "package.json";
 	const pkg = JSON.parse(readFileSync(manifestPath, "utf8"));
 	pkg.devDependencies ??= {};
@@ -57,7 +58,7 @@ function patchRootManifest(version) {
 	writeFileSync(manifestPath, `${JSON.stringify(pkg, null, "\t")}\n`);
 }
 
-function readInstalledVersions() {
+export function readInstalledVersions() {
 	for (const dependency of PI_PACKAGES) {
 		const packageJsonPath = `node_modules/${dependency}/package.json`;
 		if (!existsSync(packageJsonPath)) {
@@ -69,7 +70,7 @@ function readInstalledVersions() {
 	}
 }
 
-function restoreFiles(snapshot) {
+export function restoreFiles(snapshot) {
 	for (const [file, contents] of Object.entries(snapshot)) {
 		if (contents === null) {
 			continue;
@@ -78,30 +79,38 @@ function restoreFiles(snapshot) {
 	}
 }
 
-const { version, restore } = parseArgs(process.argv.slice(2));
-const snapshot = {
-	"package.json": readFileSync("package.json", "utf8"),
-	"pnpm-lock.yaml": existsSync("pnpm-lock.yaml") ? readFileSync("pnpm-lock.yaml", "utf8") : null,
-};
+export function main(argv = process.argv.slice(2)) {
+	const { version, restore } = parseArgs(argv);
+	const snapshot = {
+		"package.json": readFileSync("package.json", "utf8"),
+		"pnpm-lock.yaml": existsSync("pnpm-lock.yaml") ? readFileSync("pnpm-lock.yaml", "utf8") : null,
+	};
 
-console.log(`Verifying pi compatibility against ${version}`);
-if (version === MIN_VERSION) {
-	console.log("Mode: minimum supported baseline");
-} else if (version === CURRENT_VERSION) {
-	console.log("Mode: current pinned upstream runtime");
+	console.log(`Verifying pi compatibility against ${version}`);
+	if (version === MIN_VERSION) {
+		console.log("Mode: minimum supported baseline");
+	} else if (version === CURRENT_VERSION) {
+		console.log("Mode: current pinned upstream runtime");
+	}
+
+	try {
+		patchRootManifest(version);
+		run("pnpm", ["install", "--no-frozen-lockfile"]);
+		console.log("\nInstalled pi package versions:");
+		readInstalledVersions();
+		run("pnpm", ["--filter", "@ifi/oh-pi-core", "build"]);
+		run("pnpm", ["exec", "vitest", "run", ...SMOKE_TESTS]);
+	} finally {
+		if (restore) {
+			console.log("\nRestoring package.json and pnpm-lock.yaml...");
+			restoreFiles(snapshot);
+			run("pnpm", ["install", "--frozen-lockfile"]);
+		}
+	}
 }
 
-try {
-	patchRootManifest(version);
-	run("pnpm", ["install", "--no-frozen-lockfile"]);
-	console.log("\nInstalled pi package versions:");
-	readInstalledVersions();
-	run("pnpm", ["--filter", "@ifi/oh-pi-core", "build"]);
-	run("pnpm", ["exec", "vitest", "run", ...SMOKE_TESTS]);
-} finally {
-	if (restore) {
-		console.log("\nRestoring package.json and pnpm-lock.yaml...");
-		restoreFiles(snapshot);
-		run("pnpm", ["install", "--frozen-lockfile"]);
-	}
+const isMain = process.argv[1] && fileURLToPath(import.meta.url) === process.argv[1];
+
+if (isMain) {
+	main();
 }

--- a/scripts/verify-pi-compat.test.ts
+++ b/scripts/verify-pi-compat.test.ts
@@ -1,0 +1,20 @@
+import { describe, expect, it } from "vitest";
+import { CURRENT_VERSION, MIN_VERSION, SMOKE_TESTS, parseArgs } from "./verify-pi-compat.mjs";
+
+describe("verify pi compatibility script", () => {
+	it("includes the diagnostics smoke test in compatibility runs", () => {
+		expect(SMOKE_TESTS).toContain("packages/diagnostics/tests/smoke.test.ts");
+	});
+
+	it("parses explicit versions and restore mode", () => {
+		expect(parseArgs(["--version", CURRENT_VERSION, "--restore"], {})).toEqual({
+			restore: true,
+			version: CURRENT_VERSION,
+		});
+		expect(parseArgs([], { PI_COMPAT_VERSION: MIN_VERSION })).toEqual({
+			restore: false,
+			version: MIN_VERSION,
+		});
+		expect(() => parseArgs([], {})).toThrow("Missing pi compatibility version");
+	});
+});

--- a/vitest.config.ts
+++ b/vitest.config.ts
@@ -32,6 +32,7 @@ export default defineConfig({
 			"packages/core/src/**/*.test.ts",
 			"packages/adaptive-routing/**/*.test.ts",
 			"packages/cli/src/**/*.test.ts",
+			"packages/diagnostics/tests/**/*.test.ts",
 			"packages/extensions/extensions/**/*.test.ts",
 			"packages/ant-colony/tests/**/*.test.ts",
 			"packages/subagents/tests/**/*.test.ts",


### PR DESCRIPTION
## Summary
- add a standalone `@ifi/pi-diagnostics` package for prompt completion timing
- wire the new package into repo aggregation, installer package lists, release config, and `pnpm pi:local` switching
- keep diagnostics auto-installed via `npx @ifi/oh-pi` and vendorable via the CLI local writer

## What it adds
- prompt start and completion timestamps
- human-readable prompt duration after each completed prompt
- per-turn timing details for multi-turn runs
- a live diagnostics widget below the editor
- `/diagnostics [status|toggle|on|off]` and `Ctrl+Shift+D`

## Validation
- `pnpm exec vitest run packages/diagnostics/tests/*.test.ts packages/extensions/extensions/*.test.ts packages/cli/src/utils/resources.test.ts packages/cli/src/utils/writers.test.ts scripts/git-install-package.test.ts scripts/pi-source-switch.test.ts`
- `pnpm --filter @ifi/pi-diagnostics run build`
- `pnpm typecheck`
- `pnpm docs:check`
- `pnpm pi:local -- --dry-run`