### PR TITLE
perf(usage-tracker): reduce widget redraw churn

### DIFF
--- a/.changeset/usage-tracker-widget-churn.md
+++ b/.changeset/usage-tracker-widget-churn.md
@@ -1,0 +1,5 @@
+---
+default: patch
+---
+
+Reduce usage-tracker widget redraw churn by removing the fixed refresh timer, re-rendering on real usage/probe/session changes instead, and keeping the widget aligned with the latest active session after switches.

--- a/docs/startup-performance-audit.md
+++ b/docs/startup-performance-audit.md
@@ -106,12 +106,17 @@ The footer caches totals after startup, but the aggregation path is still O(n) o
 
 **Why it matters**
 
-The usage tracker hydrates from session history near startup and also schedules persisted-state loading and provider probing. For histories below the defer threshold it still does immediate session reconstruction.
+The usage tracker hydrates from session history near startup and also schedules persisted-state loading and provider probing. For histories below the defer threshold it still does immediate session reconstruction. Its widget used to wake on a fixed 15-second timer, which made it another likely contributor to background redraw churn after startup.
 
 **Current benchmark coverage**
 
 - `usage tracker session_start (200-entry history)`
 - included indirectly by the full-stack startup cases
+
+**Latest mitigation**
+
+- usage widget redraws should now be event-driven from usage/probe/session changes instead of a fixed 15-second timer
+- widget rendering should follow the latest active session context after `session_switch` without requiring a remount
 
 ### 5. `packages/ant-colony/extensions/ant-colony/*`
 

--- a/packages/extensions/extensions/usage-tracker.test.ts
+++ b/packages/extensions/extensions/usage-tracker.test.ts
@@ -1169,6 +1169,96 @@ describe("usage-tracker extension", () => {
 			expect(rendered).not.toContain("$0.050");
 		});
 
+		it("re-renders the widget when new usage arrives", () => {
+			usageTracker(pi as any);
+			pi._emit("session_start", { type: "session_start" }, ctx);
+
+			const widgetFactory = ctx._widgets.get("usage-tracker") as
+				| ((
+						tui: { requestRender: () => void },
+						theme: { fg: (_color: string, text: string) => string },
+				  ) => {
+						render: (width: number) => string[];
+				  })
+				| undefined;
+			expect(widgetFactory).toBeDefined();
+			const requestRender = vi.fn();
+			widgetFactory?.({ requestRender }, { fg: (_color: string, text: string) => text });
+			requestRender.mockClear();
+
+			pi._emit(
+				"turn_end",
+				{
+					type: "turn_end",
+					turnIndex: 0,
+					message: makeAssistantMessage({ costTotal: 0.02 }),
+					toolResults: [],
+				},
+				ctx,
+			);
+
+			expect(requestRender).toHaveBeenCalledTimes(1);
+		});
+
+		it("does not rely on a periodic widget timer while idle", () => {
+			usageTracker(pi as any);
+			pi._emit("session_start", { type: "session_start" }, ctx);
+
+			const widgetFactory = ctx._widgets.get("usage-tracker") as
+				| ((
+						tui: { requestRender: () => void },
+						theme: { fg: (_color: string, text: string) => string },
+				  ) => {
+						render: (width: number) => string[];
+				  })
+				| undefined;
+			expect(widgetFactory).toBeDefined();
+			const requestRender = vi.fn();
+			widgetFactory?.({ requestRender }, { fg: (_color: string, text: string) => text });
+			requestRender.mockClear();
+
+			vi.advanceTimersByTime(60_000);
+
+			expect(requestRender).not.toHaveBeenCalled();
+		});
+
+		it("renders against the latest active session after session_switch", () => {
+			usageTracker(pi as any);
+			pi._emit("session_start", { type: "session_start" }, ctx);
+
+			pi._emit(
+				"turn_end",
+				{
+					type: "turn_end",
+					turnIndex: 0,
+					message: makeAssistantMessage({ provider: "anthropic", model: "claude-sonnet-4-20250514", costTotal: 0.02 }),
+					toolResults: [],
+				},
+				ctx,
+			);
+
+			const widgetFactory = ctx._widgets.get("usage-tracker") as
+				| ((
+						tui: { requestRender: () => void },
+						theme: { fg: (_color: string, text: string) => string },
+				  ) => {
+						render: (width: number) => string[];
+				  })
+				| undefined;
+			expect(widgetFactory).toBeDefined();
+			const component = widgetFactory?.({ requestRender: vi.fn() }, { fg: (_color: string, text: string) => text });
+
+			const nextCtx = createMockCtx([
+				makeSessionEntry(makeAssistantMessage({ provider: "openai", model: "gpt-4o", costTotal: 0.03 })),
+			]);
+			nextCtx.model = { id: "gpt-4o", provider: "openai" } as any;
+			pi._emit("session_switch", { type: "session_switch" }, nextCtx);
+
+			const rendered = component?.render(200).join("\n") ?? "";
+			expect(rendered).toContain("$0.030");
+			expect(rendered).not.toContain("$0.020");
+		});
+
 		it("shows cached Anthropic windows in the widget when live probing is rate-limited", async () => {
 			(existsSync as ReturnType<typeof vi.fn>).mockImplementation((path: string) => String(path) === AUTH_JSON_PATH);
 			(readFileSync as ReturnType<typeof vi.fn>).mockImplementation((path: string) => {

--- a/packages/extensions/extensions/usage-tracker.ts
+++ b/packages/extensions/extensions/usage-tracker.ts
@@ -155,6 +155,10 @@ export default function usageTracker(pi: ExtensionAPI) {
 	let startupRefreshTimer: ReturnType<typeof setTimeout> | null = null;
 	let requestWidgetRender: (() => void) | null = null;
 
+	const requestUsageWidgetRender = () => {
+		requestWidgetRender?.();
+	};
+
 	const scheduleCtrlUUnbound = () => {
 		if (keybindingsSyncScheduled) {
 			return;
@@ -371,7 +375,7 @@ export default function usageTracker(pi: ExtensionAPI) {
 
 		persistedStateLoadPromise = (async () => {
 			await Promise.all([loadRollingHistory(), loadRateLimitCache()]);
-			requestWidgetRender?.();
+			requestUsageWidgetRender();
 			broadcastUsageData();
 		})();
 
@@ -736,6 +740,8 @@ export default function usageTracker(pi: ExtensionAPI) {
 			pruneRollingHistory(now);
 			saveRollingHistory();
 		}
+
+		requestUsageWidgetRender();
 	}
 
 	function recordUsage(msg: AssistantMessage, options: { persist?: boolean } = {}): void {
@@ -864,6 +870,7 @@ export default function usageTracker(pi: ExtensionAPI) {
 		const entries = ctx.sessionManager.getBranch();
 		const refresh = () => {
 			hydrateFromSessionEntries(entries);
+			requestUsageWidgetRender();
 			triggerProbe(ctx);
 			broadcastUsageData();
 		};
@@ -908,6 +915,7 @@ export default function usageTracker(pi: ExtensionAPI) {
 				rateLimits.set(provider, limits);
 				saveRateLimitCache();
 				lastProbeTime.set(provider, Date.now());
+				requestUsageWidgetRender();
 				return;
 			}
 
@@ -936,6 +944,7 @@ export default function usageTracker(pi: ExtensionAPI) {
 				});
 				saveRateLimitCache();
 				lastProbeTime.set(provider, now);
+				requestUsageWidgetRender();
 				return;
 			}
 
@@ -954,6 +963,7 @@ export default function usageTracker(pi: ExtensionAPI) {
 				});
 				saveRateLimitCache();
 				lastProbeTime.set(provider, now);
+				requestUsageWidgetRender();
 				return;
 			}
 
@@ -984,6 +994,7 @@ export default function usageTracker(pi: ExtensionAPI) {
 			rateLimits.set(provider, limits);
 			saveRateLimitCache();
 			lastProbeTime.set(provider, Date.now());
+			requestUsageWidgetRender();
 		} catch {
 			// Probe failed — keep stale data if any
 		} finally {
@@ -1521,36 +1532,41 @@ export default function usageTracker(pi: ExtensionAPI) {
 		return [parts.join(sep)];
 	}
 
+	const mountWidget = (ctx: ExtensionContext) => {
+		ctx.ui.setWidget("usage-tracker", (tui, theme) => {
+			const componentRequestRender = () => tui.requestRender();
+			requestWidgetRender = componentRequestRender;
+			const unsubSafeMode = subscribeSafeMode(() => requestUsageWidgetRender());
+			return {
+				dispose() {
+					if (requestWidgetRender === componentRequestRender) {
+						requestWidgetRender = null;
+					}
+					unsubSafeMode();
+				},
+				// biome-ignore lint/suspicious/noEmptyBlockStatements: required by Component interface
+				invalidate() {},
+				render(width: number) {
+					return renderWidget(activeCtx ?? ctx, theme).map((line) => truncateAnsi(line, width));
+				},
+			};
+		});
+	};
+
 	// ─── Event handlers ───────────────────────────────────────────────────
 
 	pi.on("session_start", (_event, ctx) => {
 		activeCtx = ctx;
 		schedulePersistedStateLoad();
 		refreshStartupState(ctx);
-
-		ctx.ui.setWidget("usage-tracker", (tui, theme) => {
-			requestWidgetRender = () => tui.requestRender();
-			const unsubSafeMode = subscribeSafeMode(() => tui.requestRender());
-			const timer = setInterval(() => tui.requestRender(), 15_000);
-			return {
-				dispose() {
-					requestWidgetRender = null;
-					unsubSafeMode();
-					clearInterval(timer);
-				},
-				// biome-ignore lint/suspicious/noEmptyBlockStatements: required by Component interface
-				invalidate() {},
-				render(width: number) {
-					return renderWidget(ctx, theme).map((line) => truncateAnsi(line, width));
-				},
-			};
-		});
+		mountWidget(ctx);
 	});
 
 	pi.on("session_switch", (_event, ctx) => {
 		activeCtx = ctx;
 		schedulePersistedStateLoad();
 		refreshStartupState(ctx);
+		requestUsageWidgetRender();
 	});
 
 	pi.on("turn_end", (event, ctx) => {
@@ -1565,6 +1581,7 @@ export default function usageTracker(pi: ExtensionAPI) {
 
 	pi.on("model_select", (_event, ctx) => {
 		activeCtx = ctx;
+		requestUsageWidgetRender();
 		triggerProbe(ctx); // Probe the new provider
 	});
 
@@ -1599,21 +1616,7 @@ export default function usageTracker(pi: ExtensionAPI) {
 		async handler(_args, ctx) {
 			widgetVisible = !widgetVisible;
 			if (widgetVisible) {
-				ctx.ui.setWidget("usage-tracker", (tui, theme) => {
-					const unsubSafeMode = subscribeSafeMode(() => tui.requestRender());
-					const timer = setInterval(() => tui.requestRender(), 15_000);
-					return {
-						dispose() {
-							unsubSafeMode();
-							clearInterval(timer);
-						},
-						// biome-ignore lint/suspicious/noEmptyBlockStatements: required by Component interface
-						invalidate() {},
-						render(width: number) {
-							return renderWidget(ctx, theme).map((line) => truncateAnsi(line, width));
-						},
-					};
-				});
+				mountWidget(ctx);
 				ctx.ui.notify("Usage widget shown.", "info");
 			} else {
 				ctx.ui.setWidget("usage-tracker", undefined);


### PR DESCRIPTION
## Summary
- remove the usage widget's fixed 15s redraw timer and re-render only when usage, probes, or session context actually change
- keep the widget aligned with the latest active session after session switches
- document the responsiveness follow-up and add regression tests for idle redraw suppression and event-driven updates

## Validation
- pnpm lint
- pnpm test
- pnpm typecheck
- pnpm bench:startup