### PR TITLE
perf(worktree): reduce startup refresh overhead

### DIFF
--- a/.changeset/worktree-startup-latency.md
+++ b/.changeset/worktree-startup-latency.md
@@ -1,0 +1,5 @@
+---
+default: patch
+---
+
+Reduce worktree startup overhead by splitting lightweight context refreshes from full worktree inventory snapshots, throttling managed-worktree touch writes, and extending startup benchmarks to track both paths.

--- a/benchmarks/startup/suite.ts
+++ b/benchmarks/startup/suite.ts
@@ -284,13 +284,25 @@ export async function createStartupBenchmarkSuite(): Promise<StartupBenchmarkSui
 			},
 		},
 		{
+			id: "worktree-context-temp-repo",
+			label: "worktree current context (single temp repo)",
+			group: "focused hotspot",
+			iterations: 20,
+			warmupIterations: 2,
+			budget: { medianMs: 120, p95Ms: 200 },
+			note: "Measures the lightweight current-worktree probe used by footer and status refreshes.",
+			run() {
+				worktreeModule.getRepoWorktreeContext(repoDir);
+			},
+		},
+		{
 			id: "worktree-snapshot-temp-repo",
 			label: "worktree snapshot (single temp repo)",
 			group: "focused hotspot",
 			iterations: 20,
 			warmupIterations: 1,
 			budget: { medianMs: 700 },
-			note: "Measures the synchronous git worktree snapshot path used by worktree and footer startup refreshes.",
+			note: "Measures the synchronous full worktree inventory path used by /worktree reporting and explicit status overlays.",
 			run() {
 				worktreeModule.getRepoWorktreeSnapshot(repoDir);
 			},

--- a/docs/startup-performance-audit.md
+++ b/docs/startup-performance-audit.md
@@ -25,8 +25,9 @@ The benchmark suite currently covers:
 3. scheduler persisted-store loading
 4. custom-footer large-history usage scans
 5. usage-tracker startup hydration
-6. worktree snapshot git probes
-7. first footer render cost
+6. lightweight worktree current-context probes
+7. full worktree snapshot git probes
+8. first footer render cost
 
 ## Ranked hotspot summary
 
@@ -47,7 +48,17 @@ That work blocks the Node event loop completely.
 
 **Current benchmark coverage**
 
+- `worktree current context (single temp repo)`
 - `worktree snapshot (single temp repo)`
+
+**Latest optimization pass**
+
+The footer and worktree status paths now use a lighter current-context probe instead of the full worktree inventory path. That splits the hot path in two:
+
+- lightweight current-context refresh for footer/status updates
+- full snapshot refresh for explicit `/worktree` reports and `/status` overlay details
+
+That change also removed the footer's 30-second timer from re-triggering worktree git probes, which was the strongest match for the reported periodic typing stalls.
 
 **Why it is the top suspect**
 

--- a/packages/extensions/extensions/custom-footer.test.ts
+++ b/packages/extensions/extensions/custom-footer.test.ts
@@ -181,7 +181,12 @@ describe("custom-footer extension", () => {
 
 	it("defers worktree snapshot refresh until after startup", async () => {
 		vi.useFakeTimers();
-		const getRepoWorktreeSnapshot = vi.spyOn(worktreeShared, "getRepoWorktreeSnapshot").mockReturnValue(null as never);
+		const getCachedRepoWorktreeContext = vi
+			.spyOn(worktreeShared, "getCachedRepoWorktreeContext")
+			.mockReturnValue(null as never);
+		const refreshRepoWorktreeContext = vi
+			.spyOn(worktreeShared, "refreshRepoWorktreeContext")
+			.mockResolvedValue(null as never);
 		try {
 			const pi = createMockPi();
 			customFooter(pi as any);
@@ -200,19 +205,64 @@ describe("custom-footer extension", () => {
 			};
 
 			await pi._emit("session_start", {}, ctx);
-			expect(getRepoWorktreeSnapshot).not.toHaveBeenCalled();
+			expect(refreshRepoWorktreeContext).not.toHaveBeenCalled();
 
 			footerFactory(
 				{ requestRender: vi.fn() },
 				{ fg: (_color: string, text: string) => text },
 				{ onBranchChange: () => () => undefined, getGitBranch: () => "main" },
 			);
-			expect(getRepoWorktreeSnapshot).not.toHaveBeenCalled();
+			expect(refreshRepoWorktreeContext).not.toHaveBeenCalled();
 
 			await vi.advanceTimersByTimeAsync(500);
-			expect(getRepoWorktreeSnapshot).toHaveBeenCalled();
+			expect(refreshRepoWorktreeContext).toHaveBeenCalledTimes(1);
 		} finally {
-			getRepoWorktreeSnapshot.mockRestore();
+			getCachedRepoWorktreeContext.mockRestore();
+			refreshRepoWorktreeContext.mockRestore();
+			vi.useRealTimers();
+		}
+	});
+
+	it("does not refresh worktree snapshots on the 30-second PR poll timer", async () => {
+		vi.useFakeTimers();
+		const getCachedRepoWorktreeContext = vi
+			.spyOn(worktreeShared, "getCachedRepoWorktreeContext")
+			.mockReturnValue(null as never);
+		const refreshRepoWorktreeContext = vi
+			.spyOn(worktreeShared, "refreshRepoWorktreeContext")
+			.mockResolvedValue(null as never);
+		try {
+			const pi = createMockPi();
+			customFooter(pi as any);
+
+			let footerFactory: any;
+			const ctx = {
+				cwd: "/tmp/project",
+				model: { id: "claude-sonnet", provider: "anthropic" },
+				getContextUsage: () => ({ percent: 12 }),
+				sessionManager: { getBranch: () => [] },
+				ui: {
+					setFooter(factory: any) {
+						footerFactory = factory;
+					},
+				},
+			};
+
+			await pi._emit("session_start", {}, ctx);
+			footerFactory(
+				{ requestRender: vi.fn() },
+				{ fg: (_color: string, text: string) => text },
+				{ onBranchChange: () => () => undefined, getGitBranch: () => "main" },
+			);
+
+			await vi.advanceTimersByTimeAsync(500);
+			expect(refreshRepoWorktreeContext).toHaveBeenCalledTimes(1);
+
+			await vi.advanceTimersByTimeAsync(30_000);
+			expect(refreshRepoWorktreeContext).toHaveBeenCalledTimes(1);
+		} finally {
+			getCachedRepoWorktreeContext.mockRestore();
+			refreshRepoWorktreeContext.mockRestore();
 			vi.useRealTimers();
 		}
 	});

--- a/packages/extensions/extensions/custom-footer.ts
+++ b/packages/extensions/extensions/custom-footer.ts
@@ -17,7 +17,15 @@ import type { AssistantMessage } from "@mariozechner/pi-ai";
 import type { ExtensionAPI, ExtensionContext, ReadonlyFooterDataProvider } from "@mariozechner/pi-coding-agent";
 import { truncateToWidth } from "@mariozechner/pi-tui";
 import { getSafeModeState, subscribeSafeMode } from "./runtime-mode";
-import { formatOwnerLabel, getRepoWorktreeSnapshot, type RepoWorktreeSnapshot } from "./worktree-shared";
+import { recordRuntimeSample } from "./watchdog-runtime-diagnostics";
+import {
+	formatOwnerLabel,
+	getCachedRepoWorktreeContext,
+	getRepoWorktreeSnapshot,
+	type RepoWorktreeContext,
+	type RepoWorktreeSnapshot,
+	refreshRepoWorktreeContext,
+} from "./worktree-shared";
 
 /** OSC 8 hyperlink: renders `text` as a clickable terminal link to `url`. */
 export function hyperlink(url: string, text: string): string {
@@ -33,7 +41,6 @@ export type PrInfo = {
 const PR_PROBE_COOLDOWN_MS = 60_000;
 const FOOTER_STARTUP_REFRESH_DELAY_MS = 250;
 const FOOTER_STARTUP_DEFER_ENTRY_THRESHOLD = 250;
-const WORKTREE_REFRESH_COOLDOWN_MS = 30_000;
 
 export type FooterUsageTotals = {
 	input: number;
@@ -96,10 +103,10 @@ export default function (pi: ExtensionAPI) {
 	let activeFooterData: ReadonlyFooterDataProvider | null = null;
 	let activeCtx: ExtensionContext | null = null;
 	let cachedPrs: PrInfo[] = [];
-	let cachedWorktreeSnapshot: RepoWorktreeSnapshot | null = null;
-	let lastWorktreeRefreshAt = 0;
+	let cachedWorktreeContext: RepoWorktreeContext | null = null;
 	let startupRefreshTimer: ReturnType<typeof setTimeout> | null = null;
 	let worktreeRefreshTimer: ReturnType<typeof setTimeout> | null = null;
+	let worktreeRefreshInFlight = false;
 	let requestFooterRender: (() => void) | null = null;
 	/** Branch name when the PR was last probed. */
 	let prProbedForBranch: string | null = null;
@@ -139,10 +146,26 @@ export default function (pi: ExtensionAPI) {
 		}, FOOTER_STARTUP_REFRESH_DELAY_MS);
 	};
 
-	const syncWorktreeSnapshot = (cwd = process.cwd()) => {
-		cachedWorktreeSnapshot = getRepoWorktreeSnapshot(cwd);
-		lastWorktreeRefreshAt = Date.now();
-		requestFooterRender?.();
+	const refreshWorktreeContext = async (cwd = process.cwd()) => {
+		if (worktreeRefreshInFlight) {
+			return;
+		}
+
+		const startedAt = Date.now();
+		worktreeRefreshInFlight = true;
+		try {
+			cachedWorktreeContext = await refreshRepoWorktreeContext(cwd);
+		} finally {
+			worktreeRefreshInFlight = false;
+			recordRuntimeSample(
+				"custom-footer",
+				"event",
+				"worktree_context_refresh",
+				Date.now() - startedAt,
+				"custom-footer",
+			);
+			requestFooterRender?.();
+		}
 	};
 
 	const clearWorktreeRefreshTimer = () => {
@@ -153,12 +176,9 @@ export default function (pi: ExtensionAPI) {
 		worktreeRefreshTimer = null;
 	};
 
-	const scheduleWorktreeSnapshotRefresh = (
-		cwd = process.cwd(),
-		options: { delayMs?: number; force?: boolean } = {},
-	) => {
+	const scheduleWorktreeContextRefresh = (cwd = process.cwd(), options: { delayMs?: number; force?: boolean } = {}) => {
 		const delayMs = Math.max(0, options.delayMs ?? 0);
-		if (!options.force && Date.now() - lastWorktreeRefreshAt < WORKTREE_REFRESH_COOLDOWN_MS) {
+		if (!options.force && (cachedWorktreeContext || worktreeRefreshTimer || worktreeRefreshInFlight)) {
 			return;
 		}
 		if (worktreeRefreshTimer) {
@@ -167,15 +187,18 @@ export default function (pi: ExtensionAPI) {
 
 		worktreeRefreshTimer = setTimeout(() => {
 			worktreeRefreshTimer = null;
-			syncWorktreeSnapshot(cwd);
+			refreshWorktreeContext(cwd).catch(() => undefined);
 		}, delayMs);
 	};
 
-	const getWorktreeSnapshot = () => {
-		if (Date.now() - lastWorktreeRefreshAt > WORKTREE_REFRESH_COOLDOWN_MS) {
-			scheduleWorktreeSnapshotRefresh(activeCtx?.cwd ?? process.cwd());
+	const getWorktreeContext = () => {
+		if (!cachedWorktreeContext) {
+			cachedWorktreeContext = getCachedRepoWorktreeContext(activeCtx?.cwd ?? process.cwd());
 		}
-		return cachedWorktreeSnapshot;
+		if (!cachedWorktreeContext) {
+			scheduleWorktreeContextRefresh(activeCtx?.cwd ?? process.cwd());
+		}
+		return cachedWorktreeContext;
 	};
 
 	const probePrs = (branch: string | null) => {
@@ -216,28 +239,31 @@ export default function (pi: ExtensionAPI) {
 	};
 
 	pi.on("session_start", async (_event, ctx) => {
+		const worktreeCwd = ctx.cwd ?? process.cwd();
 		sessionStart = Date.now();
 		activeCtx = ctx;
 		scheduleUsageTotalsRefresh(ctx);
-		scheduleWorktreeSnapshotRefresh(ctx.cwd, { delayMs: FOOTER_STARTUP_REFRESH_DELAY_MS, force: true });
+		scheduleWorktreeContextRefresh(worktreeCwd, { delayMs: FOOTER_STARTUP_REFRESH_DELAY_MS, force: true });
 
 		ctx.ui.setFooter((tui, theme, footerData) => {
 			activeFooterData = footerData;
 			requestFooterRender = () => tui.requestRender();
-			const probeActivePrs = (force = false) => {
-				scheduleWorktreeSnapshotRefresh(ctx.cwd, { force });
-				probePrs(cachedWorktreeSnapshot?.current?.branch ?? footerData.getGitBranch());
+			const probeActivePrs = () => {
+				probePrs(footerData.getGitBranch() || cachedWorktreeContext?.current?.branch || null);
 			};
 			const unsub = footerData.onBranchChange(() => {
-				probeActivePrs(true);
+				scheduleWorktreeContextRefresh(worktreeCwd, { force: true });
+				probeActivePrs();
 				tui.requestRender();
 			});
+			cachedWorktreeContext = getCachedRepoWorktreeContext(worktreeCwd);
+			scheduleWorktreeContextRefresh(worktreeCwd, { delayMs: FOOTER_STARTUP_REFRESH_DELAY_MS, force: true });
 			const unsubSafeMode = subscribeSafeMode(() => tui.requestRender());
 			const timer = setInterval(() => {
 				probeActivePrs();
 				tui.requestRender();
 			}, 30000);
-			probeActivePrs(true);
+			probeActivePrs();
 
 			return {
 				dispose() {
@@ -269,16 +295,16 @@ export default function (pi: ExtensionAPI) {
 					const parts = process.cwd().split("/");
 					const short = parts.length > 2 ? parts.slice(-2).join("/") : process.cwd();
 					const cwdStr = theme.fg("muted", `⌂ ${short}`);
-					const worktreeSnapshot = getWorktreeSnapshot();
-					const repoStr = worktreeSnapshot ? theme.fg("muted", `repo ${path.basename(worktreeSnapshot.repoRoot)}`) : "";
-					const worktreeStr = worktreeSnapshot?.isLinkedWorktree
+					const worktreeContext = getWorktreeContext();
+					const repoStr = worktreeContext ? theme.fg("muted", `repo ${path.basename(worktreeContext.repoRoot)}`) : "";
+					const worktreeStr = worktreeContext?.isLinkedWorktree
 						? theme.fg(
-								worktreeSnapshot.current?.isManaged ? "warning" : "muted",
-								`wt ${worktreeSnapshot.current?.branch ?? path.basename(worktreeSnapshot.currentWorktreeRoot)}${worktreeSnapshot.current?.isManaged ? " pi" : ""}`,
+								worktreeContext.current?.isManaged ? "warning" : "muted",
+								`wt ${worktreeContext.current?.branch ?? path.basename(worktreeContext.currentWorktreeRoot)}${worktreeContext.current?.isManaged ? " pi" : ""}`,
 							)
 						: "";
 
-					const branch = worktreeSnapshot?.current?.branch ?? footerData.getGitBranch();
+					const branch = worktreeContext?.current?.branch ?? footerData.getGitBranch();
 					let branchStr = branch ? theme.fg("accent", `⎇ ${branch}`) : "";
 					if (cachedPrs.length > 0) {
 						const prLinks = cachedPrs.map((pr) => hyperlink(pr.url, theme.fg("success", `PR #${pr.number}`))).join(" ");
@@ -314,7 +340,10 @@ export default function (pi: ExtensionAPI) {
 	pi.on("session_switch", (event, ctx) => {
 		activeCtx = ctx;
 		scheduleUsageTotalsRefresh(ctx);
-		scheduleWorktreeSnapshotRefresh(ctx.cwd, { delayMs: FOOTER_STARTUP_REFRESH_DELAY_MS, force: true });
+		scheduleWorktreeContextRefresh(ctx.cwd ?? process.cwd(), {
+			delayMs: FOOTER_STARTUP_REFRESH_DELAY_MS,
+			force: true,
+		});
 		if (event.reason === "new") {
 			sessionStart = Date.now();
 		}
@@ -339,13 +368,17 @@ export default function (pi: ExtensionAPI) {
 	pi.on("session_shutdown", () => {
 		clearStartupRefreshTimer();
 		clearWorktreeRefreshTimer();
+		cachedWorktreeContext = null;
 		requestFooterRender = null;
 	});
 
 	// ─── /status overlay ─────────────────────────────────────────────────
 
 	// biome-ignore lint/complexity/noExcessiveCognitiveComplexity: Status overlay assembles many optional sections.
-	function buildStatusLines(theme: { fg: (color: string, text: string) => string }): string[] {
+	function buildStatusLines(
+		theme: { fg: (color: string, text: string) => string },
+		worktreeSnapshot: RepoWorktreeSnapshot | null,
+	): string[] {
 		const lines: string[] = [];
 		const sep = theme.fg("dim", " │ ");
 		const divider = theme.fg("dim", "─".repeat(60));
@@ -389,25 +422,27 @@ export default function (pi: ExtensionAPI) {
 		lines.push(`  ${divider}`);
 		lines.push(`  ${theme.fg("accent", "Directory")}${sep}${process.cwd()}`);
 
-		const worktreeSnapshot = getWorktreeSnapshot();
-		if (worktreeSnapshot) {
-			lines.push(`  ${theme.fg("accent", "Repo Root")}${sep}${worktreeSnapshot.repoRoot}`);
-			lines.push(`  ${theme.fg("accent", "Worktree Root")}${sep}${worktreeSnapshot.currentWorktreeRoot}`);
+		const worktreeContext = getWorktreeContext();
+		if (worktreeContext) {
+			lines.push(`  ${theme.fg("accent", "Repo Root")}${sep}${worktreeContext.repoRoot}`);
+			lines.push(`  ${theme.fg("accent", "Worktree Root")}${sep}${worktreeContext.currentWorktreeRoot}`);
 			lines.push(
-				`  ${theme.fg("accent", "Worktree Kind")}${sep}${worktreeSnapshot.isLinkedWorktree ? (worktreeSnapshot.current?.isManaged ? "pi-owned linked worktree" : "external linked worktree") : "main checkout"}`,
+				`  ${theme.fg("accent", "Worktree Kind")}${sep}${worktreeContext.isLinkedWorktree ? (worktreeContext.current?.isManaged ? "pi-owned linked worktree" : "external linked worktree") : "main checkout"}`,
 			);
-			if (worktreeSnapshot.current?.metadata) {
-				lines.push(`  ${theme.fg("accent", "Purpose")}${sep}${worktreeSnapshot.current.metadata.purpose}`);
-				lines.push(
-					`  ${theme.fg("accent", "Owner")}${sep}${formatOwnerLabel(worktreeSnapshot.current.metadata.owner)}`,
-				);
+			if (worktreeContext.current?.metadata) {
+				lines.push(`  ${theme.fg("accent", "Purpose")}${sep}${worktreeContext.current.metadata.purpose}`);
+				lines.push(`  ${theme.fg("accent", "Owner")}${sep}${formatOwnerLabel(worktreeContext.current.metadata.owner)}`);
 			}
+		}
+
+		if (worktreeSnapshot) {
 			lines.push(
 				`  ${theme.fg("accent", "Worktrees")}${sep}${worktreeSnapshot.worktrees.length} total${worktreeSnapshot.staleManagedWorktrees.length > 0 ? `${sep}${worktreeSnapshot.staleManagedWorktrees.length} stale pi record(s)` : ""}`,
 			);
 		}
 
-		const branch = worktreeSnapshot?.current?.branch ?? activeFooterData?.getGitBranch?.();
+		const branch =
+			worktreeContext?.current?.branch ?? worktreeSnapshot?.current?.branch ?? activeFooterData?.getGitBranch?.();
 		if (branch) {
 			lines.push(`  ${theme.fg("accent", "Branch")}${sep}${theme.fg("accent", branch)}`);
 		}
@@ -455,11 +490,13 @@ export default function (pi: ExtensionAPI) {
 	pi.registerCommand("status", {
 		description: "Show a full status overview: model, session, context, workspace, PR, and extension statuses",
 		async handler(_args, ctx) {
+			const worktreeCwd = ctx.cwd ?? process.cwd();
 			activeCtx = ctx;
-			syncWorktreeSnapshot(ctx.cwd);
+			await refreshWorktreeContext(worktreeCwd);
+			const worktreeSnapshot = getRepoWorktreeSnapshot(worktreeCwd);
 			await ctx.ui.custom(
 				(_tui, theme, _keybindings, done) => {
-					const lines = buildStatusLines(theme);
+					const lines = buildStatusLines(theme, worktreeSnapshot);
 					return {
 						render(width: number) {
 							return lines.map((line) => truncateToWidth(line, width));

--- a/packages/extensions/extensions/worktree-shared.test.ts
+++ b/packages/extensions/extensions/worktree-shared.test.ts
@@ -4,10 +4,16 @@ import * as os from "node:os";
 import * as path from "node:path";
 import { afterEach, describe, expect, it } from "vitest";
 import {
+	clearRepoWorktreeSnapshotCache,
 	createManagedWorktree,
 	createOwnerMetadata,
+	getCachedRepoWorktreeContext,
+	getCachedRepoWorktreeSnapshot,
+	getRepoWorktreeContext,
 	getRepoWorktreeSnapshot,
 	loadWorktreeRegistry,
+	refreshRepoWorktreeContext,
+	refreshRepoWorktreeSnapshot,
 	removeManagedWorktree,
 	touchManagedWorktreeSeen,
 } from "./worktree-shared";
@@ -46,6 +52,8 @@ function real(value: string): string {
 }
 
 afterEach(() => {
+	clearRepoWorktreeSnapshotCache();
+
 	for (const dir of tempDirs.splice(0)) {
 		try {
 			fs.rmSync(dir, { recursive: true, force: true });
@@ -85,10 +93,37 @@ describe("worktree-shared", () => {
 		expect(snapshot?.current?.metadata?.owner.instanceId).toBe("pai-test-instance");
 		expect(snapshot?.current?.metadata?.owner.sessionName).toBe("Worktree footer session");
 
+		const context = getRepoWorktreeContext(result.worktreePath, sharedRoot);
+		expect(context?.repoRoot).toBe(real(repo));
+		expect(context?.current?.isManaged).toBe(true);
+		expect(context?.current?.metadata?.purpose).toBe("Implement worktree-aware footer context");
+
 		expect(touchManagedWorktreeSeen(repo, result.worktreePath, sharedRoot)).toBe(true);
-		const registry = loadWorktreeRegistry(repo, sharedRoot);
-		expect(registry.managedWorktrees).toHaveLength(1);
-		expect(registry.managedWorktrees[0]?.lastSeenAt).toBeTruthy();
+		const firstRegistry = loadWorktreeRegistry(repo, sharedRoot);
+		const firstSeenAt = firstRegistry.managedWorktrees[0]?.lastSeenAt ?? null;
+		expect(firstRegistry.managedWorktrees).toHaveLength(1);
+		expect(firstSeenAt).toBeTruthy();
+
+		expect(touchManagedWorktreeSeen(repo, result.worktreePath, sharedRoot)).toBe(true);
+		const secondRegistry = loadWorktreeRegistry(repo, sharedRoot);
+		expect(secondRegistry.managedWorktrees[0]?.lastSeenAt ?? null).toBe(firstSeenAt);
+	}, 30_000);
+
+	it("warms async worktree context and snapshot caches without blocking callers", async () => {
+		const repo = mkTempDir("pi-worktree-cache-repo-");
+		const sharedRoot = mkTempDir("pi-worktree-cache-store-");
+		initRepo(repo);
+
+		expect(getCachedRepoWorktreeContext(repo, sharedRoot)).toBeNull();
+		expect(getCachedRepoWorktreeSnapshot(repo, sharedRoot)).toBeNull();
+
+		const context = await refreshRepoWorktreeContext(repo, sharedRoot);
+		expect(context?.repoRoot).toBe(real(repo));
+		expect(getCachedRepoWorktreeContext(repo, sharedRoot)?.repoRoot).toBe(real(repo));
+
+		const snapshot = await refreshRepoWorktreeSnapshot(repo, sharedRoot);
+		expect(snapshot?.repoRoot).toBe(real(repo));
+		expect(getCachedRepoWorktreeSnapshot(repo, sharedRoot)?.repoRoot).toBe(real(repo));
 	}, 30_000);
 
 	it("removes only the targeted Pai-owned worktree and leaves external ones alone", () => {

--- a/packages/extensions/extensions/worktree-shared.ts
+++ b/packages/extensions/extensions/worktree-shared.ts
@@ -1,4 +1,4 @@
-import { execFileSync } from "node:child_process";
+import { execFile, execFileSync } from "node:child_process";
 import * as fs from "node:fs";
 import { homedir, hostname } from "node:os";
 import * as path from "node:path";
@@ -48,7 +48,7 @@ export interface GitWorktreeEntry {
 	metadata: ManagedWorktreeMetadata | null;
 }
 
-export interface RepoWorktreeSnapshot {
+export interface RepoWorktreeContext {
 	cwd: string;
 	repoRoot: string;
 	currentWorktreeRoot: string;
@@ -57,7 +57,10 @@ export interface RepoWorktreeSnapshot {
 	gitDir: string;
 	currentBranch: string | null;
 	isLinkedWorktree: boolean;
-	current: GitWorktreeEntry | null;
+	current: Pick<GitWorktreeEntry, "path" | "branch" | "isMain" | "isManaged" | "metadata"> | null;
+}
+
+export interface RepoWorktreeSnapshot extends RepoWorktreeContext {
 	worktrees: GitWorktreeEntry[];
 	registry: WorktreeRegistry;
 	staleManagedWorktrees: ManagedWorktreeMetadata[];
@@ -81,6 +84,27 @@ export interface CreateManagedWorktreeResult {
 }
 
 const DEFAULT_WORKTREE_ROOT = path.join(getPiAgentDirectory(), "worktrees");
+const MANAGED_WORKTREE_TOUCH_INTERVAL_MS = 5 * 60_000;
+
+type RepoWorktreeCacheEntry<TSnapshot> = {
+	snapshot: TSnapshot | null;
+	inFlight: Promise<TSnapshot | null> | null;
+};
+
+type RepoWorktreeContextProbe = {
+	normalizedCwd: string;
+	currentWorktreeRoot: string;
+	commonDir: string;
+	gitDir: string;
+	currentBranch: string | null;
+};
+
+type RepoWorktreeProbe = RepoWorktreeContextProbe & {
+	worktreeListOutput: string;
+};
+
+const repoWorktreeContextCache = new Map<string, RepoWorktreeCacheEntry<RepoWorktreeContext>>();
+const repoWorktreeSnapshotCache = new Map<string, RepoWorktreeCacheEntry<RepoWorktreeSnapshot>>();
 
 function getPiAgentDirectory(): string {
 	const getAgentDir = (PiCodingAgent as { getAgentDir?: () => string }).getAgentDir;
@@ -111,6 +135,19 @@ function git(cwd: string, args: string[]): string {
 	}).trim();
 }
 
+function gitAsync(cwd: string, args: string[]): Promise<string> {
+	return new Promise((resolve, reject) => {
+		execFile("git", ["-C", cwd, ...args], { encoding: "utf-8" }, (error, stdout) => {
+			if (error) {
+				reject(error);
+				return;
+			}
+
+			resolve(stdout.trim());
+		});
+	});
+}
+
 function gitOk(cwd: string, args: string[]): boolean {
 	try {
 		git(cwd, args);
@@ -120,8 +157,49 @@ function gitOk(cwd: string, args: string[]): boolean {
 	}
 }
 
-function resolveGitPath(cwd: string, value: string): string {
-	return normalizePath(path.resolve(cwd, value));
+function getRepoWorktreeCacheKey(cwd: string, sharedRoot = DEFAULT_WORKTREE_ROOT): string {
+	return `${normalizePath(cwd)}::${getSharedWorktreeRoot(sharedRoot)}`;
+}
+
+export function clearRepoWorktreeSnapshotCache(): void {
+	repoWorktreeContextCache.clear();
+	repoWorktreeSnapshotCache.clear();
+}
+
+function storeRepoWorktreeCacheEntry<TSnapshot>(
+	cache: Map<string, RepoWorktreeCacheEntry<TSnapshot>>,
+	cwd: string,
+	sharedRoot: string,
+	snapshot: TSnapshot | null,
+	inFlight: Promise<TSnapshot | null> | null = null,
+): TSnapshot | null {
+	cache.set(getRepoWorktreeCacheKey(cwd, sharedRoot), {
+		snapshot,
+		inFlight,
+	});
+	return snapshot;
+}
+
+function getCachedRepoWorktreeCacheEntry<TSnapshot>(
+	cache: Map<string, RepoWorktreeCacheEntry<TSnapshot>>,
+	cwd: string,
+	sharedRoot = DEFAULT_WORKTREE_ROOT,
+): TSnapshot | null {
+	return cache.get(getRepoWorktreeCacheKey(cwd, sharedRoot))?.snapshot ?? null;
+}
+
+export function getCachedRepoWorktreeContext(
+	cwd: string,
+	sharedRoot = DEFAULT_WORKTREE_ROOT,
+): RepoWorktreeContext | null {
+	return getCachedRepoWorktreeCacheEntry(repoWorktreeContextCache, cwd, sharedRoot);
+}
+
+export function getCachedRepoWorktreeSnapshot(
+	cwd: string,
+	sharedRoot = DEFAULT_WORKTREE_ROOT,
+): RepoWorktreeSnapshot | null {
+	return getCachedRepoWorktreeCacheEntry(repoWorktreeSnapshotCache, cwd, sharedRoot);
 }
 
 function sanitizeSegment(value: string): string {
@@ -251,6 +329,7 @@ export function saveWorktreeRegistry(registry: WorktreeRegistry, sharedRoot = DE
 		),
 		"utf-8",
 	);
+	clearRepoWorktreeSnapshotCache();
 }
 
 function upsertManagedWorktreeMetadata(
@@ -281,6 +360,12 @@ export function touchManagedWorktreeSeen(
 	if (!entry) {
 		return false;
 	}
+
+	const lastSeenAtMs = entry.lastSeenAt ? Date.parse(entry.lastSeenAt) : Number.NaN;
+	if (Number.isFinite(lastSeenAtMs) && Date.now() - lastSeenAtMs < MANAGED_WORKTREE_TOUCH_INTERVAL_MS) {
+		return true;
+	}
+
 	entry.lastSeenAt = nowIso();
 	saveWorktreeRegistry(registry, sharedRoot);
 	return true;
@@ -376,58 +461,265 @@ function parseWorktreeListPorcelain(output: string): Array<{
 	return entries;
 }
 
-export function getRepoWorktreeSnapshot(cwd: string, sharedRoot = DEFAULT_WORKTREE_ROOT): RepoWorktreeSnapshot | null {
-	const normalizedCwd = normalizePath(cwd);
-	try {
-		if (git(normalizedCwd, ["rev-parse", "--is-inside-work-tree"]) !== "true") {
-			return null;
+function isWithinWorktree(cwd: string, worktreePath: string): boolean {
+	return cwd === worktreePath || cwd.startsWith(`${worktreePath}${path.sep}`);
+}
+
+function findCurrentWorktreePath(normalizedCwd: string, parsedEntries: Array<{ path: string }>): string | null {
+	let match: string | null = null;
+	for (const entry of parsedEntries) {
+		if (!isWithinWorktree(normalizedCwd, entry.path)) {
+			continue;
 		}
 
-		const currentWorktreeRoot = resolveGitPath(normalizedCwd, git(normalizedCwd, ["rev-parse", "--show-toplevel"]));
-		const commonDir = resolveGitPath(currentWorktreeRoot, git(currentWorktreeRoot, ["rev-parse", "--git-common-dir"]));
-		const gitDir = resolveGitPath(currentWorktreeRoot, git(currentWorktreeRoot, ["rev-parse", "--absolute-git-dir"]));
-		const currentBranchRaw = git(currentWorktreeRoot, ["rev-parse", "--abbrev-ref", "HEAD"]);
-		const currentBranch = currentBranchRaw === "HEAD" ? null : currentBranchRaw;
-		const parsedEntries = parseWorktreeListPorcelain(git(currentWorktreeRoot, ["worktree", "list", "--porcelain"]));
-		const fallbackMainRoot =
-			path.basename(commonDir) === ".git" ? normalizePath(path.dirname(commonDir)) : currentWorktreeRoot;
-		const mainWorktreeRoot = parsedEntries[0]?.path ?? fallbackMainRoot;
-		const repoRoot = normalizePath(mainWorktreeRoot);
-		const registry = loadWorktreeRegistry(repoRoot, sharedRoot);
-		const metadataByPath = new Map(
-			registry.managedWorktrees.map((entry) => [normalizePath(entry.worktreePath), entry]),
-		);
-		const worktrees = parsedEntries.map((entry) => {
-			const metadata = metadataByPath.get(entry.path) ?? null;
-			return {
-				...entry,
-				isMain: entry.path === repoRoot,
-				isCurrent: entry.path === currentWorktreeRoot,
-				isManaged: !!metadata,
-				metadata,
-			};
-		});
-		const knownPaths = new Set(worktrees.map((entry) => entry.path));
-		const staleManagedWorktrees = registry.managedWorktrees.filter((entry) => !knownPaths.has(entry.worktreePath));
-		const current = worktrees.find((entry) => entry.isCurrent) ?? null;
+		if (!match || entry.path.length > match.length) {
+			match = entry.path;
+		}
+	}
 
-		return {
-			cwd: normalizedCwd,
-			repoRoot,
-			currentWorktreeRoot,
-			mainWorktreeRoot: repoRoot,
-			commonDir,
-			gitDir,
-			currentBranch,
-			isLinkedWorktree: currentWorktreeRoot !== repoRoot,
-			current,
-			worktrees,
-			registry,
-			staleManagedWorktrees,
-		};
-	} catch {
+	return match;
+}
+
+function readGitDirectoryInfo(worktreeRoot: string): { commonDir: string; gitDir: string } {
+	const dotGitPath = path.join(worktreeRoot, ".git");
+	const stat = fs.statSync(dotGitPath);
+	if (stat.isDirectory()) {
+		const gitDir = normalizePath(dotGitPath);
+		return { commonDir: gitDir, gitDir };
+	}
+
+	const dotGitContents = fs.readFileSync(dotGitPath, "utf-8");
+	const gitDirLine = dotGitContents.split(/\r?\n/).find((line) => line.trim().toLowerCase().startsWith("gitdir:"));
+	if (!gitDirLine) {
+		throw new Error(`Failed to resolve gitdir for worktree ${worktreeRoot}.`);
+	}
+
+	const gitDir = normalizePath(path.resolve(worktreeRoot, gitDirLine.slice("gitdir:".length).trim()));
+	const commonDirPath = path.join(gitDir, "commondir");
+	if (!fs.existsSync(commonDirPath)) {
+		return { commonDir: gitDir, gitDir };
+	}
+
+	const commonDirRelative = fs.readFileSync(commonDirPath, "utf-8").trim();
+	const commonDir = normalizePath(path.resolve(gitDir, commonDirRelative));
+	return { commonDir, gitDir };
+}
+
+function buildRepoWorktreeContextProbe(normalizedCwd: string, revParseOutput: string): RepoWorktreeContextProbe | null {
+	const [topLevelPath, branchRef] = revParseOutput.split(/\r?\n/);
+	if (!(topLevelPath && branchRef)) {
 		return null;
 	}
+
+	const currentWorktreeRoot = normalizePath(topLevelPath);
+	const { commonDir, gitDir } = readGitDirectoryInfo(currentWorktreeRoot);
+
+	return {
+		normalizedCwd,
+		currentWorktreeRoot,
+		commonDir,
+		gitDir,
+		currentBranch: branchRef === "HEAD" ? null : branchRef,
+	};
+}
+
+function buildRepoWorktreeProbe(normalizedCwd: string, worktreeListOutput: string): RepoWorktreeProbe | null {
+	const parsedEntries = parseWorktreeListPorcelain(worktreeListOutput);
+	if (parsedEntries.length === 0) {
+		return null;
+	}
+
+	const currentWorktreeRoot = findCurrentWorktreePath(normalizedCwd, parsedEntries);
+	if (!currentWorktreeRoot) {
+		return null;
+	}
+
+	const currentEntry = parsedEntries.find((entry) => entry.path === currentWorktreeRoot) ?? null;
+	const { commonDir, gitDir } = readGitDirectoryInfo(currentWorktreeRoot);
+
+	return {
+		normalizedCwd,
+		currentWorktreeRoot,
+		commonDir,
+		gitDir,
+		currentBranch: currentEntry?.branch ?? null,
+		worktreeListOutput,
+	};
+}
+
+function inferRepoRootFromCommonDir(commonDir: string, currentWorktreeRoot: string): string {
+	return path.basename(commonDir) === ".git" ? normalizePath(path.dirname(commonDir)) : currentWorktreeRoot;
+}
+
+function buildRepoWorktreeContext(
+	probe: RepoWorktreeContextProbe,
+	sharedRoot = DEFAULT_WORKTREE_ROOT,
+): RepoWorktreeContext {
+	const repoRoot = inferRepoRootFromCommonDir(probe.commonDir, probe.currentWorktreeRoot);
+	const registry = loadWorktreeRegistry(repoRoot, sharedRoot);
+	const metadata =
+		registry.managedWorktrees.find((entry) => normalizePath(entry.worktreePath) === probe.currentWorktreeRoot) ?? null;
+
+	return {
+		cwd: probe.normalizedCwd,
+		repoRoot,
+		currentWorktreeRoot: probe.currentWorktreeRoot,
+		mainWorktreeRoot: repoRoot,
+		commonDir: probe.commonDir,
+		gitDir: probe.gitDir,
+		currentBranch: probe.currentBranch,
+		isLinkedWorktree: probe.currentWorktreeRoot !== repoRoot,
+		current: {
+			path: probe.currentWorktreeRoot,
+			branch: probe.currentBranch,
+			isMain: probe.currentWorktreeRoot === repoRoot,
+			isManaged: !!metadata,
+			metadata,
+		},
+	};
+}
+
+function buildRepoWorktreeSnapshot(probe: RepoWorktreeProbe, sharedRoot = DEFAULT_WORKTREE_ROOT): RepoWorktreeSnapshot {
+	const parsedEntries = parseWorktreeListPorcelain(probe.worktreeListOutput);
+	const repoRoot = parsedEntries[0]?.path ?? probe.currentWorktreeRoot;
+	const registry = loadWorktreeRegistry(repoRoot, sharedRoot);
+	const metadataByPath = new Map(registry.managedWorktrees.map((entry) => [normalizePath(entry.worktreePath), entry]));
+	const worktrees = parsedEntries.map((entry) => {
+		const metadata = metadataByPath.get(entry.path) ?? null;
+		return {
+			...entry,
+			isMain: entry.path === repoRoot,
+			isCurrent: entry.path === probe.currentWorktreeRoot,
+			isManaged: !!metadata,
+			metadata,
+		};
+	});
+	const knownPaths = new Set(worktrees.map((entry) => entry.path));
+	const staleManagedWorktrees = registry.managedWorktrees.filter((entry) => !knownPaths.has(entry.worktreePath));
+	const current = worktrees.find((entry) => entry.isCurrent) ?? null;
+	const baseContext = buildRepoWorktreeContext(probe, sharedRoot);
+
+	return {
+		...baseContext,
+		current,
+		worktrees,
+		registry,
+		staleManagedWorktrees,
+	};
+}
+
+function readRepoWorktreeContextProbe(cwd: string): RepoWorktreeContextProbe | null {
+	const normalizedCwd = normalizePath(cwd);
+	const revParseOutput = git(normalizedCwd, ["rev-parse", "--show-toplevel", "--abbrev-ref", "HEAD"]);
+	return buildRepoWorktreeContextProbe(normalizedCwd, revParseOutput);
+}
+
+async function readRepoWorktreeContextProbeAsync(cwd: string): Promise<RepoWorktreeContextProbe | null> {
+	const normalizedCwd = normalizePath(cwd);
+	const revParseOutput = await gitAsync(normalizedCwd, ["rev-parse", "--show-toplevel", "--abbrev-ref", "HEAD"]);
+	return buildRepoWorktreeContextProbe(normalizedCwd, revParseOutput);
+}
+
+function readRepoWorktreeProbe(cwd: string): RepoWorktreeProbe | null {
+	const normalizedCwd = normalizePath(cwd);
+	const worktreeListOutput = git(normalizedCwd, ["worktree", "list", "--porcelain"]);
+	return buildRepoWorktreeProbe(normalizedCwd, worktreeListOutput);
+}
+
+async function readRepoWorktreeProbeAsync(cwd: string): Promise<RepoWorktreeProbe | null> {
+	const normalizedCwd = normalizePath(cwd);
+	const worktreeListOutput = await gitAsync(normalizedCwd, ["worktree", "list", "--porcelain"]);
+	return buildRepoWorktreeProbe(normalizedCwd, worktreeListOutput);
+}
+
+export function getRepoWorktreeContext(cwd: string, sharedRoot = DEFAULT_WORKTREE_ROOT): RepoWorktreeContext | null {
+	try {
+		const probe = readRepoWorktreeContextProbe(cwd);
+		return storeRepoWorktreeCacheEntry(
+			repoWorktreeContextCache,
+			cwd,
+			sharedRoot,
+			probe ? buildRepoWorktreeContext(probe, sharedRoot) : null,
+		);
+	} catch {
+		return storeRepoWorktreeCacheEntry(repoWorktreeContextCache, cwd, sharedRoot, null);
+	}
+}
+
+export async function refreshRepoWorktreeContext(
+	cwd: string,
+	sharedRoot = DEFAULT_WORKTREE_ROOT,
+): Promise<RepoWorktreeContext | null> {
+	const cacheKey = getRepoWorktreeCacheKey(cwd, sharedRoot);
+	const cachedEntry = repoWorktreeContextCache.get(cacheKey);
+	if (cachedEntry?.inFlight) {
+		return cachedEntry.inFlight;
+	}
+
+	const refreshPromise = (async () => {
+		try {
+			const probe = await readRepoWorktreeContextProbeAsync(cwd);
+			return storeRepoWorktreeCacheEntry(
+				repoWorktreeContextCache,
+				cwd,
+				sharedRoot,
+				probe ? buildRepoWorktreeContext(probe, sharedRoot) : null,
+			);
+		} catch {
+			return storeRepoWorktreeCacheEntry(repoWorktreeContextCache, cwd, sharedRoot, null);
+		}
+	})();
+
+	storeRepoWorktreeCacheEntry(repoWorktreeContextCache, cwd, sharedRoot, cachedEntry?.snapshot ?? null, refreshPromise);
+	return refreshPromise;
+}
+
+export function getRepoWorktreeSnapshot(cwd: string, sharedRoot = DEFAULT_WORKTREE_ROOT): RepoWorktreeSnapshot | null {
+	try {
+		const probe = readRepoWorktreeProbe(cwd);
+		return storeRepoWorktreeCacheEntry(
+			repoWorktreeSnapshotCache,
+			cwd,
+			sharedRoot,
+			probe ? buildRepoWorktreeSnapshot(probe, sharedRoot) : null,
+		);
+	} catch {
+		return storeRepoWorktreeCacheEntry(repoWorktreeSnapshotCache, cwd, sharedRoot, null);
+	}
+}
+
+export async function refreshRepoWorktreeSnapshot(
+	cwd: string,
+	sharedRoot = DEFAULT_WORKTREE_ROOT,
+): Promise<RepoWorktreeSnapshot | null> {
+	const cacheKey = getRepoWorktreeCacheKey(cwd, sharedRoot);
+	const cachedEntry = repoWorktreeSnapshotCache.get(cacheKey);
+	if (cachedEntry?.inFlight) {
+		return cachedEntry.inFlight;
+	}
+
+	const refreshPromise = (async () => {
+		try {
+			const probe = await readRepoWorktreeProbeAsync(cwd);
+			return storeRepoWorktreeCacheEntry(
+				repoWorktreeSnapshotCache,
+				cwd,
+				sharedRoot,
+				probe ? buildRepoWorktreeSnapshot(probe, sharedRoot) : null,
+			);
+		} catch {
+			return storeRepoWorktreeCacheEntry(repoWorktreeSnapshotCache, cwd, sharedRoot, null);
+		}
+	})();
+
+	storeRepoWorktreeCacheEntry(
+		repoWorktreeSnapshotCache,
+		cwd,
+		sharedRoot,
+		cachedEntry?.snapshot ?? null,
+		refreshPromise,
+	);
+	return refreshPromise;
 }
 
 function branchExists(repoRoot: string, branch: string): boolean {

--- a/packages/extensions/extensions/worktree.test.ts
+++ b/packages/extensions/extensions/worktree.test.ts
@@ -15,6 +15,7 @@ const worktreeShared = vi.hoisted(() => ({
 	})),
 	formatOwnerLabel: vi.fn((owner) => owner.instanceId),
 	formatWorktreeKind: vi.fn((entry) => (entry.isMain ? "main" : entry.isManaged ? "pi-owned" : "external")),
+	getRepoWorktreeContext: vi.fn(),
 	getRepoWorktreeSnapshot: vi.fn(),
 	removeManagedWorktree: vi.fn(),
 	touchManagedWorktreeSeen: vi.fn(),
@@ -69,14 +70,14 @@ describe("worktree extension", () => {
 		try {
 			const harness = createExtensionHarness();
 			harness.ctx.cwd = "/repo";
-			worktreeShared.getRepoWorktreeSnapshot.mockReturnValue(makeSnapshot());
+			worktreeShared.getRepoWorktreeContext.mockReturnValue(makeSnapshot());
 
 			worktreeExtension(harness.pi as never);
 			harness.emit("session_start", {}, harness.ctx);
-			expect(worktreeShared.getRepoWorktreeSnapshot).not.toHaveBeenCalled();
+			expect(worktreeShared.getRepoWorktreeContext).not.toHaveBeenCalled();
 
 			await vi.advanceTimersByTimeAsync(500);
-			expect(worktreeShared.getRepoWorktreeSnapshot).toHaveBeenCalledWith("/repo");
+			expect(worktreeShared.getRepoWorktreeContext).toHaveBeenCalledWith("/repo");
 			expect(harness.statusMap.get("pi-worktree")).toContain("main checkout");
 		} finally {
 			vi.useRealTimers();
@@ -87,6 +88,7 @@ describe("worktree extension", () => {
 		const harness = createExtensionHarness();
 		harness.ctx.cwd = "/repo";
 		harness.ctx.ui.input = vi.fn(async () => "Implement footer context");
+		worktreeShared.getRepoWorktreeContext.mockReturnValue(null);
 		worktreeShared.getRepoWorktreeSnapshot.mockReturnValue(null);
 		worktreeShared.createManagedWorktree.mockReturnValue({
 			repoRoot: "/repo",
@@ -117,6 +119,26 @@ describe("worktree extension", () => {
 	it("opens a matching worktree through the system opener helper", async () => {
 		const harness = createExtensionHarness();
 		harness.ctx.cwd = "/repo";
+		worktreeShared.getRepoWorktreeContext.mockReturnValue(
+			makeSnapshot({
+				isLinkedWorktree: true,
+				currentWorktreeRoot: "/tmp/pi/feat-footer",
+				currentBranch: "feat/footer-context",
+				current: {
+					path: "/tmp/pi/feat-footer",
+					branch: "feat/footer-context",
+					head: "abc",
+					bare: false,
+					detached: false,
+					lockedReason: null,
+					prunableReason: null,
+					isMain: false,
+					isCurrent: true,
+					isManaged: true,
+					metadata: { purpose: "Build worktree UX", owner: { instanceId: "pi-test-instance" } },
+				},
+			}),
+		);
 		worktreeShared.getRepoWorktreeSnapshot.mockReturnValue(
 			makeSnapshot({
 				isLinkedWorktree: true,
@@ -178,6 +200,7 @@ describe("worktree extension", () => {
 	it("refuses to clean external worktrees by default", async () => {
 		const harness = createExtensionHarness();
 		harness.ctx.cwd = "/repo";
+		worktreeShared.getRepoWorktreeContext.mockReturnValue(makeSnapshot());
 		worktreeShared.getRepoWorktreeSnapshot.mockReturnValue(
 			makeSnapshot({
 				worktrees: [

--- a/packages/extensions/extensions/worktree.ts
+++ b/packages/extensions/extensions/worktree.ts
@@ -1,6 +1,7 @@
 import path from "node:path";
 import process from "node:process";
 import type { ExtensionAPI, ExtensionContext } from "@mariozechner/pi-coding-agent";
+import { recordRuntimeSample } from "./watchdog-runtime-diagnostics";
 import {
 	buildPaiInstanceId,
 	createManagedWorktree,
@@ -8,8 +9,10 @@ import {
 	formatOwnerLabel,
 	formatWorktreeKind,
 	type GitWorktreeEntry,
+	getRepoWorktreeContext,
 	getRepoWorktreeSnapshot,
 	type ManagedWorktreeMetadata,
+	type RepoWorktreeContext,
 	type RepoWorktreeSnapshot,
 	removeManagedWorktree,
 	touchManagedWorktreeSeen,
@@ -242,7 +245,7 @@ async function chooseWorktreeTarget(
 	return selected ? findWorktreeEntry(snapshot, selected) : null;
 }
 
-function currentStatusText(snapshot: RepoWorktreeSnapshot | null): string | undefined {
+function currentStatusText(snapshot: RepoWorktreeContext | null): string | undefined {
 	if (!snapshot) {
 		return undefined;
 	}
@@ -258,12 +261,14 @@ function currentStatusText(snapshot: RepoWorktreeSnapshot | null): string | unde
 	return `${repo} · external wt ${branch}`;
 }
 
-function refreshStatus(ctx: ExtensionContext): RepoWorktreeSnapshot | null {
-	const snapshot = getRepoWorktreeSnapshot(ctx.cwd);
+function refreshStatus(ctx: ExtensionContext): RepoWorktreeContext | null {
+	const startedAt = Date.now();
+	const snapshot = getRepoWorktreeContext(ctx.cwd);
 	if (snapshot?.current?.isManaged) {
 		touchManagedWorktreeSeen(snapshot.repoRoot, snapshot.current.path);
 	}
 	ctx.ui.setStatus("pi-worktree", currentStatusText(snapshot));
+	recordRuntimeSample("worktree", "event", "status_refresh", Date.now() - startedAt, "worktree");
 	return snapshot;
 }
 
@@ -286,7 +291,8 @@ async function openPath(pi: ExtensionAPI, targetPath: string): Promise<boolean> 
 }
 
 async function handleStatus(pi: ExtensionAPI, ctx: ExtensionContext): Promise<void> {
-	const snapshot = refreshStatus(ctx);
+	refreshStatus(ctx);
+	const snapshot = getRepoWorktreeSnapshot(ctx.cwd);
 	if (!snapshot) {
 		ctx.ui.notify("Not inside a git repository.", "warning");
 		return;
@@ -295,7 +301,8 @@ async function handleStatus(pi: ExtensionAPI, ctx: ExtensionContext): Promise<vo
 }
 
 async function handleList(pi: ExtensionAPI, ctx: ExtensionContext): Promise<void> {
-	const snapshot = refreshStatus(ctx);
+	refreshStatus(ctx);
+	const snapshot = getRepoWorktreeSnapshot(ctx.cwd);
 	if (!snapshot) {
 		ctx.ui.notify("Not inside a git repository.", "warning");
 		return;
@@ -361,7 +368,8 @@ async function handleCreate(pi: ExtensionAPI, args: string, ctx: ExtensionContex
 }
 
 async function handleOpen(pi: ExtensionAPI, args: string, ctx: ExtensionContext): Promise<void> {
-	const snapshot = refreshStatus(ctx);
+	refreshStatus(ctx);
+	const snapshot = getRepoWorktreeSnapshot(ctx.cwd);
 	if (!snapshot) {
 		ctx.ui.notify("Not inside a git repository.", "warning");
 		return;
@@ -393,7 +401,8 @@ async function handleOpen(pi: ExtensionAPI, args: string, ctx: ExtensionContext)
 }
 
 async function handleCleanup(pi: ExtensionAPI, args: string, ctx: ExtensionContext): Promise<void> {
-	const snapshot = refreshStatus(ctx);
+	refreshStatus(ctx);
+	const snapshot = getRepoWorktreeSnapshot(ctx.cwd);
 	if (!snapshot) {
 		ctx.ui.notify("Not inside a git repository.", "warning");
 		return;


### PR DESCRIPTION
## Summary
- split worktree probing into lightweight current-context refreshes and full inventory snapshots
- move footer and worktree status refreshes onto the lighter path and throttle managed-worktree touch writes
- add runtime diagnostics, focused tests, and more robust startup benchmark coverage for both worktree paths

## Validation
- pnpm lint
- pnpm test
- pnpm typecheck
- pnpm bench:startup