### PR TITLE
perf(extensions): reduce periodic status churn

### DIFF
--- a/.changeset/scheduler-status-churn.md
+++ b/.changeset/scheduler-status-churn.md
@@ -1,0 +1,5 @@
+---
+default: patch
+---
+
+Reduce background UI churn by deduplicating repeated scheduler and watchdog status-bar updates, and by slowing footer PR polling to match the existing GitHub probe cooldown.

--- a/docs/startup-performance-audit.md
+++ b/docs/startup-performance-audit.md
@@ -82,19 +82,25 @@ This is the most expensive focused startup-adjacent benchmark today and maps dir
 
 **What to watch**
 
-The scheduler store is capped, so this path is not the largest benchmark today, but it is on the hot startup path and should stay small.
+The scheduler store is capped, so this path is not the largest benchmark today, but it is on the hot startup path and should stay small. The runtime heartbeat also updates footer status, so repeated identical `pi-scheduler` status text should stay coalesced instead of being re-sent on every periodic tick.
 
 ### 3. `packages/extensions/extensions/custom-footer.ts`
 
 **Why it matters**
 
-The footer caches totals after startup, but the aggregation path is still O(n) over assistant messages. It also schedules worktree snapshot refreshes, which means it can trigger the synchronous git path above.
+The footer caches totals after startup, but the aggregation path is still O(n) over assistant messages. It also polls for PR visibility and requests redraws on an interval, so even after the worktree split it can still contribute background UI churn if that cadence is too aggressive.
 
 **Current benchmark coverage**
 
 - `custom footer usage scan (50k messages)`
 - `custom footer first render (200-entry history)`
 - included indirectly by the full-stack startup cases
+
+**Latest mitigation**
+
+- footer PR polling now matches the 60-second GH probe cooldown instead of waking every 30 seconds
+- PR probe completions request a redraw only when the visible PR list actually changes
+- watchdog and scheduler status-bar writes should stay deduplicated so periodic clean-state refreshes do not spam identical `setStatus(...)` calls
 
 ### 4. `packages/extensions/extensions/usage-tracker.ts`
 

--- a/packages/extensions/extensions/custom-footer.test.ts
+++ b/packages/extensions/extensions/custom-footer.test.ts
@@ -223,7 +223,7 @@ describe("custom-footer extension", () => {
 		}
 	});
 
-	it("does not refresh worktree snapshots on the 30-second PR poll timer", async () => {
+	it("does not refresh worktree snapshots on the footer PR poll timer", async () => {
 		vi.useFakeTimers();
 		const getCachedRepoWorktreeContext = vi
 			.spyOn(worktreeShared, "getCachedRepoWorktreeContext")
@@ -258,7 +258,7 @@ describe("custom-footer extension", () => {
 			await vi.advanceTimersByTimeAsync(500);
 			expect(refreshRepoWorktreeContext).toHaveBeenCalledTimes(1);
 
-			await vi.advanceTimersByTimeAsync(30_000);
+			await vi.advanceTimersByTimeAsync(60_000);
 			expect(refreshRepoWorktreeContext).toHaveBeenCalledTimes(1);
 		} finally {
 			getCachedRepoWorktreeContext.mockRestore();

--- a/packages/extensions/extensions/custom-footer.ts
+++ b/packages/extensions/extensions/custom-footer.ts
@@ -39,6 +39,7 @@ export type PrInfo = {
 };
 
 const PR_PROBE_COOLDOWN_MS = 60_000;
+const FOOTER_POLL_INTERVAL_MS = 60_000;
 const FOOTER_STARTUP_REFRESH_DELAY_MS = 250;
 const FOOTER_STARTUP_DEFER_ENTRY_THRESHOLD = 250;
 
@@ -47,6 +48,16 @@ export type FooterUsageTotals = {
 	output: number;
 	cost: number;
 };
+
+function samePrs(left: PrInfo[], right: PrInfo[]): boolean {
+	return (
+		left.length === right.length &&
+		left.every((pr, index) => {
+			const candidate = right[index];
+			return pr.number === candidate?.number && pr.url === candidate?.url && pr.headRefName === candidate?.headRefName;
+		})
+	);
+}
 
 /** Format a millisecond duration as a compact human-readable string (e.g. `42s`, `3m12s`, `1h5m`). */
 export function formatElapsed(ms: number): string {
@@ -201,6 +212,15 @@ export default function (pi: ExtensionAPI) {
 		return cachedWorktreeContext;
 	};
 
+	const updateCachedPrs = (nextCachedPrs: PrInfo[]) => {
+		if (samePrs(cachedPrs, nextCachedPrs)) {
+			return;
+		}
+
+		cachedPrs = nextCachedPrs;
+		requestFooterRender?.();
+	};
+
 	const probePrs = (branch: string | null) => {
 		if (!branch || prProbeInFlight) {
 			return;
@@ -210,7 +230,7 @@ export default function (pi: ExtensionAPI) {
 			return;
 		}
 		if (branch !== prProbedForBranch) {
-			cachedPrs = [];
+			updateCachedPrs([]);
 		}
 		prProbeInFlight = true;
 		prProbedForBranch = branch;
@@ -220,18 +240,18 @@ export default function (pi: ExtensionAPI) {
 		})
 			.then(({ stdout, exitCode }) => {
 				if (exitCode !== 0 || !stdout.trim()) {
-					cachedPrs = [];
+					updateCachedPrs([]);
 					return;
 				}
 				try {
 					const parsed = JSON.parse(stdout.trim()) as Array<{ number?: number; url?: string; headRefName?: string }>;
-					cachedPrs = parsed.filter((entry): entry is PrInfo => !!entry.number && !!entry.url);
+					updateCachedPrs(parsed.filter((entry): entry is PrInfo => !!entry.number && !!entry.url));
 				} catch {
-					cachedPrs = [];
+					updateCachedPrs([]);
 				}
 			})
 			.catch(() => {
-				cachedPrs = [];
+				updateCachedPrs([]);
 			})
 			.finally(() => {
 				prProbeInFlight = false;
@@ -262,7 +282,7 @@ export default function (pi: ExtensionAPI) {
 			const timer = setInterval(() => {
 				probeActivePrs();
 				tui.requestRender();
-			}, 30000);
+			}, FOOTER_POLL_INTERVAL_MS);
 			probeActivePrs();
 
 			return {

--- a/packages/extensions/extensions/scheduler.test.ts
+++ b/packages/extensions/extensions/scheduler.test.ts
@@ -117,6 +117,7 @@ function createMockPi() {
 function createMockCtx(overrides: Record<string, any> = {}) {
 	const notifications: { msg: string; type: string }[] = [];
 	const statusMap = new Map<string, any>();
+	const statusCalls: Array<{ key: string; value: any }> = [];
 
 	return {
 		cwd: overrides.cwd ?? "/mock-project",
@@ -131,6 +132,7 @@ function createMockCtx(overrides: Record<string, any> = {}) {
 				notifications.push({ msg, type });
 			},
 			setStatus(key: string, value: any) {
+				statusCalls.push({ key, value });
 				if (value === undefined) {
 					statusMap.delete(key);
 				} else {
@@ -143,6 +145,7 @@ function createMockCtx(overrides: Record<string, any> = {}) {
 		},
 		_notifications: notifications,
 		_statusMap: statusMap,
+		_statusCalls: statusCalls,
 	};
 }
 
@@ -1260,6 +1263,20 @@ describe("SchedulerRuntime", () => {
 			runtime.setTaskEnabled(task.id, false);
 			runtime.updateStatus();
 			expect(ctx._statusMap.get("pi-scheduler")).toContain("paused");
+		});
+
+		it("coalesces identical periodic status text", () => {
+			const ctx = createMockCtx();
+			runtime.setRuntimeContext(ctx as any);
+			runtime.addRecurringIntervalTask("check", 5 * ONE_MINUTE);
+
+			runtime.updateStatus();
+			const initialCalls = ctx._statusCalls.filter((call) => call.key === "pi-scheduler");
+			expect(initialCalls).toHaveLength(1);
+
+			runtime.updateStatus();
+			const repeatedCalls = ctx._statusCalls.filter((call) => call.key === "pi-scheduler");
+			expect(repeatedCalls).toHaveLength(1);
 		});
 
 		it("does not update without UI", () => {

--- a/packages/extensions/extensions/scheduler.ts
+++ b/packages/extensions/extensions/scheduler.ts
@@ -61,6 +61,7 @@ import {
 	type ScheduleTask,
 	THREE_DAYS,
 } from "./scheduler-shared.js";
+import { createStatusBarState } from "./ui-status-cache.js";
 import { RUNTIME_DIAGNOSTICS_EVENT } from "./watchdog-runtime-diagnostics.js";
 
 export {
@@ -148,6 +149,7 @@ export class SchedulerRuntime {
 	private readonly dispatchTimestamps: number[] = [];
 	private lastRateLimitNoticeAt = 0;
 	private readonly instanceId = randomUUID().slice(0, 12);
+	private readonly statusBar = createStatusBarState();
 	private sessionId: string | null = null;
 	private dispatchMode: SchedulerDispatchMode = "auto";
 	private startupOwnershipHandled = false;
@@ -174,9 +176,9 @@ export class SchedulerRuntime {
 		}
 		this.safeModeEnabled = enabled;
 
-		if (enabled && this.runtimeCtx?.hasUI) {
-			this.runtimeCtx.ui.setStatus("pi-scheduler", undefined);
-			this.runtimeCtx.ui.setStatus("pi-scheduler-stale", undefined);
+		if (enabled) {
+			this.setStatus("pi-scheduler", undefined);
+			this.setStatus("pi-scheduler-stale", undefined);
 		}
 
 		// Restart the scheduler timer with the appropriate interval.
@@ -215,10 +217,12 @@ export class SchedulerRuntime {
 
 	clearStatus(ctx?: ExtensionContext) {
 		const target = ctx ?? this.runtimeCtx;
-		if (target?.hasUI) {
-			target.ui.setStatus("pi-scheduler", undefined);
-			target.ui.setStatus("pi-scheduler-stale", undefined);
-		}
+		this.setStatus("pi-scheduler", undefined, target);
+		this.setStatus("pi-scheduler-stale", undefined, target);
+	}
+
+	private setStatus(key: "pi-scheduler" | "pi-scheduler-stale", value: string | undefined, ctx = this.runtimeCtx) {
+		this.statusBar.set(ctx, key, value);
 	}
 
 	private resolveRecurringExpiryMs(expiresInMs?: number): number {
@@ -613,23 +617,24 @@ export class SchedulerRuntime {
 		}
 		// In safe mode, suppress all status bar updates to reduce UI churn.
 		if (this.safeModeEnabled) {
-			this.runtimeCtx.ui.setStatus("pi-scheduler", undefined);
-			this.runtimeCtx.ui.setStatus("pi-scheduler-stale", undefined);
+			this.setStatus("pi-scheduler", undefined);
+			this.setStatus("pi-scheduler-stale", undefined);
 			return;
 		}
 		// Clear the stale-task status hint when no tasks need review.
 		const staleCount = Array.from(this.tasks.values()).filter((t) => t.enabled && t.resumeRequired).length;
 		if (staleCount === 0) {
-			this.runtimeCtx.ui.setStatus("pi-scheduler-stale", undefined);
+			this.setStatus("pi-scheduler-stale", undefined);
 		}
+
 		if (this.tasks.size === 0) {
-			this.runtimeCtx.ui.setStatus("pi-scheduler", undefined);
+			this.setStatus("pi-scheduler", undefined);
 			return;
 		}
 
 		const enabled = Array.from(this.tasks.values()).filter((t) => t.enabled);
 		if (enabled.length === 0) {
-			this.runtimeCtx.ui.setStatus("pi-scheduler", `${this.tasks.size} task${this.tasks.size === 1 ? "" : "s"} paused`);
+			this.setStatus("pi-scheduler", `${this.tasks.size} task${this.tasks.size === 1 ? "" : "s"} paused`);
 			return;
 		}
 
@@ -648,7 +653,7 @@ export class SchedulerRuntime {
 			const next = new Date(nextRunAt).toLocaleTimeString([], { hour: "2-digit", minute: "2-digit" });
 			parts.push(`${scheduled.length} active • next ${next}`);
 		}
-		this.runtimeCtx.ui.setStatus("pi-scheduler", parts.join(" • ") || "paused");
+		this.setStatus("pi-scheduler", parts.join(" • ") || "paused");
 	}
 
 	private pruneDispatchHistory(now: number) {
@@ -1938,10 +1943,7 @@ export class SchedulerRuntime {
 			"warning",
 		);
 		// Persist a compact hint in the status bar so users see it without repeated notifications.
-		this.runtimeCtx.ui.setStatus(
-			"pi-scheduler-stale",
-			`⚠ ${count} stale task${count === 1 ? "" : "s"} — /schedule to review`,
-		);
+		this.setStatus("pi-scheduler-stale", `⚠ ${count} stale task${count === 1 ? "" : "s"} — /schedule to review`);
 	}
 
 	private resumeReasonLabel(reason: ResumeReason): string {

--- a/packages/extensions/extensions/ui-status-cache.ts
+++ b/packages/extensions/extensions/ui-status-cache.ts
@@ -1,0 +1,46 @@
+type StatusTarget = {
+	hasUI?: boolean;
+	ui?: {
+		setStatus?: (key: string, value: string | undefined) => unknown;
+	};
+};
+
+/**
+ * Coalesce repeated status-bar writes so periodic timers do not re-send identical text.
+ *
+ * Status updates are scoped to the active UI target. When the target changes, the cache is reset so
+ * the new session or overlay receives fresh status state.
+ */
+export function createStatusBarState() {
+	let activeTarget: object | null = null;
+	const lastValues = new Map<string, string | undefined>();
+
+	return {
+		clear() {
+			activeTarget = null;
+			lastValues.clear();
+		},
+		set(target: StatusTarget | null | undefined, key: string, value: string | undefined): boolean {
+			if (!target || typeof target !== "object") {
+				return false;
+			}
+
+			if (target !== activeTarget) {
+				activeTarget = target;
+				lastValues.clear();
+			}
+
+			if (!target.hasUI || typeof target.ui?.setStatus !== "function") {
+				return false;
+			}
+
+			if (lastValues.has(key) && lastValues.get(key) === value) {
+				return false;
+			}
+
+			lastValues.set(key, value);
+			target.ui.setStatus(key, value);
+			return true;
+		},
+	};
+}

--- a/packages/extensions/extensions/watchdog.test.ts
+++ b/packages/extensions/extensions/watchdog.test.ts
@@ -97,6 +97,7 @@ function createMockPi() {
 function createMockCtx() {
 	const notifications: Array<{ msg: string; level: string }> = [];
 	const statuses = new Map<string, string | undefined>();
+	const statusCalls: Array<{ key: string; value: string | undefined }> = [];
 	const custom = vi.fn().mockResolvedValue(undefined);
 	return {
 		hasUI: true,
@@ -105,12 +106,14 @@ function createMockCtx() {
 				notifications.push({ msg, level });
 			},
 			setStatus(key: string, value: string | undefined) {
+				statusCalls.push({ key, value });
 				statuses.set(key, value);
 			},
 			custom,
 		},
 		_notifications: notifications,
 		_statuses: statuses,
+		_statusCalls: statusCalls,
 		_custom: custom,
 	};
 }
@@ -331,6 +334,25 @@ describe("watchdog extension", () => {
 		await command.handler("off", ctx);
 		expect(getSafeModeState().enabled).toBe(false);
 		expect(ctx._statuses.get("safe-mode")).toBeUndefined();
+	});
+
+	it("coalesces repeated clean watchdog status clears", async () => {
+		const pi = createMockPi();
+		const ctx = createMockCtx();
+		watchdogExtension(pi as any);
+
+		mockCpuUsageSequence([
+			{ user: 0, system: 0 },
+			{ user: 0, system: 0 },
+			{ user: 0, system: 0 },
+		]);
+		mockMemoryUsage();
+
+		await pi._emit("session_start", {}, ctx);
+		await vi.advanceTimersByTimeAsync(10_000);
+
+		const watchdogCalls = ctx._statusCalls.filter((call) => call.key === "watchdog");
+		expect(watchdogCalls).toEqual([{ key: "watchdog", value: undefined }]);
 	});
 
 	it("resets watchdog history and clears alert status", async () => {

--- a/packages/extensions/extensions/watchdog.ts
+++ b/packages/extensions/extensions/watchdog.ts
@@ -29,6 +29,7 @@ import {
 	setSafeModeState,
 	subscribeSafeMode,
 } from "./runtime-mode";
+import { createStatusBarState } from "./ui-status-cache.js";
 import {
 	type ExtensionDiagnostic,
 	formatExtensionDiagnostic,
@@ -421,17 +422,14 @@ export default function watchdogExtension(pi: ExtensionAPI) {
 	let lastSampleAt = Date.now();
 	let configLoaded = false;
 	let startupConfigTimer: ReturnType<typeof setTimeout> | null = null;
+	const statusBar = createStatusBarState();
 
 	const setAlertStatus = (text: string | undefined) => {
-		if (activeCtx?.hasUI) {
-			activeCtx.ui.setStatus("watchdog", text);
-		}
+		statusBar.set(activeCtx, "watchdog", text);
 	};
 
 	const setSafeModeStatus = (state = getSafeModeState()) => {
-		if (activeCtx?.hasUI) {
-			activeCtx.ui.setStatus("safe-mode", formatSafeModeStatusHint(state));
-		}
+		statusBar.set(activeCtx, "safe-mode", formatSafeModeStatusHint(state));
 	};
 
 	const stopTimer = () => {
@@ -794,9 +792,7 @@ export default function watchdogExtension(pi: ExtensionAPI) {
 	pi.on("session_shutdown", () => {
 		cancelStartupConfigLoad();
 		setAlertStatus(undefined);
-		if (activeCtx?.hasUI) {
-			activeCtx.ui.setStatus("safe-mode", undefined);
-		}
+		statusBar.set(activeCtx, "safe-mode", undefined);
 		stopTimer();
 		histogram.disable();
 	});


### PR DESCRIPTION
## Summary
- coalesce repeated scheduler and watchdog status-bar writes so steady-state timers stop resending identical text
- slow footer PR polling to match the existing GitHub probe cooldown and only redraw when the visible PR list changes
- add regression tests and audit notes for the scheduler/footer/watchdog churn pass

## Validation
- pnpm lint
- pnpm test
- pnpm typecheck
- pnpm bench:startup