### PR TITLE
perf(ant-colony): reduce runtime churn

### DIFF
--- a/.changeset/ant-colony-runtime-churn.md
+++ b/.changeset/ant-colony-runtime-churn.md
@@ -1,0 +1,5 @@
+---
+default: patch
+---
+
+Reduce ant-colony runtime churn by deduplicating repeated colony status-bar updates, replacing lock spin-waiting with sleeping lock retries, and skipping pre-review TypeScript checks unless worker output actually touched a detectable TS project.

--- a/benchmarks/startup/suite.test.ts
+++ b/benchmarks/startup/suite.test.ts
@@ -1,0 +1,20 @@
+import { describe, expect, it } from "vitest";
+import { parseBenchmarkEnvList } from "./suite";
+
+describe("startup benchmark env parsing", () => {
+	it("treats an unset filter as all benchmarks", () => {
+		expect(parseBenchmarkEnvList(undefined)).toBeNull();
+		expect(parseBenchmarkEnvList("all")).toBeNull();
+	});
+
+	it("treats an explicitly empty filter as no focused benchmarks", () => {
+		expect(parseBenchmarkEnvList("")).toEqual(new Set());
+		expect(parseBenchmarkEnvList("   ")).toEqual(new Set());
+	});
+
+	it("parses comma-separated benchmark ids", () => {
+		expect(parseBenchmarkEnvList("scheduler-runtime-context-with-store, worktree-snapshot-temp-repo")).toEqual(
+			new Set(["scheduler-runtime-context-with-store", "worktree-snapshot-temp-repo"]),
+		);
+	});
+});

--- a/benchmarks/startup/suite.ts
+++ b/benchmarks/startup/suite.ts
@@ -113,18 +113,30 @@ function extensionIdFromPath(extensionPath: string): string {
 	return fileName.replace(/\.ts$/, "");
 }
 
-function parseEnvList(name: string): Set<string> | null {
-	const rawValue = process.env[name]?.trim();
-	if (!rawValue || rawValue === "all") {
+export function parseBenchmarkEnvList(rawValue: string | undefined): Set<string> | null {
+	if (rawValue === undefined) {
 		return null;
 	}
 
+	const trimmedValue = rawValue.trim();
+	if (trimmedValue === "all") {
+		return null;
+	}
+
+	if (trimmedValue === "") {
+		return new Set();
+	}
+
 	return new Set(
-		rawValue
+		trimmedValue
 			.split(",")
 			.map((value) => value.trim())
 			.filter(Boolean),
 	);
+}
+
+function parseEnvList(name: string): Set<string> | null {
+	return parseBenchmarkEnvList(process.env[name]);
 }
 
 function parseExtensionFilter(): Set<string> | null {

--- a/docs/startup-performance-audit.md
+++ b/docs/startup-performance-audit.md
@@ -128,10 +128,17 @@ The colony runtime keeps orchestration in-process. The deeper audit found severa
 - synchronous nest/state writes
 - busy-wait lock spinning
 - blocking `npx tsc --noEmit`
+- repeated background status refreshes while colonies are active
 
 **Benchmark status**
 
 The new PR-gated suite covers the default extension stack at startup, but colony runtime execution still needs a dedicated focused benchmark suite.
+
+**Latest mitigation**
+
+- background colony footer status should now be deduplicated so identical progress summaries do not keep re-sending `setStatus(...)`
+- nest lock contention now sleeps with `Atomics.wait(...)` instead of burning CPU in a tight busy loop while another process holds the lock
+- pre-review typecheck now runs only when completed worker tasks touched TypeScript files under a detectable TS project, and it prefers the local `node_modules/.bin/tsc` binary over `npx`
 
 ### 6. `packages/subagents/*`
 

--- a/packages/ant-colony/extensions/ant-colony/index.ts
+++ b/packages/ant-colony/extensions/ant-colony/index.ts
@@ -16,6 +16,7 @@ import { Container, matchesKey, Text } from "@mariozechner/pi-tui";
 import { Type } from "@sinclair/typebox";
 import { Nest } from "./nest.js";
 import { createUsageLimitsTracker, type QueenCallbacks, resumeColony, runColony } from "./queen.js";
+import { createStatusBarState } from "./status-cache.js";
 import { resolveColonyStorageOptions, shouldManageProjectGitignore } from "./storage.js";
 import type {
 	AntStreamEvent,
@@ -258,6 +259,15 @@ export default function antColonyExtension(pi: ExtensionAPI) {
 		pi.events.emit("ant-colony:render");
 	};
 
+	const statusBar = createStatusBarState();
+
+	const setColonyStatus = (
+		ctx: { ui?: { setStatus?: (key: string, value: string | undefined) => unknown } },
+		value: string | undefined,
+	) => {
+		statusBar.set(ctx, "ant-colony", value);
+	};
+
 	// Re-bind events on each session_start to ensure ctx is always current
 	let renderHandler: (() => void) | null = null;
 	let clearHandler: (() => void) | null = null;
@@ -280,13 +290,9 @@ export default function antColonyExtension(pi: ExtensionAPI) {
 			pi.events.off("oh-pi:safe-mode", safeModeHandler);
 		}
 
-		// biome-ignore lint/complexity/noExcessiveCognitiveComplexity: Colony status rendering aggregates multiple live counters and safe-mode suppression.
 		renderHandler = () => {
-			if (safeModeEnabled) {
-				ctx.ui.setStatus("ant-colony", undefined);
-				return;
-			}
-			if (colonies.size === 0) {
+			if (safeModeEnabled || colonies.size === 0) {
+				setColonyStatus(ctx, undefined);
 				return;
 			}
 			const statusParts: string[] = [];
@@ -310,10 +316,10 @@ export default function antColonyExtension(pi: ExtensionAPI) {
 				statusParts.push(parts.join(" │ "));
 			}
 
-			ctx.ui.setStatus("ant-colony", statusParts.join("  ·  "));
+			setColonyStatus(ctx, statusParts.join("  ·  "));
 		};
 		clearHandler = () => {
-			ctx.ui.setStatus("ant-colony", undefined);
+			setColonyStatus(ctx, undefined);
 		};
 		notifyHandler = (data) => {
 			ctx.ui.notify(data.msg, data.level);
@@ -321,7 +327,7 @@ export default function antColonyExtension(pi: ExtensionAPI) {
 		safeModeHandler = (data) => {
 			safeModeEnabled = Boolean((data as { enabled?: boolean } | undefined)?.enabled);
 			if (safeModeEnabled) {
-				ctx.ui.setStatus("ant-colony", undefined);
+				setColonyStatus(ctx, undefined);
 			} else {
 				renderHandler?.();
 			}

--- a/packages/ant-colony/extensions/ant-colony/nest.ts
+++ b/packages/ant-colony/extensions/ant-colony/nest.ts
@@ -43,8 +43,17 @@ const STALE_LOCK_THRESHOLD_MS = 30_000;
 /** Maximum time to wait for a live state lock before surfacing an error. */
 const STATE_LOCK_WAIT_MS = 3_000;
 
-/** Base spin duration while waiting for another process to release the state lock. */
+/** Base wait duration while waiting for another process to release the state lock. */
 const STATE_LOCK_SPIN_MS = 5;
+const LOCK_WAIT_BUFFER = new Int32Array(new SharedArrayBuffer(4));
+
+function blockingSleep(ms: number): void {
+	if (!(Number.isFinite(ms) && ms > 0)) {
+		return;
+	}
+
+	Atomics.wait(LOCK_WAIT_BUFFER, 0, 0, Math.ceil(ms));
+}
 
 /**
  * Score a task by combining its static priority with pheromone signals.
@@ -468,7 +477,6 @@ export class Nest {
 		return this.fsErrorCode(error) === "ENOENT";
 	}
 
-	// biome-ignore lint/complexity/noExcessiveCognitiveComplexity: Lock acquisition requires spin-wait + stale-lock recovery + directory recovery.
 	private withStateLock<T>(fn: () => T): T {
 		const start = Date.now();
 		while (true) {
@@ -495,11 +503,8 @@ export class Nest {
 				if (Date.now() - start > STATE_LOCK_WAIT_MS) {
 					throw new Error(this.buildStateLockTimeoutMessage());
 				}
-				// Busy-wait with jitter to avoid thundering herd.
-				const until = Date.now() + STATE_LOCK_SPIN_MS + Math.random() * STATE_LOCK_SPIN_MS * 2;
-				while (Date.now() < until) {
-					/* spin */
-				}
+				// Sleep with jitter instead of burning CPU in a tight busy loop.
+				blockingSleep(STATE_LOCK_SPIN_MS + Math.random() * STATE_LOCK_SPIN_MS * 2);
 			}
 		}
 		try {

--- a/packages/ant-colony/extensions/ant-colony/queen.ts
+++ b/packages/ant-colony/extensions/ant-colony/queen.ts
@@ -12,6 +12,9 @@
  * The scheduling loop models real ant colonies: ants leave nest → forage → return → leave again.
  */
 
+import { execFileSync } from "node:child_process";
+import { existsSync } from "node:fs";
+import { dirname, extname, join, relative, resolve } from "node:path";
 import type { AuthStorage, ModelRegistry } from "@mariozechner/pi-coding-agent";
 import {
 	applyConcurrencyCap,
@@ -142,6 +145,119 @@ export function createUsageLimitsTracker(eventBus?: ColonyEventBus): UsageLimits
 			// instance to avoid duplicate listeners on subsequent requestSnapshot() calls.
 		},
 	};
+}
+
+const REVIEW_TYPECHECK_CONFIG_FILES = ["tsconfig.json", "tsconfig.base.json", "jsconfig.json"] as const;
+const REVIEW_TYPECHECK_EXTENSIONS = new Set([".ts", ".tsx", ".mts", ".cts"]);
+const REVIEW_TYPECHECK_TIMEOUT_MS = 30_000;
+
+type ReviewTypecheckInvocation = {
+	command: string;
+	args: string[];
+	cwd: string;
+	projectFiles: string[];
+};
+
+function isTypeScriptPath(file: string): boolean {
+	return REVIEW_TYPECHECK_EXTENSIONS.has(extname(file).toLowerCase());
+}
+
+function walkCandidateDirectories(startDir: string, rootDir: string): string[] {
+	const normalizedRoot = resolve(rootDir);
+	const directories: string[] = [];
+	let currentDir = resolve(startDir);
+
+	while (true) {
+		directories.push(currentDir);
+		if (currentDir === normalizedRoot) {
+			return directories;
+		}
+
+		const parentDir = dirname(currentDir);
+		const relativeToRoot = relative(normalizedRoot, currentDir);
+		if (parentDir === currentDir || relativeToRoot.startsWith("..") || relativeToRoot === "") {
+			return directories;
+		}
+		currentDir = parentDir;
+	}
+}
+
+function findNearestReviewTypecheckProject(searchStart: string, rootDir: string): string | null {
+	for (const dir of walkCandidateDirectories(searchStart, rootDir)) {
+		for (const configFile of REVIEW_TYPECHECK_CONFIG_FILES) {
+			const candidate = join(dir, configFile);
+			if (existsSync(candidate)) {
+				return candidate;
+			}
+		}
+	}
+
+	return null;
+}
+
+export function collectReviewTypecheckProjects(executionCwd: string, tasks: Pick<Task, "files">[]): string[] {
+	const normalizedCwd = resolve(executionCwd);
+	const projectFiles = new Set<string>();
+
+	for (const task of tasks) {
+		for (const file of task.files) {
+			if (!isTypeScriptPath(file)) {
+				continue;
+			}
+
+			const filePath = resolve(normalizedCwd, file);
+			const searchStart = relative(normalizedCwd, filePath).startsWith("..") ? normalizedCwd : dirname(filePath);
+			const projectFile = findNearestReviewTypecheckProject(searchStart, normalizedCwd);
+			if (projectFile) {
+				projectFiles.add(projectFile);
+			}
+		}
+	}
+
+	return [...projectFiles].sort((left, right) => left.localeCompare(right));
+}
+
+export function resolveReviewTypecheckInvocation(
+	executionCwd: string,
+	tasks: Pick<Task, "files">[],
+): ReviewTypecheckInvocation | null {
+	const projectFiles = collectReviewTypecheckProjects(executionCwd, tasks);
+	if (projectFiles.length === 0) {
+		return null;
+	}
+
+	const normalizedCwd = resolve(executionCwd);
+	const localTsc = join(normalizedCwd, "node_modules", ".bin", process.platform === "win32" ? "tsc.cmd" : "tsc");
+	const hasLocalTsc = existsSync(localTsc);
+	const command = hasLocalTsc ? localTsc : "npx";
+	const args = hasLocalTsc
+		? ["--noEmit", ...projectFiles.flatMap((projectFile) => ["--project", projectFile])]
+		: ["tsc", "--noEmit", ...projectFiles.flatMap((projectFile) => ["--project", projectFile])];
+
+	return {
+		command,
+		args,
+		cwd: normalizedCwd,
+		projectFiles,
+	};
+}
+
+export function runReviewTypecheck(executionCwd: string, tasks: Pick<Task, "files">[]): boolean {
+	const invocation = resolveReviewTypecheckInvocation(executionCwd, tasks);
+	if (!invocation) {
+		return true;
+	}
+
+	try {
+		execFileSync(invocation.command, invocation.args, {
+			cwd: invocation.cwd,
+			timeout: REVIEW_TYPECHECK_TIMEOUT_MS,
+			stdio: "pipe",
+		});
+		return true;
+	} catch {
+		return false;
+	}
 }
 
 function makeInitialScoutTask(goal: string): Task {
@@ -1104,18 +1220,12 @@ export async function runColony(opts: QueenOptions): Promise<ColonyState> {
 			}
 		}
 
-		// ═══ Auto-check: run tsc before soldier review ═══
-		let tscPassed = true;
-		try {
-			const { execSync } = await import("node:child_process");
-			execSync("npx tsc --noEmit", { cwd: executionCwd, timeout: 30000, stdio: "pipe" });
-		} catch {
-			tscPassed = false;
-		}
+		// ═══ Auto-check: run typecheck before soldier review when worker output touched TypeScript ═══
+		const completedWorkerTasks = nest.getAllTasks().filter((t) => t.caste === "worker" && t.status === "done");
+		const tscPassed = runReviewTypecheck(executionCwd, completedWorkerTasks);
 
 		// ═══ Phase 3: Review ═══
 		waveBase.budgetPlan = refreshBudgetPlan(); // Refresh budget before review phase
-		const completedWorkerTasks = nest.getAllTasks().filter((t) => t.caste === "worker" && t.status === "done");
 		if (completedWorkerTasks.length > 0 && (!tscPassed || completedWorkerTasks.length > 3)) {
 			nest.updateState({ status: "reviewing" });
 			callbacks.onPhase?.("reviewing", "Dispatching soldier ants to review changes...");
@@ -1237,15 +1347,8 @@ export async function resumeColony(opts: QueenOptions): Promise<ColonyState> {
 		}
 
 		// Soldier review for resumed colony (conditions match runColony)
-		let tscPassed = true;
-		try {
-			const { execSync } = await import("node:child_process");
-			execSync("npx tsc --noEmit", { cwd: executionCwd, timeout: 30000, stdio: "pipe" });
-		} catch {
-			tscPassed = false;
-		}
-
 		const completedWorkerTasks = nest.getAllTasks().filter((t) => t.caste === "worker" && t.status === "done");
+		const tscPassed = runReviewTypecheck(executionCwd, completedWorkerTasks);
 		if (completedWorkerTasks.length > 0 && (!tscPassed || completedWorkerTasks.length > 3)) {
 			nest.updateState({ status: "reviewing" });
 			const reviewTask = makeReviewTask(completedWorkerTasks);

--- a/packages/ant-colony/extensions/ant-colony/status-cache.ts
+++ b/packages/ant-colony/extensions/ant-colony/status-cache.ts
@@ -1,0 +1,40 @@
+type StatusTarget = {
+	hasUI?: boolean;
+	ui?: {
+		setStatus?: (key: string, value: string | undefined) => unknown;
+	};
+};
+
+/**
+ * Coalesce repeated ant-colony status-bar writes so background progress signals do not re-send
+ * identical text on every render event.
+ */
+export function createStatusBarState() {
+	let activeTarget: object | null = null;
+	const lastValues = new Map<string, string | undefined>();
+
+	return {
+		set(target: StatusTarget | null | undefined, key: string, value: string | undefined): boolean {
+			if (!target || typeof target !== "object") {
+				return false;
+			}
+
+			if (target !== activeTarget) {
+				activeTarget = target;
+				lastValues.clear();
+			}
+
+			if (typeof target.ui?.setStatus !== "function") {
+				return false;
+			}
+
+			if (lastValues.has(key) && lastValues.get(key) === value) {
+				return false;
+			}
+
+			lastValues.set(key, value);
+			target.ui.setStatus(key, value);
+			return true;
+		},
+	};
+}

--- a/packages/ant-colony/tests/index.test.ts
+++ b/packages/ant-colony/tests/index.test.ts
@@ -463,4 +463,29 @@ describe("index-level telemetry propagation", () => {
 		expect(pi._eventHandlers.has("ant-colony:clear-ui")).toBe(true);
 		expect(pi._eventHandlers.has("ant-colony:notify")).toBe(true);
 	});
+
+	it("coalesces identical ant-colony status refreshes", async () => {
+		const pi = createMockPi();
+		antColonyExtension(pi as any);
+		const ctx = {
+			cwd: process.cwd(),
+			model: { provider: "test", id: "model" },
+			modelRegistry: {},
+			ui: {
+				setStatus: vi.fn(),
+				notify: vi.fn(),
+				custom: vi.fn().mockResolvedValue(undefined),
+			},
+		};
+
+		pi._emit("session_start", {}, ctx);
+		const colonyCommand = pi._commands.get("colony");
+		await colonyCommand.handler("status churn", ctx);
+		ctx.ui.setStatus.mockClear();
+
+		pi.events.emit("ant-colony:render");
+		pi.events.emit("ant-colony:render");
+
+		expect(ctx.ui.setStatus).toHaveBeenCalledTimes(1);
+	});
 });

--- a/packages/ant-colony/tests/nest.test.ts
+++ b/packages/ant-colony/tests/nest.test.ts
@@ -209,4 +209,16 @@ describe("withStateLock spin", () => {
 		expect(() => nest.updateState({ status: "reviewing" })).not.toThrow();
 		expect(fs.existsSync(nest.dir)).toBe(true);
 	});
+
+	it("times out cleanly when another live process keeps the state lock", () => {
+		const lockFile = (nest as { lockFile: string }).lockFile;
+		fs.writeFileSync(lockFile, `${process.pid}:invalid`, "utf-8");
+		const nowSpy = vi.spyOn(Date, "now").mockReturnValueOnce(0).mockReturnValueOnce(0).mockReturnValueOnce(3_001);
+
+		try {
+			expect(() => nest.updateState({ status: "reviewing" })).toThrow(/withStateLock timeout/);
+		} finally {
+			nowSpy.mockRestore();
+		}
+	});
 });

--- a/packages/ant-colony/tests/queen.test.ts
+++ b/packages/ant-colony/tests/queen.test.ts
@@ -24,10 +24,12 @@ vi.mock("@mariozechner/pi-ai", () => ({ getModel: vi.fn() }));
 import { Nest } from "../extensions/ant-colony/nest.js";
 import {
 	classifyError,
+	collectReviewTypecheckProjects,
 	createUsageLimitsTracker,
 	decidePromoteOrFinalize,
 	makeColonyId,
 	quorumMergeTasks,
+	resolveReviewTypecheckInvocation,
 	shouldUseScoutQuorum,
 	validateExecutionPlan,
 } from "../extensions/ant-colony/queen.js";
@@ -199,6 +201,45 @@ describe("createUsageLimitsTracker", () => {
 		tracker.requestSnapshot();
 		tracker.dispose();
 		expect(off).toHaveBeenCalledWith("usage:limits", expect.any(Function));
+	});
+});
+
+describe("review typecheck helpers", () => {
+	it("collects nearest project files for changed TypeScript tasks", () => {
+		const root = fs.mkdtempSync(path.join(os.tmpdir(), "queen-typecheck-projects-"));
+		const packageDir = path.join(root, "packages", "feature");
+		fs.mkdirSync(path.join(packageDir, "src"), { recursive: true });
+		fs.writeFileSync(path.join(packageDir, "tsconfig.json"), "{}", "utf-8");
+
+		const projects = collectReviewTypecheckProjects(root, [
+			mkTask({ files: ["packages/feature/src/index.ts"] }),
+			mkTask({ files: ["README.md"] }),
+		]);
+
+		expect(projects).toEqual([path.join(packageDir, "tsconfig.json")]);
+		fs.rmSync(root, { recursive: true, force: true });
+	});
+
+	it("skips review typecheck when no TypeScript files were changed", () => {
+		const root = fs.mkdtempSync(path.join(os.tmpdir(), "queen-typecheck-skip-"));
+		fs.writeFileSync(path.join(root, "tsconfig.json"), "{}", "utf-8");
+
+		expect(collectReviewTypecheckProjects(root, [mkTask({ files: ["README.md"] })])).toEqual([]);
+		expect(resolveReviewTypecheckInvocation(root, [mkTask({ files: ["README.md"] })])).toBeNull();
+		fs.rmSync(root, { recursive: true, force: true });
+	});
+
+	it("prefers the local tsc binary when the workspace already has dependencies installed", () => {
+		const root = fs.mkdtempSync(path.join(os.tmpdir(), "queen-typecheck-local-bin-"));
+		fs.mkdirSync(path.join(root, "node_modules", ".bin"), { recursive: true });
+		fs.writeFileSync(path.join(root, "tsconfig.json"), "{}", "utf-8");
+		fs.writeFileSync(path.join(root, "node_modules", ".bin", "tsc"), "#!/bin/sh\n", "utf-8");
+
+		const invocation = resolveReviewTypecheckInvocation(root, [mkTask({ files: ["src/index.ts"] })]);
+
+		expect(invocation?.command).toContain(path.join("node_modules", ".bin", "tsc"));
+		expect(invocation?.args).toContain(path.join(root, "tsconfig.json"));
+		fs.rmSync(root, { recursive: true, force: true });
 	});
 });
 


### PR DESCRIPTION
## Summary
- deduplicate repeated ant-colony status-bar writes so background progress signals stop resending identical footer text
- replace nest lock busy-wait spinning with sleeping lock retries and skip pre-review typechecks unless worker output actually touched a detectable TS project
- add regression coverage for colony status churn, live-lock timeout handling, and review typecheck project detection

## Validation
- pnpm lint
- pnpm test
- pnpm typecheck
- pnpm bench:startup