### PR TITLE
feat(cli): install optional routing packages

### DIFF
--- a/.changeset/routing-dashboard-package-installs.md
+++ b/.changeset/routing-dashboard-package-installs.md
@@ -1,0 +1,5 @@
+---
+default: minor
+---
+
+Let the oh-pi routing dashboard install missing optional routing and provider packages directly from the setup flow.

--- a/packages/cli/README.md
+++ b/packages/cli/README.md
@@ -8,6 +8,7 @@ Interactive TUI configurator for `pi-coding-agent`.
 - providers and auth
 - models
 - provider/routing dashboard views for session, subagents, and ant-colony
+- direct optional package installs from the routing dashboard
 - extensions
 - prompts
 - skills

--- a/packages/cli/src/tui/routing-dashboard.test.ts
+++ b/packages/cli/src/tui/routing-dashboard.test.ts
@@ -1,9 +1,17 @@
 import type { ProviderConfig } from "@ifi/oh-pi-core";
 import { describe, expect, it } from "vitest";
-import { buildRoutingDashboard, detectOptionalRoutingPackages } from "./routing-dashboard.js";
+import {
+	buildRoutingDashboard,
+	detectOptionalRoutingPackages,
+	suggestOptionalRoutingPackages,
+} from "./routing-dashboard.js";
 
 function makeProviders(): ProviderConfig[] {
 	return [
+		{
+			name: " ",
+			apiKey: "IGNORED",
+		},
 		{
 			name: "openai",
 			apiKey: "OPENAI_API_KEY",
@@ -14,19 +22,75 @@ function makeProviders(): ProviderConfig[] {
 			],
 		},
 		{
+			name: "openai",
+			apiKey: "OPENAI_API_KEY",
+			defaultModel: "gpt-5-mini",
+		},
+		{
 			name: "groq",
 			apiKey: "GROQ_API_KEY",
-			defaultModel: "llama-3.3-70b-versatile",
+			discoveredModels: [
+				{
+					id: "llama-3.3-70b-versatile",
+					reasoning: false,
+					input: ["text"],
+					contextWindow: 128000,
+					maxTokens: 32768,
+				},
+			],
+		},
+		{
+			name: "cursor-agent",
+			apiKey: "none",
 		},
 	];
 }
 
 describe("detectOptionalRoutingPackages", () => {
-	it("maps package installation state with a custom resolver", () => {
-		const packages = detectOptionalRoutingPackages((packageName) => packageName === "@ifi/pi-provider-ollama");
+	it("maps installed scopes and selected package state", () => {
+		const packages = detectOptionalRoutingPackages(
+			(packageNames) =>
+				packageNames.map((packageName) => ({
+					packageName,
+					scope:
+						packageName === "@ifi/pi-provider-ollama"
+							? "user"
+							: packageName === "@ifi/pi-provider-cursor"
+								? "project"
+								: "none",
+				})),
+			["@ifi/pi-extension-adaptive-routing"],
+		);
 
-		expect(packages.find((pkg) => pkg.packageName === "@ifi/pi-provider-ollama")?.installed).toBe(true);
-		expect(packages.find((pkg) => pkg.packageName === "@ifi/pi-provider-cursor")?.installed).toBe(false);
+		expect(packages.find((pkg) => pkg.packageName === "@ifi/pi-provider-ollama")).toMatchObject({
+			installed: true,
+			scope: "user",
+			selected: false,
+		});
+		expect(packages.find((pkg) => pkg.packageName === "@ifi/pi-provider-cursor")).toMatchObject({
+			installed: true,
+			scope: "project",
+		});
+		expect(packages.find((pkg) => pkg.packageName === "@ifi/pi-extension-adaptive-routing")).toMatchObject({
+			installed: false,
+			selected: true,
+		});
+	});
+});
+
+describe("suggestOptionalRoutingPackages", () => {
+	it("suggests routing and provider packages based on config and providers", () => {
+		expect(
+			suggestOptionalRoutingPackages(["ollama-cloud", "cursor-agent", "cursor-agent"], {
+				mode: "shadow",
+				categories: {},
+			}),
+		).toEqual(["@ifi/pi-extension-adaptive-routing", "@ifi/pi-provider-ollama", "@ifi/pi-provider-cursor"]);
+	});
+
+	it("returns an empty list when nothing is recommended", () => {
+		expect(suggestOptionalRoutingPackages(["openai"], { mode: "off", categories: {} })).toEqual([]);
+		expect(suggestOptionalRoutingPackages(["openai"])).toEqual([]);
 	});
 });
 
@@ -39,7 +103,25 @@ describe("buildRoutingDashboard", () => {
 					packageName: "@ifi/pi-extension-adaptive-routing",
 					label: "Adaptive routing package",
 					hint: "Optional /route command and per-prompt auto routing",
+					scope: "none",
+					installed: false,
+					selected: true,
+				},
+				{
+					packageName: "@ifi/pi-provider-ollama",
+					label: "Ollama provider package",
+					hint: "Ollama local and Ollama Cloud model support",
+					scope: "user",
 					installed: true,
+					selected: false,
+				},
+				{
+					packageName: "@ifi/pi-provider-cursor",
+					label: "Cursor provider package",
+					hint: "cursor-agent provider support",
+					scope: "none",
+					installed: false,
+					selected: false,
 				},
 			],
 			config: {
@@ -47,33 +129,64 @@ describe("buildRoutingDashboard", () => {
 				categories: {
 					"quick-discovery": ["groq", "openai"],
 					"planning-default": ["openai", "groq"],
-					"implementation-default": ["openai", "groq"],
+					"implementation-default": ["missing-provider", "openai"],
 					"research-default": ["openai", "groq"],
 					"review-critical": ["openai", "groq"],
-					"visual-engineering": ["openai", "groq"],
+					"visual-engineering": ["cursor-agent", "openai"],
 					"multimodal-default": ["openai", "groq"],
 				},
 			},
 		});
 
-		expect(dashboard).toContain("Adaptive routing package: installed");
-		expect(dashboard).toContain("openai/gpt-4o · 2 discovered models");
+		expect(dashboard).toContain("Adaptive routing package: selected for install");
+		expect(dashboard).toContain("Ollama provider package: installed (user)");
+		expect(dashboard).toContain("Cursor provider package: not installed");
+		expect(dashboard).toContain("install with pi install npm:@ifi/pi-provider-cursor");
+		expect(dashboard).toContain("openai/gpt-5-mini · 2 discovered models");
 		expect(dashboard).toContain("groq/llama-3.3-70b-versatile");
+		expect(dashboard).toContain("cursor-agent/<configured externally>");
 		expect(dashboard).toContain("Quick discovery: groq → openai");
-		expect(dashboard).toContain("Session default: openai/gpt-4o");
+		expect(dashboard).toContain("Implementation: missing-provider → openai");
+		expect(dashboard).toContain("Session default: openai/gpt-5-mini");
 		expect(dashboard).toContain("scout → groq/llama-3.3-70b-versatile (Quick discovery)");
-		expect(dashboard).toContain("worker, drone, backend → openai/gpt-4o (Implementation)");
+		expect(dashboard).toContain("worker, drone, backend → openai/gpt-5-mini (Implementation)");
+		expect(dashboard).toContain(
+			"artist, frontend-designer → cursor-agent/<configured externally> (Visual / design work)",
+		);
 	});
 
-	it("shows session-default fallback when delegated assignments are not configured", () => {
+	it("shows empty provider and session-default fallbacks when routing is not configured", () => {
 		const dashboard = buildRoutingDashboard({
-			providers: [{ name: "openai", apiKey: "OPENAI_API_KEY", defaultModel: "gpt-4o" }],
+			providers: [],
 			packageStates: [],
 		});
 
+		expect(dashboard).toContain("Available providers / models:");
+		expect(dashboard).toContain("- none selected yet");
 		expect(dashboard).toContain("Delegated assignments:");
 		expect(dashboard).toContain("delegated startup assignments not configured");
-		expect(dashboard).toContain("Session default: openai/gpt-4o");
+		expect(dashboard).toContain("Session default: not configured");
+		expect(dashboard).toContain("scout → session default (Quick discovery)");
+	});
+
+	it("falls back to the session default when a configured category has no matching provider", () => {
+		const dashboard = buildRoutingDashboard({
+			providers: [{ name: "openai", apiKey: "OPENAI_API_KEY", defaultModel: "gpt-4o" }],
+			packageStates: [],
+			config: {
+				mode: "off",
+				categories: {
+					"quick-discovery": ["missing-provider"],
+					"planning-default": ["openai"],
+					"implementation-default": ["openai"],
+					"research-default": ["openai"],
+					"review-critical": ["openai"],
+					"visual-engineering": ["openai"],
+					"multimodal-default": ["openai"],
+				},
+			},
+		});
+
 		expect(dashboard).toContain("scout → session default (Quick discovery)");
 	});
 });

--- a/packages/cli/src/tui/routing-dashboard.ts
+++ b/packages/cli/src/tui/routing-dashboard.ts
@@ -1,8 +1,7 @@
-import { createRequire } from "node:module";
 import type { ProviderConfig } from "@ifi/oh-pi-core";
 import type { AdaptiveRoutingSetupConfig } from "../types.js";
-
-const require = createRequire(import.meta.url);
+import type { PiPackageInstallScope, PiPackageInstallState } from "../utils/pi-packages.js";
+import { detectPiPackageInstallScopes } from "../utils/pi-packages.js";
 
 export const ROUTING_CATEGORIES = [
 	{
@@ -83,7 +82,9 @@ export interface OptionalRoutingPackageState {
 	packageName: string;
 	label: string;
 	hint: string;
+	scope: PiPackageInstallScope;
 	installed: boolean;
+	selected: boolean;
 }
 
 interface RoutingDashboardOptions {
@@ -92,22 +93,38 @@ interface RoutingDashboardOptions {
 	packageStates?: OptionalRoutingPackageState[];
 }
 
-function defaultPackageResolver(packageName: string): boolean {
-	try {
-		require.resolve(`${packageName}/package.json`);
-		return true;
-	} catch {
-		return false;
-	}
+export function detectOptionalRoutingPackages(
+	detectStates: (packageNames: string[]) => PiPackageInstallState[] = detectPiPackageInstallScopes,
+	selectedPackages: string[] = [],
+): OptionalRoutingPackageState[] {
+	const selected = new Set(selectedPackages);
+	const states = new Map(
+		detectStates(OPTIONAL_ROUTING_PACKAGES.map((pkg) => pkg.packageName)).map((pkg) => [pkg.packageName, pkg]),
+	);
+	return OPTIONAL_ROUTING_PACKAGES.map((pkg) => {
+		const state = states.get(pkg.packageName);
+		const scope = state?.scope ?? "none";
+		return {
+			...pkg,
+			scope,
+			installed: scope !== "none",
+			selected: selected.has(pkg.packageName),
+		};
+	});
 }
 
-export function detectOptionalRoutingPackages(
-	resolvePackage: (packageName: string) => boolean = defaultPackageResolver,
-): OptionalRoutingPackageState[] {
-	return OPTIONAL_ROUTING_PACKAGES.map((pkg) => ({
-		...pkg,
-		installed: resolvePackage(pkg.packageName),
-	}));
+export function suggestOptionalRoutingPackages(providerNames: string[], config?: AdaptiveRoutingSetupConfig): string[] {
+	const packages: string[] = [];
+	if (config && config.mode !== "off") {
+		packages.push("@ifi/pi-extension-adaptive-routing");
+	}
+	if (providerNames.some((provider) => provider === "ollama" || provider === "ollama-cloud")) {
+		packages.push("@ifi/pi-provider-ollama");
+	}
+	if (providerNames.some((provider) => provider === "cursor" || provider === "cursor-agent")) {
+		packages.push("@ifi/pi-provider-cursor");
+	}
+	return [...new Set(packages)];
 }
 
 function mergeProviderConfigs(providers: ProviderConfig[]): ProviderConfig[] {
@@ -156,10 +173,20 @@ function resolveCategoryTarget(
 	return "session default";
 }
 
+function formatPackageState(pkg: OptionalRoutingPackageState): string {
+	if (pkg.installed) {
+		return `installed (${pkg.scope})`;
+	}
+	if (pkg.selected) {
+		return "selected for install";
+	}
+	return "not installed";
+}
+
 function buildOptionalPackageLines(packageStates: OptionalRoutingPackageState[]): string[] {
 	return packageStates.map((pkg) => {
-		const state = pkg.installed ? "installed" : "not installed";
-		return `- ${pkg.label}: ${state} — ${pkg.hint}`;
+		const installHint = pkg.installed || pkg.selected ? "" : ` · install with pi install npm:${pkg.packageName}`;
+		return `- ${pkg.label}: ${formatPackageState(pkg)} — ${pkg.hint}${installHint}`;
 	});
 }
 
@@ -191,19 +218,14 @@ function buildConsumerLines(
 	consumerKey: "subagents" | "colony",
 ): string[] {
 	const lines = [`${title}:`];
-	let hasConsumers = false;
 	for (const category of ROUTING_CATEGORIES) {
 		const consumers = category[consumerKey];
 		if (consumers.length === 0) {
 			continue;
 		}
-		hasConsumers = true;
 		lines.push(
 			`- ${consumers.join(", ")} → ${resolveCategoryTarget(category.name, providers, config)} (${category.label})`,
 		);
-	}
-	if (!hasConsumers) {
-		lines.push("- none");
 	}
 	return lines;
 }

--- a/packages/cli/src/tui/routing-setup.test.ts
+++ b/packages/cli/src/tui/routing-setup.test.ts
@@ -1,0 +1,224 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+
+const promptState = vi.hoisted(() => ({
+	confirm: [] as unknown[],
+	select: [] as unknown[],
+	multiselect: [] as unknown[],
+	notes: [] as Array<{ message: string; title?: string }>,
+	warns: [] as string[],
+	cancels: [] as string[],
+	spinnerStarts: [] as string[],
+	spinnerStops: [] as string[],
+}));
+
+const dashboardMocks = vi.hoisted(() => ({
+	buildRoutingDashboard: vi.fn(({ config }: { config?: { mode?: string } }) => `dashboard:${config?.mode ?? "unset"}`),
+	detectOptionalRoutingPackages: vi.fn(),
+	suggestOptionalRoutingPackages: vi.fn(),
+	ROUTING_CATEGORIES: [
+		{ name: "quick-discovery", label: "Quick discovery", recommended: ["groq", "openai"] },
+		{ name: "implementation-default", label: "Implementation", recommended: ["openai", "groq"] },
+	],
+}));
+
+const packageMocks = vi.hoisted(() => ({
+	installPiPackages: vi.fn(),
+}));
+
+vi.mock("@clack/prompts", () => ({
+	confirm: vi.fn(async () => promptState.confirm.shift()),
+	select: vi.fn(async () => promptState.select.shift()),
+	multiselect: vi.fn(async () => promptState.multiselect.shift()),
+	note: vi.fn((message: string, title?: string) => {
+		promptState.notes.push({ message, title });
+	}),
+	cancel: vi.fn((message: string) => {
+		promptState.cancels.push(message);
+	}),
+	isCancel: (value: unknown) => value === "__CANCEL__",
+	log: {
+		warn: vi.fn((message: string) => {
+			promptState.warns.push(message);
+		}),
+	},
+	spinner: () => ({
+		start: (message: string) => {
+			promptState.spinnerStarts.push(message);
+		},
+		stop: (message: string) => {
+			promptState.spinnerStops.push(message);
+		},
+	}),
+}));
+
+vi.mock("./routing-dashboard.js", () => dashboardMocks);
+vi.mock("../utils/pi-packages.js", () => packageMocks);
+
+import { setupAdaptiveRouting, summarizeAdaptiveRouting } from "./routing-setup.js";
+
+function makeProviders() {
+	return [
+		{ name: "openai", apiKey: "OPENAI_API_KEY", defaultModel: "gpt-4o" },
+		{ name: "groq", apiKey: "GROQ_API_KEY", defaultModel: "llama-3.3-70b-versatile" },
+	];
+}
+
+function missingPackage(packageName: string, label = packageName) {
+	return {
+		packageName,
+		label,
+		hint: `${label} hint`,
+		scope: "none",
+		installed: false,
+		selected: false,
+	} as const;
+}
+
+beforeEach(() => {
+	promptState.confirm = [];
+	promptState.select = [];
+	promptState.multiselect = [];
+	promptState.notes = [];
+	promptState.warns = [];
+	promptState.cancels = [];
+	promptState.spinnerStarts = [];
+	promptState.spinnerStops = [];
+	dashboardMocks.buildRoutingDashboard.mockClear();
+	dashboardMocks.detectOptionalRoutingPackages.mockReset();
+	dashboardMocks.suggestOptionalRoutingPackages.mockReset();
+	packageMocks.installPiPackages.mockReset();
+});
+
+afterEach(() => {
+	vi.restoreAllMocks();
+});
+
+describe("setupAdaptiveRouting", () => {
+	it("returns undefined when no providers are available", async () => {
+		await expect(setupAdaptiveRouting([])).resolves.toBeUndefined();
+		expect(dashboardMocks.buildRoutingDashboard).not.toHaveBeenCalled();
+	});
+
+	it("installs missing packages, configures routing, and re-renders the dashboard", async () => {
+		dashboardMocks.detectOptionalRoutingPackages
+			.mockReturnValueOnce([missingPackage("@ifi/pi-provider-ollama", "Ollama provider package")])
+			.mockReturnValueOnce([]);
+		dashboardMocks.suggestOptionalRoutingPackages
+			.mockReturnValueOnce(["@ifi/pi-provider-ollama"])
+			.mockReturnValueOnce([]);
+		promptState.confirm.push(true, true);
+		promptState.multiselect.push(["@ifi/pi-provider-ollama"]);
+		promptState.select.push("shadow", "groq", "openai");
+
+		const result = await setupAdaptiveRouting(makeProviders(), undefined, { piInstalled: true });
+
+		expect(result).toEqual({
+			mode: "shadow",
+			categories: {
+				"quick-discovery": ["groq", "openai"],
+				"implementation-default": ["openai", "groq"],
+			},
+		});
+		expect(packageMocks.installPiPackages).toHaveBeenCalledWith(["@ifi/pi-provider-ollama"]);
+		expect(promptState.spinnerStarts).toEqual(["Installing optional routing packages"]);
+		expect(promptState.spinnerStops[0]).toContain("Installed 1 optional package");
+		expect(promptState.notes.map((entry) => entry.message)).toEqual([
+			"dashboard:unset",
+			"dashboard:unset",
+			"dashboard:shadow",
+		]);
+	});
+
+	it("shows a note instead of installing packages when pi is missing", async () => {
+		const currentConfig = { mode: "off" as const, categories: { "quick-discovery": ["openai"] } };
+		dashboardMocks.detectOptionalRoutingPackages.mockReturnValue([missingPackage("@ifi/pi-provider-ollama")]);
+		promptState.confirm.push(false);
+
+		const result = await setupAdaptiveRouting(makeProviders(), currentConfig, { piInstalled: false });
+
+		expect(result).toBe(currentConfig);
+		expect(packageMocks.installPiPackages).not.toHaveBeenCalled();
+		expect(promptState.notes.some((entry) => entry.title === "Optional Packages")).toBe(true);
+	});
+
+	it("skips installation when the user declines and returns the current config when not reconfiguring", async () => {
+		const currentConfig = { mode: "shadow" as const, categories: { "quick-discovery": ["openai"] } };
+		dashboardMocks.detectOptionalRoutingPackages.mockReturnValue([missingPackage("@ifi/pi-provider-ollama")]);
+		dashboardMocks.suggestOptionalRoutingPackages.mockReturnValue(["@ifi/pi-provider-ollama"]);
+		promptState.confirm.push(false, false);
+
+		const result = await setupAdaptiveRouting(makeProviders(), currentConfig, { piInstalled: true });
+
+		expect(result).toBe(currentConfig);
+		expect(packageMocks.installPiPackages).not.toHaveBeenCalled();
+	});
+
+	it("continues after install failures and warns the user", async () => {
+		dashboardMocks.detectOptionalRoutingPackages.mockReturnValue([missingPackage("@ifi/pi-provider-ollama")]);
+		dashboardMocks.suggestOptionalRoutingPackages.mockReturnValue(["@ifi/pi-provider-ollama"]);
+		packageMocks.installPiPackages.mockImplementation(() => {
+			throw new Error("network unavailable");
+		});
+		promptState.confirm.push(true, false, false);
+		promptState.multiselect.push(["@ifi/pi-provider-ollama"]);
+
+		const result = await setupAdaptiveRouting(makeProviders(), undefined, { piInstalled: true });
+
+		expect(result).toBeUndefined();
+		expect(promptState.warns).toEqual(["Error: network unavailable"]);
+		expect(promptState.spinnerStops).toContain("Optional package install failed.");
+	});
+
+	it("returns early when no optional packages are selected for installation", async () => {
+		dashboardMocks.detectOptionalRoutingPackages.mockReturnValue([missingPackage("@ifi/pi-provider-ollama")]);
+		dashboardMocks.suggestOptionalRoutingPackages.mockReturnValue(["@ifi/pi-provider-ollama"]);
+		promptState.confirm.push(true, false);
+		promptState.multiselect.push([]);
+
+		const result = await setupAdaptiveRouting(makeProviders(), undefined, { piInstalled: true });
+
+		expect(result).toBeUndefined();
+		expect(packageMocks.installPiPackages).not.toHaveBeenCalled();
+	});
+
+	it("uses the only provider when no recommended provider matches", async () => {
+		dashboardMocks.detectOptionalRoutingPackages.mockReturnValue([]);
+		promptState.confirm.push(true, false);
+		promptState.select.push("off", "custom-provider", "custom-provider");
+
+		const result = await setupAdaptiveRouting([{ name: "custom-provider", apiKey: "none", defaultModel: "model-a" }]);
+
+		expect(result).toEqual({
+			mode: "off",
+			categories: {
+				"quick-discovery": ["custom-provider"],
+				"implementation-default": ["custom-provider"],
+			},
+		});
+	});
+
+	it("cancels through the shared cancel handler", async () => {
+		dashboardMocks.detectOptionalRoutingPackages.mockReturnValue([missingPackage("@ifi/pi-provider-ollama")]);
+		dashboardMocks.suggestOptionalRoutingPackages.mockReturnValue(["@ifi/pi-provider-ollama"]);
+		promptState.confirm.push("__CANCEL__");
+		const exit = vi.spyOn(process, "exit").mockImplementation((() => {
+			throw new Error("process.exit");
+		}) as never);
+
+		await expect(setupAdaptiveRouting(makeProviders(), undefined, { piInstalled: true })).rejects.toThrow(
+			"process.exit",
+		);
+
+		expect(promptState.cancels).toEqual(["Cancelled."]);
+		expect(exit).toHaveBeenCalledWith(0);
+	});
+});
+
+describe("summarizeAdaptiveRouting", () => {
+	it("summarizes configured and missing routing states", () => {
+		expect(summarizeAdaptiveRouting(undefined)).toBe("not configured");
+		expect(summarizeAdaptiveRouting({ mode: "auto", categories: { a: ["openai"], b: ["groq"] } })).toBe(
+			"auto · 2 categories",
+		);
+	});
+});

--- a/packages/cli/src/tui/routing-setup.ts
+++ b/packages/cli/src/tui/routing-setup.ts
@@ -1,10 +1,28 @@
 import * as p from "@clack/prompts";
 import type { ProviderConfig } from "@ifi/oh-pi-core";
 import type { AdaptiveRoutingModeConfig, AdaptiveRoutingSetupConfig } from "../types.js";
-import { buildRoutingDashboard, ROUTING_CATEGORIES } from "./routing-dashboard.js";
+import { installPiPackages } from "../utils/pi-packages.js";
+import {
+	buildRoutingDashboard,
+	detectOptionalRoutingPackages,
+	ROUTING_CATEGORIES,
+	suggestOptionalRoutingPackages,
+} from "./routing-dashboard.js";
+
+interface SetupAdaptiveRoutingOptions {
+	piInstalled?: boolean;
+}
 
 function uniqueProviderNames(providers: ProviderConfig[]): string[] {
 	return [...new Set(providers.map((provider) => provider.name.trim()).filter(Boolean))];
+}
+
+function exitOnCancel<T>(value: T): Exclude<T, symbol> {
+	if (p.isCancel(value)) {
+		p.cancel("Cancelled.");
+		process.exit(0);
+	}
+	return value as Exclude<T, symbol>;
 }
 
 function orderProviders(preferred: string, providers: string[]): string[] {
@@ -20,9 +38,77 @@ function suggestedProvider(category: (typeof ROUTING_CATEGORIES)[number], provid
 	return providers[0] ?? "";
 }
 
+async function maybeInstallOptionalPackages(
+	providers: ProviderConfig[],
+	config: AdaptiveRoutingSetupConfig | undefined,
+	providerNames: string[],
+	options: SetupAdaptiveRoutingOptions,
+): Promise<void> {
+	const packageStates = detectOptionalRoutingPackages();
+	const missingPackages = packageStates.filter((pkg) => !pkg.installed);
+	if (missingPackages.length === 0) {
+		return;
+	}
+
+	if (options.piInstalled === false) {
+		p.note(
+			"pi is not installed yet. Finish setup first, then reopen the routing dashboard to install optional routing packages.",
+			"Optional Packages",
+		);
+		return;
+	}
+
+	const suggestedPackages = new Set(suggestOptionalRoutingPackages(providerNames, config));
+	const shouldInstall = exitOnCancel(
+		await p.confirm({
+			message: "Install missing optional routing/provider packages from this dashboard?",
+			initialValue: suggestedPackages.size > 0,
+		}),
+	);
+	if (!shouldInstall) {
+		return;
+	}
+
+	const selectedPackages = exitOnCancel(
+		await p.multiselect<string>({
+			message: "Select optional packages to install",
+			options: missingPackages.map((pkg) => ({
+				value: pkg.packageName,
+				label: pkg.label,
+				hint: pkg.hint,
+			})),
+			initialValues: missingPackages
+				.filter((pkg) => suggestedPackages.has(pkg.packageName))
+				.map((pkg) => pkg.packageName),
+		}),
+	);
+	if (selectedPackages.length === 0) {
+		return;
+	}
+
+	const spinner = p.spinner();
+	spinner.start("Installing optional routing packages");
+	try {
+		installPiPackages(selectedPackages);
+		spinner.stop(`Installed ${selectedPackages.length} optional package(s). Restart pi after setup to load them.`);
+	} catch (error) {
+		spinner.stop("Optional package install failed.");
+		p.log.warn(String(error));
+	}
+
+	p.note(
+		buildRoutingDashboard({
+			providers,
+			config,
+		}),
+		"Provider & Routing Dashboard",
+	);
+}
+
 export async function setupAdaptiveRouting(
 	providers: ProviderConfig[],
 	currentConfig?: AdaptiveRoutingSetupConfig,
+	options: SetupAdaptiveRoutingOptions = {},
 ): Promise<AdaptiveRoutingSetupConfig | undefined> {
 	const providerNames = uniqueProviderNames(providers);
 	if (providerNames.length === 0) {
@@ -37,55 +123,52 @@ export async function setupAdaptiveRouting(
 		"Provider & Routing Dashboard",
 	);
 
-	const shouldConfigure = await p.confirm({
-		message: currentConfig
-			? "Edit startup provider assignments for session, subagents, and ant-colony?"
-			: providerNames.length > 1
-				? "Configure startup provider assignments for session, subagents, and ant-colony?"
-				: `Use ${providerNames[0]} for delegated subagent and colony routing?`,
-		initialValue: currentConfig ? true : providerNames.length > 1,
-	});
-	if (p.isCancel(shouldConfigure)) {
-		p.cancel("Cancelled.");
-		process.exit(0);
-	}
+	await maybeInstallOptionalPackages(providers, currentConfig, providerNames, options);
+
+	const shouldConfigure = exitOnCancel(
+		await p.confirm({
+			message: currentConfig
+				? "Edit startup provider assignments for session, subagents, and ant-colony?"
+				: providerNames.length > 1
+					? "Configure startup provider assignments for session, subagents, and ant-colony?"
+					: `Use ${providerNames[0]} for delegated subagent and colony routing?`,
+			initialValue: currentConfig ? true : providerNames.length > 1,
+		}),
+	);
 	if (!shouldConfigure) {
 		return currentConfig;
 	}
 
-	const mode = await p.select<AdaptiveRoutingModeConfig>({
-		initialValue: currentConfig?.mode ?? "off",
-		message: "Prompt routing mode for the optional adaptive-routing package:",
-		options: [
-			{ value: "off", label: "Off", hint: "Only delegated startup assignments; no per-prompt auto routing" },
-			{ value: "shadow", label: "Shadow", hint: "Suggest routes without switching models automatically" },
-			{ value: "auto", label: "Auto", hint: "Automatically switch models before each turn" },
-		],
-	});
-	if (p.isCancel(mode)) {
-		p.cancel("Cancelled.");
-		process.exit(0);
-	}
+	const mode = exitOnCancel(
+		await p.select<AdaptiveRoutingModeConfig>({
+			initialValue: currentConfig?.mode ?? "off",
+			message: "Prompt routing mode for the optional adaptive-routing package:",
+			options: [
+				{ value: "off", label: "Off", hint: "Only delegated startup assignments; no per-prompt auto routing" },
+				{ value: "shadow", label: "Shadow", hint: "Suggest routes without switching models automatically" },
+				{ value: "auto", label: "Auto", hint: "Automatically switch models before each turn" },
+			],
+		}),
+	);
 
 	const categories: Record<string, string[]> = {};
 	for (const category of ROUTING_CATEGORIES) {
-		const preferred = await p.select<string>({
-			message: `${category.label} should prefer which provider?`,
-			options: providerNames.map((provider) => ({
-				value: provider,
-				label: provider,
-				hint: `Fallback order: ${orderProviders(provider, providerNames).join(" → ")}`,
-			})),
-			initialValue: currentConfig?.categories[category.name]?.[0] ?? suggestedProvider(category, providerNames),
-		});
-		if (p.isCancel(preferred)) {
-			p.cancel("Cancelled.");
-			process.exit(0);
-		}
+		const preferred = exitOnCancel(
+			await p.select<string>({
+				message: `${category.label} should prefer which provider?`,
+				options: providerNames.map((provider) => ({
+					value: provider,
+					label: provider,
+					hint: `Fallback order: ${orderProviders(provider, providerNames).join(" → ")}`,
+				})),
+				initialValue: currentConfig?.categories[category.name]?.[0] ?? suggestedProvider(category, providerNames),
+			}),
+		);
 		categories[category.name] = orderProviders(preferred, providerNames);
 	}
 
 	const config = { mode, categories };
+	await maybeInstallOptionalPackages(providers, config, providerNames, options);
 
 	p.note(
 		buildRoutingDashboard({

--- a/packages/cli/src/utils/pi-packages.test.ts
+++ b/packages/cli/src/utils/pi-packages.test.ts
@@ -1,0 +1,196 @@
+import { mkdirSync, mkdtempSync, writeFileSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { afterEach, describe, expect, it, vi } from "vitest";
+import {
+	detectPiPackageInstallScopes,
+	findPiCommand,
+	installPiPackages,
+	parseNpmPackageName,
+	resolveManagedPackageName,
+} from "./pi-packages.js";
+
+const tempDirs: string[] = [];
+
+function makeTempDir(): string {
+	const dir = mkdtempSync(join(tmpdir(), "oh-pi-pi-packages-"));
+	tempDirs.push(dir);
+	return dir;
+}
+
+afterEach(() => {
+	vi.restoreAllMocks();
+});
+
+describe("parseNpmPackageName", () => {
+	it("parses scoped and unscoped npm package sources", () => {
+		expect(parseNpmPackageName("npm:@ifi/pi-provider-ollama@0.4.4")).toBe("@ifi/pi-provider-ollama");
+		expect(parseNpmPackageName("npm:@ifi/pi-provider-cursor")).toBe("@ifi/pi-provider-cursor");
+		expect(parseNpmPackageName("npm:chalk@5")).toBe("chalk");
+		expect(parseNpmPackageName("npm:chalk")).toBe("chalk");
+	});
+
+	it("returns undefined for invalid npm sources", () => {
+		expect(parseNpmPackageName("https://example.com/package.tgz")).toBeUndefined();
+		expect(parseNpmPackageName("npm:")).toBeUndefined();
+		expect(parseNpmPackageName("npm:@ifi")).toBeUndefined();
+	});
+});
+
+describe("resolveManagedPackageName", () => {
+	it("resolves local path package names and ignores unsupported sources", () => {
+		const cwd = makeTempDir();
+		const localPackageDir = join(cwd, "local-package");
+		mkdirSync(localPackageDir, { recursive: true });
+		writeFileSync(join(localPackageDir, "package.json"), JSON.stringify({ name: "@ifi/pi-provider-catalog" }));
+
+		expect(resolveManagedPackageName("./local-package", cwd)).toBe("@ifi/pi-provider-catalog");
+		expect(resolveManagedPackageName("git:https://example.com/repo.git", cwd)).toBeUndefined();
+	});
+});
+
+describe("detectPiPackageInstallScopes", () => {
+	it("detects user, project, both, and missing package scopes", () => {
+		const homeDir = makeTempDir();
+		const cwd = makeTempDir();
+		mkdirSync(join(homeDir, ".pi", "agent"), { recursive: true });
+		mkdirSync(join(cwd, ".pi"), { recursive: true });
+		const localPackageDir = join(cwd, "local-provider");
+		mkdirSync(localPackageDir, { recursive: true });
+		writeFileSync(join(localPackageDir, "package.json"), JSON.stringify({ name: "@ifi/pi-provider-catalog" }));
+		writeFileSync(
+			join(homeDir, ".pi", "agent", "settings.json"),
+			JSON.stringify({
+				packages: [
+					"npm:@ifi/pi-provider-ollama",
+					{ source: "npm:@ifi/pi-provider-cursor@0.4.4" },
+					{ source: "./local-provider" },
+					{},
+				],
+			}),
+		);
+		writeFileSync(
+			join(cwd, ".pi", "settings.json"),
+			JSON.stringify({
+				packages: [
+					"npm:@ifi/pi-provider-cursor",
+					"npm:@ifi/pi-extension-adaptive-routing",
+					{ source: "./local-provider" },
+				],
+			}),
+		);
+
+		const states = detectPiPackageInstallScopes(
+			[
+				"@ifi/pi-provider-ollama",
+				"@ifi/pi-provider-cursor",
+				"@ifi/pi-provider-catalog",
+				"@ifi/pi-extension-adaptive-routing",
+				"@ifi/pi-provider-missing",
+			],
+			{ cwd, homeDir },
+		);
+
+		expect(states).toEqual([
+			{ packageName: "@ifi/pi-provider-ollama", scope: "user" },
+			{ packageName: "@ifi/pi-provider-cursor", scope: "both" },
+			{ packageName: "@ifi/pi-provider-catalog", scope: "both" },
+			{ packageName: "@ifi/pi-extension-adaptive-routing", scope: "project" },
+			{ packageName: "@ifi/pi-provider-missing", scope: "none" },
+		]);
+	});
+
+	it("treats missing or invalid settings files as empty package lists", () => {
+		const homeDir = makeTempDir();
+		const cwd = makeTempDir();
+		mkdirSync(join(cwd, ".pi"), { recursive: true });
+		writeFileSync(join(cwd, ".pi", "settings.json"), "{not-json");
+
+		const states = detectPiPackageInstallScopes(["@ifi/pi-provider-ollama"], { cwd, homeDir });
+
+		expect(states).toEqual([{ packageName: "@ifi/pi-provider-ollama", scope: "none" }]);
+	});
+});
+
+describe("findPiCommand", () => {
+	it("returns the first working pi command", () => {
+		const run = vi.fn(() => Buffer.from("pi 0.64.0"));
+
+		expect(findPiCommand(run)).toBe("pi");
+		expect(run).toHaveBeenCalledWith("pi", ["--version"], { stdio: "pipe", timeout: 3000, shell: false });
+	});
+
+	it("throws when pi is not available", () => {
+		const run = vi.fn(() => {
+			throw new Error("missing");
+		});
+
+		expect(() => findPiCommand(run)).toThrow("pi not found");
+	});
+});
+
+describe("installPiPackages", () => {
+	it("installs requested packages and ignores already-installed responses", () => {
+		const run = vi.fn((_file: string, args: string[]) => {
+			if (args[0] === "--version") {
+				return Buffer.from("pi 0.64.0");
+			}
+			if (args[1] === "npm:@ifi/pi-provider-cursor") {
+				const error = new Error("already installed") as Error & { stderr: Buffer };
+				error.stderr = Buffer.from("already installed");
+				throw error;
+			}
+			return Buffer.from("");
+		});
+
+		installPiPackages(["@ifi/pi-provider-ollama", "@ifi/pi-provider-cursor"], "project", run);
+
+		expect(run).toHaveBeenNthCalledWith(1, "pi", ["--version"], { stdio: "pipe", timeout: 3000, shell: false });
+		expect(run).toHaveBeenNthCalledWith(2, "pi", ["install", "npm:@ifi/pi-provider-ollama", "-l"], {
+			stdio: "pipe",
+			timeout: 60000,
+			shell: false,
+		});
+		expect(run).toHaveBeenNthCalledWith(3, "pi", ["install", "npm:@ifi/pi-provider-cursor", "-l"], {
+			stdio: "pipe",
+			timeout: 60000,
+			shell: false,
+		});
+	});
+
+	it("returns early for an empty package list", () => {
+		const run = vi.fn();
+
+		installPiPackages([], "user", run);
+
+		expect(run).not.toHaveBeenCalled();
+	});
+
+	it("throws a descriptive error when install fails", () => {
+		const run = vi.fn((_file: string, args: string[]) => {
+			if (args[0] === "--version") {
+				return Buffer.from("pi 0.64.0");
+			}
+			const error = new Error("boom") as Error & { stderr: Buffer };
+			error.stderr = Buffer.from("network unavailable\nextra output");
+			throw error;
+		});
+
+		expect(() => installPiPackages(["@ifi/pi-provider-ollama"], "user", run)).toThrow(
+			"Failed to install @ifi/pi-provider-ollama: network unavailable",
+		);
+	});
+
+	it("includes a generic suffix when install failures have no stderr", () => {
+		const run = vi.fn((_file: string, args: string[]) => {
+			if (args[0] === "--version") {
+				return Buffer.from("pi 0.64.0");
+			}
+			throw new Error("boom");
+		});
+
+		expect(() => installPiPackages(["@ifi/pi-provider-ollama"], "user", run)).toThrow(
+			"Failed to install @ifi/pi-provider-ollama.",
+		);
+	});
+});

--- a/packages/cli/src/utils/pi-packages.ts
+++ b/packages/cli/src/utils/pi-packages.ts
@@ -1,0 +1,184 @@
+import { execFileSync } from "node:child_process";
+import { existsSync, readFileSync } from "node:fs";
+import { join, resolve } from "node:path";
+import { resolvePiAgentDir } from "@ifi/oh-pi-core";
+
+const IS_WINDOWS = process.platform === "win32";
+
+type PackageSetting = string | ({ source: string } & Record<string, unknown>);
+
+type SettingsFile = {
+	packages?: PackageSetting[];
+	[key: string]: unknown;
+};
+
+type ExecFileRunner = (
+	file: string,
+	args: string[],
+	options: {
+		stdio: "pipe";
+		timeout: number;
+		shell?: boolean;
+	},
+) => unknown;
+
+export type PiPackageInstallScope = "none" | "user" | "project" | "both";
+
+export interface PiPackageInstallState {
+	packageName: string;
+	scope: PiPackageInstallScope;
+}
+
+export interface DetectPiPackageOptions {
+	cwd?: string;
+	env?: NodeJS.ProcessEnv;
+	homeDir?: string;
+}
+
+function readJsonFile<T>(filePath: string): T | undefined {
+	if (!existsSync(filePath)) {
+		return undefined;
+	}
+
+	try {
+		return JSON.parse(readFileSync(filePath, "utf8")) as T;
+	} catch {
+		return undefined;
+	}
+}
+
+function getPackageSource(entry: unknown): string | undefined {
+	if (typeof entry === "string") {
+		return entry;
+	}
+	if (entry && typeof entry === "object" && "source" in entry && typeof entry.source === "string") {
+		return entry.source;
+	}
+	return undefined;
+}
+
+export function parseNpmPackageName(source: string): string | undefined {
+	if (!source.startsWith("npm:")) {
+		return undefined;
+	}
+
+	const specifier = source.slice(4);
+	if (!specifier) {
+		return undefined;
+	}
+
+	if (specifier.startsWith("@")) {
+		const slashIndex = specifier.indexOf("/");
+		if (slashIndex === -1) {
+			return undefined;
+		}
+		const versionIndex = specifier.indexOf("@", slashIndex + 1);
+		return versionIndex === -1 ? specifier : specifier.slice(0, versionIndex);
+	}
+
+	const versionIndex = specifier.indexOf("@");
+	return versionIndex === -1 ? specifier : specifier.slice(0, versionIndex);
+}
+
+function resolvePathPackageName(source: string, sourceBaseDir: string): string | undefined {
+	if (
+		source.startsWith("git:") ||
+		source.startsWith("http://") ||
+		source.startsWith("https://") ||
+		source.startsWith("ssh://")
+	) {
+		return undefined;
+	}
+
+	const pkgJson = readJsonFile<{ name?: unknown }>(join(resolve(sourceBaseDir, source), "package.json"));
+	return typeof pkgJson?.name === "string" ? pkgJson.name : undefined;
+}
+
+export function resolveManagedPackageName(source: string, sourceBaseDir: string): string | undefined {
+	return parseNpmPackageName(source) ?? resolvePathPackageName(source, sourceBaseDir);
+}
+
+function collectManagedPackageNames(settingsPath: string, sourceBaseDir: string): Set<string> {
+	const settings = readJsonFile<SettingsFile>(settingsPath) ?? {};
+	const entries = Array.isArray(settings.packages) ? settings.packages : [];
+	const packageNames = new Set<string>();
+	for (const entry of entries) {
+		const source = getPackageSource(entry);
+		if (!source) {
+			continue;
+		}
+		const packageName = resolveManagedPackageName(source, sourceBaseDir);
+		if (packageName) {
+			packageNames.add(packageName);
+		}
+	}
+	return packageNames;
+}
+
+export function detectPiPackageInstallScopes(
+	packageNames: string[],
+	options: DetectPiPackageOptions = {},
+): PiPackageInstallState[] {
+	const cwd = options.cwd ?? process.cwd();
+	const userSettingsPath = join(resolvePiAgentDir({ env: options.env, homeDir: options.homeDir }), "settings.json");
+	const projectSettingsPath = join(cwd, ".pi", "settings.json");
+	const userPackages = collectManagedPackageNames(userSettingsPath, cwd);
+	const projectPackages = collectManagedPackageNames(projectSettingsPath, cwd);
+
+	return packageNames.map((packageName) => {
+		const installedInUser = userPackages.has(packageName);
+		const installedInProject = projectPackages.has(packageName);
+		const scope = installedInUser ? (installedInProject ? "both" : "user") : installedInProject ? "project" : "none";
+		return { packageName, scope };
+	});
+}
+
+export function findPiCommand(run: ExecFileRunner = execFileSync): string {
+	const candidates = IS_WINDOWS ? ["pi.cmd", "pi"] : ["pi"];
+	for (const candidate of candidates) {
+		try {
+			run(candidate, ["--version"], { stdio: "pipe", timeout: 3_000, shell: IS_WINDOWS });
+			return candidate;
+		} catch {
+			// try next candidate
+		}
+	}
+	throw new Error("pi not found. Install pi-coding-agent first.");
+}
+
+function readStderr(error: unknown): string {
+	if (!error || typeof error !== "object" || !("stderr" in error)) {
+		return "";
+	}
+	const stderr = (error as { stderr?: { toString(): string } }).stderr;
+	return stderr ? stderr.toString().trim() : "";
+}
+
+export function installPiPackages(
+	packageNames: string[],
+	scope: "user" | "project" = "user",
+	run: ExecFileRunner = execFileSync,
+): void {
+	if (packageNames.length === 0) {
+		return;
+	}
+
+	const pi = findPiCommand(run);
+	const scopeArgs = scope === "project" ? ["-l"] : [];
+	for (const packageName of packageNames) {
+		try {
+			run(pi, ["install", `npm:${packageName}`, ...scopeArgs], {
+				stdio: "pipe",
+				timeout: 60_000,
+				shell: IS_WINDOWS,
+			});
+		} catch (error) {
+			const stderr = readStderr(error);
+			if (stderr.includes("already installed") || stderr.includes("already exists")) {
+				continue;
+			}
+			const details = stderr ? `: ${stderr.split("\n")[0]}` : ".";
+			throw new Error(`Failed to install ${packageName}${details}`);
+		}
+	}
+}


### PR DESCRIPTION
## Summary
- let the routing dashboard detect optional package installs from pi settings instead of node resolution
- allow users to install missing routing/provider packages directly from the dashboard
- add focused tests with 100% line coverage for the changed routing dashboard, routing setup, and pi package utility files

## Validation
- node_modules/.bin/vitest run packages/cli/src/tui/config-wizard.test.ts packages/cli/src/tui/routing-dashboard.test.ts packages/cli/src/tui/routing-setup.test.ts packages/cli/src/utils/pi-packages.test.ts packages/cli/src/utils/writers.test.ts
- pnpm --filter @ifi/oh-pi-cli typecheck
- pnpm --filter @ifi/oh-pi-cli build
- node_modules/.bin/vitest run packages/cli/src/tui/routing-dashboard.test.ts packages/cli/src/tui/routing-setup.test.ts packages/cli/src/utils/pi-packages.test.ts --coverage.enabled --coverage.provider=v8 --coverage.reporter=text --coverage.include=packages/cli/src/tui/routing-dashboard.ts --coverage.include=packages/cli/src/tui/routing-setup.ts --coverage.include=packages/cli/src/utils/pi-packages.ts
