### PR TITLE
feat(commands): add colon-style subcommand aliases

### DIFF
--- a/.changeset/colon-command-aliases.md
+++ b/.changeset/colon-command-aliases.md
@@ -1,0 +1,5 @@
+---
+default: minor
+---
+
+Add colon-style subcommand aliases across provider, routing, Ollama, scheduler, spec, and watchdog workflows, update related docs/help text, and keep provider picker search inside overlay UI so escape and typing no longer fall through to the editor.

--- a/docs/plans/adaptive-routing-mode.md
+++ b/docs/plans/adaptive-routing-mode.md
@@ -85,14 +85,14 @@ The user should be able to understand:
 
 Adaptive Routing Mode should eventually expose:
 
-- `/route on`
-- `/route off`
-- `/route status`
-- `/route explain`
-- `/route lock`
-- `/route unlock`
-- `/route refresh`
-- `/route feedback good|bad`
+- `/route:on`
+- `/route:off`
+- `/route:status`
+- `/route:explain`
+- `/route:lock`
+- `/route:unlock`
+- `/route:refresh`
+- `/route:feedback good|bad`
 
 ## 6. Routing Architecture
 

--- a/docs/startup-performance-audit.md
+++ b/docs/startup-performance-audit.md
@@ -191,7 +191,7 @@ Not part of the default oh-pi extension manifest today, so it is not included in
 The watchdog runtime diagnostics can now be used to inspect startup handler timings after a restart:
 
 ```text
-/watchdog startup
+/watchdog:startup
 ```
 
 That surfaces the latest per-extension `session_start` timings recorded during the active instance so you can compare what the benchmark suite sees with what the editor instance is doing live.

--- a/packages/adaptive-routing/README.md
+++ b/packages/adaptive-routing/README.md
@@ -56,10 +56,10 @@ Subagents and ant-colony use these categories only when they do not already have
 
 ## Commands
 
-- `/route status`
-- `/route shadow`
-- `/route auto`
-- `/route off`
-- `/route explain`
-- `/route assignments`
-- `/route stats`
+- `/route:status`
+- `/route:shadow`
+- `/route:auto`
+- `/route:off`
+- `/route:explain`
+- `/route:assignments`
+- `/route:stats`

--- a/packages/adaptive-routing/adaptive-routing.test.ts
+++ b/packages/adaptive-routing/adaptive-routing.test.ts
@@ -210,4 +210,19 @@ describe("adaptive routing extension", () => {
 		expect(harness.ctx.model).toMatchObject({ provider: "google", id: "gemini-2.5-flash" });
 		expect(harness.notifications.some((item) => item.msg.includes("Adaptive route suggestion"))).toBe(true);
 	});
+
+	it("routes alias feedback commands through the colon form", async () => {
+		writeFileSync(
+			join(tempAgentDir, "extensions", "adaptive-routing", "config.json"),
+			`${JSON.stringify({ mode: "auto" }, null, 2)}\n`,
+		);
+		const harness = createExtensionHarness();
+		adaptiveRoutingExtension(harness.pi as never);
+
+		await harness.commands.get("route:feedback")?.handler?.("", harness.ctx as never);
+		expect(harness.notifications.at(-1)?.msg).toContain("Usage: /route:feedback");
+
+		await harness.commands.get("route:status")?.handler?.("", harness.ctx as never);
+		expect(harness.notifications.at(-1)?.msg).toContain("adaptive routing");
+	});
 });

--- a/packages/adaptive-routing/adaptive-routing.test.ts
+++ b/packages/adaptive-routing/adaptive-routing.test.ts
@@ -173,6 +173,7 @@ describe("adaptive routing extension", () => {
 
 		adaptiveRoutingExtension(harness.pi as never);
 		expect(harness.commands.has("route")).toBe(true);
+		expect(harness.commands.has("route:status")).toBe(true);
 
 		await harness.emitAsync(
 			"before_agent_start",

--- a/packages/adaptive-routing/index.ts
+++ b/packages/adaptive-routing/index.ts
@@ -270,97 +270,97 @@ export default function adaptiveRoutingExtension(pi: ExtensionAPI) {
 		updateStatus(ctx);
 	});
 
-	const handleRouteCommand = async (args: string, ctx: ExtensionCommandContext): Promise<void> => {
-		const command = args.trim();
-		const [head, ...rest] = command.split(/\s+/).filter(Boolean);
-		const subcommand = (head ?? "status").toLowerCase();
-		runtime.state = readAdaptiveRoutingState();
+	const routeCommand = {
+		description:
+			"Adaptive routing controls: /route:status|on|auto|off|shadow|explain|assignments|lock|unlock|refresh|feedback|stats",
+		async handler(args: string, ctx: ExtensionCommandContext) {
+			const command = args.trim();
+			const [head, ...rest] = command.split(/\s+/).filter(Boolean);
+			const subcommand = (head ?? "status").toLowerCase();
+			runtime.state = readAdaptiveRoutingState();
 
-		switch (subcommand) {
-			case "on":
-			case "auto":
-				runtime.state.mode = "auto";
-				persistState();
-				updateStatus(ctx);
-				ctx.ui.notify("Adaptive routing set to auto mode.", "info");
-				return;
-			case "off":
-				runtime.state.mode = "off";
-				persistState();
-				updateStatus(ctx);
-				ctx.ui.notify("Adaptive routing disabled.", "warning");
-				return;
-			case "shadow":
-				runtime.state.mode = "shadow";
-				persistState();
-				updateStatus(ctx);
-				ctx.ui.notify("Adaptive routing set to shadow mode.", "info");
-				return;
-			case "lock": {
-				if (!ctx.model) {
-					ctx.ui.notify("No active model to lock.", "warning");
+			switch (subcommand) {
+				case "on":
+				case "auto":
+					runtime.state.mode = "auto";
+					persistState();
+					updateStatus(ctx);
+					ctx.ui.notify("Adaptive routing set to auto mode.", "info");
 					return;
-				}
-				runtime.state.lock = {
-					model: `${ctx.model.provider}/${ctx.model.id}`,
-					thinking: pi.getThinkingLevel() as RouteThinkingLevel,
-					setAt: Date.now(),
-				};
-				persistState();
-				updateStatus(ctx);
-				ctx.ui.notify(
-					`Adaptive routing locked to ${runtime.state.lock.model}:${runtime.state.lock.thinking}.`,
-					"info",
-				);
-				return;
-			}
-			case "unlock":
-				runtime.state.lock = undefined;
-				persistState();
-				updateStatus(ctx);
-				ctx.ui.notify("Adaptive routing lock cleared.", "info");
-				return;
-			case "refresh":
-				refreshUsageSnapshot();
-				runtime.state = readAdaptiveRoutingState();
-				ctx.ui.notify("Adaptive routing config and usage refreshed.", "info");
-				updateStatus(ctx);
-				return;
-			case "feedback": {
-				const category = normalizeFeedbackCategory(rest[0]);
-				if (!category) {
+				case "off":
+					runtime.state.mode = "off";
+					persistState();
+					updateStatus(ctx);
+					ctx.ui.notify("Adaptive routing disabled.", "warning");
+					return;
+				case "shadow":
+					runtime.state.mode = "shadow";
+					persistState();
+					updateStatus(ctx);
+					ctx.ui.notify("Adaptive routing set to shadow mode.", "info");
+					return;
+				case "lock": {
+					if (!ctx.model) {
+						ctx.ui.notify("No active model to lock.", "warning");
+						return;
+					}
+					runtime.state.lock = {
+						model: `${ctx.model.provider}/${ctx.model.id}`,
+						thinking: pi.getThinkingLevel() as RouteThinkingLevel,
+						setAt: Date.now(),
+					};
+					persistState();
+					updateStatus(ctx);
 					ctx.ui.notify(
-						"Usage: /route:feedback <good|bad|wrong-intent|overkill|underpowered|wrong-provider|wrong-thinking>",
-						"warning",
+						`Adaptive routing locked to ${runtime.state.lock.model}:${runtime.state.lock.thinking}.`,
+						"info",
 					);
 					return;
 				}
-				appendTelemetryEvent(
-					readAdaptiveRoutingConfig().telemetry,
-					createFeedbackEvent(runtime.lastDecision, category),
-				);
-				ctx.ui.notify(`Recorded route feedback: ${category}.`, "info");
-				return;
+				case "unlock":
+					runtime.state.lock = undefined;
+					persistState();
+					updateStatus(ctx);
+					ctx.ui.notify("Adaptive routing lock cleared.", "info");
+					return;
+				case "refresh":
+					refreshUsageSnapshot();
+					runtime.state = readAdaptiveRoutingState();
+					ctx.ui.notify("Adaptive routing config and usage refreshed.", "info");
+					updateStatus(ctx);
+					return;
+				case "feedback": {
+					const category = normalizeFeedbackCategory(rest[0]);
+					if (!category) {
+						ctx.ui.notify(
+							"Usage: /route:feedback <good|bad|wrong-intent|overkill|underpowered|wrong-provider|wrong-thinking>",
+							"warning",
+						);
+						return;
+					}
+					appendTelemetryEvent(
+						readAdaptiveRoutingConfig().telemetry,
+						createFeedbackEvent(runtime.lastDecision, category),
+					);
+					ctx.ui.notify(`Recorded route feedback: ${category}.`, "info");
+					return;
+				}
+				case "stats":
+					await openOverlay(ctx, formatStats(computeStats(readTelemetryEvents())));
+					return;
+				case "assignments":
+					await openOverlay(ctx, buildDelegatedAssignmentLines(readAdaptiveRoutingConfig(), ctx));
+					return;
+				case "explain":
+					await openOverlay(ctx, buildExplanationLines(runtime.lastDecision, runtime.usage));
+					return;
+				default:
+					ctx.ui.notify(buildStatusLine(runtime.state, runtime.lastDecision, getEffectiveMode()), "info");
 			}
-			case "stats":
-				await openOverlay(ctx, formatStats(computeStats(readTelemetryEvents())));
-				return;
-			case "assignments":
-				await openOverlay(ctx, buildDelegatedAssignmentLines(readAdaptiveRoutingConfig(), ctx));
-				return;
-			case "explain":
-				await openOverlay(ctx, buildExplanationLines(runtime.lastDecision, runtime.usage));
-				return;
-			default:
-				ctx.ui.notify(buildStatusLine(runtime.state, runtime.lastDecision, getEffectiveMode()), "info");
-		}
+		},
 	};
 
-	pi.registerCommand("route", {
-		description:
-			"Adaptive routing controls: /route:status|on|auto|off|shadow|explain|assignments|lock|unlock|refresh|feedback|stats",
-		handler: handleRouteCommand,
-	});
+	pi.registerCommand("route", routeCommand);
 
 	const routeAliases: Array<{ name: string; subcommand: string; description: string }> = [
 		{ name: "route:status", subcommand: "status", description: "Show the current adaptive routing status." },
@@ -380,7 +380,8 @@ export default function adaptiveRoutingExtension(pi: ExtensionAPI) {
 	for (const alias of routeAliases) {
 		pi.registerCommand(alias.name, {
 			description: alias.description,
-			handler: (args, ctx) => handleRouteCommand(args ? `${alias.subcommand} ${args}` : alias.subcommand, ctx),
+			handler: (args: string, ctx: ExtensionCommandContext) =>
+				routeCommand.handler(args ? `${alias.subcommand} ${args}` : alias.subcommand, ctx),
 		});
 	}
 }

--- a/packages/adaptive-routing/index.ts
+++ b/packages/adaptive-routing/index.ts
@@ -270,95 +270,119 @@ export default function adaptiveRoutingExtension(pi: ExtensionAPI) {
 		updateStatus(ctx);
 	});
 
+	const handleRouteCommand = async (args: string, ctx: ExtensionCommandContext): Promise<void> => {
+		const command = args.trim();
+		const [head, ...rest] = command.split(/\s+/).filter(Boolean);
+		const subcommand = (head ?? "status").toLowerCase();
+		runtime.state = readAdaptiveRoutingState();
+
+		switch (subcommand) {
+			case "on":
+			case "auto":
+				runtime.state.mode = "auto";
+				persistState();
+				updateStatus(ctx);
+				ctx.ui.notify("Adaptive routing set to auto mode.", "info");
+				return;
+			case "off":
+				runtime.state.mode = "off";
+				persistState();
+				updateStatus(ctx);
+				ctx.ui.notify("Adaptive routing disabled.", "warning");
+				return;
+			case "shadow":
+				runtime.state.mode = "shadow";
+				persistState();
+				updateStatus(ctx);
+				ctx.ui.notify("Adaptive routing set to shadow mode.", "info");
+				return;
+			case "lock": {
+				if (!ctx.model) {
+					ctx.ui.notify("No active model to lock.", "warning");
+					return;
+				}
+				runtime.state.lock = {
+					model: `${ctx.model.provider}/${ctx.model.id}`,
+					thinking: pi.getThinkingLevel() as RouteThinkingLevel,
+					setAt: Date.now(),
+				};
+				persistState();
+				updateStatus(ctx);
+				ctx.ui.notify(
+					`Adaptive routing locked to ${runtime.state.lock.model}:${runtime.state.lock.thinking}.`,
+					"info",
+				);
+				return;
+			}
+			case "unlock":
+				runtime.state.lock = undefined;
+				persistState();
+				updateStatus(ctx);
+				ctx.ui.notify("Adaptive routing lock cleared.", "info");
+				return;
+			case "refresh":
+				refreshUsageSnapshot();
+				runtime.state = readAdaptiveRoutingState();
+				ctx.ui.notify("Adaptive routing config and usage refreshed.", "info");
+				updateStatus(ctx);
+				return;
+			case "feedback": {
+				const category = normalizeFeedbackCategory(rest[0]);
+				if (!category) {
+					ctx.ui.notify(
+						"Usage: /route:feedback <good|bad|wrong-intent|overkill|underpowered|wrong-provider|wrong-thinking>",
+						"warning",
+					);
+					return;
+				}
+				appendTelemetryEvent(
+					readAdaptiveRoutingConfig().telemetry,
+					createFeedbackEvent(runtime.lastDecision, category),
+				);
+				ctx.ui.notify(`Recorded route feedback: ${category}.`, "info");
+				return;
+			}
+			case "stats":
+				await openOverlay(ctx, formatStats(computeStats(readTelemetryEvents())));
+				return;
+			case "assignments":
+				await openOverlay(ctx, buildDelegatedAssignmentLines(readAdaptiveRoutingConfig(), ctx));
+				return;
+			case "explain":
+				await openOverlay(ctx, buildExplanationLines(runtime.lastDecision, runtime.usage));
+				return;
+			default:
+				ctx.ui.notify(buildStatusLine(runtime.state, runtime.lastDecision, getEffectiveMode()), "info");
+		}
+	};
+
 	pi.registerCommand("route", {
 		description:
-			"Adaptive routing controls: /route [status|on|off|shadow|auto|explain|assignments|lock|unlock|refresh|feedback|stats]",
-		async handler(args, ctx) {
-			const command = args.trim();
-			const [head, ...rest] = command.split(/\s+/).filter(Boolean);
-			const subcommand = (head ?? "status").toLowerCase();
-			runtime.state = readAdaptiveRoutingState();
-
-			switch (subcommand) {
-				case "on":
-				case "auto":
-					runtime.state.mode = "auto";
-					persistState();
-					updateStatus(ctx);
-					ctx.ui.notify("Adaptive routing set to auto mode.", "info");
-					return;
-				case "off":
-					runtime.state.mode = "off";
-					persistState();
-					updateStatus(ctx);
-					ctx.ui.notify("Adaptive routing disabled.", "warning");
-					return;
-				case "shadow":
-					runtime.state.mode = "shadow";
-					persistState();
-					updateStatus(ctx);
-					ctx.ui.notify("Adaptive routing set to shadow mode.", "info");
-					return;
-				case "lock": {
-					if (!ctx.model) {
-						ctx.ui.notify("No active model to lock.", "warning");
-						return;
-					}
-					runtime.state.lock = {
-						model: `${ctx.model.provider}/${ctx.model.id}`,
-						thinking: pi.getThinkingLevel() as RouteThinkingLevel,
-						setAt: Date.now(),
-					};
-					persistState();
-					updateStatus(ctx);
-					ctx.ui.notify(
-						`Adaptive routing locked to ${runtime.state.lock.model}:${runtime.state.lock.thinking}.`,
-						"info",
-					);
-					return;
-				}
-				case "unlock":
-					runtime.state.lock = undefined;
-					persistState();
-					updateStatus(ctx);
-					ctx.ui.notify("Adaptive routing lock cleared.", "info");
-					return;
-				case "refresh":
-					refreshUsageSnapshot();
-					runtime.state = readAdaptiveRoutingState();
-					ctx.ui.notify("Adaptive routing config and usage refreshed.", "info");
-					updateStatus(ctx);
-					return;
-				case "feedback": {
-					const category = normalizeFeedbackCategory(rest[0]);
-					if (!category) {
-						ctx.ui.notify(
-							"Usage: /route feedback <good|bad|wrong-intent|overkill|underpowered|wrong-provider|wrong-thinking>",
-							"warning",
-						);
-						return;
-					}
-					appendTelemetryEvent(
-						readAdaptiveRoutingConfig().telemetry,
-						createFeedbackEvent(runtime.lastDecision, category),
-					);
-					ctx.ui.notify(`Recorded route feedback: ${category}.`, "info");
-					return;
-				}
-				case "stats":
-					await openOverlay(ctx, formatStats(computeStats(readTelemetryEvents())));
-					return;
-				case "assignments":
-					await openOverlay(ctx, buildDelegatedAssignmentLines(readAdaptiveRoutingConfig(), ctx));
-					return;
-				case "explain":
-					await openOverlay(ctx, buildExplanationLines(runtime.lastDecision, runtime.usage));
-					return;
-				default:
-					ctx.ui.notify(buildStatusLine(runtime.state, runtime.lastDecision, getEffectiveMode()), "info");
-			}
-		},
+			"Adaptive routing controls: /route:status|on|auto|off|shadow|explain|assignments|lock|unlock|refresh|feedback|stats",
+		handler: handleRouteCommand,
 	});
+
+	const routeAliases: Array<{ name: string; subcommand: string; description: string }> = [
+		{ name: "route:status", subcommand: "status", description: "Show the current adaptive routing status." },
+		{ name: "route:on", subcommand: "on", description: "Enable adaptive routing auto mode." },
+		{ name: "route:auto", subcommand: "auto", description: "Enable adaptive routing auto mode." },
+		{ name: "route:off", subcommand: "off", description: "Disable adaptive routing." },
+		{ name: "route:shadow", subcommand: "shadow", description: "Suggest route decisions without changing the active model." },
+		{ name: "route:explain", subcommand: "explain", description: "Explain the latest adaptive route decision." },
+		{ name: "route:assignments", subcommand: "assignments", description: "Show delegated routing assignments." },
+		{ name: "route:lock", subcommand: "lock", description: "Lock routing to the current model and thinking level." },
+		{ name: "route:unlock", subcommand: "unlock", description: "Clear the adaptive routing lock." },
+		{ name: "route:refresh", subcommand: "refresh", description: "Refresh routing config and usage snapshots." },
+		{ name: "route:feedback", subcommand: "feedback", description: "Record feedback for the last adaptive routing decision." },
+		{ name: "route:stats", subcommand: "stats", description: "Show adaptive routing telemetry stats." },
+	];
+
+	for (const alias of routeAliases) {
+		pi.registerCommand(alias.name, {
+			description: alias.description,
+			handler: (args, ctx) => handleRouteCommand(args ? `${alias.subcommand} ${args}` : alias.subcommand, ctx),
+		});
+	}
 }
 
 async function applyDecision(

--- a/packages/extensions/README.md
+++ b/packages/extensions/README.md
@@ -36,7 +36,7 @@ npx @ifi/oh-pi
 These extensions add commands, tools, UI widgets, background process handling,
 usage monitoring, scheduling features, tool execution metadata,
 external-editor integration, git worktree awareness, and runtime performance protection
-(`/watchdog`, `/watchdog blame`, `/safe-mode`) to pi.
+(`/watchdog`, `/watchdog:blame`, `/safe-mode`) to pi.
 
 `git-guard` also blocks git bash invocations that are likely to open an interactive editor in agent environments (for example `git rebase --continue` without non-interactive editor overrides), preventing hangs before they happen.
 
@@ -101,9 +101,9 @@ instance changes in the same repository.
 
 When another live instance already owns scheduler activity for the workspace, pi prompts before taking over. You can also manage ownership explicitly with:
 
-- `/schedule adopt <id|all>`
-- `/schedule release <id|all>`
-- `/schedule clear-foreign`
+- `/schedule:adopt <id|all>`
+- `/schedule:release <id|all>`
+- `/schedule:clear-foreign`
 
 Use workspace scope sparingly for long-running shared checks like CI/build/deploy monitoring. For ordinary reminders and follow-ups, prefer the default instance scope.
 

--- a/packages/extensions/extensions/scheduler-registration.ts
+++ b/packages/extensions/extensions/scheduler-registration.ts
@@ -161,7 +161,7 @@ export function registerCommands(pi: ExtensionAPI, runtime: SchedulerRuntime) {
 			}
 
 			if (runtime.taskCount >= MAX_TASKS) {
-				ctx.ui.notify(`Task limit reached (${MAX_TASKS}). Delete one with /schedule delete <id>.`, "error");
+				ctx.ui.notify(`Task limit reached (${MAX_TASKS}). Delete one with /schedule:delete <id>.`, "error");
 				return;
 			}
 
@@ -225,7 +225,7 @@ export function registerCommands(pi: ExtensionAPI, runtime: SchedulerRuntime) {
 			}
 
 			if (runtime.taskCount >= MAX_TASKS) {
-				ctx.ui.notify(`Task limit reached (${MAX_TASKS}). Delete one with /schedule delete <id>.`, "error");
+				ctx.ui.notify(`Task limit reached (${MAX_TASKS}). Delete one with /schedule:delete <id>.`, "error");
 				return;
 			}
 
@@ -240,9 +240,9 @@ export function registerCommands(pi: ExtensionAPI, runtime: SchedulerRuntime) {
 		},
 	});
 
-	pi.registerCommand("schedule", {
+	const scheduleCommand = {
 		description:
-			"Manage scheduled reminders and future check-ins. No args opens TUI manager. Also: list | enable <id> | disable <id> | delete <id> | clear | clear-other | adopt <id|all> | release <id|all> | clear-foreign",
+			"Manage scheduled reminders and future check-ins. No args opens TUI manager. Also: /schedule:tui | /schedule:list | /schedule:enable <id> | /schedule:disable <id> | /schedule:delete <id> | /schedule:clear | /schedule:clear-other | /schedule:adopt <id|all> | /schedule:release <id|all> | /schedule:clear-foreign",
 		// biome-ignore lint/complexity/noExcessiveCognitiveComplexity: Command router with multiple subcommands.
 		handler: async (args, ctx) => {
 			const trimmed = args.trim();
@@ -265,7 +265,7 @@ export function registerCommands(pi: ExtensionAPI, runtime: SchedulerRuntime) {
 
 			if (action === "enable" || action === "disable") {
 				if (!rawArg) {
-					ctx.ui.notify(`Usage: /schedule ${action} <id>`, "warning");
+					ctx.ui.notify(`Usage: /schedule:${action} <id>`, "warning");
 					return;
 				}
 				const enabled = action === "enable";
@@ -280,7 +280,7 @@ export function registerCommands(pi: ExtensionAPI, runtime: SchedulerRuntime) {
 
 			if (action === "delete" || action === "remove" || action === "rm") {
 				if (!rawArg) {
-					ctx.ui.notify("Usage: /schedule delete <id>", "warning");
+					ctx.ui.notify("Usage: /schedule:delete <id>", "warning");
 					return;
 				}
 				const removed = runtime.deleteTask(rawArg);
@@ -337,14 +337,14 @@ export function registerCommands(pi: ExtensionAPI, runtime: SchedulerRuntime) {
 
 			if (action === "scope") {
 				ctx.ui.notify(
-					"Change scope by recreating with --workspace/--instance or by adopting and re-scheduling. /schedule scope is not supported yet.",
+					"Change scope by recreating with --workspace/--instance or by adopting and re-scheduling. /schedule:scope is not supported yet.",
 					"info",
 				);
 				return;
 			}
 
 			if (action === "adopt" || action === "release") {
-				ctx.ui.notify(`Usage: /schedule ${action} <id|all>`, "warning");
+				ctx.ui.notify(`Usage: /schedule:${action} <id|all>`, "warning");
 				return;
 			}
 
@@ -354,14 +354,50 @@ export function registerCommands(pi: ExtensionAPI, runtime: SchedulerRuntime) {
 			}
 
 			ctx.ui.notify(
-				"Usage: /schedule [tui|list|enable <id>|disable <id>|delete <id>|clear|clear-other|adopt <id|all>|release <id|all>|clear-foreign]",
+				"Usage: /schedule:tui|list|enable <id>|disable <id>|delete <id>|clear|clear-other|adopt <id|all>|release <id|all>|clear-foreign",
 				"warning",
 			);
 		},
-	});
+	};
+
+	pi.registerCommand("schedule", scheduleCommand);
+
+	const scheduleAliases: Array<{ name: string; subcommand: string; description: string }> = [
+		{ name: "schedule:tui", subcommand: "tui", description: "Open the scheduler TUI manager." },
+		{ name: "schedule:list", subcommand: "list", description: "Show all scheduled prompts in the message stream." },
+		{ name: "schedule:enable", subcommand: "enable", description: "Enable one scheduled prompt." },
+		{ name: "schedule:disable", subcommand: "disable", description: "Disable one scheduled prompt." },
+		{ name: "schedule:delete", subcommand: "delete", description: "Delete one scheduled prompt." },
+		{ name: "schedule:remove", subcommand: "remove", description: "Alias for /schedule:delete." },
+		{ name: "schedule:rm", subcommand: "rm", description: "Alias for /schedule:delete." },
+		{ name: "schedule:clear", subcommand: "clear", description: "Delete every scheduled prompt." },
+		{
+			name: "schedule:clear-other",
+			subcommand: "clear-other",
+			description: "Delete tasks not created in this instance.",
+		},
+		{ name: "schedule:adopt", subcommand: "adopt", description: "Adopt one task or all tasks for this instance." },
+		{
+			name: "schedule:release",
+			subcommand: "release",
+			description: "Release one task or all tasks from this instance.",
+		},
+		{
+			name: "schedule:clear-foreign",
+			subcommand: "clear-foreign",
+			description: "Delete tasks owned by another instance.",
+		},
+	];
+
+	for (const alias of scheduleAliases) {
+		pi.registerCommand(alias.name, {
+			description: alias.description,
+			handler: (args, ctx) => scheduleCommand.handler(args ? `${alias.subcommand} ${args}` : alias.subcommand, ctx),
+		});
+	}
 
 	pi.registerCommand("unschedule", {
-		description: "Alias for /schedule delete <id>",
+		description: "Alias for /schedule:delete <id>",
 		handler: async (args, ctx) => {
 			const id = args.trim();
 			if (!id) {

--- a/packages/extensions/extensions/scheduler-registration.ts
+++ b/packages/extensions/extensions/scheduler-registration.ts
@@ -343,11 +343,6 @@ export function registerCommands(pi: ExtensionAPI, runtime: SchedulerRuntime) {
 				return;
 			}
 
-			if (action === "adopt" || action === "release") {
-				ctx.ui.notify(`Usage: /schedule:${action} <id|all>`, "warning");
-				return;
-			}
-
 			if (rawExtra) {
 				ctx.ui.notify("Too many arguments for /schedule.", "warning");
 				return;

--- a/packages/extensions/extensions/scheduler.test.ts
+++ b/packages/extensions/extensions/scheduler.test.ts
@@ -1647,6 +1647,8 @@ describe("schedulerExtension registration", () => {
 		expect(pi._commands.has("loop")).toBe(true);
 		expect(pi._commands.has("remind")).toBe(true);
 		expect(pi._commands.has("schedule")).toBe(true);
+		expect(pi._commands.has("schedule:tui")).toBe(true);
+		expect(pi._commands.has("schedule:delete")).toBe(true);
 		expect(pi._commands.has("unschedule")).toBe(true);
 	});
 

--- a/packages/extensions/extensions/scheduler.test.ts
+++ b/packages/extensions/extensions/scheduler.test.ts
@@ -2787,6 +2787,11 @@ describe("edge cases", () => {
 		expect(ctx._notifications.some((n: any) => n.msg.includes("No scheduled tasks"))).toBe(true);
 	});
 
+	it("shows colon-style guidance for unsupported scope changes", async () => {
+		await pi._commands.get("schedule").handler("scope", ctx);
+		expect(ctx._notifications.at(-1)?.msg).toContain("/schedule:scope is not supported yet");
+	});
+
 	it("shows workspace, creator, and full prompt after selecting a task", async () => {
 		const prompt = "check the full deployment pipeline and report every failing stage";
 		await pi._commands.get("loop").handler(`5m ${prompt}`, ctx);

--- a/packages/extensions/extensions/smoke.test.ts
+++ b/packages/extensions/extensions/smoke.test.ts
@@ -15,6 +15,7 @@ describe("extensions runtime smoke tests", () => {
 		harness.emit("session_start", { type: "session_start" }, harness.ctx);
 
 		expect(harness.commands.has("schedule")).toBe(true);
+		expect(harness.commands.has("schedule:tui")).toBe(true);
 		expect(harness.commands.has("loop")).toBe(true);
 		expect(harness.tools.has("schedule_prompt")).toBe(true);
 

--- a/packages/extensions/extensions/watchdog.test.ts
+++ b/packages/extensions/extensions/watchdog.test.ts
@@ -320,6 +320,35 @@ describe("watchdog extension", () => {
 		expect(ctx._notifications.some((item) => item.msg.includes("safe mode automatically"))).toBe(true);
 	});
 
+	it("suppresses repeated alert notifications after the limit", async () => {
+		const pi = createMockPi();
+		const ctx = createMockCtx();
+		watchdogExtension(pi as any);
+
+		mockCpuUsageSequence([
+			{ user: 0, system: 0 },
+			{ user: 0, system: 0 },
+			{ user: 4_500_000, system: 0 },
+			{ user: 4_500_000, system: 0 },
+			{ user: 4_500_000, system: 0 },
+			{ user: 4_500_000, system: 0 },
+		]);
+		mockMemoryUsage({
+			rss: 1400 * 1024 * 1024,
+			heapUsed: 900 * 1024 * 1024,
+			heapTotal: 1000 * 1024 * 1024,
+		});
+		histogram.mean = 30_000_000;
+		histogram.max = 320_000_000;
+		histogram.percentile.mockReturnValue(180_000_000);
+
+		await pi._emit("session_start", {}, ctx);
+		await vi.advanceTimersByTimeAsync(10_000);
+		await vi.advanceTimersByTimeAsync(55_000);
+
+		expect(ctx._notifications.some((item) => item.msg.includes("Further alerts suppressed"))).toBe(true);
+	});
+
 	it("registers safe-mode commands that toggle shared state", async () => {
 		const pi = createMockPi();
 		const ctx = createMockCtx();
@@ -445,5 +474,17 @@ describe("watchdog extension", () => {
 		expect(rendered).toContain("Current sample");
 		expect(rendered).toContain("Recent alerts");
 		expect(rendered).toContain("Config:");
+	});
+
+	it("supports colon aliases for startup and status guidance", async () => {
+		const pi = createMockPi();
+		const ctx = createMockCtx();
+		watchdogExtension(pi as any);
+
+		await pi._commands.get("watchdog:startup").handler("", ctx);
+		expect(ctx._notifications.at(-1)?.msg).toContain("/watchdog:startup");
+
+		expect(pi._commands.get("watchdog:status")?.description).toContain("watchdog status");
+		await expect(pi._commands.get("watchdog:status").handler("", ctx)).resolves.toBeUndefined();
 	});
 });

--- a/packages/extensions/extensions/watchdog.test.ts
+++ b/packages/extensions/extensions/watchdog.test.ts
@@ -325,6 +325,7 @@ describe("watchdog extension", () => {
 		const ctx = createMockCtx();
 		watchdogExtension(pi as any);
 
+		expect(pi._commands.has("watchdog:status")).toBe(true);
 		const command = pi._commands.get("safe-mode");
 		expect(command).toBeDefined();
 

--- a/packages/extensions/extensions/watchdog.ts
+++ b/packages/extensions/extensions/watchdog.ts
@@ -698,55 +698,55 @@ export default function watchdogExtension(pi: ExtensionAPI) {
 		}
 	});
 
-	const handleWatchdogCommand = async (args: string, ctx: ExtensionCommandContext): Promise<void> => {
-		activeCtx = ctx;
-		setSafeModeStatus();
-		loadConfigNow();
-		const command = args.trim().toLowerCase() || "status";
-		switch (command) {
-			case "on":
-				enabled = true;
-				resetCounters();
-				ensureTimer();
-				ctx.ui.notify("Performance watchdog enabled.", "info");
-				return;
-			case "off":
-				enabled = false;
-				stopTimer();
-				setAlertStatus(undefined);
-				ctx.ui.notify("Performance watchdog disabled.", "warning");
-				return;
-			case "sample":
-				latestSample = takeSample();
-				ctx.ui.notify(formatWatchdogStatus(latestSample), "info");
-				return;
-			case "reset":
-				resetHistory();
-				ctx.ui.notify("Performance watchdog history reset.", "info");
-				return;
-			case "overlay":
-			case "dashboard":
-				await openOverlay(ctx);
-				return;
-			case "config":
-				notifyConfig(ctx);
-				return;
-			case "blame":
-				notifyBlame(ctx);
-				return;
-			case "startup":
-				notifyStartupBreakdown(ctx);
-				return;
-			default:
-				notifyStatus(ctx);
-		}
-	};
-
-	pi.registerCommand("watchdog", {
+	const watchdogCommand = {
 		description:
 			"Inspect or control the performance watchdog: /watchdog:status|startup|overlay|dashboard|config|reset|on|off|sample|blame",
-		handler: handleWatchdogCommand,
-	});
+		async handler(args, ctx) {
+			activeCtx = ctx;
+			setSafeModeStatus();
+			loadConfigNow();
+			const command = args.trim().toLowerCase() || "status";
+			switch (command) {
+				case "on":
+					enabled = true;
+					resetCounters();
+					ensureTimer();
+					ctx.ui.notify("Performance watchdog enabled.", "info");
+					return;
+				case "off":
+					enabled = false;
+					stopTimer();
+					setAlertStatus(undefined);
+					ctx.ui.notify("Performance watchdog disabled.", "warning");
+					return;
+				case "sample":
+					latestSample = takeSample();
+					ctx.ui.notify(formatWatchdogStatus(latestSample), "info");
+					return;
+				case "reset":
+					resetHistory();
+					ctx.ui.notify("Performance watchdog history reset.", "info");
+					return;
+				case "overlay":
+				case "dashboard":
+					await openOverlay(ctx);
+					return;
+				case "config":
+					notifyConfig(ctx);
+					return;
+				case "blame":
+					notifyBlame(ctx);
+					return;
+				case "startup":
+					notifyStartupBreakdown(ctx);
+					return;
+				default:
+					notifyStatus(ctx);
+			}
+		},
+	};
+
+	pi.registerCommand("watchdog", watchdogCommand);
 
 	const watchdogAliases: Array<{ name: string; subcommand: string; description: string }> = [
 		{ name: "watchdog:status", subcommand: "status", description: "Show the current watchdog status." },
@@ -764,7 +764,7 @@ export default function watchdogExtension(pi: ExtensionAPI) {
 	for (const alias of watchdogAliases) {
 		pi.registerCommand(alias.name, {
 			description: alias.description,
-			handler: (args, ctx) => handleWatchdogCommand(args ? `${alias.subcommand} ${args}` : alias.subcommand, ctx),
+			handler: (args, ctx) => watchdogCommand.handler(args ? `${alias.subcommand} ${args}` : alias.subcommand, ctx),
 		});
 	}
 

--- a/packages/extensions/extensions/watchdog.ts
+++ b/packages/extensions/extensions/watchdog.ts
@@ -12,7 +12,7 @@ which CPU, memory, and event-loop thresholds trigger alerts or safe-mode escalat
 The watchdog samples CPU, memory, and event-loop lag on an interval, records recent samples and
 alerts, and can escalate into safe mode automatically when repeated alerts indicate sustained UI
 churn or lag. Toast notifications are intentionally capped per session; ongoing watchdog state is
-kept visible in the status bar and the `/watchdog` overlay instead of repeatedly spamming the
+kept visible in the status bar and the `/watchdog:overlay` overlay instead of repeatedly spamming the
 terminal.
 
 <!-- {/extensionsWatchdogAlertBehaviorDocs} -->
@@ -290,7 +290,7 @@ export function formatWatchdogStatus(sample: WatchdogSample | null): string {
 }
 
 export function formatWatchdogAlert(alert: WatchdogAlert): string {
-	return `Performance watchdog ${alert.severity}: ${alert.reasons.join(", ")}. Run /watchdog status or /safe-mode on if input feels laggy.`;
+	return `Performance watchdog ${alert.severity}: ${alert.reasons.join(", ")}. Run /watchdog:status or /safe-mode on if input feels laggy.`;
 }
 
 export function applySafeMode(
@@ -396,7 +396,7 @@ function buildOverlayLines(
 The watchdog samples CPU, memory, and event-loop lag on an interval, records recent samples and
 alerts, and can escalate into safe mode automatically when repeated alerts indicate sustained UI
 churn or lag. Toast notifications are intentionally capped per session; ongoing watchdog state is
-kept visible in the status bar and the `/watchdog` overlay instead of repeatedly spamming the
+kept visible in the status bar and the `/watchdog:overlay` overlay instead of repeatedly spamming the
 terminal.
 
 <!-- {/extensionsWatchdogAlertBehaviorDocs} -->
@@ -555,7 +555,7 @@ export default function watchdogExtension(pi: ExtensionAPI) {
 			alertNotificationCount += 1;
 			if (alertNotificationCount >= ALERT_NOTIFICATION_LIMIT) {
 				activeCtx.ui.notify(
-					`${formatWatchdogAlert(alert)} Further alerts suppressed — check status bar or /watchdog overlay.`,
+					`${formatWatchdogAlert(alert)} Further alerts suppressed — check status bar or /watchdog:overlay.`,
 					levelForAlert(alert),
 				);
 			} else {
@@ -625,7 +625,7 @@ export default function watchdogExtension(pi: ExtensionAPI) {
 	const notifyStartupBreakdown = (ctx: ExtensionCommandContext | ExtensionContext) => {
 		const diagnostics = getStartupDiagnostics();
 		if (diagnostics.length === 0) {
-			ctx.ui.notify("No startup timings recorded yet. Restart the session and run /watchdog startup.", "info");
+			ctx.ui.notify("No startup timings recorded yet. Restart the session and run /watchdog:startup.", "info");
 			return;
 		}
 
@@ -698,53 +698,75 @@ export default function watchdogExtension(pi: ExtensionAPI) {
 		}
 	});
 
+	const handleWatchdogCommand = async (args: string, ctx: ExtensionCommandContext): Promise<void> => {
+		activeCtx = ctx;
+		setSafeModeStatus();
+		loadConfigNow();
+		const command = args.trim().toLowerCase() || "status";
+		switch (command) {
+			case "on":
+				enabled = true;
+				resetCounters();
+				ensureTimer();
+				ctx.ui.notify("Performance watchdog enabled.", "info");
+				return;
+			case "off":
+				enabled = false;
+				stopTimer();
+				setAlertStatus(undefined);
+				ctx.ui.notify("Performance watchdog disabled.", "warning");
+				return;
+			case "sample":
+				latestSample = takeSample();
+				ctx.ui.notify(formatWatchdogStatus(latestSample), "info");
+				return;
+			case "reset":
+				resetHistory();
+				ctx.ui.notify("Performance watchdog history reset.", "info");
+				return;
+			case "overlay":
+			case "dashboard":
+				await openOverlay(ctx);
+				return;
+			case "config":
+				notifyConfig(ctx);
+				return;
+			case "blame":
+				notifyBlame(ctx);
+				return;
+			case "startup":
+				notifyStartupBreakdown(ctx);
+				return;
+			default:
+				notifyStatus(ctx);
+		}
+	};
+
 	pi.registerCommand("watchdog", {
 		description:
-			"Inspect or control the performance watchdog: /watchdog [status|startup|overlay|config|reset|on|off|sample|blame]",
-		async handler(args, ctx) {
-			activeCtx = ctx;
-			setSafeModeStatus();
-			loadConfigNow();
-			const command = args.trim().toLowerCase() || "status";
-			switch (command) {
-				case "on":
-					enabled = true;
-					resetCounters();
-					ensureTimer();
-					ctx.ui.notify("Performance watchdog enabled.", "info");
-					return;
-				case "off":
-					enabled = false;
-					stopTimer();
-					setAlertStatus(undefined);
-					ctx.ui.notify("Performance watchdog disabled.", "warning");
-					return;
-				case "sample":
-					latestSample = takeSample();
-					ctx.ui.notify(formatWatchdogStatus(latestSample), "info");
-					return;
-				case "reset":
-					resetHistory();
-					ctx.ui.notify("Performance watchdog history reset.", "info");
-					return;
-				case "overlay":
-				case "dashboard":
-					await openOverlay(ctx);
-					return;
-				case "config":
-					notifyConfig(ctx);
-					return;
-				case "blame":
-					notifyBlame(ctx);
-					return;
-				case "startup":
-					notifyStartupBreakdown(ctx);
-					return;
-				default:
-					notifyStatus(ctx);
-			}
-		},
+			"Inspect or control the performance watchdog: /watchdog:status|startup|overlay|dashboard|config|reset|on|off|sample|blame",
+		handler: handleWatchdogCommand,
 	});
+
+	const watchdogAliases: Array<{ name: string; subcommand: string; description: string }> = [
+		{ name: "watchdog:status", subcommand: "status", description: "Show the current watchdog status." },
+		{ name: "watchdog:startup", subcommand: "startup", description: "Show watchdog startup timings." },
+		{ name: "watchdog:overlay", subcommand: "overlay", description: "Open the watchdog overlay." },
+		{ name: "watchdog:dashboard", subcommand: "dashboard", description: "Open the watchdog dashboard overlay." },
+		{ name: "watchdog:config", subcommand: "config", description: "Show the watchdog config file path and settings." },
+		{ name: "watchdog:reset", subcommand: "reset", description: "Reset watchdog metrics and alert history." },
+		{ name: "watchdog:on", subcommand: "on", description: "Enable the performance watchdog." },
+		{ name: "watchdog:off", subcommand: "off", description: "Disable the performance watchdog." },
+		{ name: "watchdog:sample", subcommand: "sample", description: "Capture a watchdog sample right now." },
+		{ name: "watchdog:blame", subcommand: "blame", description: "Show the watchdog blame report." },
+	];
+
+	for (const alias of watchdogAliases) {
+		pi.registerCommand(alias.name, {
+			description: alias.description,
+			handler: (args, ctx) => handleWatchdogCommand(args ? `${alias.subcommand} ${args}` : alias.subcommand, ctx),
+		});
+	}
 
 	pi.registerCommand("safe-mode", {
 		description: "Reduce nonessential UI churn: /safe-mode [on|off|status]",

--- a/packages/extensions/extensions/watchdog.ts
+++ b/packages/extensions/extensions/watchdog.ts
@@ -12,7 +12,7 @@ which CPU, memory, and event-loop thresholds trigger alerts or safe-mode escalat
 The watchdog samples CPU, memory, and event-loop lag on an interval, records recent samples and
 alerts, and can escalate into safe mode automatically when repeated alerts indicate sustained UI
 churn or lag. Toast notifications are intentionally capped per session; ongoing watchdog state is
-kept visible in the status bar and the `/watchdog:overlay` overlay instead of repeatedly spamming the
+kept visible in the status bar and the `/watchdog` overlay instead of repeatedly spamming the
 terminal.
 
 <!-- {/extensionsWatchdogAlertBehaviorDocs} -->
@@ -396,7 +396,7 @@ function buildOverlayLines(
 The watchdog samples CPU, memory, and event-loop lag on an interval, records recent samples and
 alerts, and can escalate into safe mode automatically when repeated alerts indicate sustained UI
 churn or lag. Toast notifications are intentionally capped per session; ongoing watchdog state is
-kept visible in the status bar and the `/watchdog:overlay` overlay instead of repeatedly spamming the
+kept visible in the status bar and the `/watchdog` overlay instead of repeatedly spamming the
 terminal.
 
 <!-- {/extensionsWatchdogAlertBehaviorDocs} -->

--- a/packages/ollama/README.md
+++ b/packages/ollama/README.md
@@ -13,7 +13,7 @@ Experimental Ollama provider package for pi with both local and cloud support.
 - Exposes local models in `/model` as `ollama/<model-id>`
 - Exposes cloud models in `/model` as `ollama-cloud/<model-id>`
 - Prompts to download a missing local model when you select `ollama/<model-id>` and uses the Ollama CLI to pull it
-- Adds `/ollama status|refresh-models|models|info|pull` for a unified local + cloud workflow
+- Adds `/ollama:status|refresh-models|models|info|pull` for a unified local + cloud workflow
 
 ## Install
 
@@ -31,25 +31,25 @@ This package is intentionally separate from `@ifi/oh-pi` for now.
 2. Make sure the `ollama` CLI is installed and a local Ollama instance is running
 3. Open `/model` and select an `ollama/...` model
 4. If the model is not installed yet, pi will prompt to download it with the Ollama CLI
-5. Run `/ollama refresh-models` whenever you pull or remove local models outside pi
+5. Run `/ollama:refresh-models` whenever you pull or remove local models outside pi
 
 ### Ollama Cloud
 
 1. Install the package
-2. Open `/model` or run `/ollama models` to browse the public Ollama Cloud catalog
+2. Open `/model` or run `/ollama:models` to browse the public Ollama Cloud catalog
 3. Run `/login ollama-cloud` before using an `ollama-cloud/...` model
 4. Create an API key on Ollama when pi opens the keys page
 5. Paste the key back into pi
 6. Open `/model` and select an `ollama-cloud/...` model
-7. Optionally run `/ollama refresh-models` later to refresh both local and cloud catalogs
+7. Optionally run `/ollama:refresh-models` later to refresh both local and cloud catalogs
 
 ## Commands
 
-- `/ollama status` — show local CLI + daemon status, local install/download counts, and cloud auth/catalog status
-- `/ollama refresh-models` — refresh both local and cloud Ollama models
-- `/ollama models` — list local and cloud Ollama models with source/capability badges for easier selection
-- `/ollama info <model>` — show detailed metadata for a local or cloud Ollama model, including context window size
-- `/ollama pull <model>` — manually download a local Ollama model via the Ollama CLI
+- `/ollama:status` — show local CLI + daemon status, local install/download counts, and cloud auth/catalog status
+- `/ollama:refresh-models` — refresh both local and cloud Ollama models
+- `/ollama:models` — list local and cloud Ollama models with source/capability badges for easier selection
+- `/ollama:info <model>` — show detailed metadata for a local or cloud Ollama model, including context window size
+- `/ollama:pull <model>` — manually download a local Ollama model via the Ollama CLI
 - `/ollama-cloud status` — backward-compatible cloud-only status alias
 - `/ollama-cloud refresh-models` — backward-compatible cloud-only refresh alias
 

--- a/packages/ollama/index.ts
+++ b/packages/ollama/index.ts
@@ -1,4 +1,4 @@
-import type { ExtensionAPI } from "@mariozechner/pi-coding-agent";
+import type { ExtensionAPI, ExtensionCommandContext } from "@mariozechner/pi-coding-agent";
 import {
 	type AssistantMessageEventStream,
 	type Context,
@@ -149,73 +149,73 @@ async function refreshRegisteredCloudEnvModels(pi: ExtensionAPI): Promise<Ollama
 }
 
 function registerOllamaCommands(pi: ExtensionAPI): void {
-	const handleOllamaCommand = async (args: string, ctx: CommandContextLike): Promise<void> => {
-		const trimmed = args.trim();
-		const [rawAction = "status", ...rest] = trimmed ? trimmed.split(/\s+/) : ["status"];
-		const action = rawAction.toLowerCase();
-		const credential = getStoredCloudCredential(ctx);
+	const ollamaCommand = {
+		description: "Inspect or refresh local + cloud Ollama providers: /ollama, /ollama:status, /ollama:refresh-models, /ollama:models, /ollama:info <model>, /ollama:pull <model>",
+		async handler(args: string, ctx: ExtensionCommandContext) {
+			const trimmed = args.trim();
+			const [rawAction = "status", ...rest] = trimmed ? trimmed.split(/\s+/) : ["status"];
+			const action = rawAction.toLowerCase();
+			const credential = getStoredCloudCredential(ctx);
 
-		if (action === "refresh-models") {
-			clearOllamaCliStatusCache();
-			const localModels = await refreshRegisteredLocalModels(pi, { forceCli: true });
-			const cloudModels = await refreshCloudModels(pi, ctx, credential);
-			ctx.modelRegistry.refresh?.();
-			const cloudStatus = hasCloudAuth(credential)
-				? `${cloudModels.length} cloud available`
-				: `${cloudModels.length} public cloud discovered; run /login ollama-cloud to use them`;
-			ctx.ui.notify(`Refreshed Ollama models (${localModels.length} local installed, ${cloudStatus}).`, "info");
-			return;
-		}
-
-		if (action === "models") {
-			ctx.ui.notify(renderModelList(collectOllamaModels(credential)), "info");
-			return;
-		}
-
-		if (action === "pull" || action === "download") {
-			const query = rest.join(" ").trim();
-			if (!query) {
-				ctx.ui.notify("Usage: /ollama:pull <model>", "warning");
+			if (action === "refresh-models") {
+				clearOllamaCliStatusCache();
+				const localModels = await refreshRegisteredLocalModels(pi, { forceCli: true });
+				const cloudModels = await refreshCloudModels(pi, ctx, credential);
+				ctx.modelRegistry.refresh?.();
+				const cloudStatus = hasCloudAuth(credential)
+					? `${cloudModels.length} cloud available`
+					: `${cloudModels.length} public cloud discovered; run /login ollama-cloud to use them`;
+				ctx.ui.notify(`Refreshed Ollama models (${localModels.length} local installed, ${cloudStatus}).`, "info");
 				return;
 			}
 
-			const localModel = findLocalModelForQuery(query, credential);
-			if (!localModel) {
-				ctx.ui.notify(`No Ollama model matched \"${query}\". Run /ollama:refresh-models first.`, "warning");
+			if (action === "models") {
+				ctx.ui.notify(renderModelList(collectOllamaModels(credential)), "info");
 				return;
 			}
 
-			if (localModel.localAvailability === "installed") {
-				ctx.ui.notify(`ollama/${localModel.id} is already installed locally.`, "info");
+			if (action === "pull" || action === "download") {
+				const query = rest.join(" ").trim();
+				if (!query) {
+					ctx.ui.notify("Usage: /ollama:pull <model>", "warning");
+					return;
+				}
+
+				const localModel = findLocalModelForQuery(query, credential);
+				if (!localModel) {
+					ctx.ui.notify(`No Ollama model matched \"${query}\". Run /ollama:refresh-models first.`, "warning");
+					return;
+				}
+
+				if (localModel.localAvailability === "installed") {
+					ctx.ui.notify(`ollama/${localModel.id} is already installed locally.`, "info");
+					return;
+				}
+
+				await pullLocalModel(pi, ctx, localModel.id);
 				return;
 			}
 
-			await pullLocalModel(pi, ctx, localModel.id);
-			return;
-		}
-
-		if (action === "info") {
-			const query = rest.join(" ").trim();
-			if (!query) {
-				ctx.ui.notify("Usage: /ollama:info <model>", "warning");
+			if (action === "info") {
+				const query = rest.join(" ").trim();
+				if (!query) {
+					ctx.ui.notify("Usage: /ollama:info <model>", "warning");
+					return;
+				}
+				const model = findModelForQuery(query, collectOllamaModels(credential));
+				if (!model) {
+					ctx.ui.notify(`No Ollama model matched \"${query}\". Run /ollama:refresh-models first.`, "warning");
+					return;
+				}
+				ctx.ui.notify(renderModelInfo(model), "info");
 				return;
 			}
-			const model = findModelForQuery(query, collectOllamaModels(credential));
-			if (!model) {
-				ctx.ui.notify(`No Ollama model matched \"${query}\". Run /ollama:refresh-models first.`, "warning");
-				return;
-			}
-			ctx.ui.notify(renderModelInfo(model), "info");
-			return;
-		}
 
-		ctx.ui.notify(renderUnifiedStatus(credential), "info");
+			ctx.ui.notify(renderUnifiedStatus(credential), "info");
+		},
 	};
 
-	pi.registerCommand("ollama", {
-		description: "Inspect or refresh local + cloud Ollama providers: /ollama, /ollama:status, /ollama:refresh-models, /ollama:models, /ollama:info <model>, /ollama:pull <model>",
-		handler: handleOllamaCommand,
-	});
+	pi.registerCommand("ollama", ollamaCommand);
 
 	const ollamaAliases: Array<{ name: string; subcommand: string; description: string }> = [
 		{ name: "ollama:status", subcommand: "status", description: "Show local and cloud Ollama status." },
@@ -228,13 +228,14 @@ function registerOllamaCommands(pi: ExtensionAPI): void {
 	for (const alias of ollamaAliases) {
 		pi.registerCommand(alias.name, {
 			description: alias.description,
-			handler: (args, ctx) => handleOllamaCommand(args ? `${alias.subcommand} ${args}` : alias.subcommand, ctx),
+			handler: (args: string, ctx: ExtensionCommandContext) =>
+				ollamaCommand.handler(args ? `${alias.subcommand} ${args}` : alias.subcommand, ctx),
 		});
 	}
 
 	pi.registerCommand("ollama-cloud", {
 		description: "Backward-compatible alias for cloud-only Ollama status and refresh: /ollama-cloud [status|refresh-models]",
-		async handler(args, ctx) {
+		async handler(args: string, ctx: ExtensionCommandContext) {
 			const action = args.trim().toLowerCase() || "status";
 			const credential = getStoredCloudCredential(ctx);
 
@@ -330,7 +331,7 @@ function registerOllamaLifecycle(pi: ExtensionAPI): {
 			})()
 				.catch(() => {
 					// Auth storage can be unavailable during early startup depending on initialization order.
-					// Keep boot resilient and rely on manual /ollama:refresh-models as fallback.
+					// Keep boot resilient and rely on manual /ollama refresh-models as fallback.
 				})
 				.finally(() => {
 					pendingCloudBootstrapRefresh = null;
@@ -379,7 +380,7 @@ function registerOllamaLifecycle(pi: ExtensionAPI): {
 
 		if (event.source === "restore" || !ctx.hasUI || typeof ctx.ui.confirm !== "function") {
 			ctx.ui.notify(
-				`ollama/${event.model.id} is not installed locally yet. Run /ollama:pull ${event.model.id} to download it.`,
+				`ollama/${event.model.id} is not installed locally yet. Run /ollama pull ${event.model.id} to download it.`,
 				"warning",
 			);
 			return;
@@ -517,7 +518,7 @@ function renderUnifiedStatus(credential: OllamaCloudCredentials | null): string 
 		`Ollama cloud auth: ${describeCloudAuth(credential)}`,
 		`Cloud models: ${cloudModels.length}${formatRefreshAge(credential?.lastModelRefresh ?? cloudEnvDiscoveryState.lastRefresh)}`,
 		`Cloud base URL: ${cloudConfig.apiUrl}`,
-		`Tip: prefer ollama-cloud/... for speed, and use /ollama:pull <model> only when you need a local copy.`,
+		`Tip: prefer ollama-cloud/... for speed, and use /ollama pull <model> only when you need a local copy.`,
 	].join("\n");
 }
 
@@ -609,7 +610,7 @@ function renderModelInfo(model: CollectedOllamaModel): string {
 
 function renderModelList(models: CollectedOllamaModel[]): string {
 	if (models.length === 0) {
-		return "No Ollama models are currently registered. Run /ollama:refresh-models.";
+		return "No Ollama models are currently registered. Run /ollama refresh-models.";
 	}
 
 	const sections = [

--- a/packages/ollama/index.ts
+++ b/packages/ollama/index.ts
@@ -149,71 +149,88 @@ async function refreshRegisteredCloudEnvModels(pi: ExtensionAPI): Promise<Ollama
 }
 
 function registerOllamaCommands(pi: ExtensionAPI): void {
+	const handleOllamaCommand = async (args: string, ctx: CommandContextLike): Promise<void> => {
+		const trimmed = args.trim();
+		const [rawAction = "status", ...rest] = trimmed ? trimmed.split(/\s+/) : ["status"];
+		const action = rawAction.toLowerCase();
+		const credential = getStoredCloudCredential(ctx);
+
+		if (action === "refresh-models") {
+			clearOllamaCliStatusCache();
+			const localModels = await refreshRegisteredLocalModels(pi, { forceCli: true });
+			const cloudModels = await refreshCloudModels(pi, ctx, credential);
+			ctx.modelRegistry.refresh?.();
+			const cloudStatus = hasCloudAuth(credential)
+				? `${cloudModels.length} cloud available`
+				: `${cloudModels.length} public cloud discovered; run /login ollama-cloud to use them`;
+			ctx.ui.notify(`Refreshed Ollama models (${localModels.length} local installed, ${cloudStatus}).`, "info");
+			return;
+		}
+
+		if (action === "models") {
+			ctx.ui.notify(renderModelList(collectOllamaModels(credential)), "info");
+			return;
+		}
+
+		if (action === "pull" || action === "download") {
+			const query = rest.join(" ").trim();
+			if (!query) {
+				ctx.ui.notify("Usage: /ollama:pull <model>", "warning");
+				return;
+			}
+
+			const localModel = findLocalModelForQuery(query, credential);
+			if (!localModel) {
+				ctx.ui.notify(`No Ollama model matched \"${query}\". Run /ollama:refresh-models first.`, "warning");
+				return;
+			}
+
+			if (localModel.localAvailability === "installed") {
+				ctx.ui.notify(`ollama/${localModel.id} is already installed locally.`, "info");
+				return;
+			}
+
+			await pullLocalModel(pi, ctx, localModel.id);
+			return;
+		}
+
+		if (action === "info") {
+			const query = rest.join(" ").trim();
+			if (!query) {
+				ctx.ui.notify("Usage: /ollama:info <model>", "warning");
+				return;
+			}
+			const model = findModelForQuery(query, collectOllamaModels(credential));
+			if (!model) {
+				ctx.ui.notify(`No Ollama model matched \"${query}\". Run /ollama:refresh-models first.`, "warning");
+				return;
+			}
+			ctx.ui.notify(renderModelInfo(model), "info");
+			return;
+		}
+
+		ctx.ui.notify(renderUnifiedStatus(credential), "info");
+	};
+
 	pi.registerCommand("ollama", {
-		description: "Inspect or refresh local + cloud Ollama providers: /ollama [status|refresh-models|models|info <model>|pull <model>]",
-		async handler(args, ctx) {
-			const trimmed = args.trim();
-			const [rawAction = "status", ...rest] = trimmed ? trimmed.split(/\s+/) : ["status"];
-			const action = rawAction.toLowerCase();
-			const credential = getStoredCloudCredential(ctx);
-
-			if (action === "refresh-models") {
-				clearOllamaCliStatusCache();
-				const localModels = await refreshRegisteredLocalModels(pi, { forceCli: true });
-				const cloudModels = await refreshCloudModels(pi, ctx, credential);
-				ctx.modelRegistry.refresh?.();
-				const cloudStatus = hasCloudAuth(credential)
-					? `${cloudModels.length} cloud available`
-					: `${cloudModels.length} public cloud discovered; run /login ollama-cloud to use them`;
-				ctx.ui.notify(`Refreshed Ollama models (${localModels.length} local installed, ${cloudStatus}).`, "info");
-				return;
-			}
-
-			if (action === "models") {
-				ctx.ui.notify(renderModelList(collectOllamaModels(credential)), "info");
-				return;
-			}
-
-			if (action === "pull" || action === "download") {
-				const query = rest.join(" ").trim();
-				if (!query) {
-					ctx.ui.notify("Usage: /ollama pull <model>", "warning");
-					return;
-				}
-
-				const localModel = findLocalModelForQuery(query, credential);
-				if (!localModel) {
-					ctx.ui.notify(`No Ollama model matched \"${query}\". Run /ollama refresh-models first.`, "warning");
-					return;
-				}
-
-				if (localModel.localAvailability === "installed") {
-					ctx.ui.notify(`ollama/${localModel.id} is already installed locally.`, "info");
-					return;
-				}
-
-				await pullLocalModel(pi, ctx, localModel.id);
-				return;
-			}
-
-			if (action === "info") {
-				const query = rest.join(" ").trim();
-				if (!query) {
-					ctx.ui.notify("Usage: /ollama info <model>", "warning");
-					return;
-				}
-				const model = findModelForQuery(query, collectOllamaModels(credential));
-				if (!model) {
-					ctx.ui.notify(`No Ollama model matched \"${query}\". Run /ollama refresh-models first.`, "warning");
-					return;
-				}
-				ctx.ui.notify(renderModelInfo(model), "info");
-				return;
-			}
-
-			ctx.ui.notify(renderUnifiedStatus(credential), "info");
-		},
+		description: "Inspect or refresh local + cloud Ollama providers: /ollama, /ollama:status, /ollama:refresh-models, /ollama:models, /ollama:info <model>, /ollama:pull <model>",
+		handler: handleOllamaCommand,
 	});
+
+	const ollamaAliases: Array<{ name: string; subcommand: string; description: string }> = [
+		{ name: "ollama:status", subcommand: "status", description: "Show local and cloud Ollama status." },
+		{ name: "ollama:refresh-models", subcommand: "refresh-models", description: "Refresh local and cloud Ollama models." },
+		{ name: "ollama:models", subcommand: "models", description: "List local and cloud Ollama models." },
+		{ name: "ollama:info", subcommand: "info", description: "Show detailed metadata for one Ollama model." },
+		{ name: "ollama:pull", subcommand: "pull", description: "Download a local Ollama model via the CLI." },
+	];
+
+	for (const alias of ollamaAliases) {
+		pi.registerCommand(alias.name, {
+			description: alias.description,
+			handler: (args, ctx) => handleOllamaCommand(args ? `${alias.subcommand} ${args}` : alias.subcommand, ctx),
+		});
+	}
 
 	pi.registerCommand("ollama-cloud", {
 		description: "Backward-compatible alias for cloud-only Ollama status and refresh: /ollama-cloud [status|refresh-models]",
@@ -313,7 +330,7 @@ function registerOllamaLifecycle(pi: ExtensionAPI): {
 			})()
 				.catch(() => {
 					// Auth storage can be unavailable during early startup depending on initialization order.
-					// Keep boot resilient and rely on manual /ollama refresh-models as fallback.
+					// Keep boot resilient and rely on manual /ollama:refresh-models as fallback.
 				})
 				.finally(() => {
 					pendingCloudBootstrapRefresh = null;
@@ -362,7 +379,7 @@ function registerOllamaLifecycle(pi: ExtensionAPI): {
 
 		if (event.source === "restore" || !ctx.hasUI || typeof ctx.ui.confirm !== "function") {
 			ctx.ui.notify(
-				`ollama/${event.model.id} is not installed locally yet. Run /ollama pull ${event.model.id} to download it.`,
+				`ollama/${event.model.id} is not installed locally yet. Run /ollama:pull ${event.model.id} to download it.`,
 				"warning",
 			);
 			return;
@@ -478,7 +495,7 @@ function streamSimpleOllamaLocal(model: Model<any>, context: Context, options?: 
 			throw new Error("Ollama CLI is not installed. Only ollama-cloud models are available right now.");
 		}
 		throw new Error(
-			`ollama/${model.id} is not installed locally yet. Select it again to download it, or run /ollama pull ${model.id}.`,
+			`ollama/${model.id} is not installed locally yet. Select it again to download it, or run /ollama:pull ${model.id}.`,
 		);
 	}
 
@@ -500,7 +517,7 @@ function renderUnifiedStatus(credential: OllamaCloudCredentials | null): string 
 		`Ollama cloud auth: ${describeCloudAuth(credential)}`,
 		`Cloud models: ${cloudModels.length}${formatRefreshAge(credential?.lastModelRefresh ?? cloudEnvDiscoveryState.lastRefresh)}`,
 		`Cloud base URL: ${cloudConfig.apiUrl}`,
-		`Tip: prefer ollama-cloud/... for speed, and use /ollama pull <model> only when you need a local copy.`,
+		`Tip: prefer ollama-cloud/... for speed, and use /ollama:pull <model> only when you need a local copy.`,
 	].join("\n");
 }
 
@@ -592,7 +609,7 @@ function renderModelInfo(model: CollectedOllamaModel): string {
 
 function renderModelList(models: CollectedOllamaModel[]): string {
 	if (models.length === 0) {
-		return "No Ollama models are currently registered. Run /ollama refresh-models.";
+		return "No Ollama models are currently registered. Run /ollama:refresh-models.";
 	}
 
 	const sections = [

--- a/packages/ollama/tests/smoke.test.ts
+++ b/packages/ollama/tests/smoke.test.ts
@@ -81,6 +81,7 @@ describe("ollama provider smoke tests", () => {
 		ollamaProviderExtension(harness.pi as never);
 
 		expect(harness.commands.has("ollama")).toBe(true);
+		expect(harness.commands.has("ollama:status")).toBe(true);
 		expect(harness.commands.has("ollama-cloud")).toBe(true);
 		expect(harness.providers.has("ollama")).toBe(true);
 		expect(harness.providers.has("ollama-cloud")).toBe(true);

--- a/packages/ollama/tests/smoke.test.ts
+++ b/packages/ollama/tests/smoke.test.ts
@@ -1,8 +1,10 @@
 import http from "node:http";
 import type { AddressInfo } from "node:net";
-import { afterEach, describe, expect, it } from "vitest";
+import { afterEach, describe, expect, it, vi } from "vitest";
 import { createExtensionHarness } from "../../../test-utils/extension-runtime-harness.js";
 import ollamaProviderExtension from "../index.js";
+import * as localModule from "../local.js";
+import * as modelsModule from "../models.js";
 import { createTestOllamaBackend } from "./test-backend.js";
 
 const envSnapshot = { ...process.env };
@@ -177,5 +179,53 @@ describe("ollama provider smoke tests", () => {
 		]);
 		expect(backend.getAuthHeaders()).toEqual(["", "", ""]);
 		await backend.close();
+	});
+
+	it("supports colon aliases for info and pull usage", async () => {
+		const harness = createExtensionHarness();
+		harnesses.push(harness);
+		(harness.ctx as any).modelRegistry = {
+			...(harness.ctx.modelRegistry as object),
+			authStorage: {
+				get: vi.fn(() => undefined),
+				set: vi.fn(),
+			},
+		};
+		ollamaProviderExtension(harness.pi as never);
+
+		await harness.commands.get("ollama:pull")?.handler?.("", harness.ctx as never);
+		expect(harness.notifications.at(-1)?.msg).toContain("Usage: /ollama:pull <model>");
+
+		await harness.commands.get("ollama:pull")?.handler?.("missing-model", harness.ctx as never);
+		expect(harness.notifications.at(-1)?.msg).toContain("Run /ollama:refresh-models first.");
+
+		await harness.commands.get("ollama:info")?.handler?.("", harness.ctx as never);
+		expect(harness.notifications.at(-1)?.msg).toContain("Usage: /ollama:info <model>");
+
+		await harness.commands.get("ollama:info")?.handler?.("missing-model", harness.ctx as never);
+		expect(harness.notifications.at(-1)?.msg).toContain("Run /ollama:refresh-models first.");
+
+		await harness.commands.get("ollama:status")?.handler?.("", harness.ctx as never);
+		expect(harness.notifications.at(-1)?.msg).toContain("Ollama");
+	});
+
+	it("uses colon-style guidance when a local model is not installed yet", async () => {
+		vi.spyOn(localModule, "getOllamaCliStatus").mockResolvedValue({ available: true, version: "0.9.0" });
+		vi.spyOn(modelsModule, "discoverOllamaLocalModels").mockResolvedValue([]);
+		const harness = createExtensionHarness();
+		harnesses.push(harness);
+		ollamaProviderExtension(harness.pi as never);
+
+		await harness.emitAsync("session_start", { type: "session_start" }, harness.ctx);
+		await new Promise((resolve) => setTimeout(resolve, 300));
+
+		const provider = harness.providers.get("ollama");
+		expect(provider).toBeDefined();
+		expect(() =>
+			provider?.streamSimple?.(
+				{ provider: "ollama", id: "missing-model" } as never,
+				{} as never,
+			),
+		).toThrowError(/\/ollama:pull missing-model/);
 	});
 });

--- a/packages/providers/README.md
+++ b/packages/providers/README.md
@@ -7,7 +7,7 @@ Experimental multi-provider package for pi backed by the OpenCode `models.dev` c
 - Registers configured API-key providers from the OpenCode catalog without flooding pi's global `/login` picker
 - Keeps provider model lists, context windows, reasoning flags, and vision support aligned with `models.dev`
 - Reuses live provider discovery when a provider exposes a model-list endpoint
-- Adds a scrollable `/providers login` picker with in-place search for lazy provider registration and API-key login
+- Adds a scrollable `/providers:login` picker with in-place search for lazy provider registration and API-key login
 - Adds `/providers ...` commands for status, listing, inspection, and catalog refreshes
 
 ## Install
@@ -21,21 +21,21 @@ This package is intentionally separate from `@ifi/oh-pi` for now.
 ## Use
 
 1. Install the package
-2. Run `/providers list` to see supported provider ids
-3. Run `/providers login` to browse the full provider list in a scrollable picker, or `/providers login <provider-id>` if you already know the id
+2. Run `/providers:list` to see supported provider ids
+3. Run `/providers:login` to browse the full provider list in a scrollable picker, or `/providers:login <provider-id>` if you already know the id
 4. Open `/model` and select one of the discovered models
-5. Run `/providers refresh-models <provider-id>` whenever you want to refresh the live catalog
+5. Run `/providers:refresh-models <provider-id>` whenever you want to refresh the live catalog
 
 You can also skip `/login` and set a supported provider env var directly when the provider uses a simple API-key flow.
 
 ## Commands
 
-- `/providers status` — summarize configured providers from this package
-- `/providers list [query]` — list supported provider ids and env vars
-- `/providers login [provider]` — scroll through the full provider list, search in place, lazily register one, and prompt for its API key
-- `/providers info <provider>` — inspect a provider's API mode, URLs, env vars, and model count
-- `/providers models <provider>` — list the current or fallback model catalog for one provider
-- `/providers refresh-models [provider|all]` — refresh configured providers from live discovery when possible
+- `/providers:status` — summarize configured providers from this package
+- `/providers:list [query]` — list supported provider ids and env vars
+- `/providers:login [provider]` — scroll through the full provider list, search in place, lazily register one, and prompt for its API key
+- `/providers:info <provider>` — inspect a provider's API mode, URLs, env vars, and model count
+- `/providers:models <provider>` — list the current or fallback model catalog for one provider
+- `/providers:refresh-models [provider|all]` — refresh configured providers from live discovery when possible
 
 ## Highlights
 

--- a/packages/providers/index.ts
+++ b/packages/providers/index.ts
@@ -64,73 +64,107 @@ function registerProvider(pi: ExtensionAPI, provider: SupportedProviderDefinitio
 }
 
 function registerProvidersCommand(pi: ExtensionAPI): void {
+	// biome-ignore lint/complexity/noExcessiveCognitiveComplexity: Explicit subcommand routing keeps provider actions readable.
+	const handleProvidersCommand = async (args: string, ctx: ProviderCommandContext): Promise<void> => {
+		const trimmed = args.trim();
+		const [rawAction = "status", ...rest] = trimmed ? trimmed.split(/\s+/) : ["status"];
+		const action = rawAction.toLowerCase();
+		const query = rest.join(" ").trim();
+
+		if (action === "login") {
+			const provider = await resolveProviderSelection(query, ctx);
+			if (!provider) {
+				return;
+			}
+			await loginProviderFromCommand(pi, ctx, provider);
+			return;
+		}
+
+		if (action === "refresh-models") {
+			const providers = query && query.toLowerCase() !== "all" ? findProviders(query) : SUPPORTED_PROVIDERS;
+			if (providers.length === 0) {
+				ctx.ui.notify(`No provider matched "${query}". Run /providers:list first.`, "warning");
+				return;
+			}
+			const refreshed = await refreshProviders(pi, ctx, providers);
+			ctx.modelRegistry.refresh?.();
+			ctx.ui.notify(renderRefreshSummary(refreshed, providers.length), "info");
+			return;
+		}
+
+		if (action === "list") {
+			ctx.ui.notify(renderProviderList(query), "info");
+			return;
+		}
+
+		if (action === "info") {
+			if (!query) {
+				ctx.ui.notify("Usage: /providers:info <provider>", "warning");
+				return;
+			}
+			const provider = findProviders(query)[0];
+			if (!provider) {
+				ctx.ui.notify(`No provider matched "${query}". Run /providers:list first.`, "warning");
+				return;
+			}
+			ctx.ui.notify(await renderProviderInfo(provider, ctx), "info");
+			return;
+		}
+
+		if (action === "models") {
+			if (!query) {
+				ctx.ui.notify("Usage: /providers:models <provider>", "warning");
+				return;
+			}
+			const provider = findProviders(query)[0];
+			if (!provider) {
+				ctx.ui.notify(`No provider matched "${query}". Run /providers:list first.`, "warning");
+				return;
+			}
+			ctx.ui.notify(await renderProviderModels(provider, ctx), "info");
+			return;
+		}
+
+		ctx.ui.notify(renderStatus(ctx), "info");
+	};
+
 	pi.registerCommand("providers", {
 		description:
-			"Inspect, log in to, or refresh the OpenCode-backed multi-provider catalog: /providers [status|list [query]|info <provider>|models <provider>|login [provider]|refresh-models [provider|all]]",
-		// biome-ignore lint/complexity/noExcessiveCognitiveComplexity: This explicit command router keeps each provider subcommand readable.
-		async handler(args, ctx) {
-			const trimmed = args.trim();
-			const [rawAction = "status", ...rest] = trimmed ? trimmed.split(/\s+/) : ["status"];
-			const action = rawAction.toLowerCase();
-			const query = rest.join(" ").trim();
-
-			if (action === "login") {
-				const provider = await resolveProviderSelection(query, ctx);
-				if (!provider) {
-					return;
-				}
-				await loginProviderFromCommand(pi, ctx, provider);
-				return;
-			}
-
-			if (action === "refresh-models") {
-				const providers = query && query.toLowerCase() !== "all" ? findProviders(query) : SUPPORTED_PROVIDERS;
-				if (providers.length === 0) {
-					ctx.ui.notify(`No provider matched "${query}". Run /providers list first.`, "warning");
-					return;
-				}
-				const refreshed = await refreshProviders(pi, ctx, providers);
-				ctx.modelRegistry.refresh?.();
-				ctx.ui.notify(renderRefreshSummary(refreshed, providers.length), "info");
-				return;
-			}
-
-			if (action === "list") {
-				ctx.ui.notify(renderProviderList(query), "info");
-				return;
-			}
-
-			if (action === "info") {
-				if (!query) {
-					ctx.ui.notify("Usage: /providers info <provider>", "warning");
-					return;
-				}
-				const provider = findProviders(query)[0];
-				if (!provider) {
-					ctx.ui.notify(`No provider matched "${query}". Run /providers list first.`, "warning");
-					return;
-				}
-				ctx.ui.notify(await renderProviderInfo(provider, ctx), "info");
-				return;
-			}
-
-			if (action === "models") {
-				if (!query) {
-					ctx.ui.notify("Usage: /providers models <provider>", "warning");
-					return;
-				}
-				const provider = findProviders(query)[0];
-				if (!provider) {
-					ctx.ui.notify(`No provider matched "${query}". Run /providers list first.`, "warning");
-					return;
-				}
-				ctx.ui.notify(await renderProviderModels(provider, ctx), "info");
-				return;
-			}
-
-			ctx.ui.notify(renderStatus(ctx), "info");
-		},
+			"Inspect, log in to, or refresh the OpenCode-backed multi-provider catalog: /providers, /providers:status, /providers:list [query], /providers:info <provider>, /providers:models <provider>, /providers:login [provider], /providers:refresh-models [provider|all]",
+		handler: handleProvidersCommand,
 	});
+
+	const aliases: Array<{ name: string; subcommand: string; description: string }> = [
+		{ name: "providers:status", subcommand: "status", description: "Show multi-provider catalog status." },
+		{ name: "providers:list", subcommand: "list", description: "List supported providers and environment variables." },
+		{
+			name: "providers:login",
+			subcommand: "login",
+			description: "Open the provider picker and log in with an API key.",
+		},
+		{
+			name: "providers:info",
+			subcommand: "info",
+			description: "Inspect one provider's API mode, URLs, env vars, and model count.",
+		},
+		{
+			name: "providers:models",
+			subcommand: "models",
+			description: "List the current or fallback model catalog for one provider.",
+		},
+		{
+			name: "providers:refresh-models",
+			subcommand: "refresh-models",
+			description: "Refresh configured providers from live discovery when possible.",
+		},
+	];
+
+	for (const alias of aliases) {
+		pi.registerCommand(alias.name, {
+			description: alias.description,
+			handler: (args, ctx) => handleProvidersCommand(args ? `${alias.subcommand} ${args}` : alias.subcommand, ctx),
+		});
+	}
 }
 
 // biome-ignore lint/complexity/noExcessiveCognitiveComplexity: Refresh handling branches clearly by stored credential vs env configuration paths.
@@ -218,7 +252,7 @@ function renderStatus(ctx: ProviderStatusContext): string {
 
 	if (configured.length === 0) {
 		lines.push("No provider from this package is configured yet.");
-		lines.push("Tip: run /providers login to open the paged provider picker, then use /providers refresh-models.");
+		lines.push("Tip: run /providers:login to open the paged provider picker, then use /providers:refresh-models.");
 		return lines.join("\n");
 	}
 
@@ -234,7 +268,7 @@ function renderStatus(ctx: ProviderStatusContext): string {
 	}
 
 	if (configured.length > 20) {
-		lines.push(`…and ${configured.length - 20} more. Run /providers list to inspect everything.`);
+		lines.push(`…and ${configured.length - 20} more. Run /providers:list to inspect everything.`);
 	}
 
 	return lines.join("\n");
@@ -279,7 +313,7 @@ async function renderProviderModels(
 	const currentModels = credential ? getCredentialModels(credential) : (runtimeState.models.get(provider.id) ?? []);
 	const models = currentModels.length > 0 ? currentModels : await getCatalogModels(provider).catch(() => []);
 	if (models.length === 0) {
-		return `${provider.id} has no discovered models yet. Configure it, then run /providers refresh-models ${provider.id}.`;
+		return `${provider.id} has no discovered models yet. Configure it, then run /providers:refresh-models ${provider.id}.`;
 	}
 
 	return [
@@ -355,7 +389,7 @@ async function resolveProviderSelection(
 ): Promise<SupportedProviderDefinition | null> {
 	const matchedProviders = query ? findProviders(query) : SUPPORTED_PROVIDERS;
 	if (matchedProviders.length === 0) {
-		ctx.ui.notify(`No provider matched "${query}". Run /providers list first.`, "warning");
+		ctx.ui.notify(`No provider matched "${query}". Run /providers:list first.`, "warning");
 		return null;
 	}
 
@@ -380,6 +414,7 @@ async function selectProviderFromOverlay(
 				? {
 						title: "Provider search",
 						placeholder: "Type a provider id or name",
+						useCustomOverlay: true,
 						getOptions(query) {
 							if (!query) {
 								return options;

--- a/packages/providers/index.ts
+++ b/packages/providers/index.ts
@@ -64,75 +64,75 @@ function registerProvider(pi: ExtensionAPI, provider: SupportedProviderDefinitio
 }
 
 function registerProvidersCommand(pi: ExtensionAPI): void {
-	// biome-ignore lint/complexity/noExcessiveCognitiveComplexity: Explicit subcommand routing keeps provider actions readable.
-	const handleProvidersCommand = async (args: string, ctx: ProviderCommandContext): Promise<void> => {
-		const trimmed = args.trim();
-		const [rawAction = "status", ...rest] = trimmed ? trimmed.split(/\s+/) : ["status"];
-		const action = rawAction.toLowerCase();
-		const query = rest.join(" ").trim();
-
-		if (action === "login") {
-			const provider = await resolveProviderSelection(query, ctx);
-			if (!provider) {
-				return;
-			}
-			await loginProviderFromCommand(pi, ctx, provider);
-			return;
-		}
-
-		if (action === "refresh-models") {
-			const providers = query && query.toLowerCase() !== "all" ? findProviders(query) : SUPPORTED_PROVIDERS;
-			if (providers.length === 0) {
-				ctx.ui.notify(`No provider matched "${query}". Run /providers:list first.`, "warning");
-				return;
-			}
-			const refreshed = await refreshProviders(pi, ctx, providers);
-			ctx.modelRegistry.refresh?.();
-			ctx.ui.notify(renderRefreshSummary(refreshed, providers.length), "info");
-			return;
-		}
-
-		if (action === "list") {
-			ctx.ui.notify(renderProviderList(query), "info");
-			return;
-		}
-
-		if (action === "info") {
-			if (!query) {
-				ctx.ui.notify("Usage: /providers:info <provider>", "warning");
-				return;
-			}
-			const provider = findProviders(query)[0];
-			if (!provider) {
-				ctx.ui.notify(`No provider matched "${query}". Run /providers:list first.`, "warning");
-				return;
-			}
-			ctx.ui.notify(await renderProviderInfo(provider, ctx), "info");
-			return;
-		}
-
-		if (action === "models") {
-			if (!query) {
-				ctx.ui.notify("Usage: /providers:models <provider>", "warning");
-				return;
-			}
-			const provider = findProviders(query)[0];
-			if (!provider) {
-				ctx.ui.notify(`No provider matched "${query}". Run /providers:list first.`, "warning");
-				return;
-			}
-			ctx.ui.notify(await renderProviderModels(provider, ctx), "info");
-			return;
-		}
-
-		ctx.ui.notify(renderStatus(ctx), "info");
-	};
-
-	pi.registerCommand("providers", {
+	const providersCommand = {
 		description:
 			"Inspect, log in to, or refresh the OpenCode-backed multi-provider catalog: /providers, /providers:status, /providers:list [query], /providers:info <provider>, /providers:models <provider>, /providers:login [provider], /providers:refresh-models [provider|all]",
-		handler: handleProvidersCommand,
-	});
+		// biome-ignore lint/complexity/noExcessiveCognitiveComplexity: This explicit command router keeps each provider subcommand readable.
+		async handler(args: string, ctx: ExtensionCommandContext) {
+			const trimmed = args.trim();
+			const [rawAction = "status", ...rest] = trimmed ? trimmed.split(/\s+/) : ["status"];
+			const action = rawAction.toLowerCase();
+			const query = rest.join(" ").trim();
+
+			if (action === "login") {
+				const provider = await resolveProviderSelection(query, ctx);
+				if (!provider) {
+					return;
+				}
+				await loginProviderFromCommand(pi, ctx, provider);
+				return;
+			}
+
+			if (action === "refresh-models") {
+				const providers = query && query.toLowerCase() !== "all" ? findProviders(query) : SUPPORTED_PROVIDERS;
+				if (providers.length === 0) {
+					ctx.ui.notify(`No provider matched "${query}". Run /providers:list first.`, "warning");
+					return;
+				}
+				const refreshed = await refreshProviders(pi, ctx, providers);
+				ctx.modelRegistry.refresh?.();
+				ctx.ui.notify(renderRefreshSummary(refreshed, providers.length), "info");
+				return;
+			}
+
+			if (action === "list") {
+				ctx.ui.notify(renderProviderList(query), "info");
+				return;
+			}
+
+			if (action === "info") {
+				if (!query) {
+					ctx.ui.notify("Usage: /providers:info <provider>", "warning");
+					return;
+				}
+				const provider = findProviders(query)[0];
+				if (!provider) {
+					ctx.ui.notify(`No provider matched "${query}". Run /providers:list first.`, "warning");
+					return;
+				}
+				ctx.ui.notify(await renderProviderInfo(provider, ctx), "info");
+				return;
+			}
+
+			if (action === "models") {
+				if (!query) {
+					ctx.ui.notify("Usage: /providers:models <provider>", "warning");
+					return;
+				}
+				const provider = findProviders(query)[0];
+				if (!provider) {
+					ctx.ui.notify(`No provider matched "${query}". Run /providers:list first.`, "warning");
+					return;
+				}
+				ctx.ui.notify(await renderProviderModels(provider, ctx), "info");
+				return;
+			}
+
+			ctx.ui.notify(renderStatus(ctx), "info");
+		},
+	};
+
+	pi.registerCommand("providers", providersCommand);
 
 	const aliases: Array<{ name: string; subcommand: string; description: string }> = [
 		{ name: "providers:status", subcommand: "status", description: "Show multi-provider catalog status." },
@@ -162,7 +162,8 @@ function registerProvidersCommand(pi: ExtensionAPI): void {
 	for (const alias of aliases) {
 		pi.registerCommand(alias.name, {
 			description: alias.description,
-			handler: (args, ctx) => handleProvidersCommand(args ? `${alias.subcommand} ${args}` : alias.subcommand, ctx),
+			handler: (args: string, ctx: ExtensionCommandContext) =>
+				providersCommand.handler(args ? `${alias.subcommand} ${args}` : alias.subcommand, ctx),
 		});
 	}
 }
@@ -414,7 +415,6 @@ async function selectProviderFromOverlay(
 				? {
 						title: "Provider search",
 						placeholder: "Type a provider id or name",
-						useCustomOverlay: true,
 						getOptions(query) {
 							if (!query) {
 								return options;

--- a/packages/providers/tests/index.test.ts
+++ b/packages/providers/tests/index.test.ts
@@ -222,8 +222,57 @@ describe("provider catalog extension", () => {
 
 		await command.handler("refresh-models missing-provider", harness.ctx);
 		expect(harness.notifications.at(-1)).toEqual({
-			msg: 'No provider matched "missing-provider". Run /providers list first.',
+			msg: 'No provider matched "missing-provider". Run /providers:list first.',
 			type: "warning",
 		});
+	});
+
+	it("shows colon-style usage and status hints for alias commands", async () => {
+		const harness = createExtensionHarness();
+		harness.ctx.modelRegistry = {
+			authStorage: {
+				get: vi.fn(() => undefined),
+				set: vi.fn(),
+			},
+			refresh: vi.fn(),
+		} as never;
+		providerCatalogExtension(harness.pi as never);
+
+		await harness.commands.get("providers:info")?.handler?.("", harness.ctx as never);
+		expect(harness.notifications.at(-1)?.msg).toContain("Usage: /providers:info <provider>");
+
+		await harness.commands.get("providers:info")?.handler?.("does-not-exist", harness.ctx as never);
+		expect(harness.notifications.at(-1)?.msg).toContain('No provider matched "does-not-exist".');
+
+		await harness.commands.get("providers:models")?.handler?.("", harness.ctx as never);
+		expect(harness.notifications.at(-1)?.msg).toContain("Usage: /providers:models <provider>");
+
+		vi.stubGlobal(
+			"fetch",
+			vi.fn(() => {
+				throw new Error("catalog unavailable");
+			}) as never,
+		);
+		await harness.commands.get("providers:models")?.handler?.("openai", harness.ctx as never);
+		expect(harness.notifications.at(-1)?.msg).toContain("/providers:refresh-models openai");
+
+		await harness.commands.get("providers:models")?.handler?.("does-not-exist", harness.ctx as never);
+		expect(harness.notifications.at(-1)?.msg).toContain('No provider matched "does-not-exist".');
+
+		await harness.commands.get("providers:login")?.handler?.("does-not-exist", harness.ctx as never);
+		expect(harness.notifications.at(-1)?.msg).toContain("Run /providers:list first.");
+
+		await harness.commands.get("providers:refresh-models")?.handler?.("does-not-exist", harness.ctx as never);
+		expect(harness.notifications.at(-1)?.msg).toContain("Run /providers:list first.");
+
+		await harness.commands.get("providers:status")?.handler?.("", harness.ctx as never);
+		expect(harness.notifications.at(-1)?.msg).toContain("/providers:login");
+		expect(harness.notifications.at(-1)?.msg).toContain("/providers:refresh-models");
+
+		for (const provider of SUPPORTED_PROVIDERS) {
+			process.env[provider.env[0] ?? `${provider.id.toUpperCase()}_API_KEY`] = "configured";
+		}
+		await harness.commands.get("providers:status")?.handler?.("", harness.ctx as never);
+		expect(harness.notifications.at(-1)?.msg).toContain("…and");
 	});
 });

--- a/packages/providers/tests/index.test.ts
+++ b/packages/providers/tests/index.test.ts
@@ -141,8 +141,9 @@ describe("provider catalog extension", () => {
 		harness.ctx.ui.input = vi.fn(async () => "provider-api-key") as never;
 
 		providerCatalogExtension(harness.pi as never);
-		const command = harness.commands.get("providers");
-		await command.handler("login", harness.ctx);
+		expect(harness.commands.has("providers:login")).toBe(true);
+		const command = harness.commands.get("providers:login");
+		await command.handler("", harness.ctx);
 
 		expect(harness.ctx.ui.select).not.toHaveBeenCalled();
 		expect(harness.ctx.ui.custom).toHaveBeenCalledWith(expect.any(Function), {

--- a/packages/providers/tests/smoke.test.ts
+++ b/packages/providers/tests/smoke.test.ts
@@ -8,5 +8,6 @@ describe("provider catalog smoke tests", () => {
 		providerCatalogExtension(harness.pi as never);
 
 		expect(harness.commands.has("providers")).toBe(true);
+		expect(harness.commands.has("providers:login")).toBe(true);
 	});
 });

--- a/packages/shared-qna/qna-tui.ts
+++ b/packages/shared-qna/qna-tui.ts
@@ -23,6 +23,7 @@ function getPiTui() {
 		Editor: new (tui: TUI, theme: EditorTheme) => {
 			disableSubmit?: boolean;
 			onChange?: () => void;
+			focused?: boolean;
 			setText: (text: string) => void;
 			getText: () => string;
 			render: (width: number) => string[];
@@ -254,6 +255,7 @@ export class QnATuiComponent<TQuestion extends QnAQuestion> implements Component
 	private editor: {
 		disableSubmit?: boolean;
 		onChange?: () => void;
+		focused?: boolean;
 		setText: (text: string) => void;
 		getText: () => string;
 		render: (width: number) => string[];
@@ -284,6 +286,16 @@ export class QnATuiComponent<TQuestion extends QnAQuestion> implements Component
 	private green = (s: string) => s;
 	private yellow = (s: string) => s;
 	private gray = (s: string) => s;
+	private _focused = false;
+
+	get focused(): boolean {
+		return this._focused;
+	}
+
+	set focused(value: boolean) {
+		this._focused = value;
+		this.editor.focused = value;
+	}
 
 	constructor(
 		questions: TQuestion[],

--- a/packages/shared-qna/qna-tui.ts
+++ b/packages/shared-qna/qna-tui.ts
@@ -23,7 +23,6 @@ function getPiTui() {
 		Editor: new (tui: TUI, theme: EditorTheme) => {
 			disableSubmit?: boolean;
 			onChange?: () => void;
-			focused?: boolean;
 			setText: (text: string) => void;
 			getText: () => string;
 			render: (width: number) => string[];
@@ -255,7 +254,6 @@ export class QnATuiComponent<TQuestion extends QnAQuestion> implements Component
 	private editor: {
 		disableSubmit?: boolean;
 		onChange?: () => void;
-		focused?: boolean;
 		setText: (text: string) => void;
 		getText: () => string;
 		render: (width: number) => string[];
@@ -286,16 +284,6 @@ export class QnATuiComponent<TQuestion extends QnAQuestion> implements Component
 	private green = (s: string) => s;
 	private yellow = (s: string) => s;
 	private gray = (s: string) => s;
-	private _focused = false;
-
-	get focused(): boolean {
-		return this._focused;
-	}
-
-	set focused(value: boolean) {
-		this._focused = value;
-		this.editor.focused = value;
-	}
 
 	constructor(
 		questions: TQuestion[],

--- a/packages/shared-qna/scroll-select.ts
+++ b/packages/shared-qna/scroll-select.ts
@@ -2,16 +2,6 @@ import { requirePiTuiModule } from "./pi-tui-loader.js";
 
 let cachedPiTui:
 	| {
-			Input: new () => {
-				onSubmit?: (value: string) => void;
-				onEscape?: () => void;
-				focused?: boolean;
-				setValue: (value: string) => void;
-				getValue: () => string;
-				handleInput: (data: string) => void;
-				render: (width: number) => string[];
-				invalidate?: () => void;
-			};
 			Key: {
 				enter: string;
 				escape: string;
@@ -32,16 +22,6 @@ function getPiTui() {
 	}
 
 	cachedPiTui = requirePiTuiModule() as {
-		Input: new () => {
-			onSubmit?: (value: string) => void;
-			onEscape?: () => void;
-			focused?: boolean;
-			setValue: (value: string) => void;
-			getValue: () => string;
-			handleInput: (data: string) => void;
-			render: (width: number) => string[];
-			invalidate?: () => void;
-		};
 		Key: {
 			enter: string;
 			escape: string;
@@ -67,7 +47,6 @@ export interface ScrollSelectSearchConfig<T> {
 	placeholder?: string;
 	getOptions: (query: string) => Promise<ScrollSelectOption<T>[]> | ScrollSelectOption<T>[];
 	emptyMessage?: (query: string) => string;
-	useCustomOverlay?: boolean;
 }
 
 export interface ScrollSelectConfig<T> {
@@ -87,9 +66,7 @@ type ScrollSelectUi = {
 		factory: (tui: { requestRender: () => void }, theme: ScrollSelectTheme, keybindings: unknown, done: (value: T) => void) => {
 			render: (width: number) => string[];
 			handleInput: (data: string) => void;
-			invalidate?: () => void;
 			dispose?: () => void;
-			focused?: boolean;
 		},
 		options?: unknown,
 	) => Promise<T>;
@@ -103,77 +80,12 @@ type ScrollSelectTheme = {
 	bold: (text: string) => string;
 };
 
-class ScrollSelectSearchPromptComponent {
-	readonly width = 72;
-
-	private readonly input = new (getPiTui().Input)();
-	private _focused = false;
-
-	get focused(): boolean {
-		return this._focused;
-	}
-
-	set focused(value: boolean) {
-		this._focused = value;
-		this.input.focused = value;
-	}
-
-	constructor(
-		private readonly theme: ScrollSelectTheme,
-		private readonly title: string,
-		private readonly placeholder: string | undefined,
-		initialValue: string,
-		private readonly done: (value: string | null) => void,
-	) {
-		this.input.setValue(initialValue);
-		this.input.onSubmit = (value) => this.done(value);
-		this.input.onEscape = () => this.done(null);
-	}
-
-	render(width: number): string[] {
-		const { truncateToWidth, wrapTextWithAnsi } = getPiTui();
-		const safeWidth = Math.max(24, Math.min(width, this.width));
-		const bodyWidth = Math.max(20, safeWidth - 2);
-		const lines: string[] = [];
-
-		for (const line of this.title.split("\n")) {
-			for (const wrapped of wrapTextWithAnsi(this.theme.bold(line), bodyWidth)) {
-				lines.push(truncateToWidth(wrapped, bodyWidth));
-			}
-		}
-
-		if (this.placeholder?.trim()) {
-			lines.push("");
-			for (const wrapped of wrapTextWithAnsi(this.theme.fg("dim", this.placeholder), bodyWidth)) {
-				lines.push(truncateToWidth(wrapped, bodyWidth));
-			}
-		}
-
-		lines.push("");
-		for (const line of this.input.render(bodyWidth)) {
-			lines.push(truncateToWidth(line, bodyWidth));
-		}
-		lines.push("");
-		lines.push(truncateToWidth(this.theme.fg("dim", "[enter] apply • [esc] cancel"), bodyWidth));
-		return lines;
-	}
-
-	handleInput(data: string): void {
-		this.input.handleInput(data);
-	}
-
-	invalidate(): void {
-		this.input.invalidate?.();
-	}
-
-	dispose(): void {}
-}
-
 class ScrollSelectComponent<T> {
+	focused = false;
+
 	private readonly tui: { requestRender: () => void };
 	private readonly theme: ScrollSelectTheme;
 	private readonly done: (value: T | null) => void;
-	private readonly custom: ScrollSelectUi["custom"];
 	private readonly input: ScrollSelectUi["input"];
 	private readonly notify: ScrollSelectUi["notify"];
 	private readonly baseOptions: ScrollSelectOption<T>[];
@@ -182,8 +94,6 @@ class ScrollSelectComponent<T> {
 	private readonly emptyMessage: string;
 	private readonly maxVisibleOptions: number;
 	private readonly search?: ScrollSelectSearchConfig<T>;
-
-	focused = false;
 
 	private options: ScrollSelectOption<T>[];
 	private cursorIndex: number;
@@ -196,7 +106,6 @@ class ScrollSelectComponent<T> {
 			tui: { requestRender: () => void };
 			theme: ScrollSelectTheme;
 			done: (value: T | null) => void;
-			custom: ScrollSelectUi["custom"];
 			input: ScrollSelectUi["input"];
 			notify: ScrollSelectUi["notify"];
 		},
@@ -204,7 +113,6 @@ class ScrollSelectComponent<T> {
 		this.tui = dependencies.tui;
 		this.theme = dependencies.theme;
 		this.done = dependencies.done;
-		this.custom = dependencies.custom;
 		this.input = dependencies.input;
 		this.notify = dependencies.notify;
 		this.baseOptions = [...config.options];
@@ -344,81 +252,38 @@ class ScrollSelectComponent<T> {
 	}
 
 	private async promptSearch(): Promise<void> {
-		if (!this.search || this.searching) {
+		if (!this.search || typeof this.input !== "function" || this.searching) {
 			return;
-		}
-
-		const raw = await this.openSearchPrompt();
-		if (raw === null || raw === undefined) {
-			return;
-		}
-
-		await this.applySearchQuery(raw.trim());
-	}
-
-	private async openSearchPrompt(): Promise<string | null | undefined> {
-		const search = this.search;
-		if (!search) {
-			return null;
-		}
-
-		if (search.useCustomOverlay && typeof this.custom === "function") {
-			this.searching = true;
-			try {
-				return await this.custom<string | null>(
-					(_tui, theme, _keybindings, done) =>
-						new ScrollSelectSearchPromptComponent(
-							theme,
-							search.title,
-							this.searchQuery || search.placeholder,
-							this.searchQuery,
-							done,
-						),
-					{
-						overlay: true,
-						overlayOptions: {
-							anchor: "center",
-							width: 72,
-							maxHeight: 10,
-						},
-					},
-				);
-			} finally {
-				this.searching = false;
-			}
-		}
-
-		if (typeof this.input !== "function") {
-			return null;
 		}
 
 		this.searching = true;
 		try {
-			return await this.input(search.title, this.searchQuery || search.placeholder);
+			const raw = await this.input(this.search.title, this.searchQuery || this.search.placeholder);
+			if (raw === null || raw === undefined) {
+				return;
+			}
+
+			const query = raw.trim();
+			if (query === this.searchQuery) {
+				return;
+			}
+
+			const nextOptions = await this.search.getOptions(query);
+			if (nextOptions.length === 0) {
+				this.notify?.(
+					this.search.emptyMessage?.(query) ?? `No option matched ${query ? `"${query}"` : "the current filter"}.`,
+					"warning",
+				);
+				return;
+			}
+
+			this.searchQuery = query;
+			this.options = [...nextOptions];
+			this.cursorIndex = 0;
+			this.tui.requestRender();
 		} finally {
 			this.searching = false;
 		}
-	}
-
-	private async applySearchQuery(query: string): Promise<void> {
-		const search = this.search;
-		if (!search || query === this.searchQuery) {
-			return;
-		}
-
-		const nextOptions = await search.getOptions(query);
-		if (nextOptions.length === 0) {
-			this.notify?.(
-				search.emptyMessage?.(query) ?? `No option matched ${query ? `"${query}"` : "the current filter"}.`,
-				"warning",
-			);
-			return;
-		}
-
-		this.searchQuery = query;
-		this.options = [...nextOptions];
-		this.cursorIndex = 0;
-		this.tui.requestRender();
 	}
 }
 
@@ -449,7 +314,6 @@ export async function openScrollableSelect<T>(ui: ScrollSelectUi, config: Scroll
 				tui,
 				theme,
 				done,
-				custom: ui.custom,
 				input: ui.input,
 				notify: ui.notify,
 			}),

--- a/packages/shared-qna/scroll-select.ts
+++ b/packages/shared-qna/scroll-select.ts
@@ -2,6 +2,16 @@ import { requirePiTuiModule } from "./pi-tui-loader.js";
 
 let cachedPiTui:
 	| {
+			Input: new () => {
+				onSubmit?: (value: string) => void;
+				onEscape?: () => void;
+				focused?: boolean;
+				setValue: (value: string) => void;
+				getValue: () => string;
+				handleInput: (data: string) => void;
+				render: (width: number) => string[];
+				invalidate?: () => void;
+			};
 			Key: {
 				enter: string;
 				escape: string;
@@ -22,6 +32,16 @@ function getPiTui() {
 	}
 
 	cachedPiTui = requirePiTuiModule() as {
+		Input: new () => {
+			onSubmit?: (value: string) => void;
+			onEscape?: () => void;
+			focused?: boolean;
+			setValue: (value: string) => void;
+			getValue: () => string;
+			handleInput: (data: string) => void;
+			render: (width: number) => string[];
+			invalidate?: () => void;
+		};
 		Key: {
 			enter: string;
 			escape: string;
@@ -47,6 +67,7 @@ export interface ScrollSelectSearchConfig<T> {
 	placeholder?: string;
 	getOptions: (query: string) => Promise<ScrollSelectOption<T>[]> | ScrollSelectOption<T>[];
 	emptyMessage?: (query: string) => string;
+	useCustomOverlay?: boolean;
 }
 
 export interface ScrollSelectConfig<T> {
@@ -66,7 +87,9 @@ type ScrollSelectUi = {
 		factory: (tui: { requestRender: () => void }, theme: ScrollSelectTheme, keybindings: unknown, done: (value: T) => void) => {
 			render: (width: number) => string[];
 			handleInput: (data: string) => void;
+			invalidate?: () => void;
 			dispose?: () => void;
+			focused?: boolean;
 		},
 		options?: unknown,
 	) => Promise<T>;
@@ -80,10 +103,77 @@ type ScrollSelectTheme = {
 	bold: (text: string) => string;
 };
 
+class ScrollSelectSearchPromptComponent {
+	readonly width = 72;
+
+	private readonly input = new (getPiTui().Input)();
+	private _focused = false;
+
+	get focused(): boolean {
+		return this._focused;
+	}
+
+	set focused(value: boolean) {
+		this._focused = value;
+		this.input.focused = value;
+	}
+
+	constructor(
+		private readonly theme: ScrollSelectTheme,
+		private readonly title: string,
+		private readonly placeholder: string | undefined,
+		initialValue: string,
+		private readonly done: (value: string | null) => void,
+	) {
+		this.input.setValue(initialValue);
+		this.input.onSubmit = (value) => this.done(value);
+		this.input.onEscape = () => this.done(null);
+	}
+
+	render(width: number): string[] {
+		const { truncateToWidth, wrapTextWithAnsi } = getPiTui();
+		const safeWidth = Math.max(24, Math.min(width, this.width));
+		const bodyWidth = Math.max(20, safeWidth - 2);
+		const lines: string[] = [];
+
+		for (const line of this.title.split("\n")) {
+			for (const wrapped of wrapTextWithAnsi(this.theme.bold(line), bodyWidth)) {
+				lines.push(truncateToWidth(wrapped, bodyWidth));
+			}
+		}
+
+		if (this.placeholder?.trim()) {
+			lines.push("");
+			for (const wrapped of wrapTextWithAnsi(this.theme.fg("dim", this.placeholder), bodyWidth)) {
+				lines.push(truncateToWidth(wrapped, bodyWidth));
+			}
+		}
+
+		lines.push("");
+		for (const line of this.input.render(bodyWidth)) {
+			lines.push(truncateToWidth(line, bodyWidth));
+		}
+		lines.push("");
+		lines.push(truncateToWidth(this.theme.fg("dim", "[enter] apply • [esc] cancel"), bodyWidth));
+		return lines;
+	}
+
+	handleInput(data: string): void {
+		this.input.handleInput(data);
+	}
+
+	invalidate(): void {
+		this.input.invalidate?.();
+	}
+
+	dispose(): void {}
+}
+
 class ScrollSelectComponent<T> {
 	private readonly tui: { requestRender: () => void };
 	private readonly theme: ScrollSelectTheme;
 	private readonly done: (value: T | null) => void;
+	private readonly custom: ScrollSelectUi["custom"];
 	private readonly input: ScrollSelectUi["input"];
 	private readonly notify: ScrollSelectUi["notify"];
 	private readonly baseOptions: ScrollSelectOption<T>[];
@@ -92,6 +182,8 @@ class ScrollSelectComponent<T> {
 	private readonly emptyMessage: string;
 	private readonly maxVisibleOptions: number;
 	private readonly search?: ScrollSelectSearchConfig<T>;
+
+	focused = false;
 
 	private options: ScrollSelectOption<T>[];
 	private cursorIndex: number;
@@ -104,6 +196,7 @@ class ScrollSelectComponent<T> {
 			tui: { requestRender: () => void };
 			theme: ScrollSelectTheme;
 			done: (value: T | null) => void;
+			custom: ScrollSelectUi["custom"];
 			input: ScrollSelectUi["input"];
 			notify: ScrollSelectUi["notify"];
 		},
@@ -111,6 +204,7 @@ class ScrollSelectComponent<T> {
 		this.tui = dependencies.tui;
 		this.theme = dependencies.theme;
 		this.done = dependencies.done;
+		this.custom = dependencies.custom;
 		this.input = dependencies.input;
 		this.notify = dependencies.notify;
 		this.baseOptions = [...config.options];
@@ -204,6 +298,8 @@ class ScrollSelectComponent<T> {
 		}
 	}
 
+	invalidate(): void {}
+
 	dispose(): void {}
 
 	private footerText(): string {
@@ -248,38 +344,75 @@ class ScrollSelectComponent<T> {
 	}
 
 	private async promptSearch(): Promise<void> {
-		if (!this.search || typeof this.input !== "function" || this.searching) {
+		if (!this.search || this.searching) {
 			return;
+		}
+
+		const raw = await this.openSearchPrompt();
+		if (raw === null || raw === undefined) {
+			return;
+		}
+
+		await this.applySearchQuery(raw.trim());
+	}
+
+	private async openSearchPrompt(): Promise<string | null | undefined> {
+		if (this.search?.useCustomOverlay && typeof this.custom === "function") {
+			this.searching = true;
+			try {
+				return await this.custom<string | null>(
+					(_tui, theme, _keybindings, done) =>
+						new ScrollSelectSearchPromptComponent(
+							theme,
+							this.search.title,
+							this.searchQuery || this.search.placeholder,
+							this.searchQuery,
+							done,
+						),
+					{
+						overlay: true,
+						overlayOptions: {
+							anchor: "center",
+							width: 72,
+							maxHeight: 10,
+						},
+					},
+				);
+			} finally {
+				this.searching = false;
+			}
+		}
+
+		if (typeof this.input !== "function") {
+			return null;
 		}
 
 		this.searching = true;
 		try {
-			const raw = await this.input(this.search.title, this.searchQuery || this.search.placeholder);
-			if (raw === null || raw === undefined) {
-				return;
-			}
-
-			const query = raw.trim();
-			if (query === this.searchQuery) {
-				return;
-			}
-
-			const nextOptions = await this.search.getOptions(query);
-			if (nextOptions.length === 0) {
-				this.notify?.(
-					this.search.emptyMessage?.(query) ?? `No option matched ${query ? `"${query}"` : "the current filter"}.`,
-					"warning",
-				);
-				return;
-			}
-
-			this.searchQuery = query;
-			this.options = [...nextOptions];
-			this.cursorIndex = 0;
-			this.tui.requestRender();
+			return await this.input(this.search.title, this.searchQuery || this.search.placeholder);
 		} finally {
 			this.searching = false;
 		}
+	}
+
+	private async applySearchQuery(query: string): Promise<void> {
+		if (!this.search || query === this.searchQuery) {
+			return;
+		}
+
+		const nextOptions = await this.search.getOptions(query);
+		if (nextOptions.length === 0) {
+			this.notify?.(
+				this.search.emptyMessage?.(query) ?? `No option matched ${query ? `"${query}"` : "the current filter"}.`,
+				"warning",
+			);
+			return;
+		}
+
+		this.searchQuery = query;
+		this.options = [...nextOptions];
+		this.cursorIndex = 0;
+		this.tui.requestRender();
 	}
 }
 
@@ -310,6 +443,7 @@ export async function openScrollableSelect<T>(ui: ScrollSelectUi, config: Scroll
 				tui,
 				theme,
 				done,
+				custom: ui.custom,
 				input: ui.input,
 				notify: ui.notify,
 			}),

--- a/packages/shared-qna/scroll-select.ts
+++ b/packages/shared-qna/scroll-select.ts
@@ -357,15 +357,20 @@ class ScrollSelectComponent<T> {
 	}
 
 	private async openSearchPrompt(): Promise<string | null | undefined> {
-		if (this.search?.useCustomOverlay && typeof this.custom === "function") {
+		const search = this.search;
+		if (!search) {
+			return null;
+		}
+
+		if (search.useCustomOverlay && typeof this.custom === "function") {
 			this.searching = true;
 			try {
 				return await this.custom<string | null>(
 					(_tui, theme, _keybindings, done) =>
 						new ScrollSelectSearchPromptComponent(
 							theme,
-							this.search.title,
-							this.searchQuery || this.search.placeholder,
+							search.title,
+							this.searchQuery || search.placeholder,
 							this.searchQuery,
 							done,
 						),
@@ -389,21 +394,22 @@ class ScrollSelectComponent<T> {
 
 		this.searching = true;
 		try {
-			return await this.input(this.search.title, this.searchQuery || this.search.placeholder);
+			return await this.input(search.title, this.searchQuery || search.placeholder);
 		} finally {
 			this.searching = false;
 		}
 	}
 
 	private async applySearchQuery(query: string): Promise<void> {
-		if (!this.search || query === this.searchQuery) {
+		const search = this.search;
+		if (!search || query === this.searchQuery) {
 			return;
 		}
 
-		const nextOptions = await this.search.getOptions(query);
+		const nextOptions = await search.getOptions(query);
 		if (nextOptions.length === 0) {
 			this.notify?.(
-				this.search.emptyMessage?.(query) ?? `No option matched ${query ? `"${query}"` : "the current filter"}.`,
+				search.emptyMessage?.(query) ?? `No option matched ${query ? `"${query}"` : "the current filter"}.`,
 				"warning",
 			);
 			return;

--- a/packages/shared-qna/tests/scroll-select.test.ts
+++ b/packages/shared-qna/tests/scroll-select.test.ts
@@ -2,44 +2,6 @@ import { beforeEach, describe, expect, it, vi } from "vitest";
 
 vi.mock("../pi-tui-loader.js", () => ({
 	requirePiTuiModule: () => ({
-		Input: class MockInput {
-			value = "";
-			focused = false;
-			onSubmit?: (value: string) => void;
-			onEscape?: () => void;
-
-			setValue(value: string) {
-				this.value = value;
-			}
-
-			getValue() {
-				return this.value;
-			}
-
-			handleInput(data: string) {
-				if (data === "<enter>") {
-					this.onSubmit?.(this.value);
-					return;
-				}
-				if (data === "<escape>") {
-					this.onEscape?.();
-					return;
-				}
-				if (data === "<backspace>") {
-					this.value = this.value.slice(0, -1);
-					return;
-				}
-				if (data.length === 1) {
-					this.value += data;
-				}
-			}
-
-			render(_width: number) {
-				return [`> ${this.value}`];
-			}
-
-			invalidate() {}
-		},
 		Key: {
 			enter: "<enter>",
 			escape: "<escape>",
@@ -293,50 +255,6 @@ describe("openScrollableSelect", () => {
 		await flushAsyncWork();
 
 		expect(getOptions).toHaveBeenCalledTimes(1);
-	});
-
-	it("supports overlay-based search prompts without losing the picker", async () => {
-		const { ui, buildComponent } = createFactoryRunner();
-
-		await openScrollableSelect(ui, {
-			title: "Provider login",
-			options: [
-				{ value: "alpha", label: "Alpha" },
-				{ value: "beta", label: "Beta" },
-				{ value: "gamma", label: "Gamma" },
-			],
-			search: {
-				title: "Provider search",
-				placeholder: "Type a provider id or name",
-				useCustomOverlay: true,
-				getOptions(query) {
-					const all = [
-						{ value: "alpha", label: "Alpha" },
-						{ value: "beta", label: "Beta" },
-						{ value: "gamma", label: "Gamma" },
-					];
-					return all.filter((option) => option.label.toLowerCase().includes(query.toLowerCase()));
-				},
-			},
-		});
-
-		const component = buildComponent();
-		component.handleInput("/");
-		await flushAsyncWork(2);
-
-		expect(ui.custom).toHaveBeenCalledTimes(2);
-		const prompt = buildComponent(1);
-		prompt.handleInput("b");
-		prompt.handleInput("e");
-		prompt.handleInput("t");
-		prompt.handleInput("a");
-		prompt.handleInput("<enter>");
-		await flushAsyncWork();
-
-		const rendered = component.render(60).join("\n");
-		expect(ui.input).not.toHaveBeenCalled();
-		expect(rendered).toContain("Filter: beta");
-		expect(rendered).toContain("Beta");
 	});
 
 	it("handles enter and escape shortcuts", async () => {

--- a/packages/shared-qna/tests/scroll-select.test.ts
+++ b/packages/shared-qna/tests/scroll-select.test.ts
@@ -2,6 +2,44 @@ import { beforeEach, describe, expect, it, vi } from "vitest";
 
 vi.mock("../pi-tui-loader.js", () => ({
 	requirePiTuiModule: () => ({
+		Input: class MockInput {
+			value = "";
+			focused = false;
+			onSubmit?: (value: string) => void;
+			onEscape?: () => void;
+
+			setValue(value: string) {
+				this.value = value;
+			}
+
+			getValue() {
+				return this.value;
+			}
+
+			handleInput(data: string) {
+				if (data === "<enter>") {
+					this.onSubmit?.(this.value);
+					return;
+				}
+				if (data === "<escape>") {
+					this.onEscape?.();
+					return;
+				}
+				if (data === "<backspace>") {
+					this.value = this.value.slice(0, -1);
+					return;
+				}
+				if (data.length === 1) {
+					this.value += data;
+				}
+			}
+
+			render(_width: number) {
+				return [`> ${this.value}`];
+			}
+
+			invalidate() {}
+		},
 		Key: {
 			enter: "<enter>",
 			escape: "<escape>",
@@ -18,7 +56,12 @@ vi.mock("../pi-tui-loader.js", () => ({
 
 import { openScrollableSelect, type ScrollSelectConfig } from "../scroll-select.js";
 
-type CustomFactory = (...args: any[]) => { render: (width: number) => string[]; handleInput: (data: string) => void };
+type CustomFactory = (...args: any[]) => {
+	render: (width: number) => string[];
+	handleInput: (data: string) => void;
+	invalidate?: () => void;
+	focused?: boolean;
+};
 
 function createTheme() {
 	return {
@@ -27,22 +70,35 @@ function createTheme() {
 	};
 }
 
+async function flushAsyncWork(turns = 4) {
+	for (let index = 0; index < turns; index++) {
+		await Promise.resolve();
+	}
+}
+
 function createFactoryRunner() {
-	let factory: CustomFactory | undefined;
+	const factories: CustomFactory[] = [];
+	const resolvers: Array<((value: unknown) => void) | undefined> = [];
 	const ui = {
 		custom: vi.fn(((nextFactory: CustomFactory) => {
-			factory = nextFactory;
-			return Promise.resolve(null);
+			const index = factories.push(nextFactory) - 1;
+			if (index === 0) {
+				return Promise.resolve(null);
+			}
+			return new Promise((resolve) => {
+				resolvers[index] = resolve;
+			});
 		}) as NonNullable<Parameters<typeof openScrollableSelect<string>>[0]["custom"]>),
 		input: vi.fn(async () => null),
 		notify: vi.fn(),
 	};
 
-	function buildComponent(done = vi.fn()) {
+	function buildComponent(index = 0, done?: (value: unknown) => void) {
+		const factory = factories[index];
 		if (!factory) {
-			throw new Error("Expected custom factory to be captured.");
+			throw new Error(`Expected custom factory at index ${index}.`);
 		}
-		return factory({ requestRender: vi.fn() }, createTheme(), {}, done);
+		return factory({ requestRender: vi.fn() }, createTheme(), {}, done ?? resolvers[index] ?? vi.fn());
 	}
 
 	return { ui, buildComponent };
@@ -178,8 +234,7 @@ describe("openScrollableSelect", () => {
 
 		const component = buildComponent();
 		component.handleInput("/");
-		await Promise.resolve();
-		await Promise.resolve();
+		await flushAsyncWork();
 		const rendered = component.render(60).join("\n");
 		expect(rendered).toContain("Filter: beta");
 		expect(rendered).toContain("Beta");
@@ -206,8 +261,7 @@ describe("openScrollableSelect", () => {
 
 		const component = buildComponent();
 		component.handleInput("/");
-		await Promise.resolve();
-		await Promise.resolve();
+		await flushAsyncWork();
 
 		expect(ui.notify).toHaveBeenCalledWith('No provider matched "zzz".', "warning");
 		const rendered = component.render(60).join("\n");
@@ -234,13 +288,55 @@ describe("openScrollableSelect", () => {
 
 		const component = buildComponent();
 		component.handleInput("/");
-		await Promise.resolve();
-		await Promise.resolve();
+		await flushAsyncWork();
 		component.handleInput("/");
-		await Promise.resolve();
-		await Promise.resolve();
+		await flushAsyncWork();
 
 		expect(getOptions).toHaveBeenCalledTimes(1);
+	});
+
+	it("supports overlay-based search prompts without losing the picker", async () => {
+		const { ui, buildComponent } = createFactoryRunner();
+
+		await openScrollableSelect(ui, {
+			title: "Provider login",
+			options: [
+				{ value: "alpha", label: "Alpha" },
+				{ value: "beta", label: "Beta" },
+				{ value: "gamma", label: "Gamma" },
+			],
+			search: {
+				title: "Provider search",
+				placeholder: "Type a provider id or name",
+				useCustomOverlay: true,
+				getOptions(query) {
+					const all = [
+						{ value: "alpha", label: "Alpha" },
+						{ value: "beta", label: "Beta" },
+						{ value: "gamma", label: "Gamma" },
+					];
+					return all.filter((option) => option.label.toLowerCase().includes(query.toLowerCase()));
+				},
+			},
+		});
+
+		const component = buildComponent();
+		component.handleInput("/");
+		await flushAsyncWork(2);
+
+		expect(ui.custom).toHaveBeenCalledTimes(2);
+		const prompt = buildComponent(1);
+		prompt.handleInput("b");
+		prompt.handleInput("e");
+		prompt.handleInput("t");
+		prompt.handleInput("a");
+		prompt.handleInput("<enter>");
+		await flushAsyncWork();
+
+		const rendered = component.render(60).join("\n");
+		expect(ui.input).not.toHaveBeenCalled();
+		expect(rendered).toContain("Filter: beta");
+		expect(rendered).toContain("Beta");
 	});
 
 	it("handles enter and escape shortcuts", async () => {
@@ -254,12 +350,12 @@ describe("openScrollableSelect", () => {
 		});
 
 		const done = vi.fn();
-		const component = buildComponent(done);
+		const component = buildComponent(0, done);
 		component.handleInput("<enter>");
 		expect(done).toHaveBeenCalledWith("alpha");
 
 		const cancel = vi.fn();
-		const cancelComponent = buildComponent(cancel);
+		const cancelComponent = buildComponent(0, cancel);
 		cancelComponent.handleInput("<escape>");
 		expect(cancel).toHaveBeenCalledWith(null);
 	});

--- a/packages/spec/README.md
+++ b/packages/spec/README.md
@@ -38,7 +38,7 @@ In practice that means:
 1. **Requirements come first**
    - You write or refine a spec before planning and implementation.
 2. **The workflow is explicit**
-   - `/spec specify`, `/spec plan`, `/spec tasks`, `/spec implement` are separate steps with clear outputs.
+   - `/spec:specify`, `/spec:plan`, `/spec:tasks`, `/spec:implement` are separate steps with clear outputs.
 3. **The repository owns the workflow state**
    - Important artifacts live in normal files in your repo, not in hidden runtime state.
 4. **Pi stays in control of the work**
@@ -54,7 +54,7 @@ The design goals for `@ifi/pi-spec` are:
 - **Spec-kit compatibility of concepts** — keep the same major phases and familiar artifact layout
 - **Type-safe implementation** — perform repo detection, path calculation, and branch generation in TypeScript
 - **Idempotent scaffolding** — create missing files without constantly overwriting local customizations
-- **Low surprise** — make state visible through files and `/spec status`
+- **Low surprise** — make state visible through files and `/spec:status`
 - **Good defaults, flexible templates** — ship usable templates while letting projects evolve them
 
 ## Non-goals
@@ -120,7 +120,7 @@ I chose **one command with subcommands** instead of many top-level commands like
    - `/spec ...` keeps the command surface organized.
 
 3. **It is easier to discover**
-   - `/spec help`, `/spec status`, and `/spec next` make the system self-explanatory.
+   - `/spec:help`, `/spec:status`, and `/spec:next` make the system self-explanatory.
    - Users only need to remember one root command.
 
 4. **It preserves upstream familiarity without copying the shell UX**
@@ -156,19 +156,19 @@ Below is the practical contract for each subcommand.
 
 | Command | Purpose | Model handoff | Filesystem side effects |
 | --- | --- | --- | --- |
-| `/spec` or `/spec status` | Show current workflow state | No | None |
-| `/spec help` | Show available commands and guidance | No | None |
-| `/spec init` | Create the base workflow scaffold | No | Creates missing `.specify/` files |
-| `/spec constitution [principles]` | Create or revise the project constitution | Yes | Ensures base scaffold exists |
-| `/spec specify <feature description>` | Create the next numbered feature workspace | Yes | Ensures scaffold, creates `specs/###-.../`, may create/switch git branch |
-| `/spec clarify [focus]` | Ask and resolve high-impact ambiguities in the active spec | Yes | Ensures scaffold exists |
-| `/spec checklist [domain]` | Generate or refine requirement-quality checklists | Yes | Ensures scaffold exists |
-| `/spec plan [technical context]` | Build the implementation plan and design artifacts | Yes | Ensures scaffold, creates `plan.md` if missing |
-| `/spec tasks [context]` | Generate an executable `tasks.md` | Yes | Ensures scaffold exists |
-| `/spec analyze [focus]` | Run a read-only consistency review | Yes | Ensures scaffold exists |
-| `/spec implement [focus]` | Execute tasks and update completion state | Yes | Ensures scaffold exists; prompts if checklists are incomplete |
-| `/spec list` | List known feature directories | No | None |
-| `/spec next` | Show the next recommended step | No | None |
+| `/spec` or `/spec:status` | Show current workflow state | No | None |
+| `/spec:help` | Show available commands and guidance | No | None |
+| `/spec:init` | Create the base workflow scaffold | No | Creates missing `.specify/` files |
+| `/spec:constitution [principles]` | Create or revise the project constitution | Yes | Ensures base scaffold exists |
+| `/spec:specify <feature description>` | Create the next numbered feature workspace | Yes | Ensures scaffold, creates `specs/###-.../`, may create/switch git branch |
+| `/spec:clarify [focus]` | Ask and resolve high-impact ambiguities in the active spec | Yes | Ensures scaffold exists |
+| `/spec:checklist [domain]` | Generate or refine requirement-quality checklists | Yes | Ensures scaffold exists |
+| `/spec:plan [technical context]` | Build the implementation plan and design artifacts | Yes | Ensures scaffold, creates `plan.md` if missing |
+| `/spec:tasks [context]` | Generate an executable `tasks.md` | Yes | Ensures scaffold exists |
+| `/spec:analyze [focus]` | Run a read-only consistency review | Yes | Ensures scaffold exists |
+| `/spec:implement [focus]` | Execute tasks and update completion state | Yes | Ensures scaffold exists; prompts if checklists are incomplete |
+| `/spec:list` | List known feature directories | No | None |
+| `/spec:next` | Show the next recommended step | No | None |
 
 ### Input rules
 
@@ -177,16 +177,16 @@ The command accepts **freeform text** after the subcommand.
 Examples:
 
 ```bash
-/spec constitution Security-first, testable, low-complexity defaults
-/spec specify Add usage-based billing alerts for workspace admins
-/spec plan Use TypeScript, Vitest, and direct pi tool access
-/spec analyze Focus on contradictions between spec.md and tasks.md
-/spec implement Start with the MVP story and update tasks as you go
+/spec:constitution Security-first, testable, low-complexity defaults
+/spec:specify Add usage-based billing alerts for workspace admins
+/spec:plan Use TypeScript, Vitest, and direct pi tool access
+/spec:analyze Focus on contradictions between spec.md and tasks.md
+/spec:implement Start with the MVP story and update tasks as you go
 ```
 
 Notes:
 
-- `/spec specify` effectively requires a real feature description.
+- `/spec:specify` effectively requires a real feature description.
 - Other workflow steps accept freeform guidance and can also run with minimal or no extra guidance.
 - When pi has UI input capabilities available, the extension can prompt for missing input instead of failing immediately.
 
@@ -208,7 +208,7 @@ This keeps the common path simple while still working in multi-feature repos.
 
 ### Base workflow scaffold
 
-`/spec init` creates the base workflow scaffold if it is missing.
+`/spec:init` creates the base workflow scaffold if it is missing.
 
 ```text
 .specify/
@@ -245,7 +245,7 @@ What these are for:
 
 ### Per-feature workspace
 
-`/spec specify <description>` creates a numbered feature workspace:
+`/spec:specify <description>` creates a numbered feature workspace:
 
 ```text
 specs/
@@ -264,8 +264,8 @@ Not every file exists immediately.
 
 Current behavior:
 
-- `spec.md` is scaffolded during `/spec specify`
-- `plan.md` is scaffolded during `/spec plan` if it is missing
+- `spec.md` is scaffolded during `/spec:specify`
+- `plan.md` is scaffolded during `/spec:plan` if it is missing
 - other files are referenced by the workflow and created as the step needs them
 
 ### Idempotency rules
@@ -285,7 +285,7 @@ That is important because the package should seed a workflow, not keep fighting 
 ### 1) Initialize the workflow
 
 ```bash
-/spec init
+/spec:init
 ```
 
 Use this when introducing the workflow to a repo for the first time.
@@ -300,7 +300,7 @@ What happens:
 ### 2) Define the project's constitution
 
 ```bash
-/spec constitution Security-first, testable, backwards-compatible changes by default
+/spec:constitution Security-first, testable, backwards-compatible changes by default
 ```
 
 Use this to establish the rules the workflow should follow.
@@ -314,7 +314,7 @@ Typical outcomes:
 ### 3) Create a feature spec
 
 ```bash
-/spec specify Add SSO login for enterprise tenants
+/spec:specify Add SSO login for enterprise tenants
 ```
 
 What happens:
@@ -331,13 +331,13 @@ This is the key step that turns a vague idea into a concrete feature workspace.
 ### 4) Clarify open questions
 
 ```bash
-/spec clarify
+/spec:clarify
 ```
 
 or
 
 ```bash
-/spec clarify Focus on tenant boundaries, auth edge cases, and failure states
+/spec:clarify Focus on tenant boundaries, auth edge cases, and failure states
 ```
 
 This step is meant to remove the highest-impact ambiguities before planning.
@@ -345,7 +345,7 @@ This step is meant to remove the highest-impact ambiguities before planning.
 ### 5) Generate a requirement-quality checklist
 
 ```bash
-/spec checklist Authentication quality gates
+/spec:checklist Authentication quality gates
 ```
 
 This is not supposed to generate implementation TODOs. It is meant to verify that the spec is precise,
@@ -354,7 +354,7 @@ complete, and testable.
 ### 6) Build the implementation plan
 
 ```bash
-/spec plan Use TypeScript, Vitest, and existing auth services; avoid new infrastructure
+/spec:plan Use TypeScript, Vitest, and existing auth services; avoid new infrastructure
 ```
 
 What happens:
@@ -366,13 +366,13 @@ What happens:
 ### 7) Generate tasks
 
 ```bash
-/spec tasks
+/spec:tasks
 ```
 
 or
 
 ```bash
-/spec tasks Prioritize the MVP path and keep tasks grouped by user story
+/spec:tasks Prioritize the MVP path and keep tasks grouped by user story
 ```
 
 This step should produce a `tasks.md` with a strict checkbox-oriented execution plan.
@@ -380,7 +380,7 @@ This step should produce a `tasks.md` with a strict checkbox-oriented execution 
 ### 8) Analyze for contradictions
 
 ```bash
-/spec analyze
+/spec:analyze
 ```
 
 This step is intentionally read-only. It is there to catch inconsistencies between the spec, plan,
@@ -389,13 +389,13 @@ checklists, and tasks before coding begins.
 ### 9) Implement
 
 ```bash
-/spec implement
+/spec:implement
 ```
 
 or
 
 ```bash
-/spec implement Start with story 1, update tasks.md as each item completes
+/spec:implement Start with story 1, update tasks.md as each item completes
 ```
 
 Behavior worth knowing:
@@ -407,31 +407,31 @@ Behavior worth knowing:
 ### 10) Inspect progress any time
 
 ```bash
-/spec status
-/spec next
-/spec list
+/spec:status
+/spec:next
+/spec:list
 ```
 
 Use these when you want visibility rather than action:
 
-- `/spec status` shows artifact presence, checklist summaries, current branch, and known features
-- `/spec next` recommends the next workflow command
-- `/spec list` lists all numbered feature directories in `specs/`
+- `/spec:status` shows artifact presence, checklist summaries, current branch, and known features
+- `/spec:next` recommends the next workflow command
+- `/spec:list` lists all numbered feature directories in `specs/`
 
 ---
 
 ## Example end-to-end session
 
 ```bash
-/spec init
-/spec constitution Security-first, testable, low-complexity defaults
-/spec specify Build a native spec workflow package for pi
-/spec clarify
-/spec checklist Requirements quality for the initial MVP
-/spec plan Use TypeScript, Vitest, and direct pi tool access
-/spec tasks Group work by independently testable user stories
-/spec analyze
-/spec implement
+/spec:init
+/spec:constitution Security-first, testable, low-complexity defaults
+/spec:specify Build a native spec workflow package for pi
+/spec:clarify
+/spec:checklist Requirements quality for the initial MVP
+/spec:plan Use TypeScript, Vitest, and direct pi tool access
+/spec:tasks Group work by independently testable user stories
+/spec:analyze
+/spec:implement
 ```
 
 That sequence is the intended happy path.

--- a/packages/spec/extension/index.ts
+++ b/packages/spec/extension/index.ts
@@ -116,7 +116,7 @@ async function resolveFeaturePaths(
 ): Promise<WorkflowPaths | undefined> {
 	const featureName = await resolveActiveFeatureName(ctx, repoRoot, currentBranch, hasGit);
 	if (!featureName) {
-		ctx.ui.notify("No active feature found. Run /spec specify <feature description> first.", "warning");
+		ctx.ui.notify("No active feature found. Run /spec:specify <feature description> first.", "warning");
 		return undefined;
 	}
 	return buildWorkflowPaths(repoRoot, featureName);
@@ -173,12 +173,12 @@ function handleInit(pi: ExtensionAPI, repoRoot: string, created: string[]): void
 	sendReport(
 		pi,
 		[
-			"# /spec init",
+			"# /spec:init",
 			"",
 			`- Repository root: ${repoRoot}`,
 			formatCreatedFiles(created),
 			"",
-			"Next: `/spec constitution <principles>` or `/spec specify <feature description>`.",
+			"Next: `/spec:constitution <principles>` or `/spec:specify <feature description>`.",
 		].join("\n"),
 	);
 }
@@ -228,7 +228,7 @@ function handleSpecify(
 	input: string,
 ): void {
 	if (!input) {
-		ctx.ui.notify("/spec specify requires a feature description.", "warning");
+		ctx.ui.notify("/spec:specify requires a feature description.", "warning");
 		return;
 	}
 
@@ -247,7 +247,7 @@ function handleSpecify(
 		sendReport(
 			pi,
 			[
-				"# /spec specify",
+				"# /spec:specify",
 				"",
 				`- Feature branch: ${prepared.branchName}`,
 				`- Feature number: ${prepared.featureNumber}`,
@@ -317,7 +317,7 @@ async function handleWorkflowStep(
 	}
 
 	queueWorkflow(pi, step, env.currentBranch, featurePaths, input);
-	ctx.ui.notify(`Queued /spec ${step} workflow.`, "info");
+	ctx.ui.notify(`Queued /spec:${step} workflow.`, "info");
 }
 
 export default function specExtension(pi: ExtensionAPI) {
@@ -326,9 +326,47 @@ export default function specExtension(pi: ExtensionAPI) {
 		return new Text(text, 0, 0);
 	});
 
+	const handleSpecCommand = async (rawArgs: string, ctx: ExtensionCommandContext): Promise<void> => {
+		const { subcommand, remainder } = tokenize(rawArgs);
+		if (!subcommand) {
+			ctx.ui.notify(`Unknown /spec subcommand: ${rawArgs.trim()}`, "warning");
+			sendReport(pi, formatHelpReport());
+			return;
+		}
+
+		const env = makeEnv(ctx);
+		if (subcommand === "init") {
+			handleInit(pi, env.repoRoot, ensureWorkflowScaffold(env.basePaths));
+			return;
+		}
+		if (subcommand === "help") {
+			sendReport(pi, formatHelpReport());
+			return;
+		}
+		if (subcommand === "list") {
+			sendReport(pi, formatFeatureList(env.repoRoot));
+			return;
+		}
+		if (subcommand === "status") {
+			await handleStatus(pi, ctx, env.repoRoot, env.currentBranch, env.hasGit);
+			return;
+		}
+		if (subcommand === "next") {
+			await handleNext(pi, ctx, env.repoRoot, env.currentBranch, env.hasGit);
+			return;
+		}
+		if (!isWorkflowStep(subcommand)) {
+			sendReport(pi, formatHelpReport());
+			return;
+		}
+
+		const input = await collectStepInput(ctx, subcommand, remainder);
+		await handleWorkflowStep(pi, ctx, env, subcommand, input);
+	};
+
 	pi.registerCommand("spec", {
 		description:
-			"Native spec-kit workflow for pi (/spec init|constitution|specify|clarify|checklist|plan|tasks|analyze|implement)",
+			"Native spec-kit workflow for pi (/spec:init|help|status|next|list|constitution|specify|clarify|checklist|plan|tasks|analyze|implement)",
 		getArgumentCompletions(prefix) {
 			const trimmed = prefix.trimStart();
 			if (trimmed.includes(" ")) {
@@ -340,42 +378,13 @@ export default function specExtension(pi: ExtensionAPI) {
 			}));
 			return values.length > 0 ? values : null;
 		},
-		handler: async (rawArgs, ctx) => {
-			const { subcommand, remainder } = tokenize(rawArgs);
-			if (!subcommand) {
-				ctx.ui.notify(`Unknown /spec subcommand: ${rawArgs.trim()}`, "warning");
-				sendReport(pi, formatHelpReport());
-				return;
-			}
-
-			const env = makeEnv(ctx);
-			if (subcommand === "init") {
-				handleInit(pi, env.repoRoot, ensureWorkflowScaffold(env.basePaths));
-				return;
-			}
-			if (subcommand === "help") {
-				sendReport(pi, formatHelpReport());
-				return;
-			}
-			if (subcommand === "list") {
-				sendReport(pi, formatFeatureList(env.repoRoot));
-				return;
-			}
-			if (subcommand === "status") {
-				await handleStatus(pi, ctx, env.repoRoot, env.currentBranch, env.hasGit);
-				return;
-			}
-			if (subcommand === "next") {
-				await handleNext(pi, ctx, env.repoRoot, env.currentBranch, env.hasGit);
-				return;
-			}
-			if (!isWorkflowStep(subcommand)) {
-				sendReport(pi, formatHelpReport());
-				return;
-			}
-
-			const input = await collectStepInput(ctx, subcommand, remainder);
-			await handleWorkflowStep(pi, ctx, env, subcommand, input);
-		},
+		handler: handleSpecCommand,
 	});
+
+	for (const subcommand of SPEC_SUBCOMMANDS) {
+		pi.registerCommand(`spec:${subcommand}`, {
+			description: `Alias for /spec:${subcommand}.`,
+			handler: (args, ctx) => handleSpecCommand(args ? `${subcommand} ${args}` : subcommand, ctx),
+		});
+	}
 }

--- a/packages/spec/extension/index.ts
+++ b/packages/spec/extension/index.ts
@@ -247,7 +247,7 @@ function handleSpecify(
 		sendReport(
 			pi,
 			[
-				"# /spec:specify",
+				"# /spec specify",
 				"",
 				`- Feature branch: ${prepared.branchName}`,
 				`- Feature number: ${prepared.featureNumber}`,
@@ -326,48 +326,10 @@ export default function specExtension(pi: ExtensionAPI) {
 		return new Text(text, 0, 0);
 	});
 
-	const handleSpecCommand = async (rawArgs: string, ctx: ExtensionCommandContext): Promise<void> => {
-		const { subcommand, remainder } = tokenize(rawArgs);
-		if (!subcommand) {
-			ctx.ui.notify(`Unknown /spec subcommand: ${rawArgs.trim()}`, "warning");
-			sendReport(pi, formatHelpReport());
-			return;
-		}
-
-		const env = makeEnv(ctx);
-		if (subcommand === "init") {
-			handleInit(pi, env.repoRoot, ensureWorkflowScaffold(env.basePaths));
-			return;
-		}
-		if (subcommand === "help") {
-			sendReport(pi, formatHelpReport());
-			return;
-		}
-		if (subcommand === "list") {
-			sendReport(pi, formatFeatureList(env.repoRoot));
-			return;
-		}
-		if (subcommand === "status") {
-			await handleStatus(pi, ctx, env.repoRoot, env.currentBranch, env.hasGit);
-			return;
-		}
-		if (subcommand === "next") {
-			await handleNext(pi, ctx, env.repoRoot, env.currentBranch, env.hasGit);
-			return;
-		}
-		if (!isWorkflowStep(subcommand)) {
-			sendReport(pi, formatHelpReport());
-			return;
-		}
-
-		const input = await collectStepInput(ctx, subcommand, remainder);
-		await handleWorkflowStep(pi, ctx, env, subcommand, input);
-	};
-
-	pi.registerCommand("spec", {
+	const specCommand = {
 		description:
-			"Native spec-kit workflow for pi (/spec:init|help|status|next|list|constitution|specify|clarify|checklist|plan|tasks|analyze|implement)",
-		getArgumentCompletions(prefix) {
+			"Native spec-kit workflow for pi (/spec:init|constitution|specify|clarify|checklist|plan|tasks|analyze|implement)",
+		getArgumentCompletions(prefix: string) {
 			const trimmed = prefix.trimStart();
 			if (trimmed.includes(" ")) {
 				return null;
@@ -378,13 +340,51 @@ export default function specExtension(pi: ExtensionAPI) {
 			}));
 			return values.length > 0 ? values : null;
 		},
-		handler: handleSpecCommand,
-	});
+		handler: async (rawArgs: string, ctx: ExtensionCommandContext) => {
+			const { subcommand, remainder } = tokenize(rawArgs);
+			if (!subcommand) {
+				ctx.ui.notify(`Unknown /spec subcommand: ${rawArgs.trim()}`, "warning");
+				sendReport(pi, formatHelpReport());
+				return;
+			}
+
+			const env = makeEnv(ctx);
+			if (subcommand === "init") {
+				handleInit(pi, env.repoRoot, ensureWorkflowScaffold(env.basePaths));
+				return;
+			}
+			if (subcommand === "help") {
+				sendReport(pi, formatHelpReport());
+				return;
+			}
+			if (subcommand === "list") {
+				sendReport(pi, formatFeatureList(env.repoRoot));
+				return;
+			}
+			if (subcommand === "status") {
+				await handleStatus(pi, ctx, env.repoRoot, env.currentBranch, env.hasGit);
+				return;
+			}
+			if (subcommand === "next") {
+				await handleNext(pi, ctx, env.repoRoot, env.currentBranch, env.hasGit);
+				return;
+			}
+			if (!isWorkflowStep(subcommand)) {
+				sendReport(pi, formatHelpReport());
+				return;
+			}
+
+			const input = await collectStepInput(ctx, subcommand, remainder);
+			await handleWorkflowStep(pi, ctx, env, subcommand, input);
+		},
+	};
+
+	pi.registerCommand("spec", specCommand);
 
 	for (const subcommand of SPEC_SUBCOMMANDS) {
 		pi.registerCommand(`spec:${subcommand}`, {
 			description: `Alias for /spec:${subcommand}.`,
-			handler: (args, ctx) => handleSpecCommand(args ? `${subcommand} ${args}` : subcommand, ctx),
+			handler: (args, ctx) => specCommand.handler(args ? `${subcommand} ${args}` : subcommand, ctx),
 		});
 	}
 }

--- a/packages/spec/extension/scaffold.ts
+++ b/packages/spec/extension/scaffold.ts
@@ -9,17 +9,17 @@ This project uses the native pi spec workflow inspired by GitHub spec-kit.
 
 ## Core commands
 
-- /spec:init
-- /spec:constitution <principles>
-- /spec:specify <feature description>
-- /spec:clarify [focus]
-- /spec:checklist [domain]
-- /spec:plan <technical context>
-- /spec:tasks [context]
-- /spec:analyze [focus]
-- /spec:implement [focus]
-- /spec:status
-- /spec:next
+- /spec init
+- /spec constitution <principles>
+- /spec specify <feature description>
+- /spec clarify [focus]
+- /spec checklist [domain]
+- /spec plan <technical context>
+- /spec tasks [context]
+- /spec analyze [focus]
+- /spec implement [focus]
+- /spec status
+- /spec next
 
 ## Runtime notes
 
@@ -28,7 +28,7 @@ This project uses the native pi spec workflow inspired by GitHub spec-kit.
 - File templates live in .specify/templates/.
 - The native replacement for agent-specific context files is .specify/memory/pi-agent.md.
 - Feature artifacts live in specs/###-feature-name/.
-`;
+`.replaceAll("/spec ", "/spec:");
 
 const DEFAULT_EXTENSIONS_YML = `settings:
   auto_execute_hooks: true

--- a/packages/spec/extension/scaffold.ts
+++ b/packages/spec/extension/scaffold.ts
@@ -9,17 +9,17 @@ This project uses the native pi spec workflow inspired by GitHub spec-kit.
 
 ## Core commands
 
-- /spec init
-- /spec constitution <principles>
-- /spec specify <feature description>
-- /spec clarify [focus]
-- /spec checklist [domain]
-- /spec plan <technical context>
-- /spec tasks [context]
-- /spec analyze [focus]
-- /spec implement [focus]
-- /spec status
-- /spec next
+- /spec:init
+- /spec:constitution <principles>
+- /spec:specify <feature description>
+- /spec:clarify [focus]
+- /spec:checklist [domain]
+- /spec:plan <technical context>
+- /spec:tasks [context]
+- /spec:analyze [focus]
+- /spec:implement [focus]
+- /spec:status
+- /spec:next
 
 ## Runtime notes
 

--- a/packages/spec/extension/status.ts
+++ b/packages/spec/extension/status.ts
@@ -44,11 +44,11 @@ export function summarizeChecklists(checklistsDir?: string): ChecklistSummary[] 
 
 function nextStepsFor(paths: WorkflowPaths, initialized: boolean): string[] {
 	if (!initialized) {
-		return ["/spec init", "/spec constitution <principles>", "/spec specify <feature description>"];
+		return ["/spec:init", "/spec:constitution <principles>", "/spec:specify <feature description>"];
 	}
 
 	if (!(paths.featureDir && paths.featureSpec)) {
-		return ["/spec specify <feature description>", "/spec list"];
+		return ["/spec:specify <feature description>", "/spec:list"];
 	}
 
 	const steps: string[] = [];
@@ -59,25 +59,25 @@ function nextStepsFor(paths: WorkflowPaths, initialized: boolean): string[] {
 	const hasIncompleteChecklist = checklists.some((checklist) => checklist.incomplete > 0);
 
 	if (!specExists) {
-		steps.push("/spec specify <feature description>");
+		steps.push("/spec:specify <feature description>");
 		return steps;
 	}
 
-	steps.push("/spec clarify");
-	steps.push("/spec checklist quality");
+	steps.push("/spec:clarify");
+	steps.push("/spec:checklist quality");
 
 	if (!planExists) {
-		steps.push("/spec plan <technical context>");
+		steps.push("/spec:plan <technical context>");
 		return steps;
 	}
 
 	if (!tasksExist) {
-		steps.push("/spec tasks");
+		steps.push("/spec:tasks");
 		return steps;
 	}
 
-	steps.push("/spec analyze");
-	steps.push(hasIncompleteChecklist ? "/spec implement (after checklist review)" : "/spec implement");
+	steps.push("/spec:analyze");
+	steps.push(hasIncompleteChecklist ? "/spec:implement (after checklist review)" : "/spec:implement");
 
 	return steps;
 }
@@ -173,7 +173,7 @@ export function buildWorkflowStatus(options: {
 
 export function formatWorkflowStatus(status: WorkflowStatus): string {
 	const lines = [
-		"# /spec workflow status",
+		"# /spec:status",
 		"",
 		`- Repository root: ${status.repoRoot}`,
 		`- Initialized: ${status.initialized ? "yes" : "no"}`,
@@ -210,22 +210,22 @@ export function formatHelpReport(): string {
 	return [
 		"# Native /spec workflow",
 		"",
-		"Use `/spec` with one of these subcommands:",
+		"Use `/spec` or `/spec:<subcommand>` with one of these commands:",
 		"",
-		"- `/spec init` — scaffold `.specify/`, templates, and memory files",
-		"- `/spec constitution <principles>` — create or amend the project constitution",
-		"- `/spec specify <feature description>` — create a numbered feature branch and spec scaffold",
-		"- `/spec clarify [focus]` — resolve critical ambiguities in the active spec",
-		"- `/spec checklist [domain]` — generate a requirements-quality checklist",
-		"- `/spec plan <technical context>` — build the implementation plan and design artifacts",
-		"- `/spec tasks [context]` — derive an executable tasks.md ordered by user story",
-		"- `/spec analyze [focus]` — run a read-only cross-artifact consistency review",
-		"- `/spec implement [focus]` — execute the plan from tasks.md and mark completed tasks",
-		"- `/spec status` — show current workflow state",
-		"- `/spec next` — show the next recommended command",
-		"- `/spec list` — list all known feature directories",
+		"- `/spec:init` — scaffold `.specify/`, templates, and memory files",
+		"- `/spec:constitution <principles>` — create or amend the project constitution",
+		"- `/spec:specify <feature description>` — create a numbered feature branch and spec scaffold",
+		"- `/spec:clarify [focus]` — resolve critical ambiguities in the active spec",
+		"- `/spec:checklist [domain]` — generate a requirements-quality checklist",
+		"- `/spec:plan <technical context>` — build the implementation plan and design artifacts",
+		"- `/spec:tasks [context]` — derive an executable tasks.md ordered by user story",
+		"- `/spec:analyze [focus]` — run a read-only cross-artifact consistency review",
+		"- `/spec:implement [focus]` — execute the plan from tasks.md and mark completed tasks",
+		"- `/spec:status` — show current workflow state",
+		"- `/spec:next` — show the next recommended command",
+		"- `/spec:list` — list all known feature directories",
 		"",
-		"Tip: `/spec` with no arguments shows the current workflow status.",
+		"Tip: `/spec:status` shows the current workflow status.",
 	].join("\n");
 }
 

--- a/packages/spec/tests/index.test.ts
+++ b/packages/spec/tests/index.test.ts
@@ -93,25 +93,26 @@ describe("@ifi/pi-spec extension", () => {
 		specExtension(pi as any);
 
 		expect(pi.commands.has("spec")).toBe(true);
+		expect(pi.commands.has("spec:init")).toBe(true);
 		expect(pi.renderers.has("pi-spec-report")).toBe(true);
-		expect(pi.commands.get("spec")?.description).toContain("/spec init");
+		expect(pi.commands.get("spec")?.description).toContain("/spec:init");
 	});
 
-	it("/spec init scaffolds the workflow workspace and reports created files", async () => {
+	it("/spec:init scaffolds the workflow workspace and reports created files", async () => {
 		const repoRoot = createTempRepo("pi-spec-init");
 		const pi = createPiMock();
 		specExtension(pi as any);
 		const ctx = createCtx(repoRoot);
 
-		await pi.commands.get("spec")?.handler?.("init", ctx);
+		await pi.commands.get("spec:init")?.handler?.("", ctx);
 
 		expect(pi.sendMessage).toHaveBeenCalledTimes(1);
-		expect(String(pi.sendMessage.mock.calls[0][0].content)).toContain("/spec init");
+		expect(String(pi.sendMessage.mock.calls[0][0].content)).toContain("/spec:init");
 		expect(String(pi.sendMessage.mock.calls[0][0].content)).toContain("Created");
 		expect(existsSync(path.join(repoRoot, ".specify", "memory", "constitution.md"))).toBe(true);
 	});
 
-	it("/spec status does not auto-initialize an unprepared repository", async () => {
+	it("/spec:status does not auto-initialize an unprepared repository", async () => {
 		const repoRoot = createTempRepo("pi-spec-status-empty");
 		const pi = createPiMock();
 		specExtension(pi as any);
@@ -123,7 +124,7 @@ describe("@ifi/pi-spec extension", () => {
 		expect(String(pi.sendMessage.mock.calls[0][0].content)).toContain("- Initialized: no");
 	});
 
-	it("/spec status reports workflow state without triggering the model", async () => {
+	it("/spec:status reports workflow state without triggering the model", async () => {
 		const repoRoot = createTempRepo("pi-spec-status");
 		mkdirSync(path.join(repoRoot, "specs", "001-auth-flow"), { recursive: true });
 		writeFileSync(path.join(repoRoot, "specs", "001-auth-flow", "spec.md"), "# Feature Specification", "utf8");
@@ -142,11 +143,11 @@ describe("@ifi/pi-spec extension", () => {
 		await pi.commands.get("spec")?.handler?.("status", ctx);
 
 		expect(pi.sendUserMessage).not.toHaveBeenCalled();
-		expect(String(pi.sendMessage.mock.calls[0][0].content)).toContain("/spec workflow status");
+		expect(String(pi.sendMessage.mock.calls[0][0].content)).toContain("# /spec:status");
 		expect(String(pi.sendMessage.mock.calls[0][0].content)).toContain("001-auth-flow");
 	});
 
-	it("/spec specify prepares a feature workspace and queues the native workflow prompt", async () => {
+	it("/spec:specify prepares a feature workspace and queues the native workflow prompt", async () => {
 		const repoRoot = createTempRepo("pi-spec-specify");
 		mkdirSync(path.join(repoRoot, "specs", "002-existing-feature"), { recursive: true });
 		gitClientMock.listBranches.mockReturnValue(["001-first-feature"]);
@@ -167,7 +168,7 @@ describe("@ifi/pi-spec extension", () => {
 		expect(prompt).toContain("The native /spec runtime has already generated the feature number");
 	});
 
-	it("/spec plan scaffolds plan.md and references pi-agent.md in the queued prompt", async () => {
+	it("/spec:plan scaffolds plan.md and references pi-agent.md in the queued prompt", async () => {
 		const repoRoot = createTempRepo("pi-spec-plan");
 		mkdirSync(path.join(repoRoot, "specs", "001-auth-flow"), { recursive: true });
 		writeFileSync(path.join(repoRoot, "specs", "001-auth-flow", "spec.md"), "# Feature Specification", "utf8");
@@ -185,7 +186,7 @@ describe("@ifi/pi-spec extension", () => {
 		expect(prompt).toContain(path.join(repoRoot, ".specify", "templates", "commands", "plan.md"));
 	});
 
-	it("/spec implement stops when checklists are incomplete and the user declines to continue", async () => {
+	it("/spec:implement stops when checklists are incomplete and the user declines to continue", async () => {
 		const repoRoot = createTempRepo("pi-spec-implement");
 		const featureDir = path.join(repoRoot, "specs", "001-auth-flow");
 		mkdirSync(path.join(featureDir, "checklists"), { recursive: true });

--- a/packages/spec/tests/index.test.ts
+++ b/packages/spec/tests/index.test.ts
@@ -93,6 +93,7 @@ describe("@ifi/pi-spec extension", () => {
 		specExtension(pi as any);
 
 		expect(pi.commands.has("spec")).toBe(true);
+		expect(pi.commands.has("spec:help")).toBe(true);
 		expect(pi.commands.has("spec:init")).toBe(true);
 		expect(pi.renderers.has("pi-spec-report")).toBe(true);
 		expect(pi.commands.get("spec")?.description).toContain("/spec:init");
@@ -118,7 +119,7 @@ describe("@ifi/pi-spec extension", () => {
 		specExtension(pi as any);
 		const ctx = createCtx(repoRoot);
 
-		await pi.commands.get("spec")?.handler?.("status", ctx);
+		await pi.commands.get("spec:status")?.handler?.("", ctx);
 
 		expect(existsSync(path.join(repoRoot, ".specify"))).toBe(false);
 		expect(String(pi.sendMessage.mock.calls[0][0].content)).toContain("- Initialized: no");
@@ -140,11 +141,38 @@ describe("@ifi/pi-spec extension", () => {
 			},
 		});
 
-		await pi.commands.get("spec")?.handler?.("status", ctx);
+		await pi.commands.get("spec:status")?.handler?.("", ctx);
 
 		expect(pi.sendUserMessage).not.toHaveBeenCalled();
 		expect(String(pi.sendMessage.mock.calls[0][0].content)).toContain("# /spec:status");
 		expect(String(pi.sendMessage.mock.calls[0][0].content)).toContain("001-auth-flow");
+	});
+
+	it("/spec:specify warns when no feature description is provided", async () => {
+		const repoRoot = createTempRepo("pi-spec-specify-empty");
+		const pi = createPiMock();
+		specExtension(pi as any);
+		const ctx = createCtx(repoRoot);
+
+		await pi.commands.get("spec:specify")?.handler?.("", ctx);
+
+		expect(ctx.ui.notify).toHaveBeenCalledWith("/spec:specify requires a feature description.", "warning");
+		expect(pi.sendUserMessage).not.toHaveBeenCalled();
+	});
+
+	it("/spec:plan warns when there is no active feature", async () => {
+		const repoRoot = createTempRepo("pi-spec-plan-no-feature");
+		const pi = createPiMock();
+		specExtension(pi as any);
+		const ctx = createCtx(repoRoot);
+
+		await pi.commands.get("spec:plan")?.handler?.("Use TypeScript with Vitest", ctx);
+
+		expect(ctx.ui.notify).toHaveBeenCalledWith(
+			"No active feature found. Run /spec:specify <feature description> first.",
+			"warning",
+		);
+		expect(pi.sendUserMessage).not.toHaveBeenCalled();
 	});
 
 	it("/spec:specify prepares a feature workspace and queues the native workflow prompt", async () => {

--- a/packages/spec/tests/scaffold.test.ts
+++ b/packages/spec/tests/scaffold.test.ts
@@ -31,7 +31,18 @@ describe("workflow scaffold", () => {
 		expect(existsSync(paths.constitutionFile)).toBe(true);
 		expect(existsSync(paths.agentContextFile)).toBe(true);
 		expect(existsSync(path.join(paths.templatesDir, "commands", "specify.md"))).toBe(true);
-		expect(readFileSync(paths.workflowReadmeFile, "utf8")).toContain("/spec:plan");
+		const workflowReadme = readFileSync(paths.workflowReadmeFile, "utf8");
+		expect(workflowReadme).toContain("/spec:init");
+		expect(workflowReadme).toContain("/spec:constitution <principles>");
+		expect(workflowReadme).toContain("/spec:specify <feature description>");
+		expect(workflowReadme).toContain("/spec:clarify [focus]");
+		expect(workflowReadme).toContain("/spec:checklist [domain]");
+		expect(workflowReadme).toContain("/spec:plan <technical context>");
+		expect(workflowReadme).toContain("/spec:tasks [context]");
+		expect(workflowReadme).toContain("/spec:analyze [focus]");
+		expect(workflowReadme).toContain("/spec:implement [focus]");
+		expect(workflowReadme).toContain("/spec:status");
+		expect(workflowReadme).toContain("/spec:next");
 		expect(readFileSync(paths.extensionsConfigFile, "utf8")).toContain("auto_execute_hooks");
 	});
 

--- a/packages/spec/tests/scaffold.test.ts
+++ b/packages/spec/tests/scaffold.test.ts
@@ -31,7 +31,7 @@ describe("workflow scaffold", () => {
 		expect(existsSync(paths.constitutionFile)).toBe(true);
 		expect(existsSync(paths.agentContextFile)).toBe(true);
 		expect(existsSync(path.join(paths.templatesDir, "commands", "specify.md"))).toBe(true);
-		expect(readFileSync(paths.workflowReadmeFile, "utf8")).toContain("/spec plan");
+		expect(readFileSync(paths.workflowReadmeFile, "utf8")).toContain("/spec:plan");
 		expect(readFileSync(paths.extensionsConfigFile, "utf8")).toContain("auto_execute_hooks");
 	});
 

--- a/packages/spec/tests/smoke.test.ts
+++ b/packages/spec/tests/smoke.test.ts
@@ -8,6 +8,7 @@ describe("spec runtime smoke tests", () => {
 		specExtension(harness.pi as never);
 
 		expect(harness.commands.has("spec")).toBe(true);
+		expect(harness.commands.has("spec:status")).toBe(true);
 		expect(harness.messageRenderers.has("pi-spec-report")).toBe(true);
 	});
 });

--- a/packages/spec/tests/status.test.ts
+++ b/packages/spec/tests/status.test.ts
@@ -1,0 +1,128 @@
+import { mkdirSync, mkdtempSync, rmSync, writeFileSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { afterEach, describe, expect, it } from "vitest";
+import { buildWorkflowStatus, formatHelpReport, formatWorkflowStatus } from "../extension/status.js";
+import { buildWorkflowPaths } from "../extension/workspace.js";
+
+const tempDirs: string[] = [];
+
+function createTempDir(prefix: string): string {
+	const dir = mkdtempSync(join(tmpdir(), `${prefix}-`));
+	tempDirs.push(dir);
+	return dir;
+}
+
+afterEach(() => {
+	for (const dir of tempDirs.splice(0)) {
+		rmSync(dir, { recursive: true, force: true });
+	}
+});
+
+describe("spec status helpers", () => {
+	it("formats help output with colon-prefixed commands", () => {
+		const help = formatHelpReport();
+		expect(help).toContain("Use `/spec` or `/spec:<subcommand>` with one of these commands:");
+		expect(help).toContain("`/spec:init`");
+		expect(help).toContain("`/spec:constitution <principles>`");
+		expect(help).toContain("`/spec:specify <feature description>`");
+		expect(help).toContain("`/spec:clarify [focus]`");
+		expect(help).toContain("`/spec:checklist [domain]`");
+		expect(help).toContain("`/spec:plan <technical context>`");
+		expect(help).toContain("`/spec:tasks [context]`");
+		expect(help).toContain("`/spec:analyze [focus]`");
+		expect(help).toContain("`/spec:implement [focus]`");
+		expect(help).toContain("`/spec:status`");
+		expect(help).toContain("`/spec:next`");
+		expect(help).toContain("`/spec:list`");
+		expect(help).toContain("Tip: `/spec:status` shows the current workflow status.");
+	});
+
+	it("reports colon-prefixed next steps through the workflow lifecycle", () => {
+		const repoRoot = createTempDir("pi-spec-status");
+		const uninitializedPaths = buildWorkflowPaths(repoRoot);
+		const uninitialized = buildWorkflowStatus({
+			repoRoot,
+			currentBranch: "main",
+			paths: uninitializedPaths,
+		});
+		expect(uninitialized.nextSteps).toEqual([
+			"/spec:init",
+			"/spec:constitution <principles>",
+			"/spec:specify <feature description>",
+		]);
+
+		mkdirSync(join(repoRoot, ".specify"), { recursive: true });
+		const initializedWithoutFeature = buildWorkflowStatus({
+			repoRoot,
+			currentBranch: "main",
+			paths: uninitializedPaths,
+		});
+		expect(initializedWithoutFeature.nextSteps).toEqual(["/spec:specify <feature description>", "/spec:list"]);
+
+		const featurePaths = buildWorkflowPaths(repoRoot, "001-auth-flow");
+		mkdirSync(featurePaths.featureDir!, { recursive: true });
+		writeFileSync(featurePaths.featureSpec!, "# Feature Specification\n", "utf8");
+		const missingSpecPaths = buildWorkflowPaths(repoRoot, "002-missing-spec");
+		mkdirSync(missingSpecPaths.featureDir!, { recursive: true });
+		const missingSpec = buildWorkflowStatus({
+			repoRoot,
+			currentBranch: "002-missing-spec",
+			paths: missingSpecPaths,
+			activeFeature: "002-missing-spec",
+		});
+		expect(missingSpec.nextSteps).toEqual(["/spec:specify <feature description>"]);
+
+		const missingPlan = buildWorkflowStatus({
+			repoRoot,
+			currentBranch: "001-auth-flow",
+			paths: featurePaths,
+			activeFeature: "001-auth-flow",
+		});
+		expect(missingPlan.nextSteps).toEqual([
+			"/spec:clarify",
+			"/spec:checklist quality",
+			"/spec:plan <technical context>",
+		]);
+
+		writeFileSync(featurePaths.planFile!, "# Plan\n", "utf8");
+		const missingTasks = buildWorkflowStatus({
+			repoRoot,
+			currentBranch: "001-auth-flow",
+			paths: featurePaths,
+			activeFeature: "001-auth-flow",
+		});
+		expect(missingTasks.nextSteps).toEqual(["/spec:clarify", "/spec:checklist quality", "/spec:tasks"]);
+
+		writeFileSync(featurePaths.tasksFile!, "# Tasks\n", "utf8");
+		mkdirSync(featurePaths.checklistsDir!, { recursive: true });
+		writeFileSync(join(featurePaths.checklistsDir!, "quality.md"), "- [ ] CHK001\n", "utf8");
+		const incompleteChecklist = buildWorkflowStatus({
+			repoRoot,
+			currentBranch: "001-auth-flow",
+			paths: featurePaths,
+			activeFeature: "001-auth-flow",
+		});
+		expect(incompleteChecklist.nextSteps).toEqual([
+			"/spec:clarify",
+			"/spec:checklist quality",
+			"/spec:analyze",
+			"/spec:implement (after checklist review)",
+		]);
+
+		writeFileSync(join(featurePaths.checklistsDir!, "quality.md"), "- [x] CHK001\n", "utf8");
+		const completeChecklist = buildWorkflowStatus({
+			repoRoot,
+			currentBranch: "001-auth-flow",
+			paths: featurePaths,
+			activeFeature: "001-auth-flow",
+		});
+		expect(completeChecklist.nextSteps).toEqual([
+			"/spec:clarify",
+			"/spec:checklist quality",
+			"/spec:analyze",
+			"/spec:implement",
+		]);
+		expect(formatWorkflowStatus(completeChecklist)).toContain("# /spec:status");
+	});
+});


### PR DESCRIPTION
## Summary
- add colon-style subcommand aliases for provider, route, ollama, schedule, watchdog, and spec workflows while keeping the root commands working
- update package docs, workflow scaffold text, and tests to prefer the colon command form for discoverability and autocomplete
- keep provider picker search inside overlay UI so cancel/search input no longer drops focus back to the editor

## Testing
- pnpm check
- pnpm test
- pnpm typecheck