### PR TITLE
feat(cli): add routing install scope toggle

### DIFF
--- a/.changeset/routing-dashboard-install-scope-toggle.md
+++ b/.changeset/routing-dashboard-install-scope-toggle.md
@@ -1,0 +1,5 @@
+---
+default: minor
+---
+
+Add a user/project install scope toggle when installing optional routing packages from the oh-pi routing dashboard.

--- a/packages/cli/README.md
+++ b/packages/cli/README.md
@@ -8,7 +8,7 @@ Interactive TUI configurator for `pi-coding-agent`.
 - providers and auth
 - models
 - provider/routing dashboard views for session, subagents, and ant-colony
-- direct optional package installs from the routing dashboard
+- direct optional package installs from the routing dashboard with a user/project scope toggle
 - extensions
 - prompts
 - skills

--- a/packages/cli/src/tui/routing-dashboard.test.ts
+++ b/packages/cli/src/tui/routing-dashboard.test.ts
@@ -59,7 +59,7 @@ describe("detectOptionalRoutingPackages", () => {
 								? "project"
 								: "none",
 				})),
-			["@ifi/pi-extension-adaptive-routing"],
+			[{ packageName: "@ifi/pi-extension-adaptive-routing", scope: "project" }],
 		);
 
 		expect(packages.find((pkg) => pkg.packageName === "@ifi/pi-provider-ollama")).toMatchObject({
@@ -74,6 +74,7 @@ describe("detectOptionalRoutingPackages", () => {
 		expect(packages.find((pkg) => pkg.packageName === "@ifi/pi-extension-adaptive-routing")).toMatchObject({
 			installed: false,
 			selected: true,
+			selectedScope: "project",
 		});
 	});
 });
@@ -106,6 +107,7 @@ describe("buildRoutingDashboard", () => {
 					scope: "none",
 					installed: false,
 					selected: true,
+					selectedScope: "project",
 				},
 				{
 					packageName: "@ifi/pi-provider-ollama",
@@ -138,7 +140,7 @@ describe("buildRoutingDashboard", () => {
 			},
 		});
 
-		expect(dashboard).toContain("Adaptive routing package: selected for install");
+		expect(dashboard).toContain("Adaptive routing package: selected for install (project)");
 		expect(dashboard).toContain("Ollama provider package: installed (user)");
 		expect(dashboard).toContain("Cursor provider package: not installed");
 		expect(dashboard).toContain("install with pi install npm:@ifi/pi-provider-cursor");

--- a/packages/cli/src/tui/routing-dashboard.ts
+++ b/packages/cli/src/tui/routing-dashboard.ts
@@ -1,6 +1,10 @@
 import type { ProviderConfig } from "@ifi/oh-pi-core";
 import type { AdaptiveRoutingSetupConfig } from "../types.js";
-import type { PiPackageInstallScope, PiPackageInstallState } from "../utils/pi-packages.js";
+import type {
+	PiPackageInstallScope,
+	PiPackageInstallState,
+	WritablePiPackageInstallScope,
+} from "../utils/pi-packages.js";
 import { detectPiPackageInstallScopes } from "../utils/pi-packages.js";
 
 export const ROUTING_CATEGORIES = [
@@ -85,6 +89,12 @@ export interface OptionalRoutingPackageState {
 	scope: PiPackageInstallScope;
 	installed: boolean;
 	selected: boolean;
+	selectedScope?: WritablePiPackageInstallScope;
+}
+
+export interface PendingOptionalRoutingPackageSelection {
+	packageName: string;
+	scope: WritablePiPackageInstallScope;
 }
 
 interface RoutingDashboardOptions {
@@ -95,20 +105,22 @@ interface RoutingDashboardOptions {
 
 export function detectOptionalRoutingPackages(
 	detectStates: (packageNames: string[]) => PiPackageInstallState[] = detectPiPackageInstallScopes,
-	selectedPackages: string[] = [],
+	selectedPackages: PendingOptionalRoutingPackageSelection[] = [],
 ): OptionalRoutingPackageState[] {
-	const selected = new Set(selectedPackages);
+	const selected = new Map(selectedPackages.map((pkg) => [pkg.packageName, pkg.scope]));
 	const states = new Map(
 		detectStates(OPTIONAL_ROUTING_PACKAGES.map((pkg) => pkg.packageName)).map((pkg) => [pkg.packageName, pkg]),
 	);
 	return OPTIONAL_ROUTING_PACKAGES.map((pkg) => {
 		const state = states.get(pkg.packageName);
 		const scope = state?.scope ?? "none";
+		const selectedScope = selected.get(pkg.packageName);
 		return {
 			...pkg,
 			scope,
 			installed: scope !== "none",
-			selected: selected.has(pkg.packageName),
+			selected: selectedScope !== undefined,
+			selectedScope,
 		};
 	});
 }
@@ -177,8 +189,8 @@ function formatPackageState(pkg: OptionalRoutingPackageState): string {
 	if (pkg.installed) {
 		return `installed (${pkg.scope})`;
 	}
-	if (pkg.selected) {
-		return "selected for install";
+	if (pkg.selectedScope) {
+		return `selected for install (${pkg.selectedScope})`;
 	}
 	return "not installed";
 }

--- a/packages/cli/src/tui/routing-setup.test.ts
+++ b/packages/cli/src/tui/routing-setup.test.ts
@@ -99,16 +99,17 @@ describe("setupAdaptiveRouting", () => {
 		expect(dashboardMocks.buildRoutingDashboard).not.toHaveBeenCalled();
 	});
 
-	it("installs missing packages, configures routing, and re-renders the dashboard", async () => {
+	it("installs missing packages with an explicit scope, configures routing, and re-renders the dashboard", async () => {
 		dashboardMocks.detectOptionalRoutingPackages
 			.mockReturnValueOnce([missingPackage("@ifi/pi-provider-ollama", "Ollama provider package")])
+			.mockReturnValueOnce([])
 			.mockReturnValueOnce([]);
 		dashboardMocks.suggestOptionalRoutingPackages
 			.mockReturnValueOnce(["@ifi/pi-provider-ollama"])
 			.mockReturnValueOnce([]);
 		promptState.confirm.push(true, true);
 		promptState.multiselect.push(["@ifi/pi-provider-ollama"]);
-		promptState.select.push("shadow", "groq", "openai");
+		promptState.select.push("project", "shadow", "groq", "openai");
 
 		const result = await setupAdaptiveRouting(makeProviders(), undefined, { piInstalled: true });
 
@@ -119,10 +120,14 @@ describe("setupAdaptiveRouting", () => {
 				"implementation-default": ["openai", "groq"],
 			},
 		});
-		expect(packageMocks.installPiPackages).toHaveBeenCalledWith(["@ifi/pi-provider-ollama"]);
-		expect(promptState.spinnerStarts).toEqual(["Installing optional routing packages"]);
-		expect(promptState.spinnerStops[0]).toContain("Installed 1 optional package");
+		expect(packageMocks.installPiPackages).toHaveBeenCalledWith(["@ifi/pi-provider-ollama"], "project");
+		expect(promptState.spinnerStarts).toEqual(["Installing optional routing packages (project)"]);
+		expect(promptState.spinnerStops[0]).toContain("Installed 1 optional package(s) in project scope");
+		expect(dashboardMocks.detectOptionalRoutingPackages).toHaveBeenNthCalledWith(2, undefined, [
+			{ packageName: "@ifi/pi-provider-ollama", scope: "project" },
+		]);
 		expect(promptState.notes.map((entry) => entry.message)).toEqual([
+			"dashboard:unset",
 			"dashboard:unset",
 			"dashboard:unset",
 			"dashboard:shadow",
@@ -161,6 +166,7 @@ describe("setupAdaptiveRouting", () => {
 		});
 		promptState.confirm.push(true, false, false);
 		promptState.multiselect.push(["@ifi/pi-provider-ollama"]);
+		promptState.select.push("user");
 
 		const result = await setupAdaptiveRouting(makeProviders(), undefined, { piInstalled: true });
 
@@ -201,6 +207,24 @@ describe("setupAdaptiveRouting", () => {
 		dashboardMocks.detectOptionalRoutingPackages.mockReturnValue([missingPackage("@ifi/pi-provider-ollama")]);
 		dashboardMocks.suggestOptionalRoutingPackages.mockReturnValue(["@ifi/pi-provider-ollama"]);
 		promptState.confirm.push("__CANCEL__");
+		const exit = vi.spyOn(process, "exit").mockImplementation((() => {
+			throw new Error("process.exit");
+		}) as never);
+
+		await expect(setupAdaptiveRouting(makeProviders(), undefined, { piInstalled: true })).rejects.toThrow(
+			"process.exit",
+		);
+
+		expect(promptState.cancels).toEqual(["Cancelled."]);
+		expect(exit).toHaveBeenCalledWith(0);
+	});
+
+	it("cancels when choosing the install scope", async () => {
+		dashboardMocks.detectOptionalRoutingPackages.mockReturnValue([missingPackage("@ifi/pi-provider-ollama")]);
+		dashboardMocks.suggestOptionalRoutingPackages.mockReturnValue(["@ifi/pi-provider-ollama"]);
+		promptState.confirm.push(true);
+		promptState.multiselect.push(["@ifi/pi-provider-ollama"]);
+		promptState.select.push("__CANCEL__");
 		const exit = vi.spyOn(process, "exit").mockImplementation((() => {
 			throw new Error("process.exit");
 		}) as never);

--- a/packages/cli/src/tui/routing-setup.ts
+++ b/packages/cli/src/tui/routing-setup.ts
@@ -1,10 +1,12 @@
 import * as p from "@clack/prompts";
 import type { ProviderConfig } from "@ifi/oh-pi-core";
 import type { AdaptiveRoutingModeConfig, AdaptiveRoutingSetupConfig } from "../types.js";
+import type { WritablePiPackageInstallScope } from "../utils/pi-packages.js";
 import { installPiPackages } from "../utils/pi-packages.js";
 import {
 	buildRoutingDashboard,
 	detectOptionalRoutingPackages,
+	type PendingOptionalRoutingPackageSelection,
 	ROUTING_CATEGORIES,
 	suggestOptionalRoutingPackages,
 } from "./routing-dashboard.js";
@@ -86,11 +88,36 @@ async function maybeInstallOptionalPackages(
 		return;
 	}
 
+	const installScope = exitOnCancel(
+		await p.select<WritablePiPackageInstallScope>({
+			message: "Install selected optional packages for which scope?",
+			options: [
+				{ value: "user", label: "User", hint: "Install into your user pi settings for all repos" },
+				{ value: "project", label: "Project", hint: "Install into .pi/settings.json for this repo only" },
+			],
+			initialValue: "user",
+		}),
+	);
+	const pendingSelections: PendingOptionalRoutingPackageSelection[] = selectedPackages.map((packageName) => ({
+		packageName,
+		scope: installScope,
+	}));
+	p.note(
+		buildRoutingDashboard({
+			providers,
+			config,
+			packageStates: detectOptionalRoutingPackages(undefined, pendingSelections),
+		}),
+		"Provider & Routing Dashboard",
+	);
+
 	const spinner = p.spinner();
-	spinner.start("Installing optional routing packages");
+	spinner.start(`Installing optional routing packages (${installScope})`);
 	try {
-		installPiPackages(selectedPackages);
-		spinner.stop(`Installed ${selectedPackages.length} optional package(s). Restart pi after setup to load them.`);
+		installPiPackages(selectedPackages, installScope);
+		spinner.stop(
+			`Installed ${selectedPackages.length} optional package(s) in ${installScope} scope. Restart pi after setup to load them.`,
+		);
 	} catch (error) {
 		spinner.stop("Optional package install failed.");
 		p.log.warn(String(error));

--- a/packages/cli/src/utils/pi-packages.ts
+++ b/packages/cli/src/utils/pi-packages.ts
@@ -23,6 +23,7 @@ type ExecFileRunner = (
 ) => unknown;
 
 export type PiPackageInstallScope = "none" | "user" | "project" | "both";
+export type WritablePiPackageInstallScope = Exclude<PiPackageInstallScope, "none" | "both">;
 
 export interface PiPackageInstallState {
 	packageName: string;
@@ -156,7 +157,7 @@ function readStderr(error: unknown): string {
 
 export function installPiPackages(
 	packageNames: string[],
-	scope: "user" | "project" = "user",
+	scope: WritablePiPackageInstallScope = "user",
 	run: ExecFileRunner = execFileSync,
 ): void {
 	if (packageNames.length === 0) {


### PR DESCRIPTION
## Summary
- add an explicit user/project install scope toggle for optional packages in the routing dashboard
- show selected install scope directly in the dashboard before installation
- keep changed routing files at 100% line coverage

## Validation
- node_modules/.bin/biome check packages/cli/README.md packages/cli/src/tui/routing-dashboard.ts packages/cli/src/tui/routing-dashboard.test.ts packages/cli/src/tui/routing-setup.ts packages/cli/src/tui/routing-setup.test.ts packages/cli/src/utils/pi-packages.ts packages/cli/src/utils/pi-packages.test.ts .changeset/routing-dashboard-install-scope-toggle.md
- node_modules/.bin/vitest run packages/cli/src/tui/config-wizard.test.ts packages/cli/src/tui/routing-dashboard.test.ts packages/cli/src/tui/routing-setup.test.ts packages/cli/src/utils/pi-packages.test.ts packages/cli/src/utils/writers.test.ts
- pnpm --filter @ifi/oh-pi-core build
- pnpm --filter @ifi/oh-pi-cli typecheck
- pnpm --filter @ifi/oh-pi-cli build
- node_modules/.bin/vitest run packages/cli/src/tui/routing-dashboard.test.ts packages/cli/src/tui/routing-setup.test.ts packages/cli/src/utils/pi-packages.test.ts --coverage.enabled --coverage.provider=v8 --coverage.reporter=text --coverage.include=packages/cli/src/tui/routing-dashboard.ts --coverage.include=packages/cli/src/tui/routing-setup.ts --coverage.include=packages/cli/src/utils/pi-packages.ts
