### PR TITLE
fix: use the saved session file in resume hint

### DIFF
--- a/.changeset/fix-session-resume-hint-session-file.md
+++ b/.changeset/fix-session-resume-hint-session-file.md
@@ -1,0 +1,5 @@
+---
+default: patch
+---
+
+Fix the auto-session-name resume hint so it points at the saved session file path that `pi --session` expects.

--- a/packages/extensions/extensions/auto-session-name.test.ts
+++ b/packages/extensions/extensions/auto-session-name.test.ts
@@ -60,23 +60,24 @@ describe("auto-session-name extension", () => {
 		expect(harness.userMessages.at(-1)).toBe("continue");
 	});
 
-	it("emits resume hints with the real session id on session switch and shutdown", () => {
+	it("emits resume hints with the real session file on session switch and shutdown", () => {
 		const harness = createExtensionHarness();
-		harness.ctx.sessionManager.getSessionFile = () =>
-			"/tmp/sessions/2026-04-15T06-39-22-866Z_019d8fdd-acf2-760d-a215-05659dd89ced.jsonl";
-		harness.ctx.sessionManager.getSessionId = () => "019d8fdd-acf2-760d-a215-05659dd89ced";
+		const sessionFile = "/tmp/sessions/2026-04-15T06-39-22-866Z_019d8fdd-acf2-760d-a215-05659dd89ced.jsonl";
+		harness.ctx.sessionManager.getSessionFile = () => sessionFile;
 		autoSessionNameExtension(harness.pi as never);
 
 		harness.emit("session_switch", { type: "session_switch" }, harness.ctx);
 		expect(harness.messages.at(-1)?.content).toContain("Session switched");
-		expect(harness.messages.at(-1)?.content).toContain("pi --session 019d8fdd-acf2-760d-a215-05659dd89ced");
+		expect(harness.messages.at(-1)?.content).toContain(`Session file: ${sessionFile}`);
+		expect(harness.messages.at(-1)?.content).toContain(`pi --session ${JSON.stringify(sessionFile)}`);
 		expect(harness.messages.at(-1)?.content).not.toContain("pi resume");
-		expect(harness.messages.at(-1)?.content).not.toContain("2026-04-15T06-39-22-866Z_");
+		expect(harness.messages.at(-1)?.content).not.toContain("Session id:");
 
 		harness.emit("session_shutdown", { type: "session_shutdown" }, harness.ctx);
 		expect(harness.messages.at(-1)?.content).toContain("Session saved");
-		expect(harness.messages.at(-1)?.content).toContain("pi --session 019d8fdd-acf2-760d-a215-05659dd89ced");
+		expect(harness.messages.at(-1)?.content).toContain(`Session file: ${sessionFile}`);
+		expect(harness.messages.at(-1)?.content).toContain(`pi --session ${JSON.stringify(sessionFile)}`);
 		expect(harness.messages.at(-1)?.content).not.toContain("pi resume");
-		expect(harness.messages.at(-1)?.content).not.toContain("2026-04-15T06-39-22-866Z_");
+		expect(harness.messages.at(-1)?.content).not.toContain("Session id:");
 	});
 });

--- a/packages/extensions/extensions/auto-session-name.ts
+++ b/packages/extensions/extensions/auto-session-name.ts
@@ -53,13 +53,13 @@ function overlapRatio(a: string, b: string): number {
 	return shared / Math.max(left.size, right.size);
 }
 
-function normalizeSessionId(sessionId: string | undefined): string | undefined {
-	const normalized = sessionId?.trim();
+function normalizeSessionFile(sessionFile: string | undefined): string | undefined {
+	const normalized = sessionFile?.trim();
 	return normalized || undefined;
 }
 
-function buildResumeCommandHint(sessionId: string): string {
-	return [`Session id: ${sessionId}`, `Resume now: pi --session ${sessionId}`].join("\n");
+function buildResumeCommandHint(sessionFile: string): string {
+	return [`Session file: ${sessionFile}`, `Resume now: pi --session ${JSON.stringify(sessionFile)}`].join("\n");
 }
 
 function isFocusShift(firstUserText: string, latestUserText: string): boolean {
@@ -107,16 +107,16 @@ export default function autoSessionNameExtension(pi: ExtensionAPI) {
 	let lastAutoName = "";
 	let compactContinuationQueued = false;
 
-	const emitResumeHint = (reason: "shutdown" | "switch", sessionId: string | undefined) => {
-		const normalizedSessionId = normalizeSessionId(sessionId);
-		if (!normalizedSessionId) {
+	const emitResumeHint = (reason: "shutdown" | "switch", sessionFile: string | undefined) => {
+		const normalizedSessionFile = normalizeSessionFile(sessionFile);
+		if (!normalizedSessionFile) {
 			return;
 		}
 
 		const prefix = reason === "shutdown" ? "Session saved." : "Session switched.";
 		pi.sendMessage({
 			customType: "session-resume-hint",
-			content: `${prefix}\n${buildResumeCommandHint(normalizedSessionId)}`,
+			content: `${prefix}\n${buildResumeCommandHint(normalizedSessionFile)}`,
 			display: true,
 		});
 	};
@@ -157,10 +157,10 @@ export default function autoSessionNameExtension(pi: ExtensionAPI) {
 	});
 
 	pi.on("session_switch", (_event, ctx) => {
-		emitResumeHint("switch", ctx.sessionManager?.getSessionId?.());
+		emitResumeHint("switch", ctx.sessionManager?.getSessionFile?.());
 	});
 
 	pi.on("session_shutdown", (_event, ctx) => {
-		emitResumeHint("shutdown", ctx.sessionManager?.getSessionId?.());
+		emitResumeHint("shutdown", ctx.sessionManager?.getSessionFile?.());
 	});
 }


### PR DESCRIPTION
## Summary\n- use the saved session file path when emitting session resume hints\n- keep the direct `pi --session <path>` instruction accurate\n- update the extension test and add a patch changeset\n\n## Validation\n- vitest run packages/extensions/extensions/auto-session-name.test.ts\n- biome check packages/extensions/extensions/auto-session-name.ts packages/extensions/extensions/auto-session-name.test.ts .changeset/fix-session-resume-hint-session-file.md