### PR TITLE
feat(cli): add provider routing dashboard

### DIFF
--- a/.changeset/routing-dashboard-surfacing.md
+++ b/.changeset/routing-dashboard-surfacing.md
@@ -1,0 +1,5 @@
+---
+default: minor
+---
+
+Add a dedicated provider and routing dashboard to the oh-pi setup flow so users can review optional routing packages, available providers/models, delegated assignments, and effective routing for the main session, subagents, and ant-colony.

--- a/packages/cli/README.md
+++ b/packages/cli/README.md
@@ -7,6 +7,7 @@ Interactive TUI configurator for `pi-coding-agent`.
 `@ifi/oh-pi-cli` powers the interactive `oh-pi` setup experience. It helps configure:
 - providers and auth
 - models
+- provider/routing dashboard views for session, subagents, and ant-colony
 - extensions
 - prompts
 - skills

--- a/packages/cli/src/tui/config-wizard.ts
+++ b/packages/cli/src/tui/config-wizard.ts
@@ -56,7 +56,7 @@ function buildWizardOptions(state: WizardState) {
 		},
 		{
 			value: "routing" as const,
-			label: sectionLabel("Routing", !!state.providerSetup),
+			label: sectionLabel("Routing Dashboard", !!state.providerSetup),
 			hint: summarizeRouting(state.adaptiveRouting),
 		},
 		{
@@ -109,10 +109,10 @@ export async function runConfigWizard(env: EnvInfo, initial: WizardBaseConfig): 
 
 		if (step === "providers") {
 			state.providerSetup = await setupProviders(env);
-			state.adaptiveRouting = await setupAdaptiveRouting([
-				...(env.existingProviders ?? []).map((name) => ({ name, apiKey: "none" })),
-				...state.providerSetup.providers,
-			]);
+			state.adaptiveRouting = await setupAdaptiveRouting(
+				[...(env.existingProviders ?? []).map((name) => ({ name, apiKey: "none" })), ...state.providerSetup.providers],
+				state.adaptiveRouting,
+			);
 			nextStep = "routing";
 			continue;
 		}
@@ -123,10 +123,10 @@ export async function runConfigWizard(env: EnvInfo, initial: WizardBaseConfig): 
 				nextStep = "providers";
 				continue;
 			}
-			state.adaptiveRouting = await setupAdaptiveRouting([
-				...(env.existingProviders ?? []).map((name) => ({ name, apiKey: "none" })),
-				...state.providerSetup.providers,
-			]);
+			state.adaptiveRouting = await setupAdaptiveRouting(
+				[...(env.existingProviders ?? []).map((name) => ({ name, apiKey: "none" })), ...state.providerSetup.providers],
+				state.adaptiveRouting,
+			);
 			nextStep = "appearance";
 			continue;
 		}

--- a/packages/cli/src/tui/routing-dashboard.test.ts
+++ b/packages/cli/src/tui/routing-dashboard.test.ts
@@ -1,0 +1,79 @@
+import type { ProviderConfig } from "@ifi/oh-pi-core";
+import { describe, expect, it } from "vitest";
+import { buildRoutingDashboard, detectOptionalRoutingPackages } from "./routing-dashboard.js";
+
+function makeProviders(): ProviderConfig[] {
+	return [
+		{
+			name: "openai",
+			apiKey: "OPENAI_API_KEY",
+			defaultModel: "gpt-4o",
+			discoveredModels: [
+				{ id: "gpt-4o", reasoning: false, input: ["text", "image"], contextWindow: 128000, maxTokens: 16384 },
+				{ id: "gpt-5-mini", reasoning: true, input: ["text", "image"], contextWindow: 128000, maxTokens: 16384 },
+			],
+		},
+		{
+			name: "groq",
+			apiKey: "GROQ_API_KEY",
+			defaultModel: "llama-3.3-70b-versatile",
+		},
+	];
+}
+
+describe("detectOptionalRoutingPackages", () => {
+	it("maps package installation state with a custom resolver", () => {
+		const packages = detectOptionalRoutingPackages((packageName) => packageName === "@ifi/pi-provider-ollama");
+
+		expect(packages.find((pkg) => pkg.packageName === "@ifi/pi-provider-ollama")?.installed).toBe(true);
+		expect(packages.find((pkg) => pkg.packageName === "@ifi/pi-provider-cursor")?.installed).toBe(false);
+	});
+});
+
+describe("buildRoutingDashboard", () => {
+	it("surfaces packages, providers, delegated assignments, and effective routing", () => {
+		const dashboard = buildRoutingDashboard({
+			providers: makeProviders(),
+			packageStates: [
+				{
+					packageName: "@ifi/pi-extension-adaptive-routing",
+					label: "Adaptive routing package",
+					hint: "Optional /route command and per-prompt auto routing",
+					installed: true,
+				},
+			],
+			config: {
+				mode: "shadow",
+				categories: {
+					"quick-discovery": ["groq", "openai"],
+					"planning-default": ["openai", "groq"],
+					"implementation-default": ["openai", "groq"],
+					"research-default": ["openai", "groq"],
+					"review-critical": ["openai", "groq"],
+					"visual-engineering": ["openai", "groq"],
+					"multimodal-default": ["openai", "groq"],
+				},
+			},
+		});
+
+		expect(dashboard).toContain("Adaptive routing package: installed");
+		expect(dashboard).toContain("openai/gpt-4o · 2 discovered models");
+		expect(dashboard).toContain("groq/llama-3.3-70b-versatile");
+		expect(dashboard).toContain("Quick discovery: groq → openai");
+		expect(dashboard).toContain("Session default: openai/gpt-4o");
+		expect(dashboard).toContain("scout → groq/llama-3.3-70b-versatile (Quick discovery)");
+		expect(dashboard).toContain("worker, drone, backend → openai/gpt-4o (Implementation)");
+	});
+
+	it("shows session-default fallback when delegated assignments are not configured", () => {
+		const dashboard = buildRoutingDashboard({
+			providers: [{ name: "openai", apiKey: "OPENAI_API_KEY", defaultModel: "gpt-4o" }],
+			packageStates: [],
+		});
+
+		expect(dashboard).toContain("Delegated assignments:");
+		expect(dashboard).toContain("delegated startup assignments not configured");
+		expect(dashboard).toContain("Session default: openai/gpt-4o");
+		expect(dashboard).toContain("scout → session default (Quick discovery)");
+	});
+});

--- a/packages/cli/src/tui/routing-dashboard.ts
+++ b/packages/cli/src/tui/routing-dashboard.ts
@@ -1,0 +1,234 @@
+import { createRequire } from "node:module";
+import type { ProviderConfig } from "@ifi/oh-pi-core";
+import type { AdaptiveRoutingSetupConfig } from "../types.js";
+
+const require = createRequire(import.meta.url);
+
+export const ROUTING_CATEGORIES = [
+	{
+		name: "quick-discovery",
+		label: "Quick discovery",
+		recommended: ["groq", "ollama-cloud", "ollama", "openai"],
+		subagents: ["scout"],
+		colony: ["scout"],
+	},
+	{
+		name: "planning-default",
+		label: "Planning",
+		recommended: ["openai", "ollama-cloud", "ollama", "groq"],
+		subagents: ["planner", "context-builder"],
+		colony: [],
+	},
+	{
+		name: "implementation-default",
+		label: "Implementation",
+		recommended: ["openai", "ollama-cloud", "ollama", "groq"],
+		subagents: ["worker"],
+		colony: ["worker", "drone", "backend"],
+	},
+	{
+		name: "research-default",
+		label: "Research",
+		recommended: ["openai", "groq", "ollama-cloud", "ollama"],
+		subagents: ["researcher"],
+		colony: [],
+	},
+	{
+		name: "review-critical",
+		label: "Review / critical validation",
+		recommended: ["openai", "ollama-cloud", "ollama", "groq"],
+		subagents: ["reviewer"],
+		colony: ["soldier", "review"],
+	},
+	{
+		name: "visual-engineering",
+		label: "Visual / design work",
+		recommended: ["ollama-cloud", "ollama", "openai", "groq"],
+		subagents: ["artist", "frontend-designer"],
+		colony: ["design"],
+	},
+	{
+		name: "multimodal-default",
+		label: "Multimodal media work",
+		recommended: ["ollama-cloud", "ollama", "openai", "groq"],
+		subagents: ["multimodal-summariser"],
+		colony: ["multimodal"],
+	},
+] as const;
+
+const OPTIONAL_ROUTING_PACKAGES = [
+	{
+		packageName: "@ifi/pi-extension-adaptive-routing",
+		label: "Adaptive routing package",
+		hint: "Optional /route command and per-prompt auto routing",
+	},
+	{
+		packageName: "@ifi/pi-provider-ollama",
+		label: "Ollama provider package",
+		hint: "Ollama local and Ollama Cloud model support",
+	},
+	{
+		packageName: "@ifi/pi-provider-cursor",
+		label: "Cursor provider package",
+		hint: "cursor-agent provider support",
+	},
+	{
+		packageName: "@ifi/pi-provider-catalog",
+		label: "Provider catalog package",
+		hint: "Catalog-backed provider and model discovery helpers",
+	},
+] as const;
+
+export interface OptionalRoutingPackageState {
+	packageName: string;
+	label: string;
+	hint: string;
+	installed: boolean;
+}
+
+interface RoutingDashboardOptions {
+	providers: ProviderConfig[];
+	config?: AdaptiveRoutingSetupConfig;
+	packageStates?: OptionalRoutingPackageState[];
+}
+
+function defaultPackageResolver(packageName: string): boolean {
+	try {
+		require.resolve(`${packageName}/package.json`);
+		return true;
+	} catch {
+		return false;
+	}
+}
+
+export function detectOptionalRoutingPackages(
+	resolvePackage: (packageName: string) => boolean = defaultPackageResolver,
+): OptionalRoutingPackageState[] {
+	return OPTIONAL_ROUTING_PACKAGES.map((pkg) => ({
+		...pkg,
+		installed: resolvePackage(pkg.packageName),
+	}));
+}
+
+function mergeProviderConfigs(providers: ProviderConfig[]): ProviderConfig[] {
+	const merged = new Map<string, ProviderConfig>();
+	for (const provider of providers) {
+		const name = provider.name.trim();
+		if (!name) {
+			continue;
+		}
+		const previous = merged.get(name);
+		merged.set(name, {
+			...previous,
+			...provider,
+			name,
+			defaultModel: provider.defaultModel ?? previous?.defaultModel,
+			discoveredModels: provider.discoveredModels ?? previous?.discoveredModels,
+		});
+	}
+	return [...merged.values()];
+}
+
+function primaryModel(provider: ProviderConfig): string | undefined {
+	return provider.defaultModel ?? provider.discoveredModels?.[0]?.id;
+}
+
+function formatProviderModel(provider: ProviderConfig): string {
+	const model = primaryModel(provider);
+	return model ? `${provider.name}/${model}` : `${provider.name}/<configured externally>`;
+}
+
+function resolveCategoryTarget(
+	categoryName: string,
+	providers: ProviderConfig[],
+	config?: AdaptiveRoutingSetupConfig,
+): string {
+	if (!config) {
+		return "session default";
+	}
+	const providerOrder = config.categories[categoryName] ?? [];
+	for (const providerName of providerOrder) {
+		const provider = providers.find((entry) => entry.name === providerName);
+		if (provider) {
+			return formatProviderModel(provider);
+		}
+	}
+	return "session default";
+}
+
+function buildOptionalPackageLines(packageStates: OptionalRoutingPackageState[]): string[] {
+	return packageStates.map((pkg) => {
+		const state = pkg.installed ? "installed" : "not installed";
+		return `- ${pkg.label}: ${state} — ${pkg.hint}`;
+	});
+}
+
+function buildProviderLines(providers: ProviderConfig[]): string[] {
+	if (providers.length === 0) {
+		return ["- none selected yet"];
+	}
+	return providers.map((provider) => {
+		const discoveredCount = provider.discoveredModels?.length ?? 0;
+		const discoveredSuffix = discoveredCount > 1 ? ` · ${discoveredCount} discovered models` : "";
+		return `- ${formatProviderModel(provider)}${discoveredSuffix}`;
+	});
+}
+
+function buildDelegatedAssignmentLines(config: AdaptiveRoutingSetupConfig | undefined): string[] {
+	if (!config) {
+		return ["- delegated startup assignments not configured"];
+	}
+	return ROUTING_CATEGORIES.map((category) => {
+		const order = config.categories[category.name]?.join(" → ") ?? "session default";
+		return `- ${category.label}: ${order}`;
+	});
+}
+
+function buildConsumerLines(
+	title: string,
+	providers: ProviderConfig[],
+	config: AdaptiveRoutingSetupConfig | undefined,
+	consumerKey: "subagents" | "colony",
+): string[] {
+	const lines = [`${title}:`];
+	let hasConsumers = false;
+	for (const category of ROUTING_CATEGORIES) {
+		const consumers = category[consumerKey];
+		if (consumers.length === 0) {
+			continue;
+		}
+		hasConsumers = true;
+		lines.push(
+			`- ${consumers.join(", ")} → ${resolveCategoryTarget(category.name, providers, config)} (${category.label})`,
+		);
+	}
+	if (!hasConsumers) {
+		lines.push("- none");
+	}
+	return lines;
+}
+
+export function buildRoutingDashboard({
+	providers,
+	config,
+	packageStates = detectOptionalRoutingPackages(),
+}: RoutingDashboardOptions): string {
+	const mergedProviders = mergeProviderConfigs(providers);
+	const sessionDefault = mergedProviders[0] ? formatProviderModel(mergedProviders[0]) : "not configured";
+
+	return [
+		"Optional routing / provider packages:",
+		...buildOptionalPackageLines(packageStates),
+		"",
+		"Available providers / models:",
+		...buildProviderLines(mergedProviders),
+		"",
+		"Delegated assignments:",
+		...buildDelegatedAssignmentLines(config),
+		"",
+		"Effective routing:",
+		`Session default: ${sessionDefault}`,
+		...buildConsumerLines("Subagents", mergedProviders, config, "subagents"),
+		...buildConsumerLines("Ant colony", mergedProviders, config, "colony"),
+	].join("\n");
+}

--- a/packages/cli/src/tui/routing-setup.ts
+++ b/packages/cli/src/tui/routing-setup.ts
@@ -1,32 +1,7 @@
 import * as p from "@clack/prompts";
 import type { ProviderConfig } from "@ifi/oh-pi-core";
 import type { AdaptiveRoutingModeConfig, AdaptiveRoutingSetupConfig } from "../types.js";
-
-const ROUTING_CATEGORIES = [
-	{ name: "quick-discovery", label: "Quick discovery", recommended: ["groq", "ollama-cloud", "ollama", "openai"] },
-	{ name: "planning-default", label: "Planning", recommended: ["openai", "ollama-cloud", "ollama", "groq"] },
-	{
-		name: "implementation-default",
-		label: "Implementation",
-		recommended: ["openai", "ollama-cloud", "ollama", "groq"],
-	},
-	{ name: "research-default", label: "Research", recommended: ["openai", "groq", "ollama-cloud", "ollama"] },
-	{
-		name: "review-critical",
-		label: "Review / critical validation",
-		recommended: ["openai", "ollama-cloud", "ollama", "groq"],
-	},
-	{
-		name: "visual-engineering",
-		label: "Visual / design work",
-		recommended: ["ollama-cloud", "ollama", "openai", "groq"],
-	},
-	{
-		name: "multimodal-default",
-		label: "Multimodal media work",
-		recommended: ["ollama-cloud", "ollama", "openai", "groq"],
-	},
-] as const;
+import { buildRoutingDashboard, ROUTING_CATEGORIES } from "./routing-dashboard.js";
 
 function uniqueProviderNames(providers: ProviderConfig[]): string[] {
 	return [...new Set(providers.map((provider) => provider.name.trim()).filter(Boolean))];
@@ -47,35 +22,45 @@ function suggestedProvider(category: (typeof ROUTING_CATEGORIES)[number], provid
 
 export async function setupAdaptiveRouting(
 	providers: ProviderConfig[],
+	currentConfig?: AdaptiveRoutingSetupConfig,
 ): Promise<AdaptiveRoutingSetupConfig | undefined> {
 	const providerNames = uniqueProviderNames(providers);
 	if (providerNames.length === 0) {
 		return undefined;
 	}
 
+	p.note(
+		buildRoutingDashboard({
+			providers,
+			config: currentConfig,
+		}),
+		"Provider & Routing Dashboard",
+	);
+
 	const shouldConfigure = await p.confirm({
-		message:
-			providerNames.length > 1
-				? "Configure startup provider assignments for subagents and ant-colony?"
+		message: currentConfig
+			? "Edit startup provider assignments for session, subagents, and ant-colony?"
+			: providerNames.length > 1
+				? "Configure startup provider assignments for session, subagents, and ant-colony?"
 				: `Use ${providerNames[0]} for delegated subagent and colony routing?`,
-		initialValue: providerNames.length > 1,
+		initialValue: currentConfig ? true : providerNames.length > 1,
 	});
 	if (p.isCancel(shouldConfigure)) {
 		p.cancel("Cancelled.");
 		process.exit(0);
 	}
 	if (!shouldConfigure) {
-		return undefined;
+		return currentConfig;
 	}
 
 	const mode = await p.select<AdaptiveRoutingModeConfig>({
+		initialValue: currentConfig?.mode ?? "off",
 		message: "Prompt routing mode for the optional adaptive-routing package:",
 		options: [
 			{ value: "off", label: "Off", hint: "Only delegated startup assignments; no per-prompt auto routing" },
 			{ value: "shadow", label: "Shadow", hint: "Suggest routes without switching models automatically" },
 			{ value: "auto", label: "Auto", hint: "Automatically switch models before each turn" },
 		],
-		initialValue: "off",
 	});
 	if (p.isCancel(mode)) {
 		p.cancel("Cancelled.");
@@ -91,7 +76,7 @@ export async function setupAdaptiveRouting(
 				label: provider,
 				hint: `Fallback order: ${orderProviders(provider, providerNames).join(" → ")}`,
 			})),
-			initialValue: suggestedProvider(category, providerNames),
+			initialValue: currentConfig?.categories[category.name]?.[0] ?? suggestedProvider(category, providerNames),
 		});
 		if (p.isCancel(preferred)) {
 			p.cancel("Cancelled.");
@@ -100,7 +85,17 @@ export async function setupAdaptiveRouting(
 		categories[category.name] = orderProviders(preferred, providerNames);
 	}
 
-	return { mode, categories };
+	const config = { mode, categories };
+
+	p.note(
+		buildRoutingDashboard({
+			providers,
+			config,
+		}),
+		"Provider & Routing Dashboard",
+	);
+
+	return config;
 }
 
 export function summarizeAdaptiveRouting(config: AdaptiveRoutingSetupConfig | undefined): string {


### PR DESCRIPTION
## Summary
- add a dedicated provider and routing dashboard to the setup flow
- surface optional routing/provider packages, available providers/models, delegated assignments, and effective routing
- preserve and re-edit existing routing selections in the custom wizard

## Validation
- node_modules/.bin/vitest run packages/cli/src/tui/config-wizard.test.ts packages/cli/src/tui/routing-dashboard.test.ts packages/cli/src/utils/writers.test.ts
- pnpm --filter @ifi/oh-pi-cli typecheck
- pnpm --filter @ifi/oh-pi-cli build
- pnpm build
