### PR TITLE
test(benchmarks): harden startup benchmark CI

### DIFF
--- a/.changeset/benchmark-robustness.md
+++ b/.changeset/benchmark-robustness.md
@@ -1,0 +1,5 @@
+---
+default: patch
+---
+
+Improve benchmark robustness by batching fast samples to reduce timer noise, narrowing focused startup hotspots from changed files, and adding tests for benchmark sampling and target selection.

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -376,7 +376,9 @@ jobs:
             ./benchmarks/startup/select-targets.ts coverage/benchmarks/changed-files.txt \
             > coverage/benchmarks/startup-targets.json
           TARGETS=$(node --input-type=module -e "import fs from 'node:fs'; const report = JSON.parse(fs.readFileSync('coverage/benchmarks/startup-targets.json', 'utf8')); console.log(report.mode === 'all' ? 'all' : report.selectedExtensions.join(','));")
+          FOCUSED=$(node --input-type=module -e "import fs from 'node:fs'; const report = JSON.parse(fs.readFileSync('coverage/benchmarks/startup-targets.json', 'utf8')); console.log(report.mode === 'all' ? 'all' : report.selectedFocusedBenchmarkIds.join(','));")
           echo "OH_PI_BENCH_EXTENSION_FILTER=$TARGETS" >> "$GITHUB_ENV"
+          echo "OH_PI_BENCH_FOCUSED_FILTER=$FOCUSED" >> "$GITHUB_ENV"
 
       - name: Run startup and microbench suites
         run: |

--- a/benchmarks/README.md
+++ b/benchmarks/README.md
@@ -24,13 +24,19 @@ OH_PI_BENCH_EXTENSION_FILTER=worktree pnpm bench:startup
 OH_PI_BENCH_EXTENSION_FILTER=watchdog,custom-footer pnpm bench:startup
 ```
 
-The startup suite always keeps the baseline startup/hotspot cases, then adds isolated extension startup cases for the selected extensions.
+To run only specific focused startup hotspots alongside the always-on startup baselines:
+
+```bash
+OH_PI_BENCH_FOCUSED_FILTER=worktree-context-temp-repo,worktree-snapshot-temp-repo pnpm bench:startup
+```
+
+The startup suite always keeps the baseline startup cases, adds only the selected focused hotspots when a focused filter is present, and then adds isolated extension startup cases for the selected extensions.
 
 ## CI behavior
 
 `pnpm bench:startup` runs on every pull request and push in GitHub Actions.
 
-For pull requests, the workflow computes impacted extensions from the changed files and sets `OH_PI_BENCH_EXTENSION_FILTER` automatically. If shared infrastructure changes, it benchmarks all default extensions.
+For pull requests, the workflow computes impacted extensions and focused startup hotspots from the changed files and sets `OH_PI_BENCH_EXTENSION_FILTER` plus `OH_PI_BENCH_FOCUSED_FILTER` automatically. If shared infrastructure changes, it benchmarks all default extensions and all focused hotspots.
 
 It writes machine-readable and Markdown reports to:
 
@@ -55,6 +61,8 @@ Current cases cover:
 7. first footer render cost
 
 Each benchmark has committed median/p95 budgets so regressions fail in CI while still emitting a readable report.
+
+Fast benchmarks can also use a per-sample time floor so each reported sample averages multiple inner runs. That reduces timer noise and makes CI results more stable.
 
 ## Existing manual scenario templates
 

--- a/benchmarks/shared/benchmark.test.ts
+++ b/benchmarks/shared/benchmark.test.ts
@@ -1,0 +1,29 @@
+import { describe, expect, it, vi } from "vitest";
+import { runBenchmark } from "./benchmark";
+
+describe("benchmark helper", () => {
+	it("batches fast samples until the sample floor is reached", async () => {
+		vi.useFakeTimers();
+		try {
+			const run = vi.fn(async () => {
+				await vi.advanceTimersByTimeAsync(1);
+			});
+
+			const result = await runBenchmark({
+				id: "batched-fast-sample",
+				label: "batched fast sample",
+				group: "unit",
+				iterations: 4,
+				warmupIterations: 0,
+				minSampleTimeMs: 5,
+				run,
+			});
+
+			expect(result.minSampleTimeMs).toBe(5);
+			expect(result.avgLoopsPerSample).toBeGreaterThanOrEqual(5);
+			expect(run.mock.calls.length).toBeGreaterThanOrEqual(20);
+		} finally {
+			vi.useRealTimers();
+		}
+	});
+});

--- a/benchmarks/shared/benchmark.ts
+++ b/benchmarks/shared/benchmark.ts
@@ -15,6 +15,8 @@ export type BenchmarkDefinition = {
 	warmupIterations?: number;
 	note?: string;
 	budget?: BenchmarkBudget;
+	minSampleTimeMs?: number;
+	maxSampleLoops?: number;
 	run: () => Promise<void> | void;
 };
 
@@ -26,6 +28,8 @@ export type BenchmarkResult = {
 	warmupIterations: number;
 	note?: string;
 	budget?: BenchmarkBudget;
+	minSampleTimeMs: number;
+	avgLoopsPerSample: number;
 	samplesMs: number[];
 	minMs: number;
 	maxMs: number;
@@ -91,17 +95,38 @@ function evaluateBudget(result: { medianMs: number; p95Ms: number; budget?: Benc
 	return failures;
 }
 
+async function runSample(definition: BenchmarkDefinition): Promise<{ sampleMs: number; loopCount: number }> {
+	const minSampleTimeMs = Math.max(0, definition.minSampleTimeMs ?? 0);
+	const maxSampleLoops = Math.max(1, definition.maxSampleLoops ?? 1_000);
+	let loopCount = 0;
+	const startedAt = performance.now();
+
+	while (true) {
+		await definition.run();
+		loopCount += 1;
+
+		const elapsedMs = performance.now() - startedAt;
+		if (elapsedMs >= minSampleTimeMs || loopCount >= maxSampleLoops) {
+			return {
+				sampleMs: elapsedMs / loopCount,
+				loopCount,
+			};
+		}
+	}
+}
+
 export async function runBenchmark(definition: BenchmarkDefinition): Promise<BenchmarkResult> {
 	const warmupIterations = Math.max(0, definition.warmupIterations ?? 1);
 	for (let index = 0; index < warmupIterations; index++) {
-		await definition.run();
+		await runSample(definition);
 	}
 
 	const samplesMs: number[] = [];
+	const sampleLoopCounts: number[] = [];
 	for (let index = 0; index < definition.iterations; index++) {
-		const startedAt = performance.now();
-		await definition.run();
-		samplesMs.push(performance.now() - startedAt);
+		const sample = await runSample(definition);
+		samplesMs.push(sample.sampleMs);
+		sampleLoopCounts.push(sample.loopCount);
 	}
 
 	const sortedSamples = [...samplesMs].sort((left, right) => left - right);
@@ -120,6 +145,8 @@ export async function runBenchmark(definition: BenchmarkDefinition): Promise<Ben
 		warmupIterations,
 		note: definition.note,
 		budget: definition.budget,
+		minSampleTimeMs: Math.max(0, definition.minSampleTimeMs ?? 0),
+		avgLoopsPerSample: round(mean(sampleLoopCounts)),
 		samplesMs: sortedSamples.map((value) => round(value)),
 		minMs,
 		maxMs,
@@ -140,8 +167,8 @@ function toMarkdown(report: BenchmarkSuiteReport): string {
 		`- CI: ${report.environment.ci ? "yes" : "no"}`,
 		`- SHA: ${report.environment.sha ?? "unknown"}`,
 		"",
-		"| Benchmark | Group | Median | p95 | Mean | Budget | Status |",
-		"| --- | --- | ---: | ---: | ---: | --- | --- |",
+		"| Benchmark | Group | Median | p95 | Mean | Sample Floor | Budget | Status |",
+		"| --- | --- | ---: | ---: | ---: | --- | --- | --- |",
 	];
 
 	for (const result of report.results) {
@@ -154,8 +181,12 @@ function toMarkdown(report: BenchmarkSuiteReport): string {
 					.join(" · ")
 			: "—";
 		const status = result.budgetFailures.length === 0 ? "✅ pass" : `❌ ${result.budgetFailures.join("; ")}`;
+		const sampleFloor =
+			result.minSampleTimeMs > 0
+				? `${result.minSampleTimeMs.toFixed(0)}ms floor · ${result.avgLoopsPerSample.toFixed(1)} loops/sample`
+				: "—";
 		lines.push(
-			`| ${result.label} | ${result.group} | ${result.medianMs.toFixed(2)}ms | ${result.p95Ms.toFixed(2)}ms | ${result.meanMs.toFixed(2)}ms | ${budget} | ${status} |`,
+			`| ${result.label} | ${result.group} | ${result.medianMs.toFixed(2)}ms | ${result.p95Ms.toFixed(2)}ms | ${result.meanMs.toFixed(2)}ms | ${sampleFloor} | ${budget} | ${status} |`,
 		);
 
 		if (result.note) {

--- a/benchmarks/startup/select-targets.test.ts
+++ b/benchmarks/startup/select-targets.test.ts
@@ -1,0 +1,39 @@
+import { describe, expect, it } from "vitest";
+import { computeBenchmarkTargets } from "./select-targets";
+
+describe("startup benchmark target selection", () => {
+	it("targets worktree-focused hotspots and the worktree extension for worktree changes", async () => {
+		const report = await computeBenchmarkTargets(["packages/extensions/extensions/worktree-shared.ts"]);
+
+		expect(report.mode).toBe("selected");
+		expect(report.selectedExtensions).toContain("worktree");
+		expect(report.selectedFocusedBenchmarkIds).toEqual([
+			"custom-footer-first-render",
+			"worktree-context-temp-repo",
+			"worktree-snapshot-temp-repo",
+		]);
+	});
+
+	it("targets scheduler-focused hotspots for scheduler changes", async () => {
+		const report = await computeBenchmarkTargets(["packages/extensions/extensions/scheduler-registration.ts"]);
+
+		expect(report.mode).toBe("selected");
+		expect(report.selectedExtensions).toContain("scheduler");
+		expect(report.selectedFocusedBenchmarkIds).toEqual(["scheduler-runtime-context-with-store"]);
+	});
+
+	it("falls back to all benchmark targets for shared benchmark infrastructure changes", async () => {
+		const report = await computeBenchmarkTargets(["benchmarks/startup/suite.ts"]);
+
+		expect(report.mode).toBe("all");
+		expect(report.selectedExtensions.length).toBeGreaterThan(5);
+		expect(report.selectedFocusedBenchmarkIds).toEqual([
+			"scheduler-runtime-context-with-store",
+			"custom-footer-usage-scan-large-history",
+			"usage-tracker-session-start-near-threshold",
+			"worktree-context-temp-repo",
+			"worktree-snapshot-temp-repo",
+			"custom-footer-first-render",
+		]);
+	});
+});

--- a/benchmarks/startup/select-targets.ts
+++ b/benchmarks/startup/select-targets.ts
@@ -7,9 +7,10 @@ type Manifest = {
 	};
 };
 
-type BenchmarkTargetReport = {
+export type BenchmarkTargetReport = {
 	mode: "all" | "selected";
 	selectedExtensions: string[];
+	selectedFocusedBenchmarkIds: string[];
 	reasons: string[];
 	changedFiles: string[];
 };
@@ -17,6 +18,14 @@ type BenchmarkTargetReport = {
 const ROOT = process.cwd();
 const PACKAGE_PATH = path.join(ROOT, "package.json");
 const EXTENSION_PACKAGE_PREFIX = "packages/extensions/extensions/";
+const ALL_FOCUSED_BENCHMARK_IDS = [
+	"scheduler-runtime-context-with-store",
+	"custom-footer-usage-scan-large-history",
+	"usage-tracker-session-start-near-threshold",
+	"worktree-context-temp-repo",
+	"worktree-snapshot-temp-repo",
+	"custom-footer-first-render",
+] as const;
 const GLOBAL_PATH_PREFIXES = [
 	"package.json",
 	"pnpm-lock.yaml",
@@ -26,7 +35,45 @@ const GLOBAL_PATH_PREFIXES = [
 	"packages/core/",
 	"packages/providers/",
 	"benchmarks/",
-];
+	".github/workflows/ci.yml",
+] as const;
+const FOCUSED_BENCHMARK_RULES = [
+	{
+		prefixes: [
+			"packages/extensions/extensions/scheduler.ts",
+			"packages/extensions/extensions/scheduler-shared.ts",
+			"packages/extensions/extensions/scheduler-registration.ts",
+		],
+		benchmarkIds: ["scheduler-runtime-context-with-store"],
+	},
+	{
+		prefixes: [
+			"packages/extensions/extensions/custom-footer.ts",
+			"packages/extensions/extensions/custom-footer.test.ts",
+		],
+		benchmarkIds: [
+			"custom-footer-usage-scan-large-history",
+			"custom-footer-first-render",
+			"worktree-context-temp-repo",
+		],
+	},
+	{
+		prefixes: [
+			"packages/extensions/extensions/usage-tracker.ts",
+			"packages/extensions/extensions/usage-tracker.test.ts",
+		],
+		benchmarkIds: ["usage-tracker-session-start-near-threshold"],
+	},
+	{
+		prefixes: [
+			"packages/extensions/extensions/worktree.ts",
+			"packages/extensions/extensions/worktree.test.ts",
+			"packages/extensions/extensions/worktree-shared.ts",
+			"packages/extensions/extensions/worktree-shared.test.ts",
+		],
+		benchmarkIds: ["worktree-context-temp-repo", "worktree-snapshot-temp-repo", "custom-footer-first-render"],
+	},
+] as const;
 
 function toPosix(value: string): string {
 	return value.split(path.sep).join("/");
@@ -47,7 +94,7 @@ function getPackageExtensionIds(entries: string[]): string[] {
 		.map((entry) => extensionIdFromEntry(entry));
 }
 
-function impactsAllExtensions(filePath: string): boolean {
+function impactsAllBenchmarks(filePath: string): boolean {
 	return GLOBAL_PATH_PREFIXES.some((prefix) => filePath === prefix || filePath.startsWith(prefix));
 }
 
@@ -74,32 +121,49 @@ function inferImpactedExtensions(filePath: string, entries: string[], packageExt
 	return [];
 }
 
+function inferFocusedBenchmarkIds(filePath: string): string[] {
+	for (const rule of FOCUSED_BENCHMARK_RULES) {
+		if (rule.prefixes.some((prefix) => filePath === prefix || filePath.startsWith(prefix))) {
+			return [...rule.benchmarkIds];
+		}
+	}
+
+	return [];
+}
+
 export async function computeBenchmarkTargets(changedFiles: string[]): Promise<BenchmarkTargetReport> {
 	const manifest = JSON.parse(await fs.readFile(PACKAGE_PATH, "utf-8")) as Manifest;
 	const entries = (manifest.pi?.extensions ?? []).map((entry) => toPosix(entry).replace(/^\.\//, ""));
 	const packageExtensionIds = getPackageExtensionIds(entries);
-	const selected = new Set<string>();
+	const selectedExtensions = new Set<string>();
+	const selectedFocusedBenchmarkIds = new Set<string>();
 	const reasons: string[] = [];
 	let mode: BenchmarkTargetReport["mode"] = "selected";
 
 	for (const filePath of changedFiles.map(toPosix)) {
-		if (impactsAllExtensions(filePath)) {
+		if (impactsAllBenchmarks(filePath)) {
 			mode = "all";
 			reasons.push(`${filePath} affects shared benchmark/runtime infrastructure`);
 			continue;
 		}
 
 		for (const extensionId of inferImpactedExtensions(filePath, entries, packageExtensionIds)) {
-			selected.add(extensionId);
+			selectedExtensions.add(extensionId);
 			reasons.push(`${filePath} impacts ${extensionId}`);
+		}
+
+		for (const benchmarkId of inferFocusedBenchmarkIds(filePath)) {
+			selectedFocusedBenchmarkIds.add(benchmarkId);
+			reasons.push(`${filePath} targets ${benchmarkId}`);
 		}
 	}
 
-	const selectedExtensions =
-		mode === "all" ? Array.from(new Set(entries.map(extensionIdFromEntry))).sort() : [...selected].sort();
 	return {
 		mode,
-		selectedExtensions,
+		selectedExtensions:
+			mode === "all" ? Array.from(new Set(entries.map(extensionIdFromEntry))).sort() : [...selectedExtensions].sort(),
+		selectedFocusedBenchmarkIds:
+			mode === "all" ? [...ALL_FOCUSED_BENCHMARK_IDS] : [...selectedFocusedBenchmarkIds].sort(),
 		reasons: Array.from(new Set(reasons)),
 		changedFiles: changedFiles.map(toPosix),
 	};

--- a/benchmarks/startup/suite.ts
+++ b/benchmarks/startup/suite.ts
@@ -27,6 +27,7 @@ type WorktreeExports = typeof import("../../packages/extensions/extensions/workt
 type CustomFooterExports = typeof import("../../packages/extensions/extensions/custom-footer.js");
 
 const ROOT_PACKAGE_PATH = path.resolve(process.cwd(), "package.json");
+const TEMP_ROOT_CLEANUP_RETRY_DELAYS_MS = [0, 25, 50, 100] as const;
 
 function createAssistantEntry(index: number) {
 	return {
@@ -112,18 +113,48 @@ function extensionIdFromPath(extensionPath: string): string {
 	return fileName.replace(/\.ts$/, "");
 }
 
-function parseExtensionFilter(): Set<string> | null {
-	const rawFilter = process.env.OH_PI_BENCH_EXTENSION_FILTER?.trim();
-	if (!rawFilter || rawFilter === "all") {
+function parseEnvList(name: string): Set<string> | null {
+	const rawValue = process.env[name]?.trim();
+	if (!rawValue || rawValue === "all") {
 		return null;
 	}
 
 	return new Set(
-		rawFilter
+		rawValue
 			.split(",")
 			.map((value) => value.trim())
 			.filter(Boolean),
 	);
+}
+
+function parseExtensionFilter(): Set<string> | null {
+	return parseEnvList("OH_PI_BENCH_EXTENSION_FILTER");
+}
+
+function parseFocusedBenchmarkFilter(): Set<string> | null {
+	return parseEnvList("OH_PI_BENCH_FOCUSED_FILTER");
+}
+
+async function sleep(ms: number): Promise<void> {
+	await new Promise((resolve) => setTimeout(resolve, ms));
+}
+
+async function removeDirectoryWithRetry(targetPath: string): Promise<void> {
+	let lastError: unknown;
+	for (const delayMs of TEMP_ROOT_CLEANUP_RETRY_DELAYS_MS) {
+		if (delayMs > 0) {
+			await sleep(delayMs);
+		}
+
+		try {
+			await fs.rm(targetPath, { recursive: true, force: true, maxRetries: 3, retryDelay: 25 });
+			return;
+		} catch (error) {
+			lastError = error;
+		}
+	}
+
+	throw lastError;
 }
 
 async function loadManifestExtensionEntries(): Promise<ManifestExtensionEntry[]> {
@@ -158,6 +189,7 @@ export async function createStartupBenchmarkSuite(): Promise<StartupBenchmarkSui
 	await fs.mkdir(schedulerWorkspace, { recursive: true });
 
 	const extensionFilter = parseExtensionFilter();
+	const focusedBenchmarkFilter = parseFocusedBenchmarkFilter();
 	const manifestEntries = await loadManifestExtensionEntries();
 	const filteredManifestEntries = extensionFilter
 		? manifestEntries.filter((entry) => extensionFilter.has(entry.id))
@@ -186,13 +218,14 @@ export async function createStartupBenchmarkSuite(): Promise<StartupBenchmarkSui
 		fg: (_color: string, text: string) => text,
 	};
 
-	const definitions: BenchmarkDefinition[] = [
+	const baselineDefinitions: BenchmarkDefinition[] = [
 		{
 			id: "full-stack-register-start-empty",
 			label: "full stack register + session_start (empty history)",
 			group: "startup",
 			iterations: 5,
 			warmupIterations: 1,
+			minSampleTimeMs: 50,
 			budget: { medianMs: 900, p95Ms: 1_400 },
 			note: "Loads every default oh-pi extension from package.json and fires the first session_start.",
 			async run() {
@@ -211,6 +244,7 @@ export async function createStartupBenchmarkSuite(): Promise<StartupBenchmarkSui
 			group: "startup",
 			iterations: 5,
 			warmupIterations: 1,
+			minSampleTimeMs: 50,
 			budget: { medianMs: 1_200, p95Ms: 1_800 },
 			note: "Exercises eager history scans that still happen below the 250-entry defer thresholds.",
 			async run() {
@@ -227,12 +261,16 @@ export async function createStartupBenchmarkSuite(): Promise<StartupBenchmarkSui
 				await harness.emitAsync("session_shutdown", { type: "session_shutdown" }, harness.ctx);
 			},
 		},
+	];
+
+	const targetedDefinitions: BenchmarkDefinition[] = [
 		{
 			id: "scheduler-runtime-context-with-store",
 			label: "scheduler persisted store load (50 tasks)",
 			group: "focused hotspot",
 			iterations: 25,
 			warmupIterations: 1,
+			minSampleTimeMs: 20,
 			budget: { medianMs: 40, p95Ms: 80 },
 			note: "Measures the synchronous loadTasksFromDisk path behind scheduler session_start wiring.",
 			run() {
@@ -254,6 +292,7 @@ export async function createStartupBenchmarkSuite(): Promise<StartupBenchmarkSui
 			group: "focused hotspot",
 			iterations: 20,
 			warmupIterations: 1,
+			minSampleTimeMs: 20,
 			budget: { medianMs: 90, p95Ms: 130 },
 			note: "Tracks the O(n) footer usage aggregation path that can surface during startup and redraws.",
 			run() {
@@ -270,6 +309,7 @@ export async function createStartupBenchmarkSuite(): Promise<StartupBenchmarkSui
 			group: "focused hotspot",
 			iterations: 20,
 			warmupIterations: 1,
+			minSampleTimeMs: 20,
 			budget: { medianMs: 120, p95Ms: 200 },
 			note: "Covers session hydration plus widget setup before the defer threshold kicks in.",
 			async run() {
@@ -313,6 +353,7 @@ export async function createStartupBenchmarkSuite(): Promise<StartupBenchmarkSui
 			group: "render",
 			iterations: 20,
 			warmupIterations: 1,
+			minSampleTimeMs: 20,
 			budget: { medianMs: 30, p95Ms: 50 },
 			note: "Simulates the first footer mount after startup so UI formatting regressions show up in CI.",
 			async run() {
@@ -339,7 +380,9 @@ export async function createStartupBenchmarkSuite(): Promise<StartupBenchmarkSui
 				await harness.emitAsync("session_shutdown", { type: "session_shutdown" }, harness.ctx);
 			},
 		},
-	];
+	].filter((definition) => !focusedBenchmarkFilter || focusedBenchmarkFilter.has(definition.id));
+
+	const definitions: BenchmarkDefinition[] = [...baselineDefinitions, ...targetedDefinitions];
 
 	for (const entry of filteredManifestEntries) {
 		definitions.push({
@@ -348,6 +391,7 @@ export async function createStartupBenchmarkSuite(): Promise<StartupBenchmarkSui
 			group: "extension startup",
 			iterations: 10,
 			warmupIterations: 1,
+			minSampleTimeMs: 20,
 			budget: { medianMs: 800, p95Ms: 1_000 },
 			note: `Loads only ${entry.id} (${entry.path}) and fires session_start/session_shutdown for focused regression tracking.`,
 			async run() {
@@ -379,7 +423,7 @@ export async function createStartupBenchmarkSuite(): Promise<StartupBenchmarkSui
 				process.env.USERPROFILE = previousUserProfile;
 			}
 
-			await fs.rm(tempRoot, { recursive: true, force: true });
+			await removeDirectoryWithRetry(tempRoot);
 		},
 	};
 }


### PR DESCRIPTION
## Summary
- batch fast benchmark samples to reduce timer noise and improve report stability
- tighten changed-file targeting so CI runs only the relevant focused startup hotspots
- add tests for benchmark batching and startup target selection

## Validation
- pnpm lint
- pnpm test
- pnpm typecheck
- pnpm bench:startup