### PR TITLE
test(coverage): add fast integration coverage ratchet

### DIFF
--- a/.changeset/coverage-ratchet-integration-tests.md
+++ b/.changeset/coverage-ratchet-integration-tests.md
@@ -1,0 +1,5 @@
+---
+default: patch
+---
+
+Add focused coverage for the web server, remote access extension, core worktree helpers, CLI orchestration, provider command routing, shared Q&A TUI flows, and subagent execution paths, and enforce a 100% patch-coverage gate in CI while keeping the overall Codecov project target at 60% for now.

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -286,6 +286,8 @@ jobs:
       id-token: write
     steps:
       - uses: actions/checkout@v6.0.2
+        with:
+          fetch-depth: 0
 
       - uses: pnpm/action-setup@v4.4.0
 
@@ -301,6 +303,13 @@ jobs:
 
       - name: Run tests with coverage
         run: pnpm test:coverage
+
+      - name: Enforce 100% patch coverage
+        if: github.event_name == 'pull_request'
+        env:
+          BASE_SHA: ${{ github.event.pull_request.base.sha }}
+          HEAD_SHA: ${{ github.event.pull_request.head.sha }}
+        run: node ./scripts/check-patch-coverage.mjs --threshold 100 --lcov coverage/lcov.info
 
       - name: Upload coverage artifact
         uses: actions/upload-artifact@v4.6.2

--- a/codecov.yml
+++ b/codecov.yml
@@ -8,14 +8,14 @@ coverage:
   status:
     project:
       default:
-        target: auto
-        threshold: 1%
-        informational: true
+        target: 60%
+        threshold: 0%
+        informational: false
     patch:
       default:
-        target: auto
-        threshold: 1%
-        informational: true
+        target: 100%
+        threshold: 0%
+        informational: false
 
 comment:
   behavior: default

--- a/packages/ant-colony/tests/index.test.ts
+++ b/packages/ant-colony/tests/index.test.ts
@@ -399,6 +399,96 @@ describe("ant-colony extension commands", () => {
 		expect(resumeColonyMock).toHaveBeenCalledTimes(2);
 		expect(ctx._notifications.filter((n) => n.msg.includes("Resuming:")).length).toBe(2);
 	});
+
+	it("bg_colony_status requires explicit requests and rate limits manual snapshots", async () => {
+		const colonyCmd = pi._commands.get("colony");
+		await colonyCmd.handler("Manual status goal", ctx);
+
+		const statusTool = pi._tools.get("bg_colony_status");
+		const passive = await statusTool.execute("tool-1", {}, undefined, undefined, {
+			sessionManager: {
+				getBranch: () => [{ type: "message", message: { role: "user", content: "keep working" } }],
+			},
+		});
+		expect(passive.isError).toBe(true);
+		expect(passive.content[0]?.text).toContain("Passive mode is active");
+
+		const explicitCtx = {
+			sessionManager: {
+				getBranch: () => [{ type: "message", message: { role: "user", content: "show colony status now" } }],
+			},
+		};
+		const snapshot = await statusTool.execute("tool-2", {}, undefined, undefined, explicitCtx);
+		expect(snapshot.isError).toBeFalsy();
+		expect(snapshot.content[0]?.text).toContain("Manual status goal");
+		expect(snapshot.content[0]?.text).toContain("Workspace:");
+
+		const rateLimited = await statusTool.execute("tool-3", {}, undefined, undefined, explicitCtx);
+		expect(rateLimited.isError).toBe(true);
+		expect(rateLimited.content[0]?.text).toContain("Manual status snapshot is rate-limited");
+	});
+
+	it("ant_colony tool launches background colonies, renders summaries, and rejects missing models", async () => {
+		const antColonyTool = pi._tools.get("ant_colony");
+		const launched = await antColonyTool.execute(
+			"tool-1",
+			{ goal: "Tool-driven colony", maxAnts: 3, maxCost: 1 },
+			undefined,
+			undefined,
+			{
+				hasUI: true,
+				cwd,
+				model: { provider: "anthropic", id: "claude-sonnet-4" },
+				modelRegistry: undefined,
+				sessionManager: { getSessionFile: () => null },
+			},
+		);
+		expect(launched.content[0]?.text).toContain("[COLONY_SIGNAL:LAUNCHED]");
+		expect(launched.content[0]?.text).toContain("Tool-driven colony");
+
+		const theme = {
+			fg: (_color: string, text: string) => text,
+			bold: (text: string) => text,
+		};
+		const renderedCall = antColonyTool.renderCall({ goal: "Tool-driven colony", maxAnts: 3, maxCost: 1 }, theme);
+		expect(renderedCall.text).toContain("ant_colony");
+		expect(renderedCall.text).toContain("×3");
+		expect(renderedCall.text).toContain("$1");
+
+		const renderedResult = antColonyTool.renderResult(launched, {}, theme);
+		expect(renderedResult.children).toHaveLength(3);
+		expect(renderedResult.children[0]?.text).toContain("Colony launched in background");
+
+		const missingModel = await antColonyTool.execute("tool-2", { goal: "No model" }, undefined, undefined, {
+			hasUI: false,
+			cwd,
+			model: undefined,
+		});
+		expect(missingModel.isError).toBe(true);
+		expect(missingModel.content[0]?.text).toContain("no model available");
+	});
+
+	it("registers progress and report message renderers", () => {
+		const progressRenderer = pi.registerMessageRenderer.mock.calls.find(
+			(call) => call[0] === "ant-colony-progress",
+		)?.[1];
+		const reportRenderer = pi.registerMessageRenderer.mock.calls.find((call) => call[0] === "ant-colony-report")?.[1];
+		const theme = {
+			fg: (_color: string, text: string) => text,
+			bold: (text: string) => text,
+		};
+
+		const progress = progressRenderer?.({ content: "[COLONY_SIGNAL:FAILED] colony failed loudly" }, theme);
+		expect(progress?.text).toContain("failed");
+		expect(progress?.text).toContain("colony failed loudly");
+
+		const report = reportRenderer?.(
+			{ content: "done\n**Duration:** 4s\n- ✅ Completed task\n- input: 20\n- output: 10" },
+			theme,
+		);
+		expect(report.children.length).toBeGreaterThan(0);
+		expect(report.children[0]?.text).toContain("Ant Colony Report");
+	});
 });
 
 describe("index-level telemetry propagation", () => {

--- a/packages/ant-colony/tests/queen.test.ts
+++ b/packages/ant-colony/tests/queen.test.ts
@@ -3,6 +3,14 @@ import * as os from "node:os";
 import * as path from "node:path";
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 
+const childProcessMocks = vi.hoisted(() => ({
+	execFileSync: vi.fn(),
+}));
+
+vi.mock("node:child_process", () => ({
+	execFileSync: childProcessMocks.execFileSync,
+}));
+
 vi.mock("@mariozechner/pi-coding-agent", () => ({
 	AuthStorage: class {},
 	createAgentSession: vi.fn(),
@@ -30,6 +38,7 @@ import {
 	makeColonyId,
 	quorumMergeTasks,
 	resolveReviewTypecheckInvocation,
+	runReviewTypecheck,
 	shouldUseScoutQuorum,
 	validateExecutionPlan,
 } from "../extensions/ant-colony/queen.js";
@@ -159,6 +168,12 @@ describe("validateExecutionPlan", () => {
 });
 
 describe("createUsageLimitsTracker", () => {
+	it("returns a no-op tracker when no event bus is provided", () => {
+		const tracker = createUsageLimitsTracker();
+		expect(tracker.requestSnapshot()).toBeNull();
+		expect(() => tracker.dispose()).not.toThrow();
+	});
+
 	it("supports event buses without off()", () => {
 		const handlers: Array<(data: unknown) => void> = [];
 		const bus = {
@@ -229,6 +244,31 @@ describe("review typecheck helpers", () => {
 		fs.rmSync(root, { recursive: true, force: true });
 	});
 
+	it("prefers the nearest nested project when multiple configs exist", () => {
+		const root = fs.mkdtempSync(path.join(os.tmpdir(), "queen-typecheck-nested-"));
+		const packageDir = path.join(root, "packages", "feature");
+		const srcDir = path.join(packageDir, "src");
+		fs.mkdirSync(srcDir, { recursive: true });
+		fs.writeFileSync(path.join(root, "tsconfig.json"), "{}", "utf-8");
+		fs.writeFileSync(path.join(packageDir, "tsconfig.json"), "{}", "utf-8");
+
+		const projects = collectReviewTypecheckProjects(root, [mkTask({ files: ["packages/feature/src/index.ts"] })]);
+
+		expect(projects).toEqual([path.join(packageDir, "tsconfig.json")]);
+		fs.rmSync(root, { recursive: true, force: true });
+	});
+
+	it("falls back to npx tsc when no local binary exists", () => {
+		const root = fs.mkdtempSync(path.join(os.tmpdir(), "queen-typecheck-npx-"));
+		fs.writeFileSync(path.join(root, "tsconfig.json"), "{}", "utf-8");
+
+		const invocation = resolveReviewTypecheckInvocation(root, [mkTask({ files: ["src/index.ts"] })]);
+
+		expect(invocation?.command).toBe("npx");
+		expect(invocation?.args.slice(0, 2)).toEqual(["tsc", "--noEmit"]);
+		fs.rmSync(root, { recursive: true, force: true });
+	});
+
 	it("prefers the local tsc binary when the workspace already has dependencies installed", () => {
 		const root = fs.mkdtempSync(path.join(os.tmpdir(), "queen-typecheck-local-bin-"));
 		fs.mkdirSync(path.join(root, "node_modules", ".bin"), { recursive: true });
@@ -239,6 +279,26 @@ describe("review typecheck helpers", () => {
 
 		expect(invocation?.command).toContain(path.join("node_modules", ".bin", "tsc"));
 		expect(invocation?.args).toContain(path.join(root, "tsconfig.json"));
+		fs.rmSync(root, { recursive: true, force: true });
+	});
+
+	it("returns true when typecheck succeeds and false when it fails", () => {
+		const root = fs.mkdtempSync(path.join(os.tmpdir(), "queen-typecheck-run-"));
+		fs.writeFileSync(path.join(root, "tsconfig.json"), "{}", "utf-8");
+
+		childProcessMocks.execFileSync.mockReturnValueOnce(Buffer.from("ok"));
+		expect(runReviewTypecheck(root, [mkTask({ files: ["src/index.ts"] })])).toBe(true);
+		expect(childProcessMocks.execFileSync).toHaveBeenCalledWith(
+			"npx",
+			expect.arrayContaining(["tsc", "--noEmit", "--project", path.join(root, "tsconfig.json")]),
+			expect.objectContaining({ cwd: root, stdio: "pipe" }),
+		);
+
+		childProcessMocks.execFileSync.mockImplementationOnce(() => {
+			throw new Error("boom");
+		});
+		expect(runReviewTypecheck(root, [mkTask({ files: ["src/index.ts"] })])).toBe(false);
+		expect(runReviewTypecheck(root, [mkTask({ files: ["README.md"] })])).toBe(true);
 		fs.rmSync(root, { recursive: true, force: true });
 	});
 });
@@ -312,6 +372,7 @@ let tmpDir: string;
 let nest: Nest;
 
 beforeEach(() => {
+	childProcessMocks.execFileSync.mockReset();
 	tmpDir = fs.mkdtempSync(path.join(os.tmpdir(), "queen-test-"));
 	nest = new Nest(tmpDir, "test-colony", { mode: "project" });
 	nest.init(mkState());

--- a/packages/cli/src/index.test.ts
+++ b/packages/cli/src/index.test.ts
@@ -4,28 +4,41 @@ const getLocale = vi.fn(() => "en");
 const selectLanguage = vi.fn(async () => undefined);
 const confirmApply = vi.fn(async () => undefined);
 const selectMode = vi.fn(async () => "quick");
+const selectPreset = vi.fn(async () => ({ agents: "preset-agent" }));
+const runConfigWizard = vi.fn(async (_env, initial) => ({ ...initial, providerMode: "custom", providers: [] }));
 const setupProviders = vi.fn(async () => ({ providers: [{ name: "openai", apiKey: "set" }], providerMode: "custom" }));
 const setupAdaptiveRouting = vi.fn(async () => ({ enabled: false }));
 const welcome = vi.fn();
 const detectEnv = vi.fn(async () => ({ existingProviders: ["anthropic"] }));
 
 vi.mock("@ifi/oh-pi-core", () => ({
-	EXTENSIONS: [],
+	EXTENSIONS: [
+		{ name: "git-guard", default: true },
+		{ name: "diagnostics", default: true },
+		{ name: "watchdog", default: false },
+	],
 	getLocale,
 	selectLanguage,
 }));
-vi.mock("./tui/config-wizard.js", () => ({ runConfigWizard: vi.fn() }));
+vi.mock("./tui/config-wizard.js", () => ({ runConfigWizard }));
 vi.mock("./tui/confirm-apply.js", () => ({ confirmApply }));
 vi.mock("./tui/mode-select.js", () => ({ selectMode }));
-vi.mock("./tui/preset-select.js", () => ({ selectPreset: vi.fn() }));
+vi.mock("./tui/preset-select.js", () => ({ selectPreset }));
 vi.mock("./tui/provider-setup.js", () => ({ setupProviders }));
 vi.mock("./tui/routing-setup.js", () => ({ setupAdaptiveRouting }));
 vi.mock("./tui/welcome.js", () => ({ welcome }));
 vi.mock("./utils/detect.js", () => ({ detectEnv }));
 
-describe("cli quick flow", () => {
+describe("cli setup flows", () => {
 	beforeEach(() => {
 		vi.clearAllMocks();
+		selectMode.mockResolvedValue("quick");
+		selectPreset.mockResolvedValue({ agents: "preset-agent" });
+		runConfigWizard.mockImplementation(async (_env, initial) => ({
+			...initial,
+			providerMode: "custom",
+			providers: [],
+		}));
 	});
 
 	it("includes diagnostics in the quick preset defaults", async () => {
@@ -45,5 +58,44 @@ describe("cli quick flow", () => {
 		);
 		expect(welcome).toHaveBeenCalled();
 		expect(selectLanguage).toHaveBeenCalled();
+	});
+
+	it("runs the preset flow through preset selection and the config wizard", async () => {
+		selectMode.mockResolvedValue("preset");
+		runConfigWizard.mockResolvedValue({ providerMode: "custom", providers: [], agents: "preset-agent" });
+
+		const { run } = await import("./index.js");
+		await run();
+
+		expect(selectPreset).toHaveBeenCalled();
+		expect(runConfigWizard).toHaveBeenCalledWith(expect.objectContaining({ existingProviders: ["anthropic"] }), {
+			agents: "preset-agent",
+		});
+		expect(confirmApply).toHaveBeenCalledWith(
+			expect.objectContaining({ agents: "preset-agent", locale: "en" }),
+			expect.anything(),
+		);
+		expect(setupProviders).not.toHaveBeenCalled();
+	});
+
+	it("runs the custom flow with default extension selections", async () => {
+		selectMode.mockResolvedValue("custom");
+
+		const { run } = await import("./index.js");
+		await run();
+
+		expect(runConfigWizard).toHaveBeenCalledWith(
+			expect.objectContaining({ existingProviders: ["anthropic"] }),
+			expect.objectContaining({
+				theme: "dark",
+				keybindings: "default",
+				extensions: ["git-guard", "diagnostics"],
+				prompts: expect.arrayContaining(["review", "document", "pr"]),
+				agents: "general-developer",
+				thinking: "medium",
+			}),
+		);
+		expect(confirmApply).toHaveBeenCalledWith(expect.objectContaining({ locale: "en" }), expect.anything());
+		expect(selectPreset).not.toHaveBeenCalled();
 	});
 });

--- a/packages/core/src/worktree.test.ts
+++ b/packages/core/src/worktree.test.ts
@@ -1,0 +1,178 @@
+import { execFileSync } from "node:child_process";
+import * as fs from "node:fs";
+import * as os from "node:os";
+import * as path from "node:path";
+import { afterEach, describe, expect, it } from "vitest";
+import {
+	buildPaiInstanceId,
+	createManagedWorktree,
+	createOwnerMetadata,
+	formatOwnerLabel,
+	formatWorktreeKind,
+	getManagedWorktreeParentDir,
+	getRepoWorktreeSnapshot,
+	getWorktreeRegistryPath,
+	loadWorktreeRegistry,
+	removeManagedWorktree,
+	touchManagedWorktreeSeen,
+} from "./worktree.js";
+
+function git(cwd: string, args: string[]): string {
+	return execFileSync("git", ["-C", cwd, ...args], {
+		encoding: "utf-8",
+		stdio: ["ignore", "pipe", "pipe"],
+	}).trim();
+}
+
+function createTempRepo(rootDir: string): string {
+	const repoDir = path.join(rootDir, "repo");
+	fs.mkdirSync(repoDir, { recursive: true });
+	git(repoDir, ["init", "--initial-branch", "main"]);
+	git(repoDir, ["config", "user.name", "Coverage Bot"]);
+	git(repoDir, ["config", "user.email", "coverage@example.com"]);
+	fs.writeFileSync(path.join(repoDir, "README.md"), "# repo\n", "utf-8");
+	git(repoDir, ["add", "README.md"]);
+	git(repoDir, ["commit", "-m", "chore: seed repo"]);
+	return repoDir;
+}
+
+const tempRoots: string[] = [];
+
+function createSandbox() {
+	const tempRoot = fs.mkdtempSync(path.join(os.tmpdir(), "oh-pi-worktree-test-"));
+	tempRoots.push(tempRoot);
+	return {
+		tempRoot,
+		repoDir: createTempRepo(tempRoot),
+		sharedRoot: path.join(tempRoot, "shared-worktrees"),
+	};
+}
+
+afterEach(() => {
+	for (const tempRoot of tempRoots.splice(0)) {
+		fs.rmSync(tempRoot, { recursive: true, force: true });
+	}
+});
+
+describe("worktree helpers", () => {
+	it("creates owner metadata and labels consistently", () => {
+		const owner = createOwnerMetadata({
+			instanceId: "pai-test-instance",
+			cwd: "/tmp/repo",
+			sessionFile: "/tmp/repo/.pi/session-123.jsonl",
+			sessionName: "Coverage run",
+		});
+
+		expect(owner.createdFromCwd).toBe(path.resolve("/tmp/repo"));
+		expect(owner.sessionFile).toBe(path.resolve("/tmp/repo/.pi/session-123.jsonl"));
+		expect(owner.sessionId).toBe("session-123");
+		expect(owner.sessionName).toBe("Coverage run");
+		expect(formatOwnerLabel(owner)).toBe("pai-test-instance (Coverage run)");
+		expect(formatOwnerLabel({ ...owner, sessionName: null })).toBe("pai-test-instance (session-123)");
+		expect(formatWorktreeKind({ isMain: true, isManaged: false })).toBe("main");
+		expect(formatWorktreeKind({ isMain: false, isManaged: true })).toBe("pi-owned");
+		expect(formatWorktreeKind({ isMain: false, isManaged: false })).toBe("external");
+		expect(buildPaiInstanceId(1234)).toMatch(/^pai-[a-z0-9._-]+-\d+-ya$/);
+	});
+
+	it("returns null outside a git repository and validates required fields", () => {
+		const { tempRoot } = createSandbox();
+		expect(getRepoWorktreeSnapshot(tempRoot)).toBeNull();
+
+		const owner = createOwnerMetadata({ instanceId: "pai-1", cwd: tempRoot });
+		expect(() =>
+			createManagedWorktree({ cwd: tempRoot, branch: "", purpose: "Coverage", owner, sharedRoot: tempRoot }),
+		).toThrow("Branch name is required.");
+		expect(() =>
+			createManagedWorktree({ cwd: tempRoot, branch: "test/coverage", purpose: "", owner, sharedRoot: tempRoot }),
+		).toThrow("Purpose is required.");
+	});
+
+	it("creates managed worktrees, snapshots them, and persists registry metadata", () => {
+		const { repoDir, sharedRoot } = createSandbox();
+		const normalizedRepoDir = fs.realpathSync.native(repoDir);
+		const owner = createOwnerMetadata({
+			instanceId: "pai-1",
+			cwd: repoDir,
+			sessionFile: path.join(repoDir, ".pi", "session-1.jsonl"),
+			sessionName: "Coverage run",
+		});
+
+		const initialSnapshot = getRepoWorktreeSnapshot(repoDir, sharedRoot);
+		expect(initialSnapshot?.repoRoot).toBe(normalizedRepoDir);
+		expect(initialSnapshot?.isLinkedWorktree).toBe(false);
+		expect(initialSnapshot?.worktrees).toHaveLength(1);
+		expect(initialSnapshot?.registry.managedWorktrees).toEqual([]);
+
+		const result = createManagedWorktree({
+			cwd: repoDir,
+			branch: "test/worktree-coverage",
+			purpose: "Cover git worktree flows",
+			owner,
+			sharedRoot,
+		});
+
+		expect(result.createdBranch).toBe(true);
+		expect(result.branch).toBe("test/worktree-coverage");
+		expect(fs.existsSync(result.worktreePath)).toBe(true);
+		expect(result.worktreePath.startsWith(getManagedWorktreeParentDir(normalizedRepoDir, sharedRoot))).toBe(true);
+		expect(fs.existsSync(getWorktreeRegistryPath(normalizedRepoDir, sharedRoot))).toBe(true);
+
+		const linkedSnapshot = getRepoWorktreeSnapshot(result.worktreePath, sharedRoot);
+		expect(linkedSnapshot?.isLinkedWorktree).toBe(true);
+		expect(linkedSnapshot?.currentBranch).toBe("test/worktree-coverage");
+		expect(linkedSnapshot?.current?.isManaged).toBe(true);
+		expect(linkedSnapshot?.current?.metadata?.purpose).toBe("Cover git worktree flows");
+		expect(linkedSnapshot?.worktrees).toHaveLength(2);
+
+		expect(touchManagedWorktreeSeen(normalizedRepoDir, result.worktreePath, sharedRoot)).toBe(true);
+		expect(touchManagedWorktreeSeen(normalizedRepoDir, path.join(sharedRoot, "missing"), sharedRoot)).toBe(false);
+
+		const registry = loadWorktreeRegistry(normalizedRepoDir, sharedRoot);
+		expect(registry.managedWorktrees).toHaveLength(1);
+		expect(registry.managedWorktrees[0]).toMatchObject({
+			branch: "test/worktree-coverage",
+			purpose: "Cover git worktree flows",
+			owner: { instanceId: "pai-1", sessionName: "Coverage run" },
+		});
+		expect(registry.managedWorktrees[0]?.lastSeenAt).toEqual(expect.any(String));
+
+		const removal = removeManagedWorktree(result.metadata, sharedRoot);
+		expect(removal).toMatchObject({
+			removed: true,
+			removedFromGit: true,
+			removedRegistryEntry: true,
+			note: "Removed pi-owned worktree from git worktree list.",
+		});
+		expect(fs.existsSync(result.worktreePath)).toBe(false);
+		expect(loadWorktreeRegistry(normalizedRepoDir, sharedRoot).managedWorktrees).toEqual([]);
+	}, 20_000);
+
+	it("removes stale registry entries when the worktree is already gone", () => {
+		const { repoDir, sharedRoot } = createSandbox();
+		const normalizedRepoDir = fs.realpathSync.native(repoDir);
+		const owner = createOwnerMetadata({ instanceId: "pai-1", cwd: repoDir });
+		const result = createManagedWorktree({
+			cwd: repoDir,
+			branch: "test/stale-worktree",
+			purpose: "Exercise stale cleanup",
+			owner,
+			sharedRoot,
+		});
+
+		git(repoDir, ["worktree", "remove", "--force", result.worktreePath]);
+
+		const snapshot = getRepoWorktreeSnapshot(normalizedRepoDir, sharedRoot);
+		expect(snapshot?.staleManagedWorktrees).toHaveLength(1);
+		expect(snapshot?.staleManagedWorktrees[0]?.worktreePath).toBe(result.worktreePath);
+
+		const removal = removeManagedWorktree(result.metadata, sharedRoot);
+		expect(removal).toMatchObject({
+			removed: true,
+			removedFromGit: false,
+			removedRegistryEntry: true,
+			note: "Worktree directory was already missing; removed stale pi registry entry.",
+		});
+		expect(loadWorktreeRegistry(normalizedRepoDir, sharedRoot).managedWorktrees).toEqual([]);
+	}, 20_000);
+});

--- a/packages/cursor/tests/provider-stream.test.ts
+++ b/packages/cursor/tests/provider-stream.test.ts
@@ -184,10 +184,10 @@ beforeEach(() => {
 		return stream;
 	});
 	providerMocks.buildCursorRequestPayload.mockReturnValue({
-		requestBytes: { request: true },
+		requestBytes: new Uint8Array([1, 2, 3]),
 		blobStore: new Map([["blob", new Uint8Array([1, 2, 3])]]),
 		mcpTools: [{ name: "echo" }],
-	});
+	} as never);
 	providerMocks.decodeMcpArgsMap.mockImplementation((args: Record<string, unknown>) => args);
 	providerMocks.parseCursorConversation.mockReturnValue({ seed: "seed-text", userText: "Do the thing", trailingToolResults: [] });
 	providerMocks.sendExecResult.mockImplementation(
@@ -232,7 +232,7 @@ afterEach(() => {
 
 describe("streamSimpleCursor", () => {
 	it("throws when no Cursor API key is available", () => {
-		providerMocks.getEnvApiKey.mockReturnValueOnce(undefined);
+		providerMocks.getEnvApiKey.mockReturnValueOnce(undefined as never);
 		expect(() => streamSimpleCursor(createModel() as never, createContext() as never)).toThrow(
 			"No API key for provider: cursor",
 		);
@@ -274,8 +274,8 @@ describe("streamSimpleCursor", () => {
 			seed: "seed-text",
 			userText: "",
 			trailingToolResults: [{ toolCallId: "call-1", toolName: "echo", content: "pong", isError: false }],
-		});
-		providerMocks.getActiveRun.mockReturnValueOnce(activeRun);
+		} as never);
+		providerMocks.getActiveRun.mockReturnValueOnce(activeRun as never);
 
 		const stream = streamSimpleCursor(createModel() as never, createContext() as never, { sessionId: "session-1" } as never) as any;
 		await flushMicrotasks();
@@ -298,7 +298,11 @@ describe("streamSimpleCursor", () => {
 
 	it("streams new runs, handles server messages, and switches to tool-use mode on MCP execution", async () => {
 		const onPayload = vi.fn();
-		providerMocks.getConversationState.mockReturnValueOnce({ conversationId: "saved-conv", blobStore: new Map(), lastAccessMs: 0 });
+		providerMocks.getConversationState.mockReturnValueOnce({
+			conversationId: "saved-conv",
+			blobStore: new Map(),
+			lastAccessMs: 0,
+		} as never);
 
 		const stream = streamSimpleCursor(createModel() as never, createContext() as never, {
 			sessionId: "session-1",
@@ -309,7 +313,7 @@ describe("streamSimpleCursor", () => {
 		const connection = providerMocks.connections[0];
 		expect(connection.options).toMatchObject({ accessToken: "cursor-token", rpcPath: expect.anything(), url: "https://cursor.test" });
 		expect(connection.startHeartbeat).toHaveBeenCalledWith(providerMocks.makeHeartbeatFrame);
-		expect(connection.write).toHaveBeenCalledWith({ framed: { request: true } });
+		expect(connection.write).toHaveBeenCalledWith({ framed: new Uint8Array([1, 2, 3]) });
 		expect(onPayload).toHaveBeenCalledWith({ model: "composer-2", conversationId: "saved-conv", toolCount: 1 });
 
 		connection.handlers.onData?.({

--- a/packages/cursor/tests/provider-stream.test.ts
+++ b/packages/cursor/tests/provider-stream.test.ts
@@ -1,0 +1,435 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+
+const providerMocks = vi.hoisted(() => {
+	const streams: any[] = [];
+	const connections: any[] = [];
+
+	class FakeConnection {
+		public handlers: Record<string, (...args: any[]) => void> = {};
+		public options: any;
+		public writes: any[] = [];
+		public startHeartbeat = vi.fn();
+		public write = vi.fn((data: unknown) => {
+			this.writes.push(data);
+		});
+		public setHandlers = vi.fn((handlers: Record<string, (...args: any[]) => void>) => {
+			this.handlers = handlers;
+		});
+		public clearHandlers = vi.fn(() => {
+			this.handlers = {};
+		});
+		public close = vi.fn();
+
+		constructor(options: any) {
+			this.options = options;
+			connections.push(this);
+		}
+	}
+
+	return {
+		streams,
+		connections,
+		FakeConnection,
+		create: vi.fn((_schema: unknown, value: unknown) => value),
+		fromBinary: vi.fn((_schema: unknown, value: unknown) => value),
+		toBinary: vi.fn((_schema: unknown, value: unknown) => value),
+		calculateCost: vi.fn(),
+		createAssistantMessageEventStream: vi.fn(() => {
+			const stream = {
+				events: [] as any[],
+				push: vi.fn((event: any) => {
+					stream.events.push(event);
+				}),
+				end: vi.fn(),
+			};
+			streams.push(stream);
+			return stream;
+		}),
+		getEnvApiKey: vi.fn(() => "cursor-token"),
+		buildCursorRequestPayload: vi.fn(() => ({
+			requestBytes: { framed: true },
+			blobStore: new Map([["blob", new Uint8Array([1])]]),
+			mcpTools: [{ name: "echo" }],
+		})),
+		decodeMcpArgsMap: vi.fn((args: Record<string, unknown>) => args),
+		makeHeartbeatFrame: vi.fn(() => new Uint8Array([1])),
+		parseCursorConversation: vi.fn(() => ({
+			seed: "seed-text",
+			userText: "Do the thing",
+			trailingToolResults: [],
+		})),
+		sendExecResult: vi.fn((_execId: string, _msgId: string, _kind: string, _result: unknown, write: (data: unknown) => void) => {
+			write({ ack: _kind, execId: _execId });
+		}),
+		sendKvBlobResponse: vi.fn((_message: unknown, _blobStore: Map<string, Uint8Array>, write: (data: unknown) => void) => {
+			write({ ack: "kv" });
+		}),
+		sendRequestContextResult: vi.fn((_execId: string, _msgId: string, _tools: unknown[], write: (data: unknown) => void) => {
+			write({ ack: "requestContext" });
+		}),
+		cleanupCursorRuntimeState: vi.fn(),
+		deleteActiveRun: vi.fn(),
+		deriveBridgeKey: vi.fn((conversationKey: string, modelId: string) => `${conversationKey}:${modelId}`),
+		deriveConversationKey: vi.fn((sessionId: string | undefined, seed: string) =>
+			sessionId ? `session:${sessionId}` : `seed:${seed}`,
+		),
+		deterministicConversationId: vi.fn((conversationKey: string) => `conv:${conversationKey}`),
+		getActiveRun: vi.fn(() => undefined),
+		getConversationState: vi.fn(() => undefined),
+		setActiveRun: vi.fn(),
+		upsertConversationState: vi.fn(),
+		createConnectFrameParser: vi.fn(
+			(onMessage: (payload: unknown) => void, onEnd: (payload: unknown) => void) =>
+				(payload: { kind: "message" | "end"; value: unknown }) => {
+					if (payload.kind === "end") {
+						onEnd(payload.value);
+						return;
+					}
+					onMessage(payload.value);
+				},
+		),
+		frameConnectMessage: vi.fn((payload: unknown) => ({ framed: payload })),
+		parseConnectEndStream: vi.fn(() => null),
+	};
+});
+
+vi.mock("@bufbuild/protobuf", () => ({
+	create: providerMocks.create,
+	fromBinary: providerMocks.fromBinary,
+	toBinary: providerMocks.toBinary,
+}));
+
+vi.mock("@mariozechner/pi-ai", () => ({
+	calculateCost: providerMocks.calculateCost,
+	createAssistantMessageEventStream: providerMocks.createAssistantMessageEventStream,
+	getEnvApiKey: providerMocks.getEnvApiKey,
+}));
+
+vi.mock("../messages.js", () => ({
+	buildCursorRequestPayload: providerMocks.buildCursorRequestPayload,
+	decodeMcpArgsMap: providerMocks.decodeMcpArgsMap,
+	makeHeartbeatFrame: providerMocks.makeHeartbeatFrame,
+	parseCursorConversation: providerMocks.parseCursorConversation,
+	sendExecResult: providerMocks.sendExecResult,
+	sendKvBlobResponse: providerMocks.sendKvBlobResponse,
+	sendRequestContextResult: providerMocks.sendRequestContextResult,
+}));
+
+vi.mock("../runtime.js", () => ({
+	cleanupCursorRuntimeState: providerMocks.cleanupCursorRuntimeState,
+	deleteActiveRun: providerMocks.deleteActiveRun,
+	deriveBridgeKey: providerMocks.deriveBridgeKey,
+	deriveConversationKey: providerMocks.deriveConversationKey,
+	deterministicConversationId: providerMocks.deterministicConversationId,
+	getActiveRun: providerMocks.getActiveRun,
+	getConversationState: providerMocks.getConversationState,
+	setActiveRun: providerMocks.setActiveRun,
+	upsertConversationState: providerMocks.upsertConversationState,
+}));
+
+vi.mock("../transport.js", () => ({
+	createConnectFrameParser: providerMocks.createConnectFrameParser,
+	CursorStreamingConnection: providerMocks.FakeConnection,
+	frameConnectMessage: providerMocks.frameConnectMessage,
+	parseConnectEndStream: providerMocks.parseConnectEndStream,
+}));
+
+import { streamSimpleCursor } from "../provider.js";
+
+function createModel() {
+	return {
+		provider: "cursor",
+		id: "composer-2",
+		api: "cursor-agent",
+		baseUrl: "https://cursor.test",
+	};
+}
+
+function createContext() {
+	return {
+		systemPrompt: "You are helpful.",
+		messages: [],
+		tools: [{ name: "echo", description: "Echo text", parameters: { type: "object" } }],
+	};
+}
+
+async function flushMicrotasks() {
+	await Promise.resolve();
+	await Promise.resolve();
+	await Promise.resolve();
+}
+
+beforeEach(() => {
+	providerMocks.streams.length = 0;
+	providerMocks.connections.length = 0;
+	for (const mock of Object.values(providerMocks)) {
+		if (typeof mock === "function" && "mockReset" in mock) {
+			(mock as ReturnType<typeof vi.fn>).mockReset();
+		}
+	}
+
+	providerMocks.create.mockImplementation((_schema: unknown, value: unknown) => value);
+	providerMocks.fromBinary.mockImplementation((_schema: unknown, value: unknown) => value);
+	providerMocks.toBinary.mockImplementation((_schema: unknown, value: unknown) => value);
+	providerMocks.getEnvApiKey.mockReturnValue("cursor-token");
+	providerMocks.createAssistantMessageEventStream.mockImplementation(() => {
+		const stream = {
+			events: [] as any[],
+			push: vi.fn((event: any) => {
+				stream.events.push(event);
+			}),
+			end: vi.fn(),
+		};
+		providerMocks.streams.push(stream);
+		return stream;
+	});
+	providerMocks.buildCursorRequestPayload.mockReturnValue({
+		requestBytes: { request: true },
+		blobStore: new Map([["blob", new Uint8Array([1, 2, 3])]]),
+		mcpTools: [{ name: "echo" }],
+	});
+	providerMocks.decodeMcpArgsMap.mockImplementation((args: Record<string, unknown>) => args);
+	providerMocks.parseCursorConversation.mockReturnValue({ seed: "seed-text", userText: "Do the thing", trailingToolResults: [] });
+	providerMocks.sendExecResult.mockImplementation(
+		(_execId: string, _msgId: string, kind: string, _result: unknown, write: (data: unknown) => void) => {
+			write({ ack: kind, execId: _execId });
+		},
+	);
+	providerMocks.sendKvBlobResponse.mockImplementation(
+		(_message: unknown, _blobStore: Map<string, Uint8Array>, write: (data: unknown) => void) => {
+			write({ ack: "kv" });
+		},
+	);
+	providerMocks.sendRequestContextResult.mockImplementation(
+		(_execId: string, _msgId: string, _tools: unknown[], write: (data: unknown) => void) => {
+			write({ ack: "requestContext" });
+		},
+	);
+	providerMocks.deriveBridgeKey.mockImplementation((conversationKey: string, modelId: string) => `${conversationKey}:${modelId}`);
+	providerMocks.deriveConversationKey.mockImplementation((sessionId: string | undefined, seed: string) =>
+		sessionId ? `session:${sessionId}` : `seed:${seed}`,
+	);
+	providerMocks.deterministicConversationId.mockImplementation((conversationKey: string) => `conv:${conversationKey}`);
+	providerMocks.getActiveRun.mockReturnValue(undefined);
+	providerMocks.getConversationState.mockReturnValue(undefined);
+	providerMocks.createConnectFrameParser.mockImplementation(
+		(onMessage: (payload: unknown) => void, onEnd: (payload: unknown) => void) =>
+			(payload: { kind: "message" | "end"; value: unknown }) => {
+				if (payload.kind === "end") {
+					onEnd(payload.value);
+					return;
+				}
+				onMessage(payload.value);
+			},
+	);
+	providerMocks.frameConnectMessage.mockImplementation((payload: unknown) => ({ framed: payload }));
+	providerMocks.parseConnectEndStream.mockReturnValue(null);
+});
+
+afterEach(() => {
+	vi.restoreAllMocks();
+});
+
+describe("streamSimpleCursor", () => {
+	it("throws when no Cursor API key is available", () => {
+		providerMocks.getEnvApiKey.mockReturnValueOnce(undefined);
+		expect(() => streamSimpleCursor(createModel() as never, createContext() as never)).toThrow(
+			"No API key for provider: cursor",
+		);
+	});
+
+	it("emits an error when no prompt or resumable tool results are available", async () => {
+		providerMocks.parseCursorConversation.mockReturnValueOnce({
+			seed: "seed-text",
+			userText: "   ",
+			trailingToolResults: [],
+		});
+
+		const stream = streamSimpleCursor(createModel() as never, createContext() as never, { sessionId: "session-1" } as never) as any;
+		await flushMicrotasks();
+
+		expect(providerMocks.cleanupCursorRuntimeState).toHaveBeenCalledTimes(1);
+		expect(stream.events[0]).toMatchObject({ type: "start" });
+		expect(stream.events.at(-1)).toMatchObject({
+			type: "error",
+			reason: "error",
+			error: expect.objectContaining({ errorMessage: "Cursor provider requires a user prompt or resumable tool results." }),
+		});
+		expect(stream.end).toHaveBeenCalledTimes(1);
+	});
+
+	it("resumes active runs, sends pending tool results, and completes on close", async () => {
+		const activeConnection = new providerMocks.FakeConnection({ url: "https://cursor.test" });
+		const activeRun = {
+			connection: activeConnection,
+			blobStore: new Map(),
+			mcpTools: [{ name: "echo" }],
+			pendingExecs: [
+				{ execId: "exec-1", execMsgId: "msg-1", toolCallId: "call-1", toolName: "echo", decodedArgs: "{}" },
+				{ execId: "exec-2", execMsgId: "msg-2", toolCallId: "call-2", toolName: "echo", decodedArgs: "{}" },
+			],
+			lastAccessMs: Date.now(),
+		};
+		providerMocks.parseCursorConversation.mockReturnValueOnce({
+			seed: "seed-text",
+			userText: "",
+			trailingToolResults: [{ toolCallId: "call-1", toolName: "echo", content: "pong", isError: false }],
+		});
+		providerMocks.getActiveRun.mockReturnValueOnce(activeRun);
+
+		const stream = streamSimpleCursor(createModel() as never, createContext() as never, { sessionId: "session-1" } as never) as any;
+		await flushMicrotasks();
+
+		expect(providerMocks.sendExecResult).toHaveBeenCalledTimes(2);
+		expect(activeRun.pendingExecs).toEqual([]);
+
+		activeConnection.handlers.onClose?.();
+		await flushMicrotasks();
+
+		expect(providerMocks.deleteActiveRun).toHaveBeenCalledWith("session:session-1:composer-2");
+		expect(providerMocks.calculateCost).toHaveBeenCalledTimes(1);
+		expect(stream.events.at(-1)).toMatchObject({
+			type: "done",
+			reason: "stop",
+			message: expect.objectContaining({ stopReason: "stop" }),
+		});
+		expect(stream.end).toHaveBeenCalledTimes(1);
+	});
+
+	it("streams new runs, handles server messages, and switches to tool-use mode on MCP execution", async () => {
+		const onPayload = vi.fn();
+		providerMocks.getConversationState.mockReturnValueOnce({ conversationId: "saved-conv", blobStore: new Map(), lastAccessMs: 0 });
+
+		const stream = streamSimpleCursor(createModel() as never, createContext() as never, {
+			sessionId: "session-1",
+			onPayload,
+		} as never) as any;
+		await flushMicrotasks();
+
+		const connection = providerMocks.connections[0];
+		expect(connection.options).toMatchObject({ accessToken: "cursor-token", rpcPath: expect.anything(), url: "https://cursor.test" });
+		expect(connection.startHeartbeat).toHaveBeenCalledWith(providerMocks.makeHeartbeatFrame);
+		expect(connection.write).toHaveBeenCalledWith({ framed: { request: true } });
+		expect(onPayload).toHaveBeenCalledWith({ model: "composer-2", conversationId: "saved-conv", toolCount: 1 });
+
+		connection.handlers.onData?.({
+			kind: "message",
+			value: {
+				message: { case: "interactionUpdate", value: { message: { case: "textDelta", value: { text: "Hello <think>secret" } } } },
+			},
+		});
+		connection.handlers.onData?.({
+			kind: "message",
+			value: {
+				message: { case: "interactionUpdate", value: { message: { case: "textDelta", value: { text: " plan</think> world" } } } },
+			},
+		});
+		connection.handlers.onData?.({
+			kind: "message",
+			value: {
+				message: { case: "interactionUpdate", value: { message: { case: "thinkingDelta", value: { text: "deep thought" } } } },
+			},
+		});
+		connection.handlers.onData?.({
+			kind: "message",
+			value: {
+				message: { case: "interactionUpdate", value: { message: { case: "tokenDelta", value: { tokens: 7 } } } },
+			},
+		});
+		connection.handlers.onData?.({ kind: "message", value: { message: { case: "kvServerMessage", value: { blobId: "blob-1" } } } });
+		connection.handlers.onData?.({
+			kind: "message",
+			value: {
+				message: { case: "conversationCheckpointUpdate", value: { tokenDetails: { usedTokens: 25 }, checkpoint: true } },
+			},
+		});
+		connection.handlers.onData?.({
+			kind: "message",
+			value: {
+				message: { case: "execServerMessage", value: { execId: "1", id: "a", message: { case: "requestContextArgs", value: {} } } },
+			},
+		});
+		for (const execCase of [
+			["readArgs", { path: "/tmp/readme.md" }],
+			["writeArgs", { path: "/tmp/out.md" }],
+			["deleteArgs", { path: "/tmp/old.md" }],
+			["grepArgs", {}],
+			["fetchArgs", { url: "https://example.com" }],
+			["shellArgs", { command: "ls", workingDirectory: "/repo" }],
+			["backgroundShellSpawnArgs", { command: "npm test", workingDirectory: "/repo" }],
+			["writeShellStdinArgs", {}],
+			["diagnosticsArgs", {}],
+		] as const) {
+			connection.handlers.onData?.({
+				kind: "message",
+				value: {
+					message: { case: "execServerMessage", value: { execId: `${execCase[0]}`, id: `msg-${execCase[0]}`, message: { case: execCase[0], value: execCase[1] } } },
+				},
+			});
+		}
+		connection.handlers.onData?.({
+			kind: "message",
+			value: {
+				message: {
+					case: "execServerMessage",
+					value: {
+						execId: "mcp-1",
+						id: "mcp-msg-1",
+						message: {
+							case: "mcpArgs",
+							value: { toolCallId: "tool-1", toolName: "echo", name: "echo", args: { text: "ping" } },
+						},
+					},
+				},
+			},
+		});
+		await flushMicrotasks();
+
+		expect(providerMocks.sendKvBlobResponse).toHaveBeenCalledTimes(1);
+		expect(providerMocks.sendRequestContextResult).toHaveBeenCalledTimes(1);
+		expect(providerMocks.sendExecResult).toHaveBeenCalledTimes(9);
+		expect(providerMocks.upsertConversationState).toHaveBeenCalledTimes(1);
+		expect(providerMocks.setActiveRun).toHaveBeenCalledWith(
+			"session:session-1:composer-2",
+			expect.objectContaining({ pendingExecs: expect.arrayContaining([expect.objectContaining({ toolCallId: "tool-1" })]) }),
+		);
+		expect(connection.clearHandlers).toHaveBeenCalledTimes(1);
+		expect(stream.events).toEqual(
+			expect.arrayContaining([
+				expect.objectContaining({ type: "start" }),
+				expect.objectContaining({ type: "text_start" }),
+				expect.objectContaining({ type: "text_delta", delta: "Hello " }),
+				expect.objectContaining({ type: "text_delta", delta: " world" }),
+				expect.objectContaining({ type: "thinking_start" }),
+				expect.objectContaining({ type: "thinking_delta", delta: "secret" }),
+				expect.objectContaining({ type: "thinking_delta", delta: " plan" }),
+				expect.objectContaining({ type: "thinking_delta", delta: "deep thought" }),
+				expect.objectContaining({ type: "toolcall_start" }),
+				expect.objectContaining({ type: "toolcall_delta", delta: '{"text":"ping"}' }),
+				expect.objectContaining({ type: "toolcall_end", toolCall: expect.objectContaining({ id: "tool-1", name: "echo" }) }),
+				expect.objectContaining({ type: "done", reason: "toolUse", message: expect.objectContaining({ stopReason: "toolUse" }) }),
+			]),
+		);
+		expect(stream.end).toHaveBeenCalledTimes(1);
+	});
+
+	it("emits an aborted error when the caller signal aborts an in-flight run", async () => {
+		const controller = new AbortController();
+		const stream = streamSimpleCursor(createModel() as never, createContext() as never, {
+			signal: controller.signal,
+		} as never) as any;
+		await flushMicrotasks();
+
+		const connection = providerMocks.connections[0];
+		controller.abort();
+		await flushMicrotasks();
+
+		expect(connection.close).toHaveBeenCalledTimes(1);
+		expect(stream.events.at(-1)).toMatchObject({
+			type: "error",
+			reason: "aborted",
+			error: expect.objectContaining({ stopReason: "aborted", errorMessage: "Request was aborted" }),
+		});
+		expect(stream.end).toHaveBeenCalledTimes(1);
+	});
+});

--- a/packages/cursor/tests/runtime.test.ts
+++ b/packages/cursor/tests/runtime.test.ts
@@ -1,0 +1,99 @@
+import { afterEach, describe, expect, it, vi } from "vitest";
+import {
+	cleanupCursorRuntimeState,
+	clearCursorRuntimeState,
+	deleteActiveRun,
+	deleteConversationState,
+	deterministicConversationId,
+	deriveBridgeKey,
+	deriveConversationKey,
+	getActiveRun,
+	getConversationState,
+	getCursorRuntimeStateSummary,
+	setActiveRun,
+	upsertConversationState,
+} from "../runtime.js";
+
+afterEach(() => {
+	clearCursorRuntimeState();
+	vi.restoreAllMocks();
+});
+
+describe("cursor runtime state", () => {
+	it("derives stable conversation and bridge identifiers", () => {
+		expect(deriveConversationKey(" session-1 ", "seed")).toBe("session:session-1");
+		expect(deriveConversationKey(undefined, "seed text")).toMatch(/^seed:/);
+		expect(deriveBridgeKey("session:session-1", "composer-2")).toBe("session:session-1:composer-2");
+		expect(deterministicConversationId("session:session-1")).toMatch(
+			/^[0-9a-f]{8}-[0-9a-f]{4}-4[0-9a-f]{3}-[89ab][0-9a-f]{3}-[0-9a-f]{12}$/,
+		);
+	});
+
+	it("stores, reads, summarizes, and deletes conversation checkpoints", () => {
+		const checkpoint = new Uint8Array([1, 2, 3]);
+		const first = upsertConversationState("session:one", () => ({
+			conversationId: "conv-1",
+			checkpoint,
+			blobStore: new Map([["blob", new Uint8Array([9])]]),
+			lastAccessMs: 0,
+		}));
+		expect(first.conversationId).toBe("conv-1");
+		expect(getConversationState("session:one")?.checkpoint).toEqual(checkpoint);
+		expect(getCursorRuntimeStateSummary()).toEqual({ activeRuns: 0, checkpoints: 1 });
+
+		deleteConversationState("session:one");
+		expect(getConversationState("session:one")).toBeUndefined();
+	});
+
+	it("closes stale active runs and clears runtime state", () => {
+		vi.useFakeTimers();
+		const aliveConnection = {
+			close: vi.fn(),
+			isAlive: vi.fn(() => true),
+		};
+		const staleConnection = {
+			close: vi.fn(),
+			isAlive: vi.fn(() => false),
+		};
+
+		setActiveRun("alive", {
+			connection: aliveConnection as never,
+			blobStore: new Map(),
+			mcpTools: [],
+			pendingExecs: [],
+			lastAccessMs: Date.now(),
+		});
+		setActiveRun("stale", {
+			connection: staleConnection as never,
+			blobStore: new Map(),
+			mcpTools: [],
+			pendingExecs: [],
+			lastAccessMs: Date.now() - 10 * 60 * 1000,
+		});
+
+		cleanupCursorRuntimeState();
+		expect(getActiveRun("alive")).toBeDefined();
+		expect(getActiveRun("stale")).toBeUndefined();
+		expect(staleConnection.close).toHaveBeenCalledTimes(1);
+
+		deleteActiveRun("alive");
+		expect(aliveConnection.close).toHaveBeenCalledTimes(1);
+		expect(getActiveRun("alive")).toBeUndefined();
+
+		setActiveRun("alive-2", {
+			connection: aliveConnection as never,
+			blobStore: new Map(),
+			mcpTools: [],
+			pendingExecs: [],
+			lastAccessMs: Date.now(),
+		});
+		upsertConversationState("session:two", () => ({
+			conversationId: "conv-2",
+			blobStore: new Map(),
+			lastAccessMs: 0,
+		}));
+		clearCursorRuntimeState();
+		expect(aliveConnection.close).toHaveBeenCalledTimes(2);
+		expect(getCursorRuntimeStateSummary()).toEqual({ activeRuns: 0, checkpoints: 0 });
+	});
+});

--- a/packages/cursor/tests/transport.test.ts
+++ b/packages/cursor/tests/transport.test.ts
@@ -1,0 +1,209 @@
+import { afterEach, describe, expect, it, vi } from "vitest";
+
+const http2Mocks = vi.hoisted(() => {
+	const sessions: any[] = [];
+	const constants = { HTTP2_METHOD_POST: "POST" };
+
+	class MiniEmitter {
+		private listeners = new Map<string, Array<(...args: any[]) => void>>();
+		on(event: string, handler: (...args: any[]) => void) {
+			const list = this.listeners.get(event) ?? [];
+			list.push(handler);
+			this.listeners.set(event, list);
+			return this;
+		}
+		emit(event: string, ...args: any[]) {
+			for (const handler of this.listeners.get(event) ?? []) {
+				handler(...args);
+			}
+			return true;
+		}
+		removeAllListeners() {
+			this.listeners.clear();
+			return this;
+		}
+	}
+
+	class FakeRequest extends MiniEmitter {
+		closed = false;
+		destroyed = false;
+		endedWith: Buffer | undefined;
+		writes: Buffer[] = [];
+		end(data?: Buffer) {
+			this.endedWith = data;
+		}
+		write(data: Buffer) {
+			this.writes.push(data);
+		}
+		close() {
+			this.closed = true;
+		}
+	}
+
+	class FakeSession extends MiniEmitter {
+		closed = false;
+		destroyed = false;
+		requestHeaders: any;
+		requestInstance = new FakeRequest();
+		request(headers: any) {
+			this.requestHeaders = headers;
+			return this.requestInstance;
+		}
+		close() {
+			this.closed = true;
+		}
+		destroy() {
+			this.destroyed = true;
+		}
+	}
+
+	const connect = vi.fn(() => {
+		const session = new FakeSession();
+		sessions.push(session);
+		return session;
+	});
+
+	return { connect, constants, sessions, FakeSession, FakeRequest };
+});
+
+vi.mock("node:http2", () => ({
+	default: { connect: http2Mocks.connect },
+	connect: http2Mocks.connect,
+	constants: http2Mocks.constants,
+}));
+
+import {
+	callCursorUnaryRpc,
+	createConnectFrameParser,
+	CursorStreamingConnection,
+	decodeConnectUnaryBody,
+	frameConnectMessage,
+	parseConnectEndStream,
+} from "../transport.js";
+
+afterEach(() => {
+	http2Mocks.sessions.length = 0;
+	vi.restoreAllMocks();
+	vi.useRealTimers();
+});
+
+describe("cursor transport helpers", () => {
+	it("frames and decodes Connect unary messages", () => {
+		const payload = new Uint8Array([1, 2, 3]);
+		const framed = frameConnectMessage(payload);
+		expect(framed.subarray(5)).toEqual(Buffer.from(payload));
+		expect(decodeConnectUnaryBody(framed)).toEqual(Buffer.from(payload));
+		expect(decodeConnectUnaryBody(new Uint8Array([0, 1]))).toBeNull();
+		expect(decodeConnectUnaryBody(Buffer.from([1, 0, 0, 0, 1, 9]))).toBeNull();
+	});
+
+	it("parses Connect end streams and incremental frame chunks", () => {
+		expect(parseConnectEndStream(new TextEncoder().encode('{"error":{"code":"denied","message":"Nope"}}'))?.message).toBe(
+			"Connect error denied: Nope",
+		);
+		expect(parseConnectEndStream(new TextEncoder().encode("not-json"))?.message).toBe("Failed to parse Connect end stream");
+
+		const messages: Uint8Array[] = [];
+		const ends: Uint8Array[] = [];
+		const parser = createConnectFrameParser(
+			(bytes) => messages.push(bytes),
+			(bytes) => ends.push(bytes),
+		);
+		const regular = frameConnectMessage(new Uint8Array([1, 2]));
+		const endStream = Buffer.from(frameConnectMessage(new Uint8Array([3, 4])));
+		endStream[0] = 0b00000010;
+
+		parser(Buffer.concat([regular.subarray(0, 3), regular.subarray(3), endStream]));
+		expect(messages).toEqual([Buffer.from([1, 2])]);
+		expect(ends).toEqual([Buffer.from([3, 4])]);
+	});
+
+	it("executes unary RPCs and surfaces HTTP and timeout failures", async () => {
+		const successPromise = callCursorUnaryRpc({
+			accessToken: "token",
+			rpcPath: "/rpc",
+			requestBody: new Uint8Array([9, 8]),
+			url: "https://cursor.test",
+			timeoutMs: 50,
+		});
+		const successSession = http2Mocks.sessions[0];
+		successSession.requestInstance.emit("response", { ":status": 200 });
+		successSession.requestInstance.emit("data", Buffer.from([1, 2, 3]));
+		successSession.requestInstance.emit("end");
+		await expect(successPromise).resolves.toEqual(new Uint8Array([1, 2, 3]));
+		expect(successSession.requestHeaders.authorization).toBe("Bearer token");
+		expect(successSession.requestInstance.endedWith).toEqual(Buffer.from([9, 8]));
+
+		const errorPromise = callCursorUnaryRpc({
+			accessToken: "token",
+			rpcPath: "/rpc",
+			requestBody: new Uint8Array([1]),
+			url: "https://cursor.test",
+			timeoutMs: 50,
+		});
+		const errorSession = http2Mocks.sessions[1];
+		errorSession.requestInstance.emit("response", { ":status": 500 });
+		errorSession.requestInstance.emit("data", Buffer.from("boom"));
+		errorSession.requestInstance.emit("end");
+		await expect(errorPromise).rejects.toThrow("Cursor RPC /rpc failed (500): boom");
+
+		vi.useFakeTimers();
+		const timeoutPromise = callCursorUnaryRpc({
+			accessToken: "token",
+			rpcPath: "/rpc",
+			requestBody: new Uint8Array([1]),
+			url: "https://cursor.test",
+			timeoutMs: 25,
+		});
+		const timeoutRejection = expect(timeoutPromise).rejects.toThrow("Cursor unary RPC timed out after 25ms");
+		await vi.advanceTimersByTimeAsync(25);
+		await timeoutRejection;
+	});
+
+	it("streams data, connect frames, heartbeats, and close events", async () => {
+		const connection = new CursorStreamingConnection({ accessToken: "token", rpcPath: "/stream", url: "https://cursor.test" });
+		const session = http2Mocks.sessions.at(-1);
+		const stream = session.requestInstance;
+		const chunks: Buffer[] = [];
+		const endFrames: Uint8Array[] = [];
+		const closes: number[] = [];
+		const errors: string[] = [];
+
+		stream.emit("response", { ":status": 200 });
+		stream.emit("data", Buffer.from([7, 8]));
+		connection.setHandlers({
+			onData: (chunk) => chunks.push(chunk),
+			onClose: (code) => closes.push(code),
+			onError: (error) => errors.push(error.message),
+		});
+		expect(chunks).toEqual([Buffer.from([7, 8])]);
+
+		connection.setConnectParser(
+			(bytes) => chunks.push(Buffer.from(bytes)),
+			(bytes) => endFrames.push(bytes),
+		);
+		const endStream = Buffer.from(frameConnectMessage(new Uint8Array([5, 6])));
+		endStream[0] = 0b00000010;
+		stream.emit("data", endStream);
+		expect(endFrames).toEqual([Buffer.from([5, 6])]);
+
+		vi.useFakeTimers();
+		connection.startHeartbeat(() => new Uint8Array([9]));
+		await vi.advanceTimersByTimeAsync(5_000);
+		expect(stream.writes).toContainEqual(Buffer.from([9]));
+		connection.stopHeartbeat();
+
+		connection.write(new Uint8Array([1, 2]));
+		connection.end();
+		expect(stream.writes).toContainEqual(Buffer.from([1, 2]));
+		expect(connection.isAlive()).toBe(true);
+
+		stream.emit("error", new Error("stream failed"));
+		expect(errors).toContain("stream failed");
+		expect(closes).toContain(1);
+		expect(connection.isAlive()).toBe(false);
+
+		connection.clearHandlers();
+		connection.close();
+	});
+});

--- a/packages/extensions/extensions/btw.test.ts
+++ b/packages/extensions/extensions/btw.test.ts
@@ -1,3 +1,4 @@
+import { completeSimple, streamSimple } from "@mariozechner/pi-ai";
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 
 vi.mock("@mariozechner/pi-ai", () => ({
@@ -7,7 +8,9 @@ vi.mock("@mariozechner/pi-ai", () => ({
 }));
 
 vi.mock("@mariozechner/pi-tui", () => ({
-	Text: class Text {},
+	Text: class Text {
+		constructor(public text: string) {}
+	},
 }));
 
 vi.mock("@mariozechner/pi-coding-agent", () => ({
@@ -25,11 +28,20 @@ vi.mock("@mariozechner/pi-coding-agent", () => ({
 import { createExtensionHarness } from "../../../test-utils/extension-runtime-harness.js";
 import btwExtension, { resolveBtwApiKey } from "./btw.js";
 
+const mockStreamSimple = vi.mocked(streamSimple);
+const mockCompleteSimple = vi.mocked(completeSimple);
+
 const model = {
 	provider: "anthropic",
 	id: "claude-sonnet-4",
 	api: "anthropic-messages",
 };
+
+async function* createStream(events: any[]) {
+	for (const event of events) {
+		yield event;
+	}
+}
 
 describe("resolveBtwApiKey", () => {
 	it("uses modelRegistry.getApiKey when available", async () => {
@@ -55,6 +67,220 @@ describe("resolveBtwApiKey", () => {
 
 	it("reconstructs a registry when the runtime registry lacks getApiKey", async () => {
 		await expect(resolveBtwApiKey(model as never, {})).resolves.toBe("dynamic:anthropic/claude-sonnet-4");
+	});
+});
+
+describe("btw commands and rendering", () => {
+	beforeEach(() => {
+		vi.clearAllMocks();
+	});
+
+	it("registers btw and qq command families", () => {
+		const harness = createExtensionHarness();
+		btwExtension(harness.pi as never);
+
+		expect(Array.from(harness.commands.keys()).sort()).toEqual([
+			"btw",
+			"btw:clear",
+			"btw:inject",
+			"btw:new",
+			"btw:summarize",
+			"qq",
+			"qq:clear",
+			"qq:inject",
+			"qq:new",
+			"qq:summarize",
+		]);
+	});
+
+	it("warns when /btw is called without a question", async () => {
+		const harness = createExtensionHarness();
+		btwExtension(harness.pi as never);
+
+		await harness.commands.get("btw").handler("   ", harness.ctx);
+
+		expect(harness.notifications).toContainEqual({
+			msg: "Usage: /btw [--save] <question>",
+			type: "warning",
+		});
+	});
+
+	it("shows an error when no model is active", async () => {
+		const harness = createExtensionHarness();
+		btwExtension(harness.pi as never);
+
+		await harness.commands.get("btw").handler("What changed?", harness.ctx);
+
+		expect(harness.notifications).toContainEqual({
+			msg: "No active model selected.",
+			type: "error",
+		});
+	});
+
+	it("streams a BTW answer, persists the thread entry, and saves visible notes", async () => {
+		const harness = createExtensionHarness();
+		harness.ctx.model = model as never;
+		harness.ctx.modelRegistry = { getApiKey: vi.fn().mockResolvedValue("direct-key") } as never;
+		harness.ctx.ui.setWidget = vi.fn();
+		const appendEntry = vi.fn();
+		const sendMessage = vi.fn();
+		harness.pi.appendEntry = appendEntry;
+		harness.pi.sendMessage = sendMessage;
+		mockStreamSimple.mockReturnValueOnce(
+			createStream([
+				{ type: "thinking_delta", delta: "Thinking" },
+				{ type: "text_delta", delta: "Answer" },
+				{
+					type: "done",
+					message: {
+						content: [
+							{ type: "thinking", thinking: "Thinking" },
+							{ type: "text", text: "Answer" },
+						],
+						provider: "anthropic",
+						model: "claude-sonnet-4",
+						api: "anthropic-messages",
+						usage: { input: 1, output: 2, cacheRead: 0, cacheWrite: 0, totalTokens: 3 },
+						stopReason: "stop",
+						timestamp: Date.now(),
+					},
+				},
+			]) as never,
+		);
+
+		btwExtension(harness.pi as never);
+		await harness.commands.get("btw").handler("--save What changed?", harness.ctx);
+
+		expect(appendEntry).toHaveBeenCalledWith(
+			"btw-thread-entry",
+			expect.objectContaining({ question: "What changed?", answer: "Answer", thinking: "Thinking" }),
+		);
+		expect(sendMessage).toHaveBeenCalledWith(
+			expect.objectContaining({ customType: "btw-note", content: "Q: What changed?\n\nA: Answer" }),
+		);
+		expect(harness.notifications).toContainEqual({ msg: "Saved BTW note to the session.", type: "info" });
+		expect(harness.ctx.ui.setWidget).toHaveBeenCalled();
+	});
+
+	it("queues saved btw notes as follow-up messages when the session is busy", async () => {
+		const harness = createExtensionHarness();
+		harness.ctx.model = model as never;
+		harness.ctx.modelRegistry = { getApiKey: vi.fn().mockResolvedValue("direct-key") } as never;
+		harness.ctx.isIdle = () => false;
+		const sendMessage = vi.fn();
+		harness.pi.sendMessage = sendMessage;
+		mockStreamSimple.mockReturnValueOnce(
+			createStream([
+				{
+					type: "done",
+					message: {
+						content: [{ type: "text", text: "Busy answer" }],
+						provider: "anthropic",
+						model: "claude-sonnet-4",
+						api: "anthropic-messages",
+						usage: { input: 1, output: 1, cacheRead: 0, cacheWrite: 0, totalTokens: 2 },
+						stopReason: "stop",
+						timestamp: Date.now(),
+					},
+				},
+			]) as never,
+		);
+
+		btwExtension(harness.pi as never);
+		await harness.commands.get("btw").handler("--save Busy?", harness.ctx);
+
+		expect(sendMessage).toHaveBeenCalledWith(expect.anything(), { deliverAs: "followUp" });
+		expect(harness.notifications).toContainEqual({
+			msg: "BTW note queued to save after the current turn finishes.",
+			type: "info",
+		});
+	});
+
+	it("injects or summarizes a thread back into the main session", async () => {
+		const harness = createExtensionHarness();
+		harness.ctx.model = model as never;
+		harness.ctx.modelRegistry = { getApiKey: vi.fn().mockResolvedValue("direct-key") } as never;
+		const appendEntry = vi.fn();
+		const sendUserMessage = vi.fn();
+		harness.pi.appendEntry = appendEntry;
+		harness.pi.sendUserMessage = sendUserMessage;
+		mockStreamSimple.mockReturnValueOnce(
+			createStream([
+				{
+					type: "done",
+					message: {
+						content: [{ type: "text", text: "Initial answer" }],
+						provider: "anthropic",
+						model: "claude-sonnet-4",
+						api: "anthropic-messages",
+						usage: { input: 1, output: 1, cacheRead: 0, cacheWrite: 0, totalTokens: 2 },
+						stopReason: "stop",
+						timestamp: Date.now(),
+					},
+				},
+			]) as never,
+		);
+		mockCompleteSimple.mockResolvedValueOnce({
+			content: [{ type: "text", text: "Summary of the side thread" }],
+			provider: "anthropic",
+			model: "claude-sonnet-4",
+			api: "anthropic-messages",
+			usage: { input: 1, output: 1, cacheRead: 0, cacheWrite: 0, totalTokens: 2 },
+			stopReason: "stop",
+			timestamp: Date.now(),
+		} as never);
+
+		btwExtension(harness.pi as never);
+		await harness.commands.get("btw").handler("Investigate auth", harness.ctx);
+		await harness.commands.get("btw:summarize").handler("Use this to update the plan.", harness.ctx);
+
+		expect(sendUserMessage).toHaveBeenCalledWith(
+			expect.stringContaining("Here is a summary of a side conversation I had. Use this to update the plan."),
+		);
+		expect(appendEntry).toHaveBeenCalledWith("btw-thread-reset", expect.any(Object));
+		expect(harness.notifications).toContainEqual({ msg: "Injected BTW summary (1 exchange).", type: "info" });
+	});
+
+	it("warns when inject or summarize is requested without a thread", async () => {
+		const harness = createExtensionHarness();
+		btwExtension(harness.pi as never);
+
+		await harness.commands.get("btw:inject").handler("", harness.ctx);
+		await harness.commands.get("btw:summarize").handler("", harness.ctx);
+
+		expect(harness.notifications).toContainEqual({ msg: "No BTW thread to inject.", type: "warning" });
+		expect(harness.notifications).toContainEqual({ msg: "No BTW thread to summarize.", type: "warning" });
+	});
+
+	it("filters visible BTW notes out of the main context and renders expanded messages", async () => {
+		const harness = createExtensionHarness();
+		btwExtension(harness.pi as never);
+
+		const [result] = await harness.emitAsync("context", {
+			messages: [
+				{ role: "user", content: "keep" },
+				{ role: "custom", customType: "btw-note", content: "hide" },
+			],
+		});
+		expect(result.messages).toEqual([{ role: "user", content: "keep" }]);
+
+		const renderer = harness.messageRenderers.get("btw-note");
+		const rendered = renderer(
+			{
+				content: "Q: Why?\n\nA: Because.",
+				details: {
+					provider: "anthropic",
+					model: "claude-sonnet-4",
+					thinkingLevel: "low",
+					usage: { input: 1, output: 2, totalTokens: 3 },
+				},
+			},
+			{ expanded: true },
+			{ bold: (text: string) => text, fg: (_tone: string, text: string) => text },
+		);
+		expect(rendered.text).toContain("[BTW]");
+		expect(rendered.text).toContain("model: anthropic/claude-sonnet-4");
+		expect(rendered.text).toContain("tokens: in 1 · out 2 · total 3");
 	});
 });
 

--- a/packages/plan/tests/flow-branches.test.ts
+++ b/packages/plan/tests/flow-branches.test.ts
@@ -1,0 +1,620 @@
+import path from "node:path";
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+vi.mock("@mariozechner/pi-coding-agent", () => ({
+	BorderedLoader: class BorderedLoader {
+		onAbort?: () => void;
+	},
+}));
+
+const planFileMocks = vi.hoisted(() => ({
+	createFreshPlanFilePath: vi.fn(),
+	ensurePlanFileExists: vi.fn(),
+	movePlanFile: vi.fn(),
+	pathExists: vi.fn(),
+	readPlanFile: vi.fn(),
+	resolveActivePlanFilePath: vi.fn(),
+	resolvePlanLocationInput: vi.fn(),
+	resetPlanFile: vi.fn(),
+}));
+
+const stateMocks = vi.hoisted(() => ({
+	getFirstUserMessageId: vi.fn(),
+	hasEntryInSession: vi.fn(),
+}));
+
+vi.mock("../plan-files", () => planFileMocks);
+vi.mock("../state", () => stateMocks);
+
+const { registerPlanModeCommand } = await import("../flow");
+
+function createStateManager(initialState: {
+	version: number;
+	active: boolean;
+	originLeafId?: string;
+	planFilePath: string;
+	lastPlanLeafId?: string;
+}) {
+	let state = initialState;
+
+	return {
+		getState: () => state,
+		setState: vi.fn((_ctx, nextState) => {
+			state = nextState;
+		}),
+		startPlanMode: vi.fn(),
+	};
+}
+
+function createRegisteredBindings(
+	stateManager: ReturnType<typeof createStateManager>,
+	onPlanModeExited?: (summary: unknown) => void,
+) {
+	let handler: ((args: string, ctx: any) => Promise<void>) | undefined;
+	let shortcutHandler: ((ctx: any) => Promise<void>) | undefined;
+
+	registerPlanModeCommand(
+		{
+			registerCommand: (_name: string, command: { handler: (args: string, ctx: any) => Promise<void> }) => {
+				handler = command.handler;
+			},
+			registerShortcut: (_shortcut: string, options: { handler: (ctx: any) => Promise<void> }) => {
+				shortcutHandler = options.handler;
+			},
+		} as any,
+		{ stateManager, onPlanModeExited: onPlanModeExited as never },
+	);
+
+	if (!(handler && shortcutHandler)) {
+		throw new Error("Plan mode commands were not registered");
+	}
+
+	return { handler, shortcutHandler };
+}
+
+function createContext(overrides: Record<string, unknown> = {}) {
+	const base = {
+		cwd: "/tmp",
+		hasUI: true,
+		isIdle: () => true,
+		waitForIdle: vi.fn(async () => {}),
+		navigateTree: vi.fn(async () => ({ cancelled: false })),
+		ui: {
+			confirm: vi.fn(async () => true),
+			custom: vi.fn(async () => ({ cancelled: false })),
+			getEditorText: vi.fn(() => ""),
+			notify: vi.fn(),
+			select: vi.fn(() => undefined),
+			setEditorText: vi.fn(),
+		},
+		sessionManager: {
+			appendLabelChange: vi.fn(),
+			branch: vi.fn(),
+			getEntries: vi.fn(() => []),
+			getEntry: vi.fn(() => undefined),
+			getLeafId: vi.fn(() => "current-leaf"),
+			getSessionDir: vi.fn(() => "/tmp"),
+			getSessionFile: vi.fn(() => undefined),
+			getSessionId: vi.fn(() => "session-1"),
+			resetLeaf: vi.fn(),
+		},
+	};
+
+	return {
+		...base,
+		...overrides,
+		ui: {
+			...base.ui,
+			...((overrides.ui as Record<string, unknown> | undefined) ?? {}),
+		},
+		sessionManager: {
+			...base.sessionManager,
+			...((overrides.sessionManager as Record<string, unknown> | undefined) ?? {}),
+		},
+	};
+}
+
+beforeEach(() => {
+	vi.clearAllMocks();
+
+	planFileMocks.createFreshPlanFilePath.mockResolvedValue("/plans/fresh.plan.md");
+	planFileMocks.ensurePlanFileExists.mockResolvedValue(undefined);
+	planFileMocks.movePlanFile.mockResolvedValue(undefined);
+	planFileMocks.pathExists.mockResolvedValue(false);
+	planFileMocks.readPlanFile.mockResolvedValue(undefined);
+	planFileMocks.resolveActivePlanFilePath.mockImplementation((_ctx, planFilePath: string) => planFilePath);
+	planFileMocks.resolvePlanLocationInput.mockImplementation((_ctx, rawLocation: string) => {
+		return Promise.resolve(rawLocation ? path.join("/plans", path.basename(rawLocation)) : null);
+	});
+	planFileMocks.resetPlanFile.mockResolvedValue(undefined);
+
+	stateMocks.getFirstUserMessageId.mockReturnValue("user-1");
+	stateMocks.hasEntryInSession.mockReturnValue(true);
+});
+
+describe("plan flow branches", () => {
+	it("moves the active plan file to a new location", async () => {
+		const stateManager = createStateManager({
+			version: 1,
+			active: true,
+			planFilePath: "/plans/current.plan.md",
+		});
+		const { handler } = createRegisteredBindings(stateManager);
+		const notifications: Array<{ message: string; level: string }> = [];
+		const ctx = createContext({
+			hasUI: false,
+			ui: {
+				notify: (message: string, level: string) => {
+					notifications.push({ message, level });
+				},
+			},
+		});
+
+		planFileMocks.pathExists.mockResolvedValueOnce(true).mockResolvedValueOnce(false);
+		planFileMocks.resolvePlanLocationInput.mockResolvedValue("/plans/next.plan.md");
+
+		await handler("next.plan.md", ctx);
+
+		expect(planFileMocks.movePlanFile).toHaveBeenCalledWith("/plans/current.plan.md", "/plans/next.plan.md");
+		expect(stateManager.setState).toHaveBeenCalledWith(
+			ctx,
+			expect.objectContaining({ planFilePath: "/plans/next.plan.md" }),
+		);
+		expect(notifications).toContainEqual({
+			message: "Plan file moved to /plans/next.plan.md.",
+			level: "info",
+		});
+	});
+
+	it("warns when an active plan move resolves to no valid path", async () => {
+		const stateManager = createStateManager({
+			version: 1,
+			active: true,
+			planFilePath: "/plans/current.plan.md",
+		});
+		const { handler } = createRegisteredBindings(stateManager);
+		const notifications: Array<{ message: string; level: string }> = [];
+		const ctx = createContext({
+			hasUI: false,
+			ui: {
+				notify: (message: string, level: string) => {
+					notifications.push({ message, level });
+				},
+			},
+		});
+
+		planFileMocks.resolvePlanLocationInput.mockResolvedValue(null);
+
+		await handler("bad-path", ctx);
+
+		expect(planFileMocks.movePlanFile).not.toHaveBeenCalled();
+		expect(notifications).toContainEqual({
+			message: "Please enter a valid plan file location.",
+			level: "warning",
+		});
+	});
+
+	it("starts fresh planning in an empty branch and clears the editor", async () => {
+		const stateManager = createStateManager({
+			version: 1,
+			active: false,
+			planFilePath: "/plans/session.plan.md",
+		});
+		const { handler } = createRegisteredBindings(stateManager);
+		const setEditorText = vi.fn();
+		const navigateTree = vi.fn(async () => ({ cancelled: false }));
+		const ctx = createContext({
+			navigateTree,
+			ui: {
+				select: () => "Empty branch",
+				setEditorText,
+			},
+			sessionManager: {
+				getLeafId: () => "assistant-leaf",
+			},
+		});
+
+		await handler("", ctx);
+
+		expect(navigateTree).toHaveBeenCalledWith("user-1", {
+			summarize: false,
+			label: "plan",
+		});
+		expect(setEditorText).toHaveBeenCalledWith("");
+		expect(planFileMocks.resetPlanFile).toHaveBeenCalledWith("/plans/session.plan.md");
+		expect(planFileMocks.ensurePlanFileExists).toHaveBeenCalledWith("/plans/session.plan.md");
+		expect(stateManager.startPlanMode).toHaveBeenCalledWith(ctx, {
+			originLeafId: "assistant-leaf",
+			planFilePath: "/plans/session.plan.md",
+		});
+	});
+
+	it("cancels UI activation before choosing a plan branch", async () => {
+		const stateManager = createStateManager({
+			version: 1,
+			active: false,
+			planFilePath: "/plans/session.plan.md",
+		});
+		const { handler } = createRegisteredBindings(stateManager);
+		const notifications: Array<{ message: string; level: string }> = [];
+		const ctx = createContext({
+			ui: {
+				notify: (message: string, level: string) => {
+					notifications.push({ message, level });
+				},
+				select: () => undefined,
+			},
+			sessionManager: {
+				getLeafId: () => "assistant-leaf",
+			},
+		});
+
+		await handler("", ctx);
+
+		expect(notifications).toContainEqual({
+			message: "Plan mode activation cancelled.",
+			level: "info",
+		});
+		expect(stateManager.startPlanMode).not.toHaveBeenCalled();
+	});
+
+	it("stops empty-branch activation when creating the planning branch is cancelled", async () => {
+		const stateManager = createStateManager({
+			version: 1,
+			active: false,
+			planFilePath: "/plans/session.plan.md",
+		});
+		const { handler } = createRegisteredBindings(stateManager);
+		const notifications: Array<{ message: string; level: string }> = [];
+		const navigateTree = vi.fn(async () => ({ cancelled: true }));
+		const ctx = createContext({
+			navigateTree,
+			ui: {
+				notify: (message: string, level: string) => {
+					notifications.push({ message, level });
+				},
+				select: () => "Empty branch",
+			},
+			sessionManager: {
+				getLeafId: () => "assistant-leaf",
+			},
+		});
+
+		await handler("", ctx);
+
+		expect(navigateTree).toHaveBeenCalledWith("user-1", {
+			summarize: false,
+			label: "plan",
+		});
+		expect(notifications).toContainEqual({
+			message: "Plan mode activation cancelled.",
+			level: "info",
+		});
+		expect(stateManager.startPlanMode).not.toHaveBeenCalled();
+	});
+
+	it("moves an existing plan to a requested path before continuing planning", async () => {
+		const stateManager = createStateManager({
+			version: 1,
+			active: false,
+			planFilePath: "/plans/session.plan.md",
+			lastPlanLeafId: undefined,
+		});
+		const { handler } = createRegisteredBindings(stateManager);
+		const ctx = createContext({
+			hasUI: false,
+			sessionManager: {
+				getLeafId: () => "current-leaf",
+			},
+		});
+
+		planFileMocks.readPlanFile.mockResolvedValue("# Existing plan\n");
+		planFileMocks.resolvePlanLocationInput.mockResolvedValue("/plans/requested.plan.md");
+		planFileMocks.pathExists.mockResolvedValue(false);
+
+		await handler("requested.plan.md", ctx);
+
+		expect(planFileMocks.movePlanFile).toHaveBeenCalledWith("/plans/session.plan.md", "/plans/requested.plan.md");
+		expect(planFileMocks.ensurePlanFileExists).toHaveBeenCalledWith("/plans/requested.plan.md");
+		expect(stateManager.startPlanMode).toHaveBeenCalledWith(ctx, {
+			originLeafId: "current-leaf",
+			planFilePath: "/plans/requested.plan.md",
+		});
+	});
+
+	it("cancels continue planning when restoring the saved branch is cancelled", async () => {
+		const stateManager = createStateManager({
+			version: 1,
+			active: false,
+			planFilePath: "/plans/session.plan.md",
+			lastPlanLeafId: "saved-leaf",
+		});
+		const { handler } = createRegisteredBindings(stateManager);
+		const notifications: Array<{ message: string; level: string }> = [];
+		const navigateTree = vi.fn(async () => ({ cancelled: true }));
+		const ctx = createContext({
+			navigateTree,
+			ui: {
+				notify: (message: string, level: string) => {
+					notifications.push({ message, level });
+				},
+				select: () => "Continue planning",
+			},
+		});
+
+		planFileMocks.readPlanFile.mockResolvedValue("# Existing plan\n");
+
+		await handler("", ctx);
+
+		expect(navigateTree).toHaveBeenCalledWith("saved-leaf", {
+			summarize: false,
+			label: "plan",
+		});
+		expect(notifications).toContainEqual({
+			message: "Plan mode activation cancelled.",
+			level: "info",
+		});
+		expect(stateManager.startPlanMode).not.toHaveBeenCalled();
+	});
+
+	it("summarizes the planning branch when exiting plan mode with summary", async () => {
+		const onPlanModeExited = vi.fn();
+		const stateManager = createStateManager({
+			version: 1,
+			active: true,
+			originLeafId: "origin-leaf",
+			planFilePath: "/plans/session.plan.md",
+			lastPlanLeafId: "old-leaf",
+		});
+		const { handler } = createRegisteredBindings(stateManager, onPlanModeExited);
+		const navigateTree = vi.fn(async () => ({ cancelled: false }));
+		const setEditorText = vi.fn();
+		const ctx = createContext({
+			navigateTree,
+			ui: {
+				custom: (render: (tui: unknown, theme: unknown, kb: unknown, done: (result: unknown) => void) => unknown) => {
+					return new Promise((resolve) => {
+						render(undefined, undefined, undefined, resolve);
+					});
+				},
+				getEditorText: () => "",
+				select: () => "Exit & summarize branch",
+				setEditorText,
+			},
+			sessionManager: {
+				getLeafId: () => "planning-leaf",
+			},
+		});
+
+		planFileMocks.readPlanFile.mockResolvedValue("# Approved plan\n");
+
+		await handler("", ctx);
+
+		expect(navigateTree).toHaveBeenCalledWith(
+			"origin-leaf",
+			expect.objectContaining({
+				summarize: true,
+				replaceInstructions: true,
+			}),
+		);
+		expect(stateManager.setState).toHaveBeenCalledWith(
+			ctx,
+			expect.objectContaining({ active: false, lastPlanLeafId: "planning-leaf" }),
+		);
+		expect(setEditorText).toHaveBeenCalledWith(expect.stringContaining("/plans/session.plan.md"));
+		expect(onPlanModeExited).toHaveBeenCalledWith({
+			planFilePath: "/plans/session.plan.md",
+			planText: "# Approved plan",
+		});
+	});
+
+	it("keeps plan mode active when exit selection is dismissed", async () => {
+		const stateManager = createStateManager({
+			version: 1,
+			active: true,
+			originLeafId: "origin-leaf",
+			planFilePath: "/plans/session.plan.md",
+		});
+		const { handler } = createRegisteredBindings(stateManager);
+		const notifications: Array<{ message: string; level: string }> = [];
+		const ctx = createContext({
+			ui: {
+				notify: (message: string, level: string) => {
+					notifications.push({ message, level });
+				},
+				select: () => undefined,
+			},
+		});
+
+		await handler("", ctx);
+
+		expect(notifications).toContainEqual({
+			message: "Continuing in Plan mode (Esc).",
+			level: "info",
+		});
+		expect(stateManager.setState).not.toHaveBeenCalled();
+	});
+
+	it("reports fresh plan path allocation failures before starting a new plan", async () => {
+		const stateManager = createStateManager({
+			version: 1,
+			active: false,
+			planFilePath: "/plans/session.plan.md",
+		});
+		const { handler } = createRegisteredBindings(stateManager);
+		const notifications: Array<{ message: string; level: string }> = [];
+		const ctx = createContext({
+			ui: {
+				notify: (message: string, level: string) => {
+					notifications.push({ message, level });
+				},
+				select: () => "Start fresh",
+			},
+			sessionManager: {
+				getLeafId: () => "user-1",
+			},
+		});
+
+		planFileMocks.readPlanFile.mockResolvedValue("# Existing plan\n");
+		planFileMocks.createFreshPlanFilePath.mockRejectedValue(new Error("no slot available"));
+
+		await handler("", ctx);
+
+		expect(notifications).toContainEqual({
+			message: "Failed to allocate a fresh plan file path: no slot available",
+			level: "error",
+		});
+		expect(planFileMocks.resetPlanFile).not.toHaveBeenCalled();
+		expect(stateManager.startPlanMode).not.toHaveBeenCalled();
+	});
+
+	it("refuses to overwrite an existing requested path without interactive confirmation", async () => {
+		const stateManager = createStateManager({
+			version: 1,
+			active: false,
+			planFilePath: "/plans/session.plan.md",
+		});
+		const { handler } = createRegisteredBindings(stateManager);
+		const notifications: Array<{ message: string; level: string }> = [];
+		const ctx = createContext({
+			hasUI: false,
+			ui: {
+				notify: (message: string, level: string) => {
+					notifications.push({ message, level });
+				},
+			},
+		});
+
+		planFileMocks.resolvePlanLocationInput.mockResolvedValue("/plans/requested.plan.md");
+		planFileMocks.pathExists.mockResolvedValue(true);
+
+		await handler("requested.plan.md", ctx);
+
+		expect(notifications).toContainEqual({
+			message: "Refusing to overwrite existing plan file without interactive confirmation: /plans/requested.plan.md",
+			level: "error",
+		});
+		expect(planFileMocks.resetPlanFile).not.toHaveBeenCalled();
+		expect(stateManager.startPlanMode).not.toHaveBeenCalled();
+	});
+
+	it("cancels interactive fresh planning when the requested path overwrite is rejected", async () => {
+		const stateManager = createStateManager({
+			version: 1,
+			active: false,
+			planFilePath: "/plans/session.plan.md",
+		});
+		const { handler } = createRegisteredBindings(stateManager);
+		const notifications: Array<{ message: string; level: string }> = [];
+		const ctx = createContext({
+			ui: {
+				confirm: async () => false,
+				notify: (message: string, level: string) => {
+					notifications.push({ message, level });
+				},
+				select: () => "Current branch",
+			},
+			sessionManager: {
+				getLeafId: () => "user-1",
+			},
+		});
+
+		planFileMocks.resolvePlanLocationInput.mockResolvedValue("/plans/requested.plan.md");
+		planFileMocks.pathExists.mockResolvedValue(true);
+
+		await handler("requested.plan.md", ctx);
+
+		expect(notifications).toContainEqual({
+			message: "Plan mode activation cancelled.",
+			level: "info",
+		});
+		expect(planFileMocks.resetPlanFile).not.toHaveBeenCalled();
+		expect(stateManager.startPlanMode).not.toHaveBeenCalled();
+	});
+
+	it("reports requested path lookup failures before overwriting a plan file", async () => {
+		const stateManager = createStateManager({
+			version: 1,
+			active: false,
+			planFilePath: "/plans/session.plan.md",
+		});
+		const { handler } = createRegisteredBindings(stateManager);
+		const notifications: Array<{ message: string; level: string }> = [];
+		const ctx = createContext({
+			hasUI: false,
+			ui: {
+				notify: (message: string, level: string) => {
+					notifications.push({ message, level });
+				},
+			},
+		});
+
+		planFileMocks.resolvePlanLocationInput.mockResolvedValue("/plans/requested.plan.md");
+		planFileMocks.pathExists.mockRejectedValue(new Error("stat failed"));
+
+		await handler("requested.plan.md", ctx);
+
+		expect(notifications).toContainEqual({
+			message: "Failed to check requested plan path: stat failed",
+			level: "error",
+		});
+		expect(planFileMocks.resetPlanFile).not.toHaveBeenCalled();
+	});
+
+	it("reports reset failures before entering plan mode", async () => {
+		const stateManager = createStateManager({
+			version: 1,
+			active: false,
+			planFilePath: "/plans/session.plan.md",
+		});
+		const { handler } = createRegisteredBindings(stateManager);
+		const notifications: Array<{ message: string; level: string }> = [];
+		const ctx = createContext({
+			hasUI: false,
+			ui: {
+				notify: (message: string, level: string) => {
+					notifications.push({ message, level });
+				},
+			},
+		});
+
+		planFileMocks.resetPlanFile.mockRejectedValue(new Error("locked"));
+
+		await handler("", ctx);
+
+		expect(notifications).toContainEqual({
+			message: "Failed to reset plan file: locked",
+			level: "error",
+		});
+		expect(planFileMocks.ensurePlanFileExists).not.toHaveBeenCalled();
+		expect(stateManager.startPlanMode).not.toHaveBeenCalled();
+	});
+
+	it("reports initialization failures before entering plan mode", async () => {
+		const stateManager = createStateManager({
+			version: 1,
+			active: false,
+			planFilePath: "/plans/session.plan.md",
+		});
+		const { handler } = createRegisteredBindings(stateManager);
+		const notifications: Array<{ message: string; level: string }> = [];
+		const ctx = createContext({
+			hasUI: false,
+			ui: {
+				notify: (message: string, level: string) => {
+					notifications.push({ message, level });
+				},
+			},
+		});
+
+		planFileMocks.ensurePlanFileExists.mockRejectedValue(new Error("disk full"));
+
+		await handler("", ctx);
+
+		expect(notifications).toContainEqual({
+			message: "Failed to initialize plan file: disk full",
+			level: "error",
+		});
+		expect(stateManager.startPlanMode).not.toHaveBeenCalled();
+	});
+});

--- a/packages/plan/tests/index.test.ts
+++ b/packages/plan/tests/index.test.ts
@@ -1,0 +1,118 @@
+import { mkdtemp, readFile, rm } from "node:fs/promises";
+import os from "node:os";
+import path from "node:path";
+import { afterEach, describe, expect, it, vi } from "vitest";
+import { createExtensionHarness } from "../../../test-utils/extension-runtime-harness.js";
+import planExtension from "../index.js";
+
+const tempDirs: string[] = [];
+
+async function createTempDir(): Promise<string> {
+	const tempDir = await mkdtemp(path.join(os.tmpdir(), "oh-pi-plan-index-"));
+	tempDirs.push(tempDir);
+	return tempDir;
+}
+
+afterEach(async () => {
+	while (tempDirs.length > 0) {
+		const tempDir = tempDirs.pop();
+		if (!tempDir) {
+			continue;
+		}
+		await rm(tempDir, { recursive: true, force: true });
+	}
+	vi.restoreAllMocks();
+});
+
+describe("plan extension", () => {
+	it("writes plans only while plan mode is active", async () => {
+		const harness = createExtensionHarness();
+		planExtension(harness.pi as never);
+		const setPlan = harness.tools.get("set_plan");
+
+		const inactive = await setPlan.execute(
+			"tool-1",
+			{ plan: "# New plan" },
+			new AbortController().signal,
+			() => {},
+			harness.ctx,
+		);
+		expect(inactive.isError).toBe(true);
+		expect(inactive.content).toEqual([{ type: "text", text: "set_plan is only available while plan mode is active." }]);
+	});
+
+	it("rejects empty plans and writes the canonical plan file when active", async () => {
+		const harness = createExtensionHarness();
+		const tempDir = await createTempDir();
+		const planFilePath = path.join(tempDir, "session.plan.md");
+		harness.ctx.ui.setWidget = vi.fn();
+		harness.ctx.sessionManager.getEntries = () => [
+			{
+				type: "custom",
+				customType: "pi-plan:state",
+				data: {
+					version: 1,
+					active: true,
+					originLeafId: "leaf-1",
+					planFilePath,
+					lastPlanLeafId: null,
+				},
+			},
+		];
+
+		planExtension(harness.pi as never);
+		await harness.emitAsync("session_switch", { type: "session_switch" }, harness.ctx);
+		const setPlan = harness.tools.get("set_plan");
+
+		const empty = await setPlan.execute("tool-2", { plan: "   " }, new AbortController().signal, () => {}, harness.ctx);
+		expect(empty.isError).toBe(true);
+		expect(empty.content).toEqual([{ type: "text", text: "set_plan requires non-empty plan text." }]);
+
+		const result = await setPlan.execute(
+			"tool-3",
+			{ plan: "# Canonical Plan\n\n- verify behavior\n- add coverage" },
+			new AbortController().signal,
+			() => {},
+			harness.ctx,
+		);
+		expect(result.content).toEqual([{ type: "text", text: "Plan written." }]);
+		expect(result.details).toEqual({
+			plan: "# Canonical Plan\n\n- verify behavior\n- add coverage",
+		});
+		expect(await readFile(planFilePath, "utf8")).toBe("# Canonical Plan\n\n- verify behavior\n- add coverage\n");
+		expect(harness.ctx.ui.setWidget).toHaveBeenCalledWith(
+			"pi-plan-banner",
+			expect.any(Function),
+			expect.objectContaining({ placement: "aboveEditor" }),
+		);
+	});
+
+	it("injects the plan prompt before agent start when plan mode is active", async () => {
+		const harness = createExtensionHarness();
+		harness.ctx.sessionManager.getEntries = () => [
+			{
+				type: "custom",
+				customType: "pi-plan:state",
+				data: {
+					version: 1,
+					active: true,
+					originLeafId: "leaf-1",
+					planFilePath: "/tmp/session.plan.md",
+					lastPlanLeafId: null,
+				},
+			},
+		];
+
+		planExtension(harness.pi as never);
+		await harness.emitAsync("session_switch", { type: "session_switch" }, harness.ctx);
+		const [entry] = await harness.emitAsync("before_agent_start");
+
+		expect(entry).toEqual({
+			message: expect.objectContaining({
+				customType: "pi-plan:context",
+				content: expect.stringContaining("set_plan"),
+				display: false,
+			}),
+		});
+	});
+});

--- a/packages/plan/tests/task-agents.test.ts
+++ b/packages/plan/tests/task-agents.test.ts
@@ -8,6 +8,18 @@ vi.mock("@ifi/pi-extension-subagents/utils.ts", () => ({
 	getFinalOutput: vi.fn(),
 }));
 
+vi.mock("@ifi/pi-shared-qna", () => ({
+	requirePiTuiModule: () => ({
+		Text: class Text {
+			constructor(
+				public text: string,
+				public x: number,
+				public y: number,
+			) {}
+		},
+	}),
+}));
+
 import { runSync } from "@ifi/pi-extension-subagents/execution.ts";
 import { getFinalOutput } from "@ifi/pi-extension-subagents/utils.ts";
 import { buildTaskAgentRunDetails, normalizeTaskAgentTasks, registerTaskAgentTools } from "../task-agents.js";
@@ -26,11 +38,11 @@ function makeSingleResult(exitCode: number, error?: string) {
 	};
 }
 
-function registerTools(getState = () => ({ active: true })) {
+function registerTools(getState = () => ({ active: true }), activeTools?: string[]) {
 	const tools = new Map<string, any>();
 	registerTaskAgentTools(
 		{
-			getActiveTools: () => ["read", "grep", "find", "ls", "bash", "web_search"],
+			getActiveTools: () => activeTools ?? ["read", "grep", "find", "ls", "bash", "web_search"],
 			registerTool: (tool: { name: string }) => {
 				tools.set(tool.name, tool);
 			},
@@ -102,6 +114,30 @@ describe("task agent tool registration", () => {
 		expect(Array.from(tools.keys()).sort()).toEqual(["steer_task_agent", "task_agents"]);
 	});
 
+	it("renders compact call previews for task agent batches", () => {
+		const tools = registerTools();
+		const taskAgentsTool = tools.get("task_agents");
+		const rendered = taskAgentsTool.renderCall(
+			{
+				tasks: [
+					{ id: "a", prompt: "Inspect auth middleware ordering" },
+					{ id: "b", prompt: "Inspect docs and summarize deployment notes" },
+					{ id: "c", prompt: "Inspect tests" },
+					{ id: "d", prompt: "Inspect config" },
+					{ id: "e", prompt: "Inspect more files" },
+				],
+			},
+			{
+				bold: (text: string) => text,
+				fg: (_tone: string, text: string) => text,
+			},
+		);
+
+		expect(rendered.text).toContain("task agents 5 tasks");
+		expect(rendered.text).toContain("- a:");
+		expect(rendered.text).toContain("... +1 more");
+	});
+
 	it("rejects task_agents when plan mode is inactive", async () => {
 		const tools = registerTools(() => ({ active: false }));
 		const taskAgentsTool = tools.get("task_agents");
@@ -119,6 +155,54 @@ describe("task agent tool registration", () => {
 });
 
 describe("task_agents tool", () => {
+	it("renders partial and expanded task progress output", () => {
+		const tools = registerTools();
+		const taskAgentsTool = tools.get("task_agents");
+		const result = {
+			details: {
+				runId: "run-1",
+				completed: 1,
+				total: 5,
+				tasks: [
+					{
+						taskId: "a",
+						prompt: "Inspect auth",
+						status: "running",
+						latestActivity: "→ read src/auth.ts",
+						activityCount: 2,
+					},
+					{ taskId: "b", prompt: "Inspect docs", status: "completed", latestActivity: "done", activityCount: 1 },
+					{ taskId: "c", prompt: "Inspect cli", status: "failed", latestActivity: "boom", activityCount: 4 },
+					{ taskId: "d", prompt: "Inspect ui", status: "queued", activityCount: 0 },
+					{ taskId: "e", prompt: "Inspect build", status: "queued", activityCount: 0 },
+				],
+			},
+			content: [{ type: "text", text: "progress" }],
+		};
+
+		const compact = taskAgentsTool.renderResult(
+			result,
+			{ expanded: false, isPartial: true },
+			{
+				bold: (text: string) => text,
+				fg: (_tone: string, text: string) => text,
+			},
+		);
+		expect(compact.text).toContain("run-1 1/5");
+		expect(compact.text).toContain("Press Ctrl+O to expand");
+
+		const expanded = taskAgentsTool.renderResult(
+			result,
+			{ expanded: true, isPartial: true },
+			{
+				bold: (text: string) => text,
+				fg: (_tone: string, text: string) => text,
+			},
+		);
+		expect(expanded.text).toContain("a running");
+		expect(expanded.text).not.toContain("Press Ctrl+O to expand");
+	});
+
 	it("runs planning tasks through the bundled subagent runtime", async () => {
 		const tools = registerTools();
 		const taskAgentsTool = tools.get("task_agents");
@@ -153,6 +237,64 @@ describe("task_agents tool", () => {
 		expect(result.content[0]?.text).toContain("Use steer_task_agent");
 	});
 
+	it("renders expanded completed results and plain fallback output", () => {
+		const tools = registerTools();
+		const taskAgentsTool = tools.get("task_agents");
+		const detailed = taskAgentsTool.renderResult(
+			{
+				details: {
+					runId: "run-2",
+					successCount: 1,
+					totalCount: 2,
+					tasks: [
+						{
+							taskId: "auth",
+							task: "Inspect auth",
+							cwd: "/repo",
+							output: "Summary",
+							references: ["src/auth.ts"],
+							exitCode: 0,
+							stderr: "",
+							activities: [{ kind: "assistant", text: "summary", timestamp: 1 }],
+							startedAt: 1,
+							finishedAt: 2_001,
+							steeringNotes: ["Focus on middleware"],
+						},
+						{
+							taskId: "docs",
+							task: "Inspect docs",
+							cwd: "/repo/docs",
+							output: "",
+							references: [],
+							exitCode: 1,
+							stderr: "failed badly",
+							activities: [],
+							startedAt: 1,
+							finishedAt: 61_001,
+							steeringNotes: [],
+						},
+					],
+				},
+				content: [{ type: "text", text: "done" }],
+			},
+			{ expanded: true, isPartial: false },
+			{ bold: (text: string) => text, fg: (_tone: string, text: string) => text },
+		);
+
+		expect(detailed.text).toContain("Steering notes:");
+		expect(detailed.text).toContain("Duration:");
+		expect(detailed.text).toContain("References:");
+		expect(detailed.text).toContain("failed badly");
+		expect(detailed.text).toContain("Ctrl+O to collapse.");
+
+		const fallback = taskAgentsTool.renderResult(
+			{ details: undefined, content: [{ type: "text", text: "plain fallback" }] },
+			{ expanded: false, isPartial: false },
+			{ bold: (text: string) => text, fg: (_tone: string, text: string) => text },
+		);
+		expect(fallback.text).toBe("plain fallback");
+	});
+
 	it("marks the overall result as error when any delegated task fails", async () => {
 		const tools = registerTools();
 		const taskAgentsTool = tools.get("task_agents");
@@ -179,6 +321,81 @@ describe("task_agents tool", () => {
 });
 
 describe("steer_task_agent", () => {
+	it("renders steer call previews", () => {
+		const tools = registerTools();
+		const steerTaskAgentTool = tools.get("steer_task_agent");
+		const rendered = steerTaskAgentTool.renderCall(
+			{ runId: "run-1", taskId: "auth", instruction: "Focus carefully on middleware ordering and auth regressions" },
+			{ bold: (text: string) => text, fg: (_tone: string, text: string) => text },
+		);
+
+		expect(rendered.text).toContain("steer task agent run-1/auth");
+		expect(rendered.text).toContain("Focus carefully on middleware ordering");
+	});
+
+	it("rejects steer_task_agent when plan mode is inactive", async () => {
+		const tools = registerTools(() => ({ active: false }));
+		const steerTaskAgentTool = tools.get("steer_task_agent");
+		const result = await steerTaskAgentTool.execute(
+			"call-1",
+			{ runId: "x", taskId: "y", instruction: "z" },
+			undefined,
+			undefined,
+			{
+				cwd: "/repo",
+			},
+		);
+
+		expect(result.isError).toBe(true);
+		expect(result.content[0]?.text).toContain("steer_task_agent is only available while plan mode is active");
+	});
+
+	it("rejects invalid or unknown steer requests", async () => {
+		const tools = registerTools();
+		const taskAgentsTool = tools.get("task_agents");
+		const steerTaskAgentTool = tools.get("steer_task_agent");
+		(runSync as MockRunSync).mockResolvedValueOnce(makeSingleResult(0));
+		(getFinalOutput as MockGetFinalOutput).mockReturnValueOnce("Initial summary");
+
+		const firstRun = await taskAgentsTool.execute(
+			"call-1",
+			{ tasks: [{ id: "auth-scan", prompt: "Inspect auth" }], concurrency: 1 },
+			undefined,
+			undefined,
+			{ cwd: "/repo" },
+		);
+
+		const missingArgs = await steerTaskAgentTool.execute(
+			"call-2",
+			{ runId: "", taskId: "", instruction: "" },
+			undefined,
+			undefined,
+			{ cwd: "/repo" },
+		);
+		expect(missingArgs.isError).toBe(true);
+		expect(missingArgs.content[0]?.text).toContain("runId, taskId, and instruction are required");
+
+		const unknownRun = await steerTaskAgentTool.execute(
+			"call-3",
+			{ runId: "unknown", taskId: "auth-scan", instruction: "retry" },
+			undefined,
+			undefined,
+			{ cwd: "/repo" },
+		);
+		expect(unknownRun.isError).toBe(true);
+		expect(unknownRun.content[0]?.text).toContain("Known runIds");
+
+		const unknownTask = await steerTaskAgentTool.execute(
+			"call-4",
+			{ runId: firstRun.details.runId, taskId: "missing", instruction: "retry" },
+			undefined,
+			undefined,
+			{ cwd: "/repo" },
+		);
+		expect(unknownTask.isError).toBe(true);
+		expect(unknownTask.content[0]?.text).toContain("Known taskIds: auth-scan");
+	});
+
 	it("reruns a previous task with extra steering via the subagent runtime", async () => {
 		const tools = registerTools();
 		const taskAgentsTool = tools.get("task_agents");

--- a/packages/providers/tests/index.test.ts
+++ b/packages/providers/tests/index.test.ts
@@ -170,4 +170,59 @@ describe("provider catalog extension", () => {
 		expect(stored.get(provider.id)).toMatchObject({ type: "oauth", providerId: provider.id });
 		expect(refresh).toHaveBeenCalledTimes(1);
 	});
+
+	it("routes list, info, models, and refresh-models subcommands", async () => {
+		const provider = getSupportedProvider("moonshotai");
+		const harness = createExtensionHarness();
+		harness.ctx.modelRegistry = {
+			authStorage: {
+				get: vi.fn((providerId: string) =>
+					providerId === provider.id
+						? {
+								type: "oauth",
+								providerId: provider.id,
+								refresh: "moonshot-key",
+								access: "moonshot-key",
+								expires: Date.now() + 60_000,
+								lastModelRefresh: Date.now(),
+								models: [
+									{
+										id: "moonshot-v1",
+										name: "Moonshot V1",
+										contextWindow: 131072,
+										outputTokens: 16384,
+										input: ["text", "image"],
+										output: ["text"],
+										reasoning: true,
+										cost: { input: 0, output: 0 },
+									},
+								],
+							}
+						: undefined,
+				),
+				set: vi.fn(),
+			},
+			refresh: vi.fn(),
+		} as never;
+
+		providerCatalogExtension(harness.pi as never);
+		const command = harness.commands.get("providers");
+
+		await command.handler("list moon", harness.ctx);
+		expect(harness.notifications.at(-1)?.msg).toContain(`${provider.id} — ${provider.name}`);
+
+		await command.handler(`info ${provider.id}`, harness.ctx);
+		expect(harness.notifications.at(-1)?.msg).toContain("Configured via: login");
+		expect(harness.notifications.at(-1)?.msg).toContain("Models available: 1");
+
+		await command.handler(`models ${provider.id}`, harness.ctx);
+		expect(harness.notifications.at(-1)?.msg).toContain(`${provider.id} models:`);
+		expect(harness.notifications.at(-1)?.msg).toContain("Moonshot V1 [reasoning · vision]");
+
+		await command.handler("refresh-models missing-provider", harness.ctx);
+		expect(harness.notifications.at(-1)).toEqual({
+			msg: 'No provider matched "missing-provider". Run /providers list first.',
+			type: "warning",
+		});
+	});
 });

--- a/packages/shared-qna/tests/qna-tui.test.ts
+++ b/packages/shared-qna/tests/qna-tui.test.ts
@@ -1,104 +1,286 @@
-import { describe, expect, it } from "vitest";
+import { afterEach, describe, expect, it, vi } from "vitest";
+
+vi.mock("../pi-tui-loader.js", () => {
+	class FakeEditor {
+		disableSubmit?: boolean;
+		onChange?: () => void;
+		private text = "";
+
+		setText(text: string) {
+			this.text = text;
+		}
+
+		getText() {
+			return this.text;
+		}
+
+		render(_width: number) {
+			return ["┌", this.text || " ", "└"];
+		}
+
+		handleInput(data: string) {
+			if (data === "<shift-enter>") {
+				this.text += "\n";
+			} else if (data === "<backspace>") {
+				this.text = this.text.slice(0, -1);
+			} else if (data.length === 1) {
+				this.text += data;
+			}
+			this.onChange?.();
+		}
+	}
+
+	return {
+		requirePiTuiModule: () => ({
+			Editor: FakeEditor,
+			Key: {
+				enter: "<enter>",
+				tab: "<tab>",
+				escape: "<escape>",
+				up: "<up>",
+				down: "<down>",
+				ctrl: (key: string) => `<ctrl-${key}>`,
+				shift: (key: string) => `<shift-${key}>`,
+			},
+			matchesKey: (input: string, key: string) => input === key,
+			truncateToWidth: (text: string, width: number) => (text.length <= width ? text : text.slice(0, width)),
+			visibleWidth: (text: string) => text.length,
+			wrapTextWithAnsi: (text: string, width: number) => {
+				if (width <= 0 || text.length <= width) {
+					return [text];
+				}
+				const lines: string[] = [];
+				for (let index = 0; index < text.length; index += width) {
+					lines.push(text.slice(index, index + width));
+				}
+				return lines;
+			},
+		}),
+	};
+});
+
 import {
+	cloneResponses,
 	deriveAnswersFromResponses,
 	formatResponseAnswer,
 	getQuestionOptions,
 	hasResponseContent,
 	normalizeResponseForQuestion,
 	normalizeResponses,
+	QnATuiComponent,
 } from "../index.js";
 
-describe("getQuestionOptions", () => {
-	it("defaults missing options to an empty array", () => {
-		expect(getQuestionOptions({ question: "Which runtime?" })).toEqual([]);
-	});
+afterEach(() => {
+	vi.restoreAllMocks();
 });
 
-describe("formatResponseAnswer", () => {
-	it("returns the selected option label", () => {
-		const answer = formatResponseAnswer(
-			{
-				question: "Which runtime?",
-				options: [
-					{ label: "Node", description: "Use Node.js" },
-					{ label: "Bun", description: "Use Bun" },
-				],
-			},
-			{ selectedOptionIndex: 1, customText: "", selectionTouched: true, committed: true },
-		);
-		expect(answer).toBe("Bun");
-	});
+function createTui() {
+	return {
+		requestRender: vi.fn(),
+	};
+}
 
-	it("returns custom text for freeform questions", () => {
-		const answer = formatResponseAnswer(
-			{ question: "Any constraints?" },
-			{ selectedOptionIndex: 0, customText: "Two-phase rollout", selectionTouched: true, committed: true },
-		);
-		expect(answer).toBe("Two-phase rollout");
-	});
-});
-
-describe("normalizeResponseForQuestion", () => {
-	it("infers the other option when fallback text does not match a listed option", () => {
-		const normalized = normalizeResponseForQuestion(
-			{
-				question: "Which runtime?",
-				options: [
-					{ label: "Node", description: "Use Node.js" },
-					{ label: "Bun", description: "Use Bun" },
-				],
-			},
-			undefined,
-			"Use Deno",
-			true,
-		);
-		expect(normalized.selectedOptionIndex).toBe(2);
-		expect(normalized.customText).toBe("Use Deno");
-		expect(normalized.selectionTouched).toBe(true);
-		expect(normalized.committed).toBe(true);
-	});
-	it("treats freeform fallback text as committed content", () => {
-		const normalized = normalizeResponseForQuestion({ question: "Any constraints?" }, undefined, "Need Bun APIs", true);
-		expect(normalized.selectedOptionIndex).toBe(0);
-		expect(normalized.customText).toBe("Need Bun APIs");
-		expect(normalized.selectionTouched).toBe(true);
-		expect(normalized.committed).toBe(true);
-	});
-});
-
-describe("normalizeResponses", () => {
-	it("normalizes every question/response pair", () => {
-		const responses = normalizeResponses(
-			[
-				{ question: "Which runtime?", options: [{ label: "Node", description: "Use Node.js" }] },
-				{ question: "Any constraints?" },
-			],
-			[
-				{ selectedOptionIndex: 0, committed: true },
-				{ customText: "Keep SSR", committed: true },
-			],
-			undefined,
-			true,
-		);
-		expect(responses).toHaveLength(2);
-		expect(responses[0]?.selectedOptionIndex).toBe(0);
-		expect(responses[1]?.customText).toBe("Keep SSR");
-	});
-});
-
-describe("deriveAnswersFromResponses and hasResponseContent", () => {
-	it("derives answers and detects whether content exists", () => {
+describe("qna helpers", () => {
+	it("normalizes responses, clones state, and derives answers", () => {
 		const questions = [
-			{ question: "Which runtime?", options: [{ label: "Node", description: "Use Node.js" }] },
-			{ question: "Any constraints?" },
+			{
+				question: "Choose a runtime",
+				options: [
+					{ label: "Node", description: "Default" },
+					{ label: "Bun", description: "Fast" },
+				],
+			},
+			{ question: "Any rollout notes?" },
 		] as const;
-		const responses = [
-			{ selectedOptionIndex: 0, customText: "", selectionTouched: true, committed: true },
-			{ selectedOptionIndex: 0, customText: "Keep SSR", selectionTouched: true, committed: true },
-		];
-		const answers = deriveAnswersFromResponses(questions, responses);
-		expect(answers).toEqual(["Node", "Keep SSR"]);
-		expect(hasResponseContent(questions[0], responses[0])).toBe(true);
-		expect(hasResponseContent(questions[1], responses[1])).toBe(true);
+
+		const normalized = normalizeResponses(
+			questions,
+			[
+				{ selectedOptionIndex: 99, selectionTouched: true, committed: true },
+				{ customText: "Ship behind a flag", committed: true },
+			],
+			undefined,
+			true,
+		);
+
+		expect(normalized[0]).toEqual({
+			selectedOptionIndex: 2,
+			customText: "",
+			selectionTouched: true,
+			committed: true,
+		});
+		expect(cloneResponses(normalized)).toEqual(normalized);
+		expect(deriveAnswersFromResponses(questions, normalized)).toEqual(["", "Ship behind a flag"]);
+		expect(getQuestionOptions({ question: "Freeform only" })).toEqual([]);
+		expect(hasResponseContent(questions[1], normalized[1])).toBe(true);
+	});
+
+	it("formats option answers, custom answers, and inferred fallback selections", () => {
+		const question = {
+			question: "Choose a runtime",
+			options: [
+				{ label: "Node", description: "Default" },
+				{ label: "Bun", description: "Fast" },
+			],
+		};
+		expect(
+			formatResponseAnswer(question, {
+				selectedOptionIndex: 1,
+				customText: "",
+				selectionTouched: true,
+				committed: true,
+			}),
+		).toBe("Bun");
+		expect(normalizeResponseForQuestion(question, undefined, "Deno", true)).toMatchObject({
+			selectedOptionIndex: 2,
+			customText: "Deno",
+			committed: true,
+		});
+		expect(normalizeResponseForQuestion({ question: "Notes" }, undefined, "Roll out slowly", true)).toMatchObject({
+			selectedOptionIndex: 0,
+			customText: "Roll out slowly",
+			committed: true,
+		});
+	});
+});
+
+describe("QnATuiComponent", () => {
+	it("renders the current question and reuses cached output for the same width", () => {
+		const done = vi.fn();
+		const component = new QnATuiComponent(
+			[
+				{
+					header: "Deployment",
+					question: "Choose a runtime",
+					context: "Pick the default environment for production.",
+					options: [
+						{ label: "Node", description: "Use Node.js" },
+						{ label: "Bun", description: "Use Bun" },
+					],
+				},
+			],
+			createTui(),
+			done,
+			{ title: "Setup" },
+		);
+
+		const firstRender = component.render(80);
+		const secondRender = component.render(80);
+		expect(secondRender).toBe(firstRender);
+		const rendered = firstRender.join("\n");
+		expect(rendered).toContain("Setup (1/1)");
+		expect(rendered).toContain("Deployment");
+		expect(rendered).toContain("Choose a runtime");
+		expect(rendered).toContain("Pick the default environment");
+		expect(rendered).toContain("Ctrl+C");
+		expect(done).not.toHaveBeenCalled();
+	});
+
+	it("selects options, applies templates, reviews answers, and submits", () => {
+		const tui = createTui();
+		const done = vi.fn();
+		const onResponsesChange = vi.fn();
+		const component = new QnATuiComponent(
+			[
+				{
+					question: "Choose a runtime",
+					options: [
+						{ label: "Node", description: "Use Node.js" },
+						{ label: "Bun", description: "Use Bun" },
+					],
+				},
+				{ question: "Any rollout notes?" },
+			],
+			tui,
+			done,
+			{
+				templates: [{ label: "Brief", template: "{{index}}/{{total}} {{question}} => {{answer}}" }],
+				onResponsesChange,
+				questionSummaryLabel: (_question, index) => `Prompt ${index + 1}`,
+			},
+		);
+
+		component.handleInput("2");
+		expect(onResponsesChange.mock.calls.at(-1)?.[0][0]).toMatchObject({
+			selectedOptionIndex: 1,
+			selectionTouched: true,
+		});
+
+		component.handleInput("<enter>");
+		expect(onResponsesChange.mock.calls.at(-1)?.[0][0]).toMatchObject({ committed: true });
+
+		component.handleInput("<ctrl-t>");
+		component.handleInput("!");
+		component.handleInput("<shift-enter>");
+		component.handleInput("R");
+		component.handleInput("<enter>");
+
+		const confirmation = component.render(90).join("\n");
+		expect(confirmation).toContain("Review before submit:");
+		expect(confirmation).toContain("Prompt 1");
+		expect(confirmation).toContain("Prompt 2");
+		expect(confirmation).toContain("Submit all answers?");
+
+		component.handleInput("<enter>");
+		const result = done.mock.calls[0]?.[0];
+		expect(result.answers).toEqual(["Bun", "2/2 Any rollout notes? => !\nR"]);
+		expect(result.text).toContain("Q: Choose a runtime");
+		expect(result.text).toContain("A: Bun");
+		expect(result.text).toContain("Q: Any rollout notes?");
+		expect(result.responses[1]).toMatchObject({ committed: true, selectionTouched: true });
+		expect(tui.requestRender).toHaveBeenCalled();
+	});
+
+	it("switches to custom input for printable text and can navigate back from an empty other answer", () => {
+		const onResponsesChange = vi.fn();
+		const component = new QnATuiComponent(
+			[
+				{
+					question: "Choose a runtime",
+					options: [
+						{ label: "Node", description: "Use Node.js" },
+						{ label: "Bun", description: "Use Bun" },
+					],
+				},
+			],
+			createTui(),
+			vi.fn(),
+			{ onResponsesChange },
+		);
+
+		component.handleInput("x");
+		expect(onResponsesChange.mock.calls.at(-1)?.[0][0]).toMatchObject({
+			selectedOptionIndex: 2,
+			customText: "x",
+			selectionTouched: true,
+		});
+
+		component.handleInput("<backspace>");
+		component.handleInput("<up>");
+		expect(onResponsesChange.mock.calls.at(-1)?.[0][0]).toMatchObject({
+			selectedOptionIndex: 1,
+			customText: "",
+			selectionTouched: true,
+		});
+
+		const rendered = component.render(80).join("\n");
+		expect(rendered).toContain("A: Bun");
+	});
+
+	it("supports escape from confirmation and ctrl+c cancellation", () => {
+		const done = vi.fn();
+		const component = new QnATuiComponent([{ question: "Any notes?" }], createTui(), done, {
+			fallbackAnswers: ["Keep rollback ready"],
+			inferCommittedFromContent: true,
+		});
+
+		component.handleInput("<enter>");
+		expect(component.render(80).join("\n")).toContain("Review before submit:");
+
+		component.handleInput("<escape>");
+		expect(component.render(80).join("\n")).not.toContain("Review before submit:");
+
+		component.handleInput("<ctrl-c>");
+		expect(done).toHaveBeenCalledWith(null);
 	});
 });

--- a/packages/subagents/tests/agent-management.test.ts
+++ b/packages/subagents/tests/agent-management.test.ts
@@ -1,0 +1,262 @@
+import * as fs from "node:fs";
+import * as os from "node:os";
+import * as path from "node:path";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+
+const discoveryState = vi.hoisted(() => ({
+	builtin: [] as any[],
+	user: [] as any[],
+	project: [] as any[],
+	chains: [] as any[],
+	userDir: "",
+	projectDir: "",
+}));
+
+const serializeAgentMock = vi.hoisted(() => vi.fn((agent: { name: string }) => `agent:${agent.name}`));
+const serializeChainMock = vi.hoisted(() => vi.fn((chain: { name: string }) => `chain:${chain.name}`));
+const discoverSkillsMock = vi.hoisted(() => vi.fn(() => [{ name: "git" }, { name: "context7" }]));
+
+vi.mock("../agents.js", () => ({
+	discoverAgentsAll: vi.fn(() => ({ ...discoveryState })),
+}));
+
+vi.mock("../agent-serializer.js", () => ({
+	serializeAgent: serializeAgentMock,
+}));
+
+vi.mock("../chain-serializer.js", () => ({
+	serializeChain: serializeChainMock,
+}));
+
+vi.mock("../skills.js", () => ({
+	discoverAvailableSkills: discoverSkillsMock,
+}));
+
+import { handleManagementAction } from "../agent-management.js";
+
+function createCtx(cwd: string) {
+	return {
+		cwd,
+		modelRegistry: {
+			getAvailable: () => [{ provider: "anthropic", id: "claude-sonnet-4" }],
+		},
+	};
+}
+
+const tempDirs: string[] = [];
+
+function createDirs() {
+	const root = fs.mkdtempSync(path.join(os.tmpdir(), "oh-pi-agent-management-"));
+	tempDirs.push(root);
+	const userDir = path.join(root, "user-agents");
+	const projectDir = path.join(root, "project-agents");
+	fs.mkdirSync(userDir, { recursive: true });
+	fs.mkdirSync(projectDir, { recursive: true });
+	discoveryState.userDir = userDir;
+	discoveryState.projectDir = projectDir;
+	return { root, userDir, projectDir };
+}
+
+beforeEach(() => {
+	discoveryState.builtin = [];
+	discoveryState.user = [];
+	discoveryState.project = [];
+	discoveryState.chains = [];
+	serializeAgentMock.mockClear();
+	serializeChainMock.mockClear();
+	discoverSkillsMock.mockClear();
+});
+
+afterEach(() => {
+	for (const dir of tempDirs.splice(0)) {
+		fs.rmSync(dir, { recursive: true, force: true });
+	}
+	vi.restoreAllMocks();
+});
+
+describe("handleManagementAction", () => {
+	it("lists and gets agents and chains across scopes", () => {
+		const { root, userDir, projectDir } = createDirs();
+		const userAgentPath = path.join(userDir, "helper.md");
+		const chainPath = path.join(projectDir, "delivery.chain.md");
+		fs.writeFileSync(userAgentPath, "agent:helper", "utf8");
+		fs.writeFileSync(chainPath, "chain:delivery", "utf8");
+		discoveryState.builtin = [
+			{ name: "scout", description: "Builtin scout", source: "builtin", filePath: "/builtin/scout.md" },
+		];
+		discoveryState.user = [
+			{
+				name: "helper",
+				description: "User helper",
+				source: "user",
+				filePath: userAgentPath,
+				systemPrompt: "Be useful",
+				skills: ["git"],
+				tools: ["read"],
+				extraFields: { category: "analysis" },
+			},
+		];
+		discoveryState.project = [];
+		discoveryState.chains = [
+			{
+				name: "delivery",
+				description: "Ship work",
+				source: "project",
+				filePath: chainPath,
+				steps: [{ agent: "helper", task: "inspect", output: "report.md", reads: ["spec.md"], progress: true }],
+			},
+		];
+
+		const ctx = createCtx(root);
+		const listResult = handleManagementAction("list", {}, ctx as never);
+		expect(listResult.isError).toBeFalsy();
+		expect(listResult.content[0]?.text).toContain("- scout (builtin): Builtin scout");
+		expect(listResult.content[0]?.text).toContain("- helper (user): User helper");
+		expect(listResult.content[0]?.text).toContain("- delivery (project): Ship work");
+
+		const getResult = handleManagementAction("get", { agent: "helper", chainName: "delivery" }, ctx as never);
+		expect(getResult.content[0]?.text).toContain("Agent: helper (user)");
+		expect(getResult.content[0]?.text).toContain("Skills: git");
+		expect(getResult.content[0]?.text).toContain("Chain: delivery (project)");
+		expect(getResult.content[0]?.text).toContain("Output: report.md");
+	});
+
+	it("creates agents and chains with warnings for unknown models, skills, and agents", () => {
+		const { root, projectDir } = createDirs();
+		const ctx = createCtx(root);
+
+		const createAgent = handleManagementAction(
+			"create",
+			{
+				config: {
+					name: "My Helper",
+					description: "Created from tests",
+					scope: "project",
+					systemPrompt: "Assist with repo work",
+					tools: "read,write,mcp:github",
+					skills: "git,missing-skill",
+					model: "openai/gpt-5",
+					extensions: "prompt.md,npm:@scope/pkg",
+					reads: "spec.md,notes.md",
+					progress: true,
+				},
+			},
+			ctx as never,
+		);
+
+		const createdAgentPath = path.join(projectDir, "my-helper.md");
+		expect(fs.existsSync(createdAgentPath)).toBe(true);
+		expect(fs.readFileSync(createdAgentPath, "utf8")).toBe("agent:my-helper");
+		expect(createAgent.content[0]?.text).toContain(`Created agent 'my-helper' at ${createdAgentPath}.`);
+		expect(createAgent.content[0]?.text).toContain(
+			"Warning: model 'openai/gpt-5' is not in the current model registry.",
+		);
+		expect(createAgent.content[0]?.text).toContain("Warning: skills not found: missing-skill.");
+
+		const createChain = handleManagementAction(
+			"create",
+			{
+				config: {
+					name: "Delivery Chain",
+					description: "Coordinate steps",
+					scope: "project",
+					steps: [
+						{ agent: "my-helper", task: "inspect" },
+						{ agent: "missing-agent", task: "ship", model: "missing-model", skills: ["missing-skill"] },
+					],
+				},
+			},
+			ctx as never,
+		);
+
+		const createdChainPath = path.join(projectDir, "delivery-chain.chain.md");
+		expect(fs.existsSync(createdChainPath)).toBe(true);
+		expect(fs.readFileSync(createdChainPath, "utf8")).toBe("chain:delivery-chain");
+		expect(createChain.content[0]?.text).toContain("Warning: chain steps reference unknown agents:");
+		expect(createChain.content[0]?.text).toContain("missing-agent");
+		expect(createChain.content[0]?.text).toContain("my-helper");
+		expect(createChain.content[0]?.text).toContain(
+			"Warning: step 2 (missing-agent): model 'missing-model' is not in the current model registry.",
+		);
+		expect(createChain.content[0]?.text).toContain("Warning: step 2 (missing-agent): skills not found: missing-skill.");
+	});
+
+	it("updates renamed agents and warns about chain references", () => {
+		const { root, userDir } = createDirs();
+		const ctx = createCtx(root);
+		const oldPath = path.join(userDir, "helper.md");
+		fs.writeFileSync(oldPath, "agent:helper", "utf8");
+		discoveryState.user = [
+			{
+				name: "helper",
+				description: "User helper",
+				source: "user",
+				filePath: oldPath,
+				systemPrompt: "Be useful",
+				extraFields: { createdBy: "management-api" },
+			},
+		];
+		discoveryState.chains = [
+			{
+				name: "delivery",
+				description: "Ship work",
+				source: "project",
+				filePath: path.join(root, "delivery.chain.md"),
+				steps: [{ agent: "helper", task: "inspect" }],
+			},
+		];
+
+		const updateResult = handleManagementAction(
+			"update",
+			{
+				agent: "helper",
+				config: {
+					name: "Renamed Helper",
+					description: "Renamed helper",
+					skills: "git,missing-skill",
+				},
+			},
+			ctx as never,
+		);
+
+		const renamedPath = path.join(userDir, "renamed-helper.md");
+		expect(fs.existsSync(oldPath)).toBe(false);
+		expect(fs.existsSync(renamedPath)).toBe(true);
+		expect(fs.readFileSync(renamedPath, "utf8")).toBe("agent:renamed-helper");
+		expect(updateResult.content[0]?.text).toContain(`Updated agent 'helper' to 'renamed-helper' at ${renamedPath}.`);
+		expect(updateResult.content[0]?.text).toContain("Warning: skills not found: missing-skill.");
+		expect(updateResult.content[0]?.text).toContain("Warning: chains still reference 'helper': delivery (project).");
+	});
+
+	it("rejects deleting builtin agents and deletes mutable chains", () => {
+		const { root, projectDir } = createDirs();
+		const ctx = createCtx(root);
+		const chainPath = path.join(projectDir, "delivery.chain.md");
+		fs.writeFileSync(chainPath, "chain:delivery", "utf8");
+		discoveryState.builtin = [
+			{ name: "scout", description: "Builtin scout", source: "builtin", filePath: "/builtin/scout.md" },
+		];
+		discoveryState.chains = [
+			{
+				name: "delivery",
+				description: "Ship work",
+				source: "project",
+				filePath: chainPath,
+				steps: [{ agent: "scout", task: "inspect" }],
+			},
+		];
+
+		const builtinDelete = handleManagementAction("delete", { agent: "scout" }, ctx as never);
+		expect(builtinDelete.isError).toBe(true);
+		expect(builtinDelete.content[0]?.text).toContain("Agent 'scout' is builtin and cannot be modified.");
+
+		const deleteChain = handleManagementAction(
+			"delete",
+			{ chainName: "delivery", agentScope: "project" },
+			ctx as never,
+		);
+		expect(deleteChain.isError).toBeFalsy();
+		expect(deleteChain.content[0]?.text).toBe(`Deleted chain 'delivery' at ${chainPath}.`);
+		expect(fs.existsSync(chainPath)).toBe(false);
+	});
+});

--- a/packages/subagents/tests/async-execution.test.ts
+++ b/packages/subagents/tests/async-execution.test.ts
@@ -1,0 +1,301 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+const asyncMocks = vi.hoisted(() => {
+	const createRequire = () => {
+		const requireFn = ((specifier: string) => {
+			throw new Error(`Unexpected require: ${specifier}`);
+		}) as ((specifier: string) => never) & { resolve: (specifier: string) => string };
+		requireFn.resolve = (specifier: string) => `/virtual/${specifier}`;
+		return requireFn;
+	};
+
+	return {
+		spawn: vi.fn(() => ({ pid: 4242, unref: vi.fn() })),
+		mkdtempSync: vi.fn(() => "/tmp/pi-async-cfg-123"),
+		writeFileSync: vi.fn(),
+		mkdirSync: vi.fn(),
+		existsSync: vi.fn((filePath: string) => filePath.includes("jiti-cli.mjs")),
+		realpathSync: vi.fn(() => "/virtual/pi/bin/pi.js"),
+		createRequire,
+		applyThinkingSuffix: vi.fn((model: string | undefined, thinking: string | undefined) =>
+			model && thinking && thinking !== "off" ? `${model}:${thinking}` : model,
+		),
+		injectSingleOutputInstruction: vi.fn((task: string, outputPath?: string) =>
+			outputPath ? `${task}\nWRITE ${outputPath}` : task,
+		),
+		resolveSingleOutputPath: vi.fn((output: string | false | undefined, _runtimeCwd: string, cwd?: string) => {
+			if (!output || output === false) {
+				return undefined;
+			}
+			return `${cwd ?? "/repo"}/${output}`;
+		}),
+		isParallelStep: vi.fn((step: any) => Boolean(step?.parallel)),
+		resolveStepBehavior: vi.fn((_agent: any, stepOverrides: any, chainSkills: string[]) => ({
+			skills: stepOverrides.skills ?? chainSkills,
+		})),
+		resolvePiPackageRoot: vi.fn(() => "/virtual/pi-root"),
+		buildSkillInjection: vi.fn(
+			(skills: Array<{ name: string }>) => `INJECT:${skills.map((skill) => skill.name).join(",")}`,
+		),
+		normalizeSkillInput: vi.fn((value: unknown) => value),
+		resolveSkills: vi.fn((skillNames: string[]) => ({
+			resolved: skillNames.map((name) => ({ name })),
+			missing: [],
+		})),
+		resolveSubagentModelResolution: vi.fn((_agent: any, _models: any[], explicitModel?: string) => ({
+			model: explicitModel,
+			source: explicitModel ? "runtime-override" : "agent-default",
+			category: explicitModel ? "explicit" : undefined,
+		})),
+	};
+});
+
+vi.mock("node:child_process", () => ({ spawn: asyncMocks.spawn }));
+vi.mock("node:fs", () => ({
+	mkdtempSync: asyncMocks.mkdtempSync,
+	writeFileSync: asyncMocks.writeFileSync,
+	mkdirSync: asyncMocks.mkdirSync,
+	existsSync: asyncMocks.existsSync,
+	realpathSync: asyncMocks.realpathSync,
+}));
+vi.mock("node:module", () => ({
+	createRequire: () => asyncMocks.createRequire(),
+}));
+vi.mock("../execution.js", () => ({
+	applyThinkingSuffix: asyncMocks.applyThinkingSuffix,
+}));
+vi.mock("../single-output.js", () => ({
+	injectSingleOutputInstruction: asyncMocks.injectSingleOutputInstruction,
+	resolveSingleOutputPath: asyncMocks.resolveSingleOutputPath,
+}));
+vi.mock("../settings.js", () => ({
+	isParallelStep: asyncMocks.isParallelStep,
+	resolveStepBehavior: asyncMocks.resolveStepBehavior,
+}));
+vi.mock("../pi-spawn.js", () => ({
+	resolvePiPackageRoot: asyncMocks.resolvePiPackageRoot,
+}));
+vi.mock("../skills.js", () => ({
+	buildSkillInjection: asyncMocks.buildSkillInjection,
+	normalizeSkillInput: asyncMocks.normalizeSkillInput,
+	resolveSkills: asyncMocks.resolveSkills,
+}));
+vi.mock("../types.js", () => ({
+	ASYNC_DIR: "/tmp/pi-async-subagent-runs",
+	RESULTS_DIR: "/tmp/pi-async-subagent-results",
+}));
+vi.mock("../model-routing.js", () => ({
+	resolveSubagentModelResolution: asyncMocks.resolveSubagentModelResolution,
+}));
+
+import { executeAsyncChain, executeAsyncSingle, isAsyncAvailable } from "../async-execution.js";
+
+function createCtx() {
+	return {
+		cwd: "/repo",
+		currentSessionId: "session-1",
+		currentModel: "anthropic/claude-sonnet-4",
+		availableModels: [{ provider: "anthropic", id: "claude-sonnet-4", fullId: "anthropic/claude-sonnet-4" }],
+		pi: {
+			events: {
+				emit: vi.fn(),
+			},
+		},
+	};
+}
+
+function lastRunnerConfig() {
+	const call = asyncMocks.writeFileSync.mock.calls.at(-1);
+	if (!call) {
+		throw new Error("Expected runner config to be written");
+	}
+	return JSON.parse(call[1]);
+}
+
+beforeEach(() => {
+	for (const mock of Object.values(asyncMocks)) {
+		if (typeof mock === "function" && "mockReset" in mock) {
+			(mock as ReturnType<typeof vi.fn>).mockReset();
+		}
+	}
+
+	asyncMocks.spawn.mockReturnValue({ pid: 4242, unref: vi.fn() });
+	asyncMocks.mkdtempSync.mockReturnValue("/tmp/pi-async-cfg-123");
+	asyncMocks.existsSync.mockImplementation((filePath: string) => filePath.includes("jiti-cli.mjs"));
+	asyncMocks.realpathSync.mockReturnValue("/virtual/pi/bin/pi.js");
+	asyncMocks.resolveStepBehavior.mockImplementation((_agent: any, stepOverrides: any, chainSkills: string[]) => ({
+		skills: stepOverrides.skills ?? chainSkills,
+	}));
+	asyncMocks.resolveSkills.mockImplementation((skillNames: string[]) => ({
+		resolved: skillNames.map((name) => ({ name })),
+		missing: [],
+	}));
+	asyncMocks.resolveSubagentModelResolution.mockImplementation(
+		(_agent: any, _models: any[], explicitModel?: string) => ({
+			model: explicitModel,
+			source: explicitModel ? "runtime-override" : "agent-default",
+			category: explicitModel ? "explicit" : undefined,
+		}),
+	);
+});
+
+describe("async execution helpers", () => {
+	it("reports async support when the jiti runner is available", () => {
+		expect(isAsyncAvailable()).toBe(true);
+	});
+
+	it("builds async single-runner configs, injects output instructions, and emits start events", () => {
+		const ctx = createCtx();
+		const result = executeAsyncSingle("run-1", {
+			agent: "scout",
+			task: "Inspect the repo",
+			agentConfig: {
+				name: "scout",
+				systemPrompt: "Base system prompt",
+				thinking: "high",
+				skills: ["git", "context7"],
+				tools: ["bash"],
+				extensions: ["./extensions/worktree.ts"],
+				mcpDirectTools: ["read"],
+			},
+			ctx,
+			cwd: "/workspace",
+			output: "report.md",
+			shareEnabled: true,
+			sessionRoot: "/tmp/sessions",
+			artifactConfig: { enabled: true },
+			artifactsDir: "/tmp/artifacts",
+			maxOutput: { bytes: 1000, lines: 20 },
+		});
+
+		expect(result).toEqual({
+			content: [{ type: "text", text: "Async: scout [run-1]" }],
+			details: { mode: "single", results: [], asyncId: "run-1", asyncDir: "/tmp/pi-async-subagent-runs/run-1" },
+		});
+		expect(asyncMocks.mkdirSync).toHaveBeenCalledWith("/tmp/pi-async-subagent-runs/run-1", { recursive: true });
+		expect(asyncMocks.spawn).toHaveBeenCalledWith(
+			"node",
+			expect.arrayContaining([
+				expect.stringContaining("jiti-cli.mjs"),
+				expect.stringContaining("subagent-runner.ts"),
+				"/tmp/pi-async-cfg-123/run-1.json",
+			]),
+			expect.objectContaining({ cwd: "/workspace", detached: true, stdio: "ignore", windowsHide: true }),
+		);
+
+		const config = lastRunnerConfig();
+		expect(config).toMatchObject({
+			id: "run-1",
+			cwd: "/workspace",
+			resultPath: "/tmp/pi-async-subagent-results/run-1.json",
+			artifactsDir: "/tmp/artifacts",
+			share: true,
+			sessionDir: "/tmp/sessions/async-run-1",
+			sessionId: "session-1",
+			piPackageRoot: "/virtual/pi-root",
+		});
+		expect(config.steps[0]).toMatchObject({
+			agent: "scout",
+			task: "Inspect the repo\nWRITE /workspace/report.md",
+			model: "anthropic/claude-sonnet-4:high",
+			tools: ["bash"],
+			extensions: ["./extensions/worktree.ts"],
+			mcpDirectTools: ["read"],
+			skills: ["git", "context7"],
+			outputPath: "/workspace/report.md",
+		});
+		expect(config.steps[0].systemPrompt).toBe("Base system prompt\n\nINJECT:git,context7");
+		expect(ctx.pi.events.emit).toHaveBeenCalledWith("subagent:started", {
+			id: "run-1",
+			pid: 4242,
+			agent: "scout",
+			task: "Inspect the repo",
+			cwd: "/workspace",
+			asyncDir: "/tmp/pi-async-subagent-runs/run-1",
+		});
+	});
+
+	it("fails fast for unknown agents in async chains", () => {
+		const ctx = createCtx();
+		const result = executeAsyncChain("chain-1", {
+			chain: [{ agent: "missing", task: "Inspect" }],
+			agents: [{ name: "scout" }],
+			ctx,
+			shareEnabled: false,
+			artifactConfig: { enabled: false },
+		});
+
+		expect(result.isError).toBe(true);
+		expect(result.content[0]?.text).toBe("Unknown agent: missing");
+		expect(asyncMocks.spawn).not.toHaveBeenCalled();
+	});
+
+	it("builds sequential and parallel async chain configs with resolved skills and outputs", () => {
+		const ctx = createCtx();
+		asyncMocks.resolveSubagentModelResolution
+			.mockReturnValueOnce({ model: "openai/gpt-5", source: "runtime-override", category: "explicit" })
+			.mockReturnValue({ model: undefined, source: "agent-default", category: undefined });
+
+		const result = executeAsyncChain("chain-2", {
+			chain: [
+				{ agent: "scout", task: "Inspect {task}", output: "notes.md", skill: ["git"] },
+				{
+					parallel: [
+						{ agent: "planner", task: "Plan {previous}", output: "plan.md", cwd: "/workspace/a" },
+						{ agent: "reviewer", task: "Review {previous}", skill: ["context7"] },
+					],
+					concurrency: 2,
+					failFast: true,
+				},
+			],
+			agents: [
+				{ name: "scout", systemPrompt: "Scout", thinking: "minimal" },
+				{ name: "planner", systemPrompt: "Plan" },
+				{ name: "reviewer", systemPrompt: "Review" },
+			],
+			ctx,
+			cwd: "/workspace",
+			shareEnabled: true,
+			sessionRoot: "/tmp/sessions",
+			artifactConfig: { enabled: false },
+			chainSkills: ["shared-skill"],
+		});
+
+		expect(result).toEqual({
+			content: [{ type: "text", text: "Async chain: scout -> [planner+reviewer] [chain-2]" }],
+			details: { mode: "chain", results: [], asyncId: "chain-2", asyncDir: "/tmp/pi-async-subagent-runs/chain-2" },
+		});
+
+		const config = lastRunnerConfig();
+		expect(config.steps[0]).toMatchObject({
+			agent: "scout",
+			task: "Inspect {task}\nWRITE /workspace/notes.md",
+			model: "openai/gpt-5:minimal",
+			skills: ["git"],
+			outputPath: "/workspace/notes.md",
+		});
+		expect(config.steps[1]).toMatchObject({ concurrency: 2, failFast: true });
+		expect(config.steps[1].parallel[0]).toMatchObject({
+			agent: "planner",
+			task: "Plan {previous}\nWRITE /workspace/a/plan.md",
+			model: "anthropic/claude-sonnet-4",
+			skills: ["shared-skill"],
+			outputPath: "/workspace/a/plan.md",
+		});
+		expect(config.steps[1].parallel[1]).toMatchObject({
+			agent: "reviewer",
+			task: "Review {previous}",
+			model: "anthropic/claude-sonnet-4",
+			skills: ["context7"],
+		});
+		expect(ctx.pi.events.emit).toHaveBeenCalledWith("subagent:started", {
+			id: "chain-2",
+			pid: 4242,
+			agent: "scout",
+			task: "Inspect {task}",
+			chain: ["scout", "[planner+reviewer]"],
+			cwd: "/workspace",
+			asyncDir: "/tmp/pi-async-subagent-runs/chain-2",
+		});
+	});
+});

--- a/packages/subagents/tests/chain-execution.test.ts
+++ b/packages/subagents/tests/chain-execution.test.ts
@@ -1,0 +1,347 @@
+import fs from "node:fs";
+import os from "node:os";
+import path from "node:path";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+
+const chainMocks = vi.hoisted(() => ({
+	resolveChainTemplates: vi.fn((chain: any[]) =>
+		chain.map((step) =>
+			Array.isArray(step.parallel)
+				? step.parallel.map((task: any) => task.task ?? "{previous}")
+				: (step.task ?? "{previous}"),
+		),
+	),
+	createChainDir: vi.fn((_runId: string, base?: string) => base ?? path.join(os.tmpdir(), "pi-chain-fallback")),
+	removeChainDir: vi.fn(),
+	resolveStepBehavior: vi.fn((_agent: any, override: any, chainSkills: string[]) => ({
+		output: override.output,
+		reads: override.reads,
+		progress: override.progress,
+		skills: override.skills ?? chainSkills,
+	})),
+	resolveParallelBehaviors: vi.fn((parallel: any[], _agents: any[], _stepIndex: number, chainSkills: string[]) =>
+		parallel.map((task: any) => ({
+			output: task.output,
+			reads: task.reads,
+			progress: task.progress,
+			skills: task.skill ?? chainSkills,
+		})),
+	),
+	buildChainInstructions: vi.fn((behavior: any, chainDir: string) => ({
+		prefix: `READ ${behavior.reads?.join(",") ?? "none"} FROM ${chainDir}\n`,
+		suffix: behavior.output ? `\nWRITE ${behavior.output}` : "",
+	})),
+	createParallelDirs: vi.fn(),
+	aggregateParallelOutputs: vi.fn((taskResults: any[]) => taskResults.map((task) => task.output).join("\n---\n")),
+	isParallelStep: vi.fn((step: any) => Array.isArray(step?.parallel)),
+	normalizeSkillInput: vi.fn((value: unknown) => value),
+	discoverAvailableSkills: vi.fn(() => [{ name: "git" }, { name: "context7" }]),
+	runSync: vi.fn(),
+	buildChainSummary: vi.fn(
+		(_chain: any[], _results: any[], chainDir: string, status: string, failure?: any) =>
+			`summary:${status}:${path.basename(chainDir)}:${failure?.error ?? "ok"}`,
+	),
+	getFinalOutput: vi.fn((messages: any[]) => messages.map((message) => message.content?.[0]?.text ?? "").join("\n")),
+	mapConcurrent: vi.fn((items: any[], _concurrency: number, mapper: (item: any, index: number) => Promise<any>) =>
+		Promise.all(items.map((item, index) => mapper(item, index))),
+	),
+	recordRun: vi.fn(),
+	resolveSubagentModelResolution: vi.fn((_agent: any, _models: any[], explicitModel?: string) => ({
+		model: explicitModel,
+		source: explicitModel ? "runtime-override" : "agent-default",
+		category: explicitModel ? "explicit" : undefined,
+	})),
+}));
+
+vi.mock("../chain-clarify.js", () => ({
+	ChainClarifyComponent: class {},
+}));
+vi.mock("../settings.js", () => ({
+	resolveChainTemplates: chainMocks.resolveChainTemplates,
+	createChainDir: chainMocks.createChainDir,
+	removeChainDir: chainMocks.removeChainDir,
+	resolveStepBehavior: chainMocks.resolveStepBehavior,
+	resolveParallelBehaviors: chainMocks.resolveParallelBehaviors,
+	buildChainInstructions: chainMocks.buildChainInstructions,
+	createParallelDirs: chainMocks.createParallelDirs,
+	aggregateParallelOutputs: chainMocks.aggregateParallelOutputs,
+	isParallelStep: chainMocks.isParallelStep,
+}));
+vi.mock("../skills.js", () => ({
+	discoverAvailableSkills: chainMocks.discoverAvailableSkills,
+	normalizeSkillInput: chainMocks.normalizeSkillInput,
+}));
+vi.mock("../execution.js", () => ({
+	runSync: chainMocks.runSync,
+}));
+vi.mock("../formatters.js", () => ({
+	buildChainSummary: chainMocks.buildChainSummary,
+}));
+vi.mock("../utils.js", () => ({
+	getFinalOutput: chainMocks.getFinalOutput,
+	mapConcurrent: chainMocks.mapConcurrent,
+}));
+vi.mock("../run-history.js", () => ({
+	recordRun: chainMocks.recordRun,
+}));
+vi.mock("../model-routing.js", () => ({
+	resolveSubagentModelResolution: chainMocks.resolveSubagentModelResolution,
+}));
+vi.mock("../types.js", () => ({
+	MAX_CONCURRENCY: 4,
+}));
+
+import { executeChain } from "../chain-execution.js";
+
+const tempDirs: string[] = [];
+
+function createTempDir(prefix: string) {
+	const dir = fs.mkdtempSync(path.join(os.tmpdir(), prefix));
+	tempDirs.push(dir);
+	return dir;
+}
+
+function createCtx(overrides: Record<string, unknown> = {}) {
+	return {
+		cwd: "/repo",
+		hasUI: true,
+		model: { provider: "anthropic", id: "claude-sonnet-4" },
+		modelRegistry: {
+			getAvailable: () => [
+				{ provider: "anthropic", id: "claude-sonnet-4" },
+				{ provider: "openai", id: "gpt-5" },
+			],
+		},
+		ui: {
+			custom: vi.fn(),
+		},
+		...overrides,
+	};
+}
+
+function createResult(agent: string, exitCode: number, text: string, extra: Record<string, unknown> = {}) {
+	return {
+		agent,
+		task: text,
+		exitCode,
+		messages: [{ role: "assistant", content: [{ type: "text", text }] }],
+		usage: { input: 0, output: 0, cacheRead: 0, cacheWrite: 0, cost: 0, turns: 1 },
+		progressSummary: { durationMs: 12 },
+		...extra,
+	};
+}
+
+beforeEach(() => {
+	for (const mock of Object.values(chainMocks)) {
+		if (typeof mock === "function" && "mockReset" in mock) {
+			(mock as ReturnType<typeof vi.fn>).mockReset();
+		}
+	}
+
+	chainMocks.resolveChainTemplates.mockImplementation((chain: any[]) =>
+		chain.map((step) =>
+			Array.isArray(step.parallel)
+				? step.parallel.map((task: any) => task.task ?? "{previous}")
+				: (step.task ?? "{previous}"),
+		),
+	);
+	chainMocks.createChainDir.mockImplementation((_runId: string, base?: string) => base ?? createTempDir("pi-chain-"));
+	chainMocks.resolveStepBehavior.mockImplementation((_agent: any, override: any, chainSkills: string[]) => ({
+		output: override.output,
+		reads: override.reads,
+		progress: override.progress,
+		skills: override.skills ?? chainSkills,
+	}));
+	chainMocks.resolveParallelBehaviors.mockImplementation(
+		(parallel: any[], _agents: any[], _stepIndex: number, chainSkills: string[]) =>
+			parallel.map((task: any) => ({
+				output: task.output,
+				reads: task.reads,
+				progress: task.progress,
+				skills: task.skill ?? chainSkills,
+			})),
+	);
+	chainMocks.buildChainInstructions.mockImplementation((behavior: any, chainDir: string) => ({
+		prefix: `READ ${behavior.reads?.join(",") ?? "none"} FROM ${chainDir}\n`,
+		suffix: behavior.output ? `\nWRITE ${behavior.output}` : "",
+	}));
+	chainMocks.aggregateParallelOutputs.mockImplementation((taskResults: any[]) =>
+		taskResults.map((task) => task.output).join("\n---\n"),
+	);
+	chainMocks.getFinalOutput.mockImplementation((messages: any[]) =>
+		messages.map((message) => message.content?.[0]?.text ?? "").join("\n"),
+	);
+	chainMocks.mapConcurrent.mockImplementation(
+		(items: any[], _concurrency: number, mapper: (item: any, index: number) => Promise<any>) =>
+			Promise.all(items.map((item, index) => mapper(item, index))),
+	);
+	chainMocks.discoverAvailableSkills.mockReturnValue([{ name: "git" }, { name: "context7" }]);
+	chainMocks.resolveSubagentModelResolution.mockImplementation(
+		(_agent: any, _models: any[], explicitModel?: string) => ({
+			model: explicitModel,
+			source: explicitModel ? "runtime-override" : "agent-default",
+			category: explicitModel ? "explicit" : undefined,
+		}),
+	);
+});
+
+afterEach(() => {
+	for (const dir of tempDirs) {
+		fs.rmSync(dir, { recursive: true, force: true });
+	}
+	tempDirs.length = 0;
+});
+
+describe("executeChain", () => {
+	const agents = [{ name: "scout", model: "anthropic/claude-sonnet-4" }, { name: "planner" }, { name: "reviewer" }];
+
+	it("cancels clarified chains and removes the chain dir", async () => {
+		const chainDir = createTempDir("pi-chain-cancel-");
+		const ctx = createCtx();
+		ctx.ui.custom.mockResolvedValueOnce(null);
+
+		const result = await executeChain({
+			chain: [{ agent: "scout", task: "Inspect {task}" }],
+			task: "the repo",
+			agents,
+			ctx: ctx as never,
+			runId: "chain-cancel",
+			shareEnabled: false,
+			sessionDirForIndex: () => undefined,
+			artifactsDir: "/tmp/artifacts",
+			artifactConfig: { enabled: false } as never,
+			chainDir,
+		});
+
+		expect(result).toEqual({
+			content: [{ type: "text", text: "Chain cancelled" }],
+			details: { mode: "chain", results: [] },
+		});
+		expect(chainMocks.removeChainDir).toHaveBeenCalledWith(chainDir);
+		expect(chainMocks.runSync).not.toHaveBeenCalled();
+	});
+
+	it("returns async launch requests when clarify asks to run in the background", async () => {
+		const chainDir = createTempDir("pi-chain-bg-");
+		const ctx = createCtx();
+		ctx.ui.custom.mockResolvedValueOnce({
+			confirmed: true,
+			runInBackground: true,
+			templates: ["Rewrite {task}"],
+			behaviorOverrides: [
+				{
+					model: "openai/gpt-5",
+					output: "deliver.md",
+					reads: ["spec.md"],
+					progress: true,
+					skills: ["git"],
+				},
+			],
+		});
+
+		const result = await executeChain({
+			chain: [{ agent: "scout", task: "Inspect {task}" }],
+			task: "the repo",
+			agents,
+			ctx: ctx as never,
+			runId: "chain-bg",
+			shareEnabled: false,
+			sessionDirForIndex: () => undefined,
+			artifactsDir: "/tmp/artifacts",
+			artifactConfig: { enabled: false } as never,
+			chainDir,
+		});
+
+		expect(result.content[0]?.text).toBe("Launching in background...");
+		expect(result.requestedAsync).toEqual({
+			chain: [
+				{
+					agent: "scout",
+					task: "Rewrite {task}",
+					model: "openai/gpt-5",
+					output: "deliver.md",
+					reads: ["spec.md"],
+					progress: true,
+					skill: ["git"],
+				},
+			],
+			chainSkills: [],
+		});
+		expect(chainMocks.removeChainDir).toHaveBeenCalledWith(chainDir);
+	});
+
+	it("fails parallel steps with a summarized error and preserves progress details", async () => {
+		const chainDir = createTempDir("pi-chain-parallel-");
+		const ctx = createCtx({ hasUI: false });
+		chainMocks.runSync
+			.mockResolvedValueOnce(createResult("planner", 0, "Plan output"))
+			.mockResolvedValueOnce(createResult("reviewer", 1, "Review failed", { error: "boom" }));
+
+		const result = await executeChain({
+			chain: [
+				{
+					parallel: [
+						{ agent: "planner", task: "Plan {task}", progress: true, output: "plan.md" },
+						{ agent: "reviewer", task: "Review {task}", progress: true },
+					],
+					concurrency: 2,
+					failFast: true,
+				},
+			],
+			task: "the repo",
+			agents,
+			ctx: ctx as never,
+			runId: "chain-parallel",
+			shareEnabled: false,
+			sessionDirForIndex: () => undefined,
+			artifactsDir: "/tmp/artifacts",
+			artifactConfig: { enabled: false } as never,
+			includeProgress: true,
+			chainDir,
+		});
+
+		expect(result.isError).toBe(true);
+		expect(result.content[0]?.text).toContain("summary:failed");
+		expect(result.details.results).toHaveLength(2);
+		expect(result.details.progress).toHaveLength(0);
+		expect(fs.existsSync(path.join(chainDir, "progress.md"))).toBe(true);
+		expect(chainMocks.createParallelDirs).toHaveBeenCalledWith(chainDir, 0, 2, ["planner", "reviewer"]);
+		expect(chainMocks.aggregateParallelOutputs).not.toHaveBeenCalled();
+	});
+
+	it("completes sequential chains and annotates missing expected outputs", async () => {
+		const chainDir = createTempDir("pi-chain-seq-");
+		fs.writeFileSync(path.join(chainDir, "alt.md"), "alternate output");
+		const ctx = createCtx({ hasUI: false });
+		chainMocks.runSync.mockResolvedValueOnce(
+			createResult("scout", 0, "Scout output", {
+				progress: { index: 0, agent: "scout", status: "completed" },
+				artifactPaths: { inputPath: "in.md", outputPath: "out.md", metadataPath: "meta.json", jsonlPath: "run.jsonl" },
+			}),
+		);
+
+		const result = await executeChain({
+			chain: [{ agent: "scout", task: "Inspect {task}", output: "report.md", reads: ["spec.md"], progress: true }],
+			task: "the repo",
+			agents,
+			ctx: ctx as never,
+			runId: "chain-seq",
+			shareEnabled: true,
+			sessionDirForIndex: () => "/tmp/sessions/0",
+			artifactsDir: "/tmp/artifacts",
+			artifactConfig: { enabled: true } as never,
+			includeProgress: true,
+			chainDir,
+		});
+
+		expect(result.isError).toBeUndefined();
+		expect(result.content[0]?.text).toContain("summary:completed");
+		expect(result.details.results[0]?.error).toContain("Agent wrote to different file(s): alt.md instead of report.md");
+		expect(result.details.progress).toEqual([{ index: 0, agent: "scout", status: "completed" }]);
+		expect(result.details.artifacts).toEqual({
+			dir: "/tmp/artifacts",
+			files: [{ inputPath: "in.md", outputPath: "out.md", metadataPath: "meta.json", jsonlPath: "run.jsonl" }],
+		});
+		expect(chainMocks.recordRun).toHaveBeenCalledWith("scout", "Inspect the repo", 0, 12);
+	});
+});

--- a/packages/subagents/tests/command-registration.test.ts
+++ b/packages/subagents/tests/command-registration.test.ts
@@ -1,0 +1,134 @@
+import { describe, expect, it, vi } from "vitest";
+
+const discoverAgentsMock = vi.hoisted(() => vi.fn());
+
+vi.mock("../agents.js", () => ({
+	discoverAgents: discoverAgentsMock,
+}));
+
+vi.mock("../types.js", () => ({
+	MAX_PARALLEL: 2,
+}));
+
+import { registerSubagentCommands } from "../command-registration.js";
+
+function createPi() {
+	const commands = new Map<string, any>();
+	return {
+		commands,
+		registerCommand: vi.fn((name: string, spec: any) => {
+			commands.set(name, spec);
+		}),
+		registerShortcut: vi.fn(),
+		sendUserMessage: vi.fn(),
+	};
+}
+
+function createCtx() {
+	const notifications: Array<{ msg: string; level: string }> = [];
+	return {
+		notifications,
+		ui: {
+			notify: (msg: string, level: string) => {
+				notifications.push({ msg, level });
+			},
+		},
+	};
+}
+
+describe("registerSubagentCommands", () => {
+	it("opens the agent manager and offers agent completions", async () => {
+		discoverAgentsMock.mockReturnValue({
+			agents: [{ name: "scout" }, { name: "planner" }, { name: "reviewer" }],
+		});
+		const pi = createPi();
+		const openAgentManager = vi.fn(async () => {});
+		registerSubagentCommands(pi as never, {
+			getBaseCwd: () => "/repo",
+			openAgentManager,
+		});
+
+		await pi.commands.get("agents").handler("", {});
+		expect(openAgentManager).toHaveBeenCalledTimes(1);
+
+		const completions = pi.commands.get("run").getArgumentCompletions("pl");
+		expect(completions).toEqual([{ value: "planner", label: "planner" }]);
+	});
+
+	it("validates /run and sends exact single-agent tool calls", async () => {
+		discoverAgentsMock.mockReturnValue({ agents: [{ name: "scout" }, { name: "planner" }] });
+		const pi = createPi();
+		const ctx = createCtx();
+		registerSubagentCommands(pi as never, {
+			getBaseCwd: () => "/repo",
+			openAgentManager: vi.fn(),
+		});
+
+		await pi.commands.get("run").handler("unknown investigate", ctx);
+		expect(ctx.notifications.at(-1)).toEqual({ msg: "Unknown agent: unknown", level: "error" });
+
+		await pi.commands
+			.get("run")
+			.handler(
+				"scout[output=notes.md,reads=spec.md+design.md,skill=context7+git,model=anthropic/claude-sonnet-4] inspect api --bg",
+				ctx,
+			);
+
+		const sent = pi.sendUserMessage.mock.calls.at(-1)?.[0];
+		expect(sent).toContain('"agent":"scout"');
+		expect(sent).toContain('"task":"[Read from: spec.md, design.md]\\n\\ninspect api"');
+		expect(sent).toContain('"output":"notes.md"');
+		expect(sent).toContain('"skill":["context7","git"]');
+		expect(sent).toContain('"model":"anthropic/claude-sonnet-4"');
+		expect(sent).toContain('"async":true');
+		expect(sent).toContain('"agentScope":"both"');
+	});
+
+	it("builds sequential chain calls with inline overrides", async () => {
+		discoverAgentsMock.mockReturnValue({
+			agents: [{ name: "scout" }, { name: "planner" }, { name: "reviewer" }],
+		});
+		const pi = createPi();
+		const ctx = createCtx();
+		registerSubagentCommands(pi as never, {
+			getBaseCwd: () => "/repo",
+			openAgentManager: vi.fn(),
+		});
+
+		await pi.commands
+			.get("chain")
+			.handler(
+				'scout[progress] "inspect repo" -> planner[output=plan.md,reads=false,skills=context7+git,model=openai/gpt-5] "draft plan" --bg',
+				ctx,
+			);
+
+		expect(pi.sendUserMessage).toHaveBeenLastCalledWith(
+			'Call the subagent tool with these exact parameters: {"chain":[{"agent":"scout","task":"inspect repo","progress":true},{"agent":"planner","task":"draft plan","output":"plan.md","reads":false,"model":"openai/gpt-5","skill":["context7","git"]}],"task":"inspect repo","clarify":false,"agentScope":"both","async":true}',
+		);
+
+		const completions = pi.commands.get("chain").getArgumentCompletions("scout -> pl");
+		expect(completions).toEqual([{ value: "scout -> planner", label: "planner" }]);
+	});
+
+	it("builds parallel chain calls and enforces the parallel cap", async () => {
+		discoverAgentsMock.mockReturnValue({
+			agents: [{ name: "scout" }, { name: "planner" }, { name: "reviewer" }],
+		});
+		const pi = createPi();
+		const ctx = createCtx();
+		registerSubagentCommands(pi as never, {
+			getBaseCwd: () => "/repo",
+			openAgentManager: vi.fn(),
+		});
+
+		await pi.commands.get("parallel").handler('scout "inspect" -> planner "plan" -> reviewer "review"', ctx);
+		expect(ctx.notifications.at(-1)).toEqual({ msg: "Max 2 parallel tasks", level: "error" });
+
+		await pi.commands
+			.get("parallel")
+			.handler('scout[progress] "inspect" -> planner[skill=false,model=anthropic/claude-sonnet-4] "plan" --bg', ctx);
+		expect(pi.sendUserMessage).toHaveBeenLastCalledWith(
+			'Call the subagent tool with these exact parameters: {"chain":[{"parallel":[{"agent":"scout","task":"inspect","progress":true},{"agent":"planner","task":"plan","model":"anthropic/claude-sonnet-4","skill":false}]}],"task":"inspect","clarify":false,"agentScope":"both","async":true}',
+		);
+	});
+});

--- a/packages/subagents/tests/execution.test.ts
+++ b/packages/subagents/tests/execution.test.ts
@@ -1,0 +1,371 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+const executionMocks = vi.hoisted(() => {
+	class MiniEmitter {
+		private listeners = new Map<string, Array<(...args: any[]) => void>>();
+
+		on(event: string, handler: (...args: any[]) => void) {
+			const handlers = this.listeners.get(event) ?? [];
+			handlers.push(handler);
+			this.listeners.set(event, handlers);
+			return this;
+		}
+
+		emit(event: string, ...args: any[]) {
+			for (const handler of this.listeners.get(event) ?? []) {
+				handler(...args);
+			}
+			return true;
+		}
+	}
+
+	const procs: any[] = [];
+	const spawn = vi.fn(() => {
+		const events = new MiniEmitter();
+		const proc = {
+			stdout: new MiniEmitter(),
+			stderr: new MiniEmitter(),
+			on: vi.fn(function (this: any, event: string, handler: (...args: any[]) => void) {
+				events.on(event, handler);
+				return this;
+			}),
+			emit(event: string, ...args: any[]) {
+				return events.emit(event, ...args);
+			},
+			kill: vi.fn(),
+			killed: false,
+		};
+		procs.push(proc);
+		return proc;
+	});
+
+	return {
+		procs,
+		spawn,
+		mkdirSync: vi.fn(),
+		mkdtempSync: vi.fn(() => "/tmp/pi-subagent-task-dir"),
+		writeFileSync: vi.fn(),
+		rmSync: vi.fn(),
+		writePrompt: vi.fn(() => ({ dir: "/tmp/pi-prompt", path: "/tmp/pi-prompt/system.md" })),
+		getFinalOutput: vi.fn((messages: any[]) => messages.map((message) => message.content?.[0]?.text ?? "").join("\n")),
+		findLatestSessionFile: vi.fn(() => "/tmp/session/run.jsonl"),
+		detectSubagentError: vi.fn(() => ({ hasError: false })),
+		extractToolArgsPreview: vi.fn((args: Record<string, unknown>) => JSON.stringify(args)),
+		extractTextFromContent: vi.fn((content: any[]) =>
+			content
+				.filter((item) => item.type === "text")
+				.map((item) => item.text)
+				.join("\n"),
+		),
+		buildSkillInjection: vi.fn(
+			(skills: Array<{ name: string }>) => `INJECT:${skills.map((skill) => skill.name).join(",")}`,
+		),
+		resolveSkills: vi.fn((skills: string[]) => ({
+			resolved: skills.filter((skill) => skill !== "missing").map((name) => ({ name })),
+			missing: skills.filter((skill) => skill === "missing"),
+		})),
+		getPiSpawnCommand: vi.fn((args: string[]) => ({ command: "pi", args })),
+		createJsonlWriter: vi.fn(() => ({ writeLine: vi.fn(), close: vi.fn(async () => {}) })),
+		ensureArtifactsDir: vi.fn(),
+		getArtifactPaths: vi.fn(() => ({
+			inputPath: "/tmp/artifacts/input.md",
+			outputPath: "/tmp/artifacts/output.md",
+			metadataPath: "/tmp/artifacts/metadata.json",
+			jsonlPath: "/tmp/artifacts/run.jsonl",
+		})),
+		writeArtifact: vi.fn(),
+		writeMetadata: vi.fn(),
+		truncateOutput: vi.fn(() => ({ truncated: true, output: "trimmed" })),
+		getSubagentDepthEnv: vi.fn(() => ({ PI_SUBAGENT_DEPTH: "1" })),
+	};
+});
+
+vi.mock("node:child_process", () => ({ spawn: executionMocks.spawn }));
+vi.mock("node:fs", () => ({
+	mkdirSync: executionMocks.mkdirSync,
+	mkdtempSync: executionMocks.mkdtempSync,
+	writeFileSync: executionMocks.writeFileSync,
+	rmSync: executionMocks.rmSync,
+}));
+vi.mock("../artifacts.js", () => ({
+	ensureArtifactsDir: executionMocks.ensureArtifactsDir,
+	getArtifactPaths: executionMocks.getArtifactPaths,
+	writeArtifact: executionMocks.writeArtifact,
+	writeMetadata: executionMocks.writeMetadata,
+}));
+vi.mock("../types.js", () => ({
+	DEFAULT_MAX_OUTPUT: { bytes: 200 * 1024, lines: 5000 },
+	truncateOutput: executionMocks.truncateOutput,
+	getSubagentDepthEnv: executionMocks.getSubagentDepthEnv,
+}));
+vi.mock("../utils.js", () => ({
+	writePrompt: executionMocks.writePrompt,
+	getFinalOutput: executionMocks.getFinalOutput,
+	findLatestSessionFile: executionMocks.findLatestSessionFile,
+	detectSubagentError: executionMocks.detectSubagentError,
+	extractToolArgsPreview: executionMocks.extractToolArgsPreview,
+	extractTextFromContent: executionMocks.extractTextFromContent,
+}));
+vi.mock("../skills.js", () => ({
+	buildSkillInjection: executionMocks.buildSkillInjection,
+	resolveSkills: executionMocks.resolveSkills,
+}));
+vi.mock("../pi-spawn.js", () => ({
+	getPiSpawnCommand: executionMocks.getPiSpawnCommand,
+}));
+vi.mock("../jsonl-writer.js", () => ({
+	createJsonlWriter: executionMocks.createJsonlWriter,
+}));
+
+import { applyThinkingSuffix, runSync } from "../execution.js";
+
+function emitStdoutLines(proc: any, lines: string[]) {
+	proc.stdout.emit("data", Buffer.from(`${lines.join("\n")}\n`));
+}
+
+beforeEach(() => {
+	for (const mock of Object.values(executionMocks)) {
+		if (typeof mock === "function" && "mockReset" in mock) {
+			(mock as ReturnType<typeof vi.fn>).mockReset();
+		}
+	}
+
+	executionMocks.procs.length = 0;
+	executionMocks.spawn.mockImplementation(() => {
+		const proc = {
+			stdout: {
+				listeners: new Map<string, Array<(...args: any[]) => void>>(),
+				on(event: string, handler: (...args: any[]) => void) {
+					const handlers = this.listeners.get(event) ?? [];
+					handlers.push(handler);
+					this.listeners.set(event, handlers);
+					return this;
+				},
+				emit(event: string, ...args: any[]) {
+					for (const handler of this.listeners.get(event) ?? []) {
+						handler(...args);
+					}
+					return true;
+				},
+			},
+			stderr: {
+				listeners: new Map<string, Array<(...args: any[]) => void>>(),
+				on(event: string, handler: (...args: any[]) => void) {
+					const handlers = this.listeners.get(event) ?? [];
+					handlers.push(handler);
+					this.listeners.set(event, handlers);
+					return this;
+				},
+				emit(event: string, ...args: any[]) {
+					for (const handler of this.listeners.get(event) ?? []) {
+						handler(...args);
+					}
+					return true;
+				},
+			},
+			listeners: new Map<string, Array<(...args: any[]) => void>>(),
+			on(event: string, handler: (...args: any[]) => void) {
+				const handlers = this.listeners.get(event) ?? [];
+				handlers.push(handler);
+				this.listeners.set(event, handlers);
+				return this;
+			},
+			emit(event: string, ...args: any[]) {
+				for (const handler of this.listeners.get(event) ?? []) {
+					handler(...args);
+				}
+				return true;
+			},
+			kill: vi.fn(),
+			killed: false,
+		};
+		executionMocks.procs.push(proc);
+		return proc;
+	});
+	executionMocks.resolveSkills.mockImplementation((skills: string[]) => ({
+		resolved: skills.filter((skill) => skill !== "missing").map((name) => ({ name })),
+		missing: skills.filter((skill) => skill === "missing"),
+	}));
+	executionMocks.detectSubagentError.mockReturnValue({ hasError: false });
+	executionMocks.findLatestSessionFile.mockReturnValue("/tmp/session/run.jsonl");
+	executionMocks.createJsonlWriter.mockReturnValue({ writeLine: vi.fn(), close: vi.fn(async () => {}) });
+	executionMocks.truncateOutput.mockReturnValue({ truncated: true, output: "trimmed" });
+});
+
+describe("applyThinkingSuffix", () => {
+	it("adds thinking levels when needed and preserves existing suffixes", () => {
+		expect(applyThinkingSuffix("anthropic/claude-sonnet-4", "high")).toBe("anthropic/claude-sonnet-4:high");
+		expect(applyThinkingSuffix("anthropic/claude-sonnet-4:low", "high")).toBe("anthropic/claude-sonnet-4:low");
+		expect(applyThinkingSuffix("anthropic/claude-sonnet-4", "off")).toBe("anthropic/claude-sonnet-4");
+	});
+});
+
+describe("runSync", () => {
+	it("returns an explicit error for unknown agents", async () => {
+		await expect(runSync("/repo", [], "missing", "Inspect", { share: false })).resolves.toMatchObject({
+			agent: "missing",
+			exitCode: 1,
+			error: "Unknown agent: missing",
+		});
+	});
+
+	it("streams successful runs, writes artifacts, and records truncation + shared sessions", async () => {
+		const onUpdate = vi.fn();
+		const longTask = "A".repeat(9000);
+		const runPromise = runSync(
+			"/repo",
+			[
+				{
+					name: "scout",
+					model: "anthropic/claude-sonnet-4",
+					thinking: "high",
+					tools: ["bash", "./tools/custom.ts"],
+					extensions: ["./extensions/extra.ts"],
+					systemPrompt: "Base prompt",
+					skills: ["git", "missing"],
+					mcpDirectTools: ["read"],
+				},
+			],
+			"scout",
+			longTask,
+			{
+				cwd: "/workspace",
+				onUpdate,
+				share: true,
+				sessionDir: "/tmp/session",
+				runId: "run-1",
+				index: 2,
+				artifactsDir: "/tmp/artifacts",
+				artifactConfig: { enabled: true },
+				maxOutput: { bytes: 100, lines: 10 },
+				modelOverride: "openai/gpt-5",
+				modelSource: "runtime-override",
+				modelCategory: "explicit",
+			},
+		);
+
+		const proc = executionMocks.procs[0];
+		emitStdoutLines(proc, [
+			JSON.stringify({ type: "tool_execution_start", toolName: "bash", args: { cmd: "ls" } }),
+			JSON.stringify({ type: "tool_execution_end" }),
+			JSON.stringify({
+				type: "message_end",
+				message: {
+					role: "assistant",
+					model: "openai/gpt-5:high",
+					content: [{ type: "text", text: "Hello\nWorld" }],
+					usage: { input: 10, output: 5, cacheRead: 1, cacheWrite: 2, cost: { total: 1.25 } },
+				},
+			}),
+			JSON.stringify({
+				type: "tool_result_end",
+				message: { role: "assistant", content: [{ type: "text", text: "Tool result" }] },
+			}),
+		]);
+		proc.emit("close", 0);
+
+		const result = await runPromise;
+
+		expect(executionMocks.spawn).toHaveBeenCalledWith(
+			"pi",
+			expect.arrayContaining([
+				"--mode",
+				"json",
+				"-p",
+				"--session-dir",
+				"/tmp/session",
+				"--models",
+				"openai/gpt-5:high",
+				"--tools",
+				"bash",
+				"--no-skills",
+				"--no-extensions",
+				"--extension",
+				"./extensions/extra.ts",
+				"--append-system-prompt",
+				"/tmp/pi-prompt/system.md",
+				"@/tmp/pi-prompt/task.md",
+			]),
+			expect.objectContaining({ cwd: "/workspace", stdio: ["ignore", "pipe", "pipe"] }),
+		);
+		expect(executionMocks.writeFileSync).toHaveBeenCalledWith(
+			"/tmp/pi-prompt/task.md",
+			expect.stringContaining(longTask),
+			expect.objectContaining({ mode: 0o600 }),
+		);
+		expect(result).toMatchObject({
+			agent: "scout",
+			exitCode: 0,
+			model: "openai/gpt-5:high",
+			modelSource: "runtime-override",
+			modelCategory: "explicit",
+			skills: ["git"],
+			skillsWarning: "Skills not found: missing",
+			sessionFile: "/tmp/session/run.jsonl",
+			artifactPaths: {
+				inputPath: "/tmp/artifacts/input.md",
+				outputPath: "/tmp/artifacts/output.md",
+				metadataPath: "/tmp/artifacts/metadata.json",
+				jsonlPath: "/tmp/artifacts/run.jsonl",
+			},
+			truncation: { truncated: true, output: "trimmed" },
+			progressSummary: { toolCount: 1, tokens: 15, durationMs: expect.any(Number) },
+		});
+		expect(result.usage).toMatchObject({ input: 10, output: 5, cacheRead: 1, cacheWrite: 2, cost: 1.25, turns: 1 });
+		expect(result.progress).toMatchObject({
+			status: "completed",
+			currentTool: undefined,
+			recentOutput: ["Hello", "World", "Tool result"],
+			toolCount: 1,
+			tokens: 15,
+		});
+		expect(onUpdate).toHaveBeenCalled();
+		expect(executionMocks.ensureArtifactsDir).toHaveBeenCalledWith("/tmp/artifacts");
+		expect(executionMocks.writeArtifact).toHaveBeenCalledWith(
+			"/tmp/artifacts/input.md",
+			expect.stringContaining("Task for scout"),
+		);
+		expect(executionMocks.writeArtifact).toHaveBeenCalledWith("/tmp/artifacts/output.md", "Hello\nWorld\nTool result");
+		expect(executionMocks.writeMetadata).toHaveBeenCalledWith(
+			"/tmp/artifacts/metadata.json",
+			expect.objectContaining({ runId: "run-1", agent: "scout", exitCode: 0, skills: ["git"] }),
+		);
+		expect(executionMocks.rmSync).toHaveBeenCalledWith("/tmp/pi-prompt", { recursive: true, force: true });
+	});
+
+	it("captures parse errors, surfaces detected internal failures, and handles abort signals", async () => {
+		vi.useFakeTimers();
+		executionMocks.detectSubagentError.mockReturnValue({
+			hasError: true,
+			exitCode: 9,
+			errorType: "tool_result",
+			details: "Tool crashed",
+		});
+		const controller = new AbortController();
+		const runPromise = runSync(
+			"/repo",
+			[{ name: "reviewer", model: "anthropic/claude-sonnet-4" }],
+			"reviewer",
+			"Inspect",
+			{ signal: controller.signal, share: false },
+		);
+
+		const proc = executionMocks.procs[0];
+		emitStdoutLines(proc, ["not-json"]);
+		controller.abort();
+		await vi.advanceTimersByTimeAsync(3000);
+		proc.emit("close", 0);
+
+		const result = await runPromise;
+		expect(proc.kill).toHaveBeenCalledWith("SIGTERM");
+		expect(proc.kill).toHaveBeenCalledWith("SIGKILL");
+		expect(result).toMatchObject({
+			exitCode: 9,
+			aborted: true,
+			parseErrors: 1,
+			error: "tool_result failed (exit 9): Tool crashed",
+		});
+		expect(result.progress).toMatchObject({ status: "failed", error: "tool_result failed (exit 9): Tool crashed" });
+		vi.useRealTimers();
+	});
+});

--- a/packages/subagents/tests/index-entrypoint.test.ts
+++ b/packages/subagents/tests/index-entrypoint.test.ts
@@ -1,0 +1,581 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+
+const runtimeMonitorMock = vi.hoisted(() => ({
+	refreshWidget: vi.fn(),
+	ensurePoller: vi.fn(),
+	stop: vi.fn(),
+	clearResults: vi.fn(),
+}));
+
+const mocks = vi.hoisted(() => ({
+	discoverAgents: vi.fn(),
+	discoverAgentsAll: vi.fn(() => ({ agents: [], builtin: [], user: [], project: [], chains: [] })),
+	resolveExecutionAgentScope: vi.fn(() => "both"),
+	cleanupOldChainDirs: vi.fn(),
+	getStepAgents: vi.fn((step: any) =>
+		"parallel" in step ? step.parallel.map((task: any) => task.agent) : [step.agent],
+	),
+	isParallelStep: vi.fn((step: any) => Boolean(step && typeof step === "object" && Array.isArray(step.parallel))),
+	resolveStepBehavior: vi.fn(() => ({ skills: undefined })),
+	cleanupAllArtifactDirs: vi.fn(),
+	cleanupOldArtifacts: vi.fn(),
+	getArtifactsDir: vi.fn(() => "/tmp/artifacts"),
+	checkSubagentDepth: vi.fn(() => ({ blocked: false, depth: 0, maxDepth: 2 })),
+	findByPrefix: vi.fn(() => null),
+	getFinalOutput: vi.fn(() => "final output"),
+	mapConcurrent: vi.fn((items: any[], concurrencyOrFn: any, maybeFn?: any) => {
+		const mapper = typeof concurrencyOrFn === "function" ? concurrencyOrFn : maybeFn;
+		return Promise.all(items.map((item, index) => mapper(item, index)));
+	}),
+	readStatus: vi.fn(() => null),
+	runSync: vi.fn(),
+	renderWidget: vi.fn(),
+	renderSubagentResult: vi.fn(),
+	executeChain: vi.fn(),
+	isAsyncAvailable: vi.fn(() => true),
+	executeAsyncChain: vi.fn(),
+	executeAsyncSingle: vi.fn(),
+	discoverAvailableSkills: vi.fn(() => [{ name: "git" }, { name: "context7" }]),
+	normalizeSkillInput: vi.fn((value: unknown) => value),
+	finalizeSingleOutput: vi.fn(({ truncatedOutput, fullOutput }: any) => ({
+		displayOutput: truncatedOutput || fullOutput || "(no output)",
+	})),
+	injectSingleOutputInstruction: vi.fn((task: string) => task),
+	resolveSingleOutputPath: vi.fn((output: string | undefined) => (output ? `/tmp/${output}` : undefined)),
+	recordRun: vi.fn(),
+	handleManagementAction: vi.fn(),
+	registerSubagentCommands: vi.fn(),
+	ensureAccessibleDir: vi.fn(),
+	expandTildePath: vi.fn((value: string) => value),
+	getSubagentSessionRoot: vi.fn(() => "/tmp/subagent-session-root"),
+	loadSubagentConfig: vi.fn(() => ({})),
+	resolveSubagentModelResolution: vi.fn(() => ({ model: undefined, source: "agent-default" })),
+	createSubagentRuntimeMonitor: vi.fn(() => runtimeMonitorMock),
+}));
+
+vi.mock("node:fs", () => ({
+	constants: { R_OK: 4, W_OK: 2 },
+	existsSync: vi.fn(() => false),
+	readFileSync: vi.fn(() => '{"id":"result-1","success":true,"summary":"done"}'),
+	mkdirSync: vi.fn(),
+	accessSync: vi.fn(),
+	rmSync: vi.fn(),
+	watch: vi.fn(() => ({
+		on: vi.fn(),
+		unref: vi.fn(),
+		close: vi.fn(),
+	})),
+	readdirSync: vi.fn(() => []),
+	unlinkSync: vi.fn(),
+}));
+
+vi.mock("@mariozechner/pi-coding-agent", () => ({
+	getAgentDir: () => "/tmp/pi-agent",
+	VERSION: "test",
+}));
+
+vi.mock("@mariozechner/pi-tui", () => ({
+	Text: class {},
+}));
+
+vi.mock("../agents.js", () => ({
+	discoverAgents: mocks.discoverAgents,
+	discoverAgentsAll: mocks.discoverAgentsAll,
+}));
+vi.mock("../agent-scope.js", () => ({
+	resolveExecutionAgentScope: mocks.resolveExecutionAgentScope,
+}));
+vi.mock("../settings.js", () => ({
+	cleanupOldChainDirs: mocks.cleanupOldChainDirs,
+	getStepAgents: mocks.getStepAgents,
+	isParallelStep: mocks.isParallelStep,
+	resolveStepBehavior: mocks.resolveStepBehavior,
+}));
+vi.mock("../chain-clarify.js", () => ({
+	ChainClarifyComponent: class {},
+}));
+vi.mock("../artifacts.js", () => ({
+	cleanupAllArtifactDirs: mocks.cleanupAllArtifactDirs,
+	cleanupOldArtifacts: mocks.cleanupOldArtifacts,
+	getArtifactsDir: mocks.getArtifactsDir,
+}));
+vi.mock("../types.js", () => ({
+	ASYNC_DIR: "/tmp/pi-async-subagent-runs",
+	RESULTS_DIR: "/tmp/pi-async-subagent-results",
+	DEFAULT_ARTIFACT_CONFIG: { cleanupDays: 7 },
+	DEFAULT_MAX_OUTPUT: { bytes: 200 * 1024, lines: 5000 },
+	MAX_CONCURRENCY: 4,
+	MAX_PARALLEL: 3,
+	WIDGET_KEY: "subagent-async",
+	checkSubagentDepth: mocks.checkSubagentDepth,
+}));
+vi.mock("../utils.js", () => ({
+	readStatus: mocks.readStatus,
+	findByPrefix: mocks.findByPrefix,
+	getFinalOutput: mocks.getFinalOutput,
+	mapConcurrent: mocks.mapConcurrent,
+}));
+vi.mock("../execution.js", () => ({
+	runSync: mocks.runSync,
+}));
+vi.mock("../render.js", () => ({
+	renderWidget: mocks.renderWidget,
+	renderSubagentResult: mocks.renderSubagentResult,
+}));
+vi.mock("../schemas.js", () => ({
+	SubagentParams: {},
+	StatusParams: {},
+}));
+vi.mock("../chain-execution.js", () => ({
+	executeChain: mocks.executeChain,
+}));
+vi.mock("../async-execution.js", () => ({
+	isAsyncAvailable: mocks.isAsyncAvailable,
+	executeAsyncChain: mocks.executeAsyncChain,
+	executeAsyncSingle: mocks.executeAsyncSingle,
+}));
+vi.mock("../skills.js", () => ({
+	discoverAvailableSkills: mocks.discoverAvailableSkills,
+	normalizeSkillInput: mocks.normalizeSkillInput,
+}));
+vi.mock("../single-output.js", () => ({
+	finalizeSingleOutput: mocks.finalizeSingleOutput,
+	injectSingleOutputInstruction: mocks.injectSingleOutputInstruction,
+	resolveSingleOutputPath: mocks.resolveSingleOutputPath,
+}));
+vi.mock("../agent-manager.js", () => ({
+	AgentManagerComponent: class {},
+}));
+vi.mock("../run-history.js", () => ({
+	recordRun: mocks.recordRun,
+}));
+vi.mock("../agent-management.js", () => ({
+	handleManagementAction: mocks.handleManagementAction,
+}));
+vi.mock("../command-registration.js", () => ({
+	registerSubagentCommands: mocks.registerSubagentCommands,
+}));
+vi.mock("../bootstrap.js", () => ({
+	ensureAccessibleDir: mocks.ensureAccessibleDir,
+	expandTildePath: mocks.expandTildePath,
+	getSubagentSessionRoot: mocks.getSubagentSessionRoot,
+	loadSubagentConfig: mocks.loadSubagentConfig,
+}));
+vi.mock("../runtime-monitor.js", () => ({
+	createSubagentRuntimeMonitor: mocks.createSubagentRuntimeMonitor,
+}));
+vi.mock("../model-routing.js", () => ({
+	resolveSubagentModelResolution: mocks.resolveSubagentModelResolution,
+}));
+
+import registerSubagentExtension from "../index.js";
+
+function createMockPi() {
+	const handlers = new Map<string, Array<(...args: any[]) => any>>();
+	const eventHandlers = new Map<string, Array<(data: unknown) => void>>();
+	const tools = new Map<string, any>();
+	const shortcuts = new Map<string, any>();
+
+	return {
+		handlers,
+		eventHandlers,
+		tools,
+		shortcuts,
+		on(event: string, handler: (...args: any[]) => any) {
+			if (!handlers.has(event)) {
+				handlers.set(event, []);
+			}
+			handlers.get(event)?.push(handler);
+		},
+		registerTool: vi.fn((tool: any) => {
+			tools.set(tool.name, tool);
+		}),
+		registerCommand: vi.fn(),
+		registerShortcut: vi.fn((name: string, spec: any) => {
+			shortcuts.set(name, spec);
+		}),
+		sendUserMessage: vi.fn(),
+		events: {
+			on(event: string, handler: (data: unknown) => void) {
+				if (!eventHandlers.has(event)) {
+					eventHandlers.set(event, []);
+				}
+				eventHandlers.get(event)?.push(handler);
+			},
+			off: vi.fn(),
+			emit(event: string, data: unknown) {
+				for (const handler of eventHandlers.get(event) ?? []) {
+					handler(data);
+				}
+			},
+		},
+	};
+}
+
+function createCtx() {
+	return {
+		cwd: "/repo",
+		hasUI: true,
+		model: { provider: "anthropic", id: "claude-sonnet-4" },
+		modelRegistry: {
+			getAvailable: () => [
+				{ provider: "anthropic", id: "claude-sonnet-4" },
+				{ provider: "openai", id: "gpt-5" },
+			],
+		},
+		sessionManager: {
+			getSessionFile: () => "/tmp/session.jsonl",
+			getSessionId: () => "session-1",
+		},
+		ui: {
+			theme: {
+				fg: (_color: string, text: string) => text,
+				bold: (text: string) => text,
+			},
+			setWidget: vi.fn(),
+			notify: vi.fn(),
+			custom: vi.fn(),
+		},
+		getContextUsage: () => undefined,
+	};
+}
+
+const agentConfigs = [
+	{ name: "scout", output: "scout.md" },
+	{ name: "planner", output: "plan.md" },
+	{ name: "reviewer" },
+];
+
+beforeEach(() => {
+	for (const mock of Object.values(mocks)) {
+		if (typeof mock === "function" && "mockReset" in mock) {
+			(mock as ReturnType<typeof vi.fn>).mockReset();
+		}
+	}
+	mocks.discoverAgents.mockReturnValue({ agents: agentConfigs });
+	mocks.discoverAgentsAll.mockReturnValue({ agents: agentConfigs, builtin: [], user: [], project: [], chains: [] });
+	mocks.resolveExecutionAgentScope.mockReturnValue("both");
+	mocks.checkSubagentDepth.mockReturnValue({ blocked: false, depth: 0, maxDepth: 2 });
+	mocks.getArtifactsDir.mockReturnValue("/tmp/artifacts");
+	mocks.isAsyncAvailable.mockReturnValue(true);
+	mocks.normalizeSkillInput.mockImplementation((value: unknown) => value);
+	mocks.handleManagementAction.mockReturnValue({
+		content: [{ type: "text", text: "listed" }],
+		details: { mode: "management", results: [] },
+	});
+	mocks.executeChain.mockResolvedValue({
+		content: [{ type: "text", text: "chain complete" }],
+		details: { mode: "chain", results: [] },
+	});
+	mocks.executeAsyncChain.mockResolvedValue({
+		content: [{ type: "text", text: "async chain launched" }],
+		details: { mode: "chain", results: [] },
+	});
+	mocks.executeAsyncSingle.mockResolvedValue({
+		content: [{ type: "text", text: "async single launched" }],
+		details: { mode: "single", results: [] },
+	});
+	mocks.runSync.mockResolvedValue({
+		agent: "scout",
+		exitCode: 0,
+		messages: [{ role: "assistant", content: "final output" }],
+		truncation: undefined,
+		progressSummary: { durationMs: 12 },
+	});
+	mocks.resolveSubagentModelResolution.mockReturnValue({
+		model: undefined,
+		source: "agent-default",
+		category: undefined,
+	});
+	mocks.finalizeSingleOutput.mockImplementation(({ truncatedOutput, fullOutput }: any) => ({
+		displayOutput: truncatedOutput || fullOutput || "(no output)",
+	}));
+	mocks.injectSingleOutputInstruction.mockImplementation((task: string) => task);
+	mocks.resolveSingleOutputPath.mockImplementation((output: string | undefined) =>
+		output ? `/tmp/${output}` : undefined,
+	);
+	mocks.findByPrefix.mockReturnValue(null);
+	mocks.readStatus.mockReturnValue(null);
+	mocks.loadSubagentConfig.mockReturnValue({});
+});
+
+afterEach(() => {
+	vi.restoreAllMocks();
+});
+
+describe("subagent entrypoint", () => {
+	it("registers tools and delegates known management actions", async () => {
+		const pi = createMockPi();
+		const ctx = createCtx();
+		registerSubagentExtension(pi as never);
+
+		const tool = pi.tools.get("subagent");
+		const result = await tool.execute("tool-1", { action: "list" }, undefined, undefined, ctx);
+		expect(mocks.handleManagementAction).toHaveBeenCalledWith("list", { action: "list" }, ctx);
+		expect(result.content[0]?.text).toBe("listed");
+
+		const invalid = await tool.execute("tool-2", { action: "bogus" }, undefined, undefined, ctx);
+		expect(invalid.isError).toBe(true);
+		expect(invalid.content[0]?.text).toContain("Unknown action: bogus");
+	});
+
+	it("rejects nested subagent depth and invalid mode combinations", async () => {
+		const pi = createMockPi();
+		const ctx = createCtx();
+		registerSubagentExtension(pi as never);
+		const tool = pi.tools.get("subagent");
+
+		mocks.checkSubagentDepth.mockReturnValueOnce({ blocked: true, depth: 2, maxDepth: 2 });
+		const blocked = await tool.execute("tool-1", { agent: "scout", task: "inspect" }, undefined, undefined, ctx);
+		expect(blocked.isError).toBe(true);
+		expect(blocked.content[0]?.text).toContain("Nested subagent call blocked");
+
+		const invalid = await tool.execute("tool-2", {}, undefined, undefined, ctx);
+		expect(invalid.isError).toBe(true);
+		expect(invalid.content[0]?.text).toContain("Provide exactly one mode");
+	});
+
+	it("validates chain shapes before execution", async () => {
+		const pi = createMockPi();
+		const ctx = createCtx();
+		registerSubagentExtension(pi as never);
+		const tool = pi.tools.get("subagent");
+
+		await expect(tool.execute("c0", { chain: [] }, undefined, undefined, ctx)).resolves.toMatchObject({
+			isError: true,
+			content: [{ type: "text", text: "Provide exactly one mode. Agents: scout, planner, reviewer" }],
+		});
+
+		const firstStepMissingTask = await tool.execute("c1", { chain: [{ agent: "scout" }] }, undefined, undefined, ctx);
+		expect(firstStepMissingTask.isError).toBe(true);
+		expect(firstStepMissingTask.content[0]?.text).toBe("First step in chain must have a task");
+
+		const firstParallelMissingTask = await tool.execute(
+			"c2",
+			{ chain: [{ parallel: [{ agent: "scout" }] }] },
+			undefined,
+			undefined,
+			ctx,
+		);
+		expect(firstParallelMissingTask.isError).toBe(true);
+		expect(firstParallelMissingTask.content[0]?.text).toContain("First parallel step: task 1 must have a task");
+
+		const unknownAgent = await tool.execute(
+			"c3",
+			{ chain: [{ agent: "unknown", task: "inspect" }] },
+			undefined,
+			undefined,
+			ctx,
+		);
+		expect(unknownAgent.isError).toBe(true);
+		expect(unknownAgent.content[0]?.text).toBe("Unknown agent: unknown (step 1)");
+
+		const emptyParallel = await tool.execute(
+			"c4",
+			{ chain: [{ parallel: [] }], task: "inspect" },
+			undefined,
+			undefined,
+			ctx,
+		);
+		expect(emptyParallel.isError).toBe(true);
+		expect(emptyParallel.content[0]?.text).toBe("Parallel step 1 must have at least one task");
+	});
+
+	it("routes chain clarify background launches through the async chain executor", async () => {
+		const pi = createMockPi();
+		const ctx = createCtx();
+		registerSubagentExtension(pi as never);
+		const tool = pi.tools.get("subagent");
+		mocks.executeChain.mockResolvedValueOnce({
+			content: [{ type: "text", text: "launching" }],
+			details: { mode: "chain", results: [] },
+			requestedAsync: {
+				chain: [{ agent: "scout", task: "inspect" }],
+				chainSkills: ["git"],
+			},
+		});
+
+		mocks.isAsyncAvailable.mockReturnValueOnce(false);
+		const unavailable = await tool.execute(
+			"chain-1",
+			{ chain: [{ agent: "scout", task: "inspect" }] },
+			undefined,
+			undefined,
+			ctx,
+		);
+		expect(unavailable.isError).toBe(true);
+		expect(unavailable.content[0]?.text).toContain("Background mode requires jiti");
+
+		mocks.executeChain.mockResolvedValueOnce({
+			content: [{ type: "text", text: "launching" }],
+			details: { mode: "chain", results: [] },
+			requestedAsync: {
+				chain: [{ agent: "scout", task: "inspect" }],
+				chainSkills: ["git"],
+			},
+		});
+		const available = await tool.execute(
+			"chain-2",
+			{ chain: [{ agent: "scout", task: "inspect" }] },
+			undefined,
+			undefined,
+			ctx,
+		);
+		expect(mocks.executeAsyncChain).toHaveBeenCalledTimes(1);
+		expect(available.content[0]?.text).toBe("async chain launched");
+	});
+
+	it("validates parallel tasks and supports clarify-driven background launches", async () => {
+		const pi = createMockPi();
+		const ctx = createCtx();
+		registerSubagentExtension(pi as never);
+		const tool = pi.tools.get("subagent");
+
+		const tooMany = await tool.execute(
+			"p1",
+			{
+				tasks: [
+					{ agent: "scout", task: "inspect" },
+					{ agent: "planner", task: "plan" },
+					{ agent: "reviewer", task: "review" },
+					{ agent: "scout", task: "again" },
+				],
+			},
+			undefined,
+			undefined,
+			ctx,
+		);
+		expect(tooMany.isError).toBe(true);
+		expect(tooMany.content[0]?.text).toBe("Max 3 tasks");
+
+		const unknownAgent = await tool.execute(
+			"p2",
+			{ tasks: [{ agent: "unknown", task: "inspect" }] },
+			undefined,
+			undefined,
+			ctx,
+		);
+		expect(unknownAgent.isError).toBe(true);
+		expect(unknownAgent.content[0]?.text).toBe("Unknown agent: unknown");
+
+		ctx.ui.custom = vi.fn().mockResolvedValue({
+			confirmed: true,
+			templates: ["inspect", "plan"],
+			behaviorOverrides: [{}, { model: "openai/gpt-5", skills: false }],
+			runInBackground: true,
+		});
+		const launched = await tool.execute(
+			"p3",
+			{
+				tasks: [
+					{ agent: "scout", task: "inspect" },
+					{ agent: "planner", task: "plan" },
+				],
+				clarify: true,
+			},
+			undefined,
+			undefined,
+			ctx,
+		);
+		expect(mocks.executeAsyncChain).toHaveBeenCalledTimes(1);
+		expect(mocks.executeAsyncChain.mock.calls[0]?.[1]?.chain).toEqual([
+			{
+				parallel: [
+					expect.objectContaining({ agent: "scout", task: "inspect", model: "anthropic/claude-sonnet-4" }),
+					expect.objectContaining({ agent: "planner", task: "plan", model: "openai/gpt-5", skill: false }),
+				],
+			},
+		]);
+		expect(launched.content[0]?.text).toBe("async chain launched");
+	});
+
+	it("executes single runs, supports clarify cancellation/background, and reports failures", async () => {
+		const pi = createMockPi();
+		const ctx = createCtx();
+		registerSubagentExtension(pi as never);
+		const tool = pi.tools.get("subagent");
+
+		const unknownAgent = await tool.execute("s0", { agent: "unknown", task: "inspect" }, undefined, undefined, ctx);
+		expect(unknownAgent.isError).toBe(true);
+		expect(unknownAgent.content[0]?.text).toBe("Unknown agent: unknown");
+
+		ctx.ui.custom = vi.fn().mockResolvedValueOnce(undefined);
+		const cancelled = await tool.execute(
+			"s1",
+			{ agent: "scout", task: "inspect", clarify: true },
+			undefined,
+			undefined,
+			ctx,
+		);
+		expect(cancelled.content[0]?.text).toBe("Cancelled");
+
+		ctx.ui.custom = vi.fn().mockResolvedValueOnce({
+			confirmed: true,
+			templates: ["inspect carefully"],
+			behaviorOverrides: [{ output: "notes.md", model: "openai/gpt-5", skills: ["git"] }],
+			runInBackground: true,
+		});
+		const background = await tool.execute(
+			"s2",
+			{ agent: "scout", task: "inspect", clarify: true },
+			undefined,
+			undefined,
+			ctx,
+		);
+		expect(mocks.executeAsyncSingle).toHaveBeenCalledTimes(1);
+		expect(mocks.executeAsyncSingle.mock.calls[0]?.[1]).toMatchObject({
+			agent: "scout",
+			task: "inspect carefully",
+			output: "notes.md",
+			skills: ["git"],
+		});
+		expect(background.content[0]?.text).toBe("async single launched");
+
+		mocks.runSync.mockResolvedValueOnce({
+			agent: "scout",
+			exitCode: 0,
+			messages: [{ role: "assistant", content: "single output" }],
+			truncation: undefined,
+			progressSummary: { durationMs: 12 },
+		});
+		const success = await tool.execute(
+			"s3",
+			{ agent: "scout", task: "inspect", output: true },
+			undefined,
+			undefined,
+			ctx,
+		);
+		expect(mocks.resolveSingleOutputPath).toHaveBeenCalledWith("scout.md", "/repo", undefined);
+		expect(success.content[0]?.text).toBe("final output");
+
+		mocks.runSync.mockResolvedValueOnce({
+			agent: "scout",
+			exitCode: 1,
+			messages: [],
+			truncation: { text: "truncated" },
+			error: "boom",
+			progressSummary: { durationMs: 5 },
+		});
+		const failure = await tool.execute("s4", { agent: "scout", task: "inspect" }, undefined, undefined, ctx);
+		expect(failure.isError).toBe(true);
+		expect(failure.content[0]?.text).toBe("boom");
+	});
+
+	it("reports async run status from result files and not-found cases", async () => {
+		const pi = createMockPi();
+		const ctx = createCtx();
+		registerSubagentExtension(pi as never);
+		const statusTool = pi.tools.get("subagent_status");
+
+		const missing = await statusTool.execute("status-1", { id: "missing" }, undefined, undefined, ctx);
+		expect(missing.isError).toBe(true);
+		expect(missing.content[0]?.text).toBe("Async run not found. Provide id or dir.");
+
+		mocks.findByPrefix
+			.mockImplementationOnce(() => null)
+			.mockImplementationOnce(() => "/tmp/pi-async-subagent-results/result-1.json");
+		const found = await statusTool.execute("status-2", { id: "result-1" }, undefined, undefined, ctx);
+		expect(found.content[0]?.text).toContain("Run: result-1");
+		expect(found.content[0]?.text).toContain("State: complete");
+	});
+});

--- a/packages/subagents/tests/render.test.ts
+++ b/packages/subagents/tests/render.test.ts
@@ -1,59 +1,106 @@
-import { describe, expect, it, vi } from "vitest";
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+const renderMocks = vi.hoisted(() => ({
+	getFinalOutput: vi.fn((messages: any[]) => messages.at(-1)?.content?.[0]?.text ?? ""),
+	getDisplayItems: vi.fn(() => []),
+	getOutputTail: vi.fn(() => ["line a", "line b"]),
+	getLastActivity: vi.fn(() => "recent activity"),
+}));
 
 vi.mock("@mariozechner/pi-coding-agent", () => ({
-	getMarkdownTheme: () => ({}),
+	getMarkdownTheme: () => ({ theme: "markdown" }),
 }));
 
 vi.mock("@mariozechner/pi-tui", () => ({
-	Container: class {},
-	Markdown: class {},
-	Spacer: class {},
-	Text: class {
-		constructor(public text: string) {}
+	Container: class {
+		children: unknown[] = [];
+		addChild(child: unknown) {
+			this.children.push(child);
+		}
 	},
-	truncateToWidth: (text: string, width: number) => text.slice(0, width),
-	visibleWidth: (text: string) => text.length,
+	Markdown: class {
+		constructor(
+			public text: string,
+			public x: number,
+			public y: number,
+			public theme: unknown,
+		) {}
+	},
+	Spacer: class {
+		constructor(public size: number) {}
+	},
+	Text: class {
+		constructor(
+			public text: string,
+			public x = 0,
+			public y = 0,
+		) {}
+	},
+	truncateToWidth: (text: string, width: number) => (text.length <= width ? text : `${text.slice(0, width - 1)}…`),
+	visibleWidth: (text: string) => text.replaceAll("\u001b[0m", "").length,
 }));
 
 vi.mock("../formatters.js", () => ({
-	formatTokens: (value: number) => `${value}`,
-	formatUsage: () => "usage",
+	formatTokens: (value: number) => `${value}t`,
+	formatUsage: (_usage: unknown, model?: string) => `usage:${model ?? "none"}`,
 	formatDuration: (value: number) => `${value}ms`,
-	formatToolCall: () => "tool",
-	shortenPath: (value: string) => value,
+	formatToolCall: (name: string) => `tool:${name}`,
+	shortenPath: (value: string) => value.replace(process.env.HOME ?? "", "~"),
 }));
 
 vi.mock("../utils.js", () => ({
-	getFinalOutput: () => "",
-	getDisplayItems: () => [],
-	getOutputTail: () => ["line a", "line b"],
-	getLastActivity: () => "recent activity",
+	getFinalOutput: renderMocks.getFinalOutput,
+	getDisplayItems: renderMocks.getDisplayItems,
+	getOutputTail: renderMocks.getOutputTail,
+	getLastActivity: renderMocks.getLastActivity,
 }));
 
-import { renderWidget } from "../render.js";
+import { renderSubagentResult, renderWidget } from "../render.js";
 import { WIDGET_KEY } from "../types.js";
 
-function createCtx() {
-	const widgets = new Map<string, unknown>();
+function createTheme() {
 	return {
-		hasUI: true,
-		ui: {
-			theme: {
-				fg: (_color: string, text: string) => text,
-			},
-			setWidget(key: string, value: unknown) {
-				widgets.set(key, value);
-			},
-		},
-		_widgets: widgets,
+		fg: (_color: string, text: string) => text,
+		bold: (text: string) => `**${text}**`,
+		accent: (text: string) => text,
+		toolTitle: (text: string) => text,
+		success: (text: string) => text,
+		error: (text: string) => text,
+		warning: (text: string) => text,
+		dim: (text: string) => text,
+		muted: (text: string) => text,
 	};
 }
 
+function createCtx() {
+	const widgets = new Map<string, unknown>();
+	const setWidget = vi.fn((key: string, value: unknown) => {
+		widgets.set(key, value);
+	});
+	return {
+		hasUI: true,
+		ui: {
+			theme: createTheme(),
+			setWidget,
+		},
+		_widgets: widgets,
+		_setWidget: setWidget,
+	};
+}
+
+beforeEach(() => {
+	renderMocks.getFinalOutput.mockImplementation((messages: any[]) => messages.at(-1)?.content?.[0]?.text ?? "");
+	renderMocks.getDisplayItems.mockReturnValue([]);
+	renderMocks.getOutputTail.mockReturnValue(["line a", "line b"]);
+	renderMocks.getLastActivity.mockReturnValue("recent activity");
+	renderWidget(createCtx() as never, [], { suppressed: true });
+});
+
 describe("subagent async widget rendering", () => {
-	it("suppresses the widget when safe mode requests suppression", () => {
+	it("suppresses and clears widgets when requested", () => {
 		const ctx = createCtx();
 		renderWidget(
-			ctx as any,
+			ctx as never,
 			[
 				{
 					asyncId: "abc123",
@@ -64,15 +111,28 @@ describe("subagent async widget rendering", () => {
 					startedAt: Date.now() - 1000,
 				},
 			],
-			{ suppressed: true },
+			{},
 		);
+		expect(ctx._widgets.get(WIDGET_KEY)).toBeDefined();
 
+		renderWidget(ctx as never, [], { suppressed: true });
 		expect(ctx._widgets.get(WIDGET_KEY)).toBeUndefined();
 	});
 
-	it("renders active jobs when not suppressed", () => {
+	it("renders running jobs with tail output and avoids redundant completed rerenders", () => {
 		const ctx = createCtx();
-		renderWidget(ctx as any, [
+		const completedJob = {
+			asyncId: "done123",
+			asyncDir: "/tmp/done",
+			status: "complete",
+			mode: "chain",
+			agents: ["scout", "planner"],
+			updatedAt: Date.now(),
+			startedAt: Date.now() - 2000,
+			totalTokens: { input: 10, output: 5, total: 15 },
+		};
+
+		renderWidget(ctx as never, [
 			{
 				asyncId: "abc123",
 				asyncDir: "/tmp/run",
@@ -85,9 +145,179 @@ describe("subagent async widget rendering", () => {
 				totalTokens: { input: 10, output: 5, total: 15 },
 			},
 		]);
-
 		const lines = ctx._widgets.get(WIDGET_KEY) as string[];
 		expect(lines[0]).toContain("Async subagents");
 		expect(lines.join("\n")).toContain("recent activity");
+		expect(lines.join("\n")).toContain("line a");
+		expect(lines.join("\n")).toContain("15t tok");
+
+		const callsBefore = ctx._setWidget.mock.calls.length;
+		renderWidget(ctx as never, [completedJob]);
+		renderWidget(ctx as never, [completedJob]);
+		expect(ctx._setWidget.mock.calls.length).toBe(callsBefore + 1);
+	});
+});
+
+describe("renderSubagentResult", () => {
+	it("renders plain text when no detailed results are available", () => {
+		const widget: any = renderSubagentResult(
+			{ content: [{ type: "text", text: "Fallback output" }] } as never,
+			{ expanded: false },
+			createTheme() as never,
+		);
+
+		expect(widget.text).toContain("Fallback output");
+	});
+
+	it("renders single-result details including tools, markdown, skills, and artifacts", () => {
+		renderMocks.getDisplayItems.mockReturnValue([{ type: "tool", name: "bash", args: { command: "ls" } }]);
+		const widget: any = renderSubagentResult(
+			{
+				content: [{ type: "text", text: "ok" }],
+				details: {
+					mode: "single",
+					results: [
+						{
+							agent: "scout",
+							task: "Inspect the repo carefully",
+							exitCode: 0,
+							messages: [{ role: "assistant", content: [{ type: "text", text: "Final answer" }] }],
+							usage: { input: 10, output: 5, cacheRead: 1, cacheWrite: 0, cost: 0.2, turns: 1 },
+							model: "anthropic/claude-sonnet-4",
+							skills: ["git"],
+							skillsWarning: "Missing: context7",
+							sessionFile: "/tmp/session/run.jsonl",
+							artifactPaths: {
+								inputPath: "/tmp/artifacts/input.md",
+								outputPath: "/tmp/artifacts/output.md",
+								metadataPath: "/tmp/artifacts/meta.json",
+								jsonlPath: "/tmp/artifacts/run.jsonl",
+							},
+							truncation: { text: "Trimmed output", truncated: true },
+							progressSummary: { toolCount: 2, tokens: 15, durationMs: 99 },
+						},
+					],
+				},
+			} as never,
+			{ expanded: true },
+			createTheme() as never,
+		);
+
+		const childTexts = widget.children
+			.map((child: any) => child.text)
+			.filter(Boolean)
+			.join("\n");
+		expect(childTexts).toContain("**scout**");
+		expect(childTexts).toContain("Task: Inspect the repo carefully");
+		expect(childTexts).toContain("tool:bash");
+		expect(childTexts).toContain("Skills: git");
+		expect(childTexts).toContain("[!] Missing: context7");
+		expect(childTexts).toContain("usage:anthropic/claude-sonnet-4");
+		expect(childTexts).toContain("Session: /tmp/session/run.jsonl");
+		expect(childTexts).toContain("Artifacts: /tmp/artifacts/output.md");
+		expect(widget.children.some((child: any) => child.text === "Trimmed output")).toBe(true);
+		expect(widget.children.some((child: any) => child.constructor.name === "Markdown")).toBe(true);
+	});
+
+	it("renders chain results with chain visualization, pending steps, running details, and artifact dirs", () => {
+		const widget: any = renderSubagentResult(
+			{
+				content: [{ type: "text", text: "chain" }],
+				details: {
+					mode: "chain",
+					chainAgents: ["scout", "planner", "reviewer"],
+					totalSteps: 3,
+					currentStepIndex: 1,
+					results: [
+						{
+							agent: "scout",
+							task: "Collect facts",
+							exitCode: 0,
+							messages: [{ role: "assistant", content: [{ type: "text", text: "" }] }],
+							usage: { input: 0, output: 0, cacheRead: 0, cacheWrite: 0, cost: 0, turns: 0 },
+							progress: {
+								index: 0,
+								agent: "scout",
+								status: "completed",
+								task: "Collect facts",
+								recentTools: [],
+								recentOutput: [],
+								toolCount: 1,
+								tokens: 5,
+								durationMs: 20,
+							},
+						},
+						{
+							agent: "planner",
+							task: "[Write to: /tmp/plan.md] Draft plan",
+							exitCode: 0,
+							messages: [{ role: "assistant", content: [{ type: "text", text: "Plan draft" }] }],
+							usage: { input: 0, output: 0, cacheRead: 0, cacheWrite: 0, cost: 0, turns: 0 },
+							model: "openai/gpt-5",
+							skills: ["plan"],
+							skillsWarning: "Missing: context7",
+							progress: {
+								index: 1,
+								agent: "planner",
+								status: "running",
+								task: "Draft plan",
+								skills: ["plan"],
+								currentTool: "write",
+								currentToolArgs: '{"path":"/tmp/plan.md"}',
+								recentTools: [{ tool: "read", args: "spec.md", endMs: Date.now() }],
+								recentOutput: ["Drafting", "Polishing"],
+								toolCount: 2,
+								tokens: 10,
+								durationMs: 40,
+							},
+						},
+					],
+					progress: [
+						{
+							index: 0,
+							agent: "scout",
+							status: "completed",
+							task: "Collect facts",
+							recentTools: [],
+							recentOutput: [],
+							toolCount: 1,
+							tokens: 5,
+							durationMs: 20,
+						},
+						{
+							index: 1,
+							agent: "planner",
+							status: "running",
+							task: "Draft plan",
+							recentTools: [],
+							recentOutput: [],
+							toolCount: 2,
+							tokens: 10,
+							durationMs: 40,
+						},
+					],
+					artifacts: { dir: "/tmp/artifacts", files: [] },
+				},
+			} as never,
+			{ expanded: true },
+			createTheme() as never,
+		);
+
+		const childTexts = widget.children
+			.map((child: any) => child.text)
+			.filter(Boolean)
+			.join("\n");
+		expect(childTexts).toContain("**chain** 2/3");
+		expect(childTexts).toContain("scout →");
+		expect(childTexts).toContain("planner →");
+		expect(childTexts).toContain("reviewer");
+		expect(childTexts).toContain("Step 1: **scout**");
+		expect(childTexts).toContain("status: ○ pending");
+		expect(childTexts).toContain("output: /tmp/plan.md");
+		expect(childTexts).toContain("skills: plan");
+		expect(childTexts).toContain("[!] Missing: context7");
+		expect(childTexts).toContain('> write: {"path":"/tmp/plan.md"}');
+		expect(childTexts).toContain("read: spec.md");
+		expect(childTexts).toContain("Artifacts dir: /tmp/artifacts");
 	});
 });

--- a/packages/subagents/tests/settings.test.ts
+++ b/packages/subagents/tests/settings.test.ts
@@ -1,0 +1,221 @@
+import fs from "node:fs";
+import os from "node:os";
+import path from "node:path";
+import { afterEach, describe, expect, it, vi } from "vitest";
+
+vi.mock("../skills.js", () => ({
+	normalizeSkillInput: (value: unknown) => {
+		if (value === false) {
+			return false;
+		}
+		if (Array.isArray(value)) {
+			return value;
+		}
+		if (typeof value === "string") {
+			return value
+				.split(",")
+				.map((item) => item.trim())
+				.filter(Boolean);
+		}
+		return undefined;
+	},
+}));
+
+import {
+	aggregateParallelOutputs,
+	buildChainInstructions,
+	cleanupOldChainDirs,
+	createChainDir,
+	createParallelDirs,
+	getStepAgents,
+	isParallelStep,
+	removeChainDir,
+	resolveChainTemplates,
+	resolveParallelBehaviors,
+	resolveStepBehavior,
+} from "../settings.js";
+
+const tempDirs: string[] = [];
+
+function createTempDir(prefix: string) {
+	const dir = fs.mkdtempSync(path.join(os.tmpdir(), prefix));
+	tempDirs.push(dir);
+	return dir;
+}
+
+afterEach(() => {
+	for (const dir of tempDirs) {
+		fs.rmSync(dir, { recursive: true, force: true });
+	}
+	tempDirs.length = 0;
+});
+
+describe("subagent settings helpers", () => {
+	it("detects parallel steps and resolves default templates", () => {
+		const steps = [
+			{ agent: "scout", task: "Inspect {task}" },
+			{ agent: "planner" },
+			{
+				parallel: [{ agent: "reviewer", task: "Review {previous}" }, { agent: "qa" }],
+			},
+		] as const;
+
+		expect(isParallelStep(steps[2])).toBe(true);
+		expect(getStepAgents(steps[0])).toEqual(["scout"]);
+		expect(getStepAgents(steps[2])).toEqual(["reviewer", "qa"]);
+		expect(resolveChainTemplates(steps as never)).toEqual([
+			"Inspect {task}",
+			"{previous}",
+			["Review {previous}", "{previous}"],
+		]);
+	});
+
+	it("creates, removes, and cleans up stale chain directories", async () => {
+		const created = createChainDir(`settings-chain-${Date.now()}`);
+		expect(fs.existsSync(created)).toBe(true);
+		removeChainDir(created);
+		expect(fs.existsSync(created)).toBe(false);
+
+		const chainRunsDir = path.join(os.tmpdir(), "pi-chain-runs");
+		const staleDir = path.join(chainRunsDir, `stale-${Date.now()}`);
+		const freshDir = path.join(chainRunsDir, `fresh-${Date.now()}`);
+		fs.mkdirSync(staleDir, { recursive: true });
+		fs.mkdirSync(freshDir, { recursive: true });
+		tempDirs.push(staleDir, freshDir);
+		const staleTime = Date.now() / 1000 - 2 * 24 * 60 * 60;
+		fs.utimesSync(staleDir, staleTime, staleTime);
+
+		await cleanupOldChainDirs();
+
+		expect(fs.existsSync(staleDir)).toBe(false);
+		expect(fs.existsSync(freshDir)).toBe(true);
+	});
+
+	it("resolves step behavior with overrides and chain-level skills", () => {
+		const behavior = resolveStepBehavior(
+			{
+				name: "scout",
+				output: "agent.md",
+				defaultReads: ["brief.md"],
+				defaultProgress: true,
+				skills: ["git"],
+				model: "anthropic/claude-sonnet-4",
+			},
+			{
+				output: "override.md",
+				reads: ["spec.md"],
+				progress: false,
+				skills: ["context7"],
+				model: "openai/gpt-5",
+			},
+			["shared-skill"],
+		);
+
+		expect(behavior).toEqual({
+			output: "override.md",
+			reads: ["spec.md"],
+			progress: false,
+			skills: ["context7", "shared-skill"],
+			model: "openai/gpt-5",
+		});
+		expect(
+			resolveStepBehavior({ name: "planner", skills: ["plan"], defaultProgress: false }, { skills: false }, ["shared"]),
+		).toMatchObject({ skills: false, progress: false, output: false, reads: false });
+	});
+
+	it("builds read/write/progress instructions with previous-step summaries", () => {
+		const chainDir = "/tmp/pi-chain-demo";
+		const instructions = buildChainInstructions(
+			{
+				output: "report.md",
+				reads: ["spec.md", "/abs/notes.md"],
+				progress: true,
+				skills: ["git"],
+			},
+			chainDir,
+			true,
+			"Previous output",
+		);
+
+		expect(instructions.prefix).toContain("[Read from: /tmp/pi-chain-demo/spec.md, /abs/notes.md]");
+		expect(instructions.prefix).toContain("[Write to: /tmp/pi-chain-demo/report.md]");
+		expect(instructions.suffix).toContain("Create and maintain progress at: /tmp/pi-chain-demo/progress.md");
+		expect(instructions.suffix).toContain("Previous step output:\nPrevious output");
+	});
+
+	it("namespaces parallel behaviors and creates parallel output directories", () => {
+		const chainDir = createTempDir("pi-chain-parallel-settings-");
+		const behaviors = resolveParallelBehaviors(
+			[
+				{ agent: "planner", output: "plan.md", reads: ["spec.md"], progress: true, skill: ["plan"] },
+				{ agent: "reviewer", skill: false, output: "/abs/review.md" },
+				{ agent: "writer" },
+			],
+			[
+				{
+					name: "planner",
+					output: "planner.md",
+					defaultReads: ["default.md"],
+					defaultProgress: false,
+					skills: ["git"],
+				},
+				{ name: "reviewer", output: "review.md", skills: ["review"] },
+				{ name: "writer", output: "write.md", skills: ["docs"], model: "anthropic/claude-sonnet-4" },
+			],
+			2,
+			["shared"],
+		);
+
+		expect(behaviors).toEqual([
+			{
+				output: path.join("parallel-2", "0-planner", "plan.md"),
+				reads: ["spec.md"],
+				progress: true,
+				skills: ["plan", "shared"],
+				model: undefined,
+			},
+			{
+				output: "/abs/review.md",
+				reads: false,
+				progress: false,
+				skills: false,
+				model: undefined,
+			},
+			{
+				output: path.join("parallel-2", "2-writer", "write.md"),
+				reads: false,
+				progress: false,
+				skills: ["docs", "shared"],
+				model: "anthropic/claude-sonnet-4",
+			},
+		]);
+
+		createParallelDirs(chainDir, 2, 3, ["planner", "reviewer", "writer"]);
+		expect(fs.existsSync(path.join(chainDir, "parallel-2", "0-planner"))).toBe(true);
+		expect(fs.existsSync(path.join(chainDir, "parallel-2", "1-reviewer"))).toBe(true);
+		expect(fs.existsSync(path.join(chainDir, "parallel-2", "2-writer"))).toBe(true);
+	});
+
+	it("aggregates parallel outputs with clear status markers", () => {
+		const summary = aggregateParallelOutputs([
+			{ agent: "planner", taskIndex: 0, output: "Plan complete", exitCode: 0 },
+			{ agent: "reviewer", taskIndex: 1, output: "", exitCode: 0, error: "Used fallback file" },
+			{
+				agent: "qa",
+				taskIndex: 2,
+				output: "",
+				exitCode: 0,
+				outputTargetPath: "/tmp/qa.md",
+				outputTargetExists: false,
+			},
+			{ agent: "docs", taskIndex: 3, output: "", exitCode: -1 },
+			{ agent: "deploy", taskIndex: 4, output: "Logs", exitCode: 1, error: "boom" },
+		]);
+
+		expect(summary).toContain("=== Parallel Task 1 (planner) ===\nPlan complete");
+		expect(summary).toContain("[!] WARNING: Used fallback file");
+		expect(summary).toContain("[!] EMPTY OUTPUT (expected output file missing: /tmp/qa.md)");
+		expect(summary).toContain("⏭️ SKIPPED");
+		expect(summary).toContain("[!] FAILED (exit code 1): boom\nLogs");
+	});
+});

--- a/packages/subagents/tests/skills.test.ts
+++ b/packages/subagents/tests/skills.test.ts
@@ -1,0 +1,240 @@
+import fs from "node:fs";
+import os from "node:os";
+import path from "node:path";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+
+const skillsMocks = vi.hoisted(() => ({
+	execSync: vi.fn(() => "/tmp/global-node-modules\n"),
+	expandHomeDir: vi.fn((value: string) => value.replace(/^~\//, "/tmp/home/")),
+	loadSkills: vi.fn(() => ({ skills: [] })),
+	resolveAgentDir: vi.fn(() => "/tmp/pi-agent"),
+}));
+
+vi.mock("node:child_process", () => ({
+	execSync: skillsMocks.execSync,
+}));
+
+vi.mock("@ifi/oh-pi-core", () => ({
+	expandHomeDir: skillsMocks.expandHomeDir,
+}));
+
+vi.mock("@mariozechner/pi-coding-agent", () => ({
+	loadSkills: skillsMocks.loadSkills,
+}));
+
+vi.mock("../paths.js", () => ({
+	resolveAgentDir: skillsMocks.resolveAgentDir,
+}));
+
+import {
+	buildSkillInjection,
+	clearSkillCache,
+	discoverAvailableSkills,
+	normalizeSkillInput,
+	resolveSkillPath,
+	resolveSkills,
+} from "../skills.js";
+
+const tempDirs: string[] = [];
+
+function createTempDir(prefix: string) {
+	const dir = fs.mkdtempSync(path.join(os.tmpdir(), prefix));
+	tempDirs.push(dir);
+	return dir;
+}
+
+beforeEach(() => {
+	clearSkillCache();
+	for (const mock of Object.values(skillsMocks)) {
+		if (typeof mock === "function" && "mockReset" in mock) {
+			(mock as ReturnType<typeof vi.fn>).mockReset();
+		}
+	}
+	skillsMocks.execSync.mockReturnValue("/tmp/global-node-modules\n");
+	skillsMocks.expandHomeDir.mockImplementation((value: string) => value.replace(/^~\//, "/tmp/home/"));
+	skillsMocks.resolveAgentDir.mockReturnValue("/tmp/pi-agent");
+});
+
+afterEach(() => {
+	clearSkillCache();
+	for (const dir of tempDirs) {
+		fs.rmSync(dir, { recursive: true, force: true });
+	}
+	tempDirs.length = 0;
+});
+
+describe("subagent skills", () => {
+	it("normalizes skill input formats and builds injections", () => {
+		expect(normalizeSkillInput(false)).toBe(false);
+		expect(normalizeSkillInput(true)).toBeUndefined();
+		expect(normalizeSkillInput([" git ", "git", "context7"])).toEqual(["git", "context7"]);
+		expect(normalizeSkillInput('["git","context7"]')).toEqual(["git", "context7"]);
+		expect(normalizeSkillInput("git, context7, git")).toEqual(["git", "context7"]);
+		expect(
+			buildSkillInjection([
+				{ name: "git", path: "/skills/git.md", source: "project", content: "Use git carefully." },
+				{ name: "context7", path: "/skills/context7.md", source: "user", content: "Query docs first." },
+			]),
+		).toBe('<skill name="git">\nUse git carefully.\n</skill>\n\n<skill name="context7">\nQuery docs first.\n</skill>');
+	});
+
+	it("discovers skills from default, package, settings, and global locations with source priority", () => {
+		const cwd = createTempDir("pi-subagent-skills-project-");
+		const agentDir = "/tmp/pi-agent";
+		const globalRoot = "/tmp/global-node-modules";
+		const homeRoot = "/tmp/home";
+		for (const dir of [agentDir, globalRoot, homeRoot]) {
+			fs.mkdirSync(dir, { recursive: true });
+			tempDirs.push(dir);
+		}
+
+		const projectDefaultSkills = path.join(cwd, ".pi", "skills");
+		const userDefaultSkills = path.join(agentDir, "skills");
+		const projectPkgRoot = path.join(cwd, ".pi", "npm", "node_modules", "@scope", "pkg-a");
+		const userPkgRoot = path.join(agentDir, "npm", "node_modules", "pkg-b");
+		const globalPkgRoot = path.join(globalRoot, "pkg-c");
+		const projectSettingsSkillDir = path.join(cwd, ".pi", "custom", "project-skill");
+		const userSettingsSkillDir = path.join(homeRoot, "custom-user-skill");
+		for (const dir of [
+			projectDefaultSkills,
+			userDefaultSkills,
+			projectPkgRoot,
+			userPkgRoot,
+			globalPkgRoot,
+			projectSettingsSkillDir,
+			userSettingsSkillDir,
+		]) {
+			fs.mkdirSync(dir, { recursive: true });
+		}
+
+		fs.writeFileSync(
+			path.join(projectPkgRoot, "package.json"),
+			JSON.stringify({ name: "@scope/pkg-a", pi: { skills: ["./package-skills"] } }),
+		);
+		fs.writeFileSync(
+			path.join(userPkgRoot, "package.json"),
+			JSON.stringify({ name: "pkg-b", pi: { skills: ["./user-package-skills"] } }),
+		);
+		fs.writeFileSync(
+			path.join(globalPkgRoot, "package.json"),
+			JSON.stringify({ name: "pkg-c", pi: { skills: ["./global-package-skills"] } }),
+		);
+		fs.writeFileSync(path.join(cwd, ".pi", "settings.json"), JSON.stringify({ skills: ["./custom/project-skill"] }));
+		fs.writeFileSync(path.join(agentDir, "settings.json"), JSON.stringify({ skills: ["~/custom-user-skill"] }));
+
+		skillsMocks.loadSkills.mockImplementation(({ skillPaths }: { skillPaths: string[] }) => {
+			expect(skillPaths).toEqual(
+				expect.arrayContaining([
+					projectDefaultSkills,
+					userDefaultSkills,
+					path.join(projectPkgRoot, "package-skills"),
+					path.join(userPkgRoot, "user-package-skills"),
+					path.join(globalPkgRoot, "global-package-skills"),
+					projectSettingsSkillDir,
+					userSettingsSkillDir,
+				]),
+			);
+			return {
+				skills: [
+					{
+						name: "shared",
+						filePath: path.join(agentDir, "skills", "shared", "SKILL.md"),
+						source: "user",
+						description: "User copy",
+					},
+					{
+						name: "shared",
+						filePath: path.join(cwd, ".pi", "skills", "shared", "SKILL.md"),
+						source: "project",
+						description: "Project copy",
+					},
+					{
+						name: "pkg-project",
+						filePath: path.join(projectPkgRoot, "package-skills", "pkg-project", "SKILL.md"),
+						source: "package",
+						description: "Project package",
+					},
+					{
+						name: "pkg-user",
+						filePath: path.join(userPkgRoot, "user-package-skills", "pkg-user", "SKILL.md"),
+						source: "package",
+						description: "User package",
+					},
+					{
+						name: "pkg-global",
+						filePath: path.join(globalPkgRoot, "global-package-skills", "pkg-global", "SKILL.md"),
+						source: "package",
+						description: "Global package",
+					},
+					{
+						name: "settings-project",
+						filePath: path.join(projectSettingsSkillDir, "SKILL.md"),
+						source: "settings",
+						description: "Project settings",
+					},
+					{
+						name: "settings-user",
+						filePath: path.join(userSettingsSkillDir, "SKILL.md"),
+						source: "settings",
+						description: "User settings",
+					},
+					{
+						name: "builtin-skill",
+						filePath: "/builtin/skill.md",
+						source: "builtin",
+						description: "Builtin",
+					},
+				],
+			};
+		});
+
+		const available = discoverAvailableSkills(cwd);
+		expect(available).toEqual([
+			{ name: "builtin-skill", source: "builtin", description: "Builtin" },
+			{ name: "pkg-global", source: "user-package", description: "Global package" },
+			{ name: "pkg-project", source: "project-package", description: "Project package" },
+			{ name: "pkg-user", source: "user-package", description: "User package" },
+			{ name: "settings-project", source: "project-settings", description: "Project settings" },
+			{ name: "settings-user", source: "unknown", description: "User settings" },
+			{ name: "shared", source: "project", description: "Project copy" },
+		]);
+		expect(resolveSkillPath("shared", cwd)).toEqual({
+			path: path.join(cwd, ".pi", "skills", "shared", "SKILL.md"),
+			source: "project",
+		});
+
+		discoverAvailableSkills(cwd);
+		expect(skillsMocks.loadSkills).toHaveBeenCalledTimes(1);
+		clearSkillCache();
+		discoverAvailableSkills(cwd);
+		expect(skillsMocks.loadSkills).toHaveBeenCalledTimes(2);
+	});
+
+	it("reads skills, strips frontmatter, and reports missing skills", () => {
+		const cwd = createTempDir("pi-subagent-skill-read-");
+		const agentDir = createTempDir("pi-subagent-skill-read-agent-");
+		skillsMocks.resolveAgentDir.mockReturnValue(agentDir);
+
+		const sharedSkillFile = path.join(cwd, ".pi", "skills", "shared", "SKILL.md");
+		const packageSkillFile = path.join(cwd, ".pi", "package-skill", "SKILL.md");
+		fs.mkdirSync(path.dirname(sharedSkillFile), { recursive: true });
+		fs.mkdirSync(path.dirname(packageSkillFile), { recursive: true });
+		fs.writeFileSync(sharedSkillFile, "---\ndescription: test\n---\nProject instructions\n");
+		fs.writeFileSync(packageSkillFile, "Package instructions\n");
+
+		skillsMocks.loadSkills.mockReturnValue({
+			skills: [
+				{ name: "shared", filePath: sharedSkillFile, source: "project", description: "Project" },
+				{ name: "package", filePath: packageSkillFile, source: "package", description: "Package" },
+				{ name: "broken", filePath: path.join(cwd, "missing", "SKILL.md"), source: "project" },
+			],
+		});
+
+		const resolved = resolveSkills(["shared", "package", "missing", "broken"], cwd);
+		expect(resolved.resolved).toEqual([
+			{ name: "shared", path: sharedSkillFile, content: "Project instructions", source: "project" },
+			{ name: "package", path: packageSkillFile, content: "Package instructions\n", source: "project-package" },
+		]);
+		expect(resolved.missing).toEqual(["missing", "broken"]);
+	});
+});

--- a/packages/subagents/tests/utils-extra.test.ts
+++ b/packages/subagents/tests/utils-extra.test.ts
@@ -1,0 +1,204 @@
+import fs from "node:fs";
+import os from "node:os";
+import path from "node:path";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import {
+	detectSubagentError,
+	extractTextFromContent,
+	extractToolArgsPreview,
+	findByPrefix,
+	findLatestSessionFile,
+	getDisplayItems,
+	getFinalOutput,
+	getLastActivity,
+	getOutputTail,
+	mapConcurrent,
+	readStatus,
+	writePrompt,
+} from "../utils.js";
+
+const tempDirs: string[] = [];
+
+function createTempDir(prefix: string) {
+	const dir = fs.mkdtempSync(path.join(os.tmpdir(), prefix));
+	tempDirs.push(dir);
+	return dir;
+}
+
+beforeEach(() => {
+	vi.useRealTimers();
+});
+
+afterEach(() => {
+	for (const dir of tempDirs) {
+		fs.rmSync(dir, { recursive: true, force: true });
+	}
+	tempDirs.length = 0;
+	vi.restoreAllMocks();
+	vi.useRealTimers();
+});
+
+describe("subagent utils", () => {
+	it("reads cached async status files and refreshes when mtimes change", () => {
+		const asyncDir = createTempDir("pi-subagent-status-");
+		const statusPath = path.join(asyncDir, "status.json");
+		fs.writeFileSync(statusPath, JSON.stringify({ runId: "run-1", state: "running" }));
+
+		const first = readStatus(asyncDir);
+		const second = readStatus(asyncDir);
+		expect(first).toEqual({ runId: "run-1", state: "running" });
+		expect(second).toBe(first);
+
+		fs.writeFileSync(statusPath, JSON.stringify({ runId: "run-1", state: "complete" }));
+		const nextTime = new Date(Date.now() + 5_000);
+		fs.utimesSync(statusPath, nextTime, nextTime);
+		const third = readStatus(asyncDir);
+		expect(third).toEqual({ runId: "run-1", state: "complete" });
+		expect(readStatus(path.join(asyncDir, "missing"))).toBeNull();
+	});
+
+	it("reads output tails with caching and reports last activity", () => {
+		const outputDir = createTempDir("pi-subagent-output-");
+		const outputPath = path.join(outputDir, "output.log");
+		fs.writeFileSync(outputPath, `${"x".repeat(150)}\nline two\nline three\nline four\n`);
+
+		const tail = getOutputTail(outputPath, 2);
+		expect(tail).toHaveLength(2);
+		expect(tail[0]).toContain("line three");
+		expect(tail[1]).toContain("line four");
+		expect(getOutputTail(outputPath, 2)).toEqual(tail);
+		expect(getOutputTail(undefined)).toEqual([]);
+		expect(getLastActivity(outputPath)).toBe("active now");
+
+		const oneMinuteAgo = new Date(Date.now() - 65_000);
+		fs.utimesSync(outputPath, oneMinuteAgo, oneMinuteAgo);
+		expect(getLastActivity(outputPath)).toBe("active 1m ago");
+		expect(getLastActivity(path.join(outputDir, "missing.log"))).toBe("");
+	});
+
+	it("finds files by prefix, latest sessions, and writes prompts safely", () => {
+		const dir = createTempDir("pi-subagent-files-");
+		fs.writeFileSync(path.join(dir, "abc-first.json"), "one");
+		fs.writeFileSync(path.join(dir, "abc-second.txt"), "two");
+		fs.writeFileSync(path.join(dir, "other.txt"), "three");
+
+		expect(findByPrefix(dir, "abc-")).toBe(path.join(dir, "abc-first.json"));
+		expect(findByPrefix(dir, "abc-", ".txt")).toBe(path.join(dir, "abc-second.txt"));
+		expect(findByPrefix(dir, "missing")).toBeNull();
+
+		const sessionDir = createTempDir("pi-subagent-sessions-");
+		const older = path.join(sessionDir, "old.jsonl");
+		const newer = path.join(sessionDir, "new.jsonl");
+		fs.writeFileSync(older, "old");
+		fs.writeFileSync(newer, "new");
+		const oldTime = new Date(Date.now() - 10_000);
+		const newTime = new Date(Date.now() + 10_000);
+		fs.utimesSync(older, oldTime, oldTime);
+		fs.utimesSync(newer, newTime, newTime);
+		expect(findLatestSessionFile(sessionDir)).toBe(newer);
+		expect(findLatestSessionFile(path.join(sessionDir, "missing"))).toBeNull();
+
+		const prompt = writePrompt("agent/name", "System prompt");
+		tempDirs.push(prompt.dir);
+		expect(prompt.path).toContain("agent_name.md");
+		expect(fs.readFileSync(prompt.path, "utf8")).toBe("System prompt");
+	});
+
+	it("extracts outputs, tool previews, display items, and nested text content", () => {
+		const messages = [
+			{
+				role: "assistant",
+				content: [
+					{ type: "text", text: "First" },
+					{ type: "toolCall", name: "bash", arguments: { command: "ls" } },
+				],
+			},
+			{ role: "assistant", content: [{ type: "text", text: "Second" }] },
+		] as never;
+
+		expect(getFinalOutput(messages)).toBe("Second");
+		expect(getDisplayItems(messages)).toEqual([
+			{ type: "text", text: "First" },
+			{ type: "tool", name: "bash", args: { command: "ls" } },
+			{ type: "text", text: "Second" },
+		]);
+		expect(extractToolArgsPreview({ tool: "search", server: "docs", args: '{"q":"pi"}' })).toBe(
+			'docs/search {"q":"pi"}',
+		);
+		expect(extractToolArgsPreview({ command: "x".repeat(70) })).toBe(`${"x".repeat(57)}...`);
+		expect(extractToolArgsPreview({ note: "brief detail" })).toBe("note=brief detail");
+		expect(extractToolArgsPreview({})).toBe("");
+		expect(
+			extractTextFromContent([
+				{ type: "text", text: "Hello" },
+				{ type: "tool_result", content: [{ type: "text", text: "Nested" }] },
+				{ text: "Loose text" },
+			]),
+		).toBe("Hello\nNested\nLoose text");
+		expect(extractTextFromContent("plain text")).toBe("plain text");
+		expect(extractTextFromContent(null)).toBe("");
+	});
+
+	it("detects recovered and unrecovered tool failures", () => {
+		const recovered = detectSubagentError([
+			{ role: "toolResult", toolName: "bash", content: [{ type: "text", text: "exit code 1" }], isError: true },
+			{ role: "assistant", content: [{ type: "text", text: "Recovered response" }] },
+		] as never);
+		expect(recovered).toEqual({ hasError: false });
+
+		const explicitError = detectSubagentError([
+			{ role: "assistant", content: [{ type: "text", text: "Started" }] },
+			{ role: "toolResult", toolName: "read", content: [{ type: "text", text: "permission denied" }], isError: true },
+		] as never);
+		expect(explicitError).toMatchObject({ hasError: true, exitCode: 1, errorType: "read" });
+
+		const bashExit = detectSubagentError([
+			{
+				role: "toolResult",
+				toolName: "bash",
+				content: [{ type: "text", text: "Command failed with exit code 23" }],
+				isError: false,
+			},
+		] as never);
+		expect(bashExit).toEqual({
+			hasError: true,
+			exitCode: 23,
+			errorType: "bash",
+			details: "Command failed with exit code 23",
+		});
+
+		const bashFatal = detectSubagentError([
+			{
+				role: "toolResult",
+				toolName: "bash",
+				content: [{ type: "text", text: "Connection refused while contacting host" }],
+				isError: false,
+			},
+		] as never);
+		expect(bashFatal).toMatchObject({ hasError: true, exitCode: 1, errorType: "bash" });
+	});
+
+	it("maps work with concurrency limits and optional staggering", async () => {
+		vi.useFakeTimers();
+		const startOrder: number[] = [];
+		const finishOrder: number[] = [];
+		const promise = mapConcurrent(
+			["a", "b", "c"],
+			0,
+			async (item, index) => {
+				startOrder.push(index);
+				await new Promise((resolve) => setTimeout(resolve, item === "a" ? 20 : 5));
+				finishOrder.push(index);
+				return item.toUpperCase();
+			},
+			10,
+		);
+
+		await vi.advanceTimersByTimeAsync(60);
+		await expect(promise).resolves.toEqual(["A", "B", "C"]);
+		expect(startOrder[0]).toBe(0);
+		expect(finishOrder).toContain(0);
+
+		await expect(mapConcurrent([1, 2], 5, async (item) => item * 2, 0)).resolves.toEqual([2, 4]);
+	});
+});

--- a/packages/web-remote/tests/index.test.ts
+++ b/packages/web-remote/tests/index.test.ts
@@ -1,0 +1,189 @@
+import { afterEach, describe, expect, it, vi } from "vitest";
+import { createExtensionHarness } from "../../../test-utils/extension-runtime-harness.js";
+
+const webServerModule = vi.hoisted(() => ({
+	createPiWebServer: vi.fn(),
+	detectTunnelProvider: vi.fn(),
+	getLanIp: vi.fn(),
+	startTunnel: vi.fn(),
+}));
+
+vi.mock("@ifi/pi-web-server", () => webServerModule);
+
+import remoteExtension from "../index.ts";
+
+type MockServer = ReturnType<typeof createMockServer>;
+
+function createMockServer(overrides: Partial<Record<string, unknown>> = {}) {
+	const handlers = {
+		client_connect: [] as Array<(clientId: string) => void>,
+		client_disconnect: [] as Array<(clientId: string) => void>,
+	};
+	let running = false;
+	let tunnelUrl: string | undefined;
+	let connectedClients = 0;
+
+	const server = {
+		url: "http://localhost:3100",
+		token: "test-token",
+		instanceId: "instance-42",
+		start: vi.fn(() => {
+			running = true;
+			return Promise.resolve({ url: server.url, token: server.token, instanceId: server.instanceId });
+		}),
+		stop: vi.fn(() => {
+			running = false;
+			return Promise.resolve();
+		}),
+		on: vi.fn((event: keyof typeof handlers, handler: (clientId: string) => void) => {
+			handlers[event].push(handler);
+			return vi.fn(() => {
+				handlers[event] = handlers[event].filter((entry) => entry !== handler);
+			});
+		}),
+		setTunnel: vi.fn((tunnel: { publicUrl: string }) => {
+			tunnelUrl = tunnel.publicUrl;
+		}),
+		emit(event: keyof typeof handlers, clientId = "client-1") {
+			for (const handler of handlers[event]) {
+				handler(clientId);
+			}
+		},
+		get isRunning() {
+			return running;
+		},
+		get connectedClients() {
+			return connectedClients;
+		},
+		set connectedClients(value: number) {
+			connectedClients = value;
+		},
+		get tunnelUrl() {
+			return tunnelUrl;
+		},
+		...overrides,
+	};
+
+	return server;
+}
+
+afterEach(() => {
+	vi.restoreAllMocks();
+});
+
+describe("web-remote extension", () => {
+	it("starts remote access, prefers tunnel URLs, and reuses the active session", async () => {
+		const harness = createExtensionHarness();
+		const server = createMockServer();
+		webServerModule.createPiWebServer.mockReturnValue(server);
+		webServerModule.detectTunnelProvider.mockReturnValue("cloudflared");
+		webServerModule.startTunnel.mockResolvedValue({
+			publicUrl: "https://quiet-river.trycloudflare.com",
+			provider: "cloudflared",
+			stop: vi.fn(),
+		});
+		webServerModule.getLanIp.mockReturnValue("192.168.1.20");
+
+		remoteExtension(harness.pi as never);
+		const command = harness.commands.get("remote");
+		await command.handler(undefined, harness.ctx);
+
+		expect(webServerModule.createPiWebServer).toHaveBeenCalledTimes(1);
+		expect(webServerModule.startTunnel).toHaveBeenCalledWith(3100, "cloudflared");
+		expect(server.setTunnel).toHaveBeenCalledWith(
+			expect.objectContaining({ publicUrl: "https://quiet-river.trycloudflare.com" }),
+		);
+		expect(harness.notifications.map((entry) => entry.msg)).toEqual([
+			"Starting remote access...",
+			"🌐 Remote active · instance-42\nhttps://pi-remote.dev?host=https%3A%2F%2Fquiet-river.trycloudflare.com&t=test-token",
+		]);
+		expect(harness.statusMap.get("remote")).toBe("🌐 Remote: 0 clients");
+
+		server.connectedClients = 2;
+		await command.handler(undefined, harness.ctx);
+		expect(harness.notifications.at(-1)?.msg).toBe(
+			"Remote active · 2 client(s) · instance-42\nhttps://pi-remote.dev?host=https%3A%2F%2Fquiet-river.trycloudflare.com&t=test-token",
+		);
+	});
+
+	it("falls back to LAN and localhost URLs when no tunnel is available", async () => {
+		const harness = createExtensionHarness();
+		const lanServer = createMockServer();
+		webServerModule.createPiWebServer.mockReturnValueOnce(lanServer);
+		webServerModule.detectTunnelProvider.mockReturnValue(undefined);
+		webServerModule.getLanIp.mockReturnValueOnce("192.168.1.20").mockReturnValueOnce(undefined);
+
+		remoteExtension(harness.pi as never);
+		const command = harness.commands.get("remote");
+		await command.handler(undefined, harness.ctx);
+		expect(harness.notifications.at(-1)?.msg).toContain("http://192.168.1.20:3100?t=test-token");
+
+		const localhostServer = createMockServer({ url: "http://localhost:4100", token: "local-token" });
+		webServerModule.createPiWebServer.mockReturnValueOnce(localhostServer);
+		await command.handler("stop", harness.ctx);
+		await command.handler(undefined, harness.ctx);
+		expect(harness.notifications.at(-1)?.msg).toContain("http://localhost:4100?t=local-token");
+	});
+
+	it("keeps running when tunnel startup fails", async () => {
+		const harness = createExtensionHarness();
+		const server = createMockServer();
+		webServerModule.createPiWebServer.mockReturnValue(server);
+		webServerModule.detectTunnelProvider.mockReturnValue("cloudflared");
+		webServerModule.startTunnel.mockRejectedValue(new Error("tunnel failed"));
+		webServerModule.getLanIp.mockReturnValue(undefined);
+
+		remoteExtension(harness.pi as never);
+		await harness.commands.get("remote").handler(undefined, harness.ctx);
+
+		expect(server.setTunnel).not.toHaveBeenCalled();
+		expect(harness.notifications.at(-1)?.msg).toContain("http://localhost:3100?t=test-token");
+	});
+
+	it("updates status when clients connect and disconnect", async () => {
+		const harness = createExtensionHarness();
+		const server = createMockServer();
+		webServerModule.createPiWebServer.mockReturnValue(server);
+		webServerModule.detectTunnelProvider.mockReturnValue(undefined);
+		webServerModule.getLanIp.mockReturnValue("192.168.1.20");
+
+		remoteExtension(harness.pi as never);
+		await harness.commands.get("remote").handler(undefined, harness.ctx);
+
+		server.connectedClients = 1;
+		server.emit("client_connect");
+		expect(harness.notifications.at(-1)?.msg).toBe("Client connected");
+		expect(harness.statusMap.get("remote")).toBe("🌐 Remote: 1 client");
+
+		server.connectedClients = 0;
+		server.emit("client_disconnect");
+		expect(harness.notifications.at(-1)?.msg).toBe("Client disconnected");
+		expect(harness.statusMap.get("remote")).toBe("🌐 Remote: 0 clients");
+	});
+
+	it("handles stop requests and session shutdown cleanup", async () => {
+		const harness = createExtensionHarness();
+		const server = createMockServer();
+		webServerModule.createPiWebServer.mockReturnValue(server);
+		webServerModule.detectTunnelProvider.mockReturnValue(undefined);
+		webServerModule.getLanIp.mockReturnValue("192.168.1.20");
+
+		remoteExtension(harness.pi as never);
+		const command = harness.commands.get("remote");
+
+		await command.handler("stop", harness.ctx);
+		expect(harness.notifications.at(-1)?.msg).toBe("Remote access is not active.");
+
+		await command.handler(undefined, harness.ctx);
+		await command.handler("stop", harness.ctx);
+		expect(server.stop).toHaveBeenCalledTimes(1);
+		expect(harness.statusMap.has("remote")).toBe(false);
+		expect(harness.notifications.at(-1)?.msg).toBe("Remote access stopped.");
+
+		const nextServer = createMockServer({ instanceId: "instance-2" });
+		webServerModule.createPiWebServer.mockReturnValueOnce(nextServer);
+		await command.handler(undefined, harness.ctx);
+		await harness.emitAsync("session_shutdown");
+		expect(nextServer.stop).toHaveBeenCalledTimes(1);
+	});
+});

--- a/packages/web-server/tests/lan.test.ts
+++ b/packages/web-server/tests/lan.test.ts
@@ -1,0 +1,37 @@
+import { afterEach, describe, expect, it, vi } from "vitest";
+
+const osModule = vi.hoisted(() => ({
+	networkInterfaces: vi.fn(),
+}));
+
+vi.mock("node:os", () => osModule);
+
+import { getLanIp } from "../src/lan.js";
+
+afterEach(() => {
+	vi.restoreAllMocks();
+});
+
+describe("getLanIp", () => {
+	it("returns the first non-internal IPv4 address", () => {
+		osModule.networkInterfaces.mockReturnValue({
+			lo0: [{ family: "IPv4", internal: true, address: "127.0.0.1" }],
+			en0: [
+				{ family: "IPv6", internal: false, address: "fe80::1" },
+				{ family: "IPv4", internal: false, address: "192.168.1.23" },
+			],
+		});
+
+		expect(getLanIp()).toBe("192.168.1.23");
+	});
+
+	it("returns undefined when no LAN IPv4 address is available", () => {
+		osModule.networkInterfaces.mockReturnValue({
+			lo0: [{ family: "IPv4", internal: true, address: "127.0.0.1" }],
+			utun0: [{ family: "IPv6", internal: false, address: "fe80::1" }],
+			en0: undefined,
+		});
+
+		expect(getLanIp()).toBeUndefined();
+	});
+});

--- a/packages/web-server/tests/routes.test.ts
+++ b/packages/web-server/tests/routes.test.ts
@@ -1,0 +1,130 @@
+import { describe, expect, it } from "vitest";
+import { createRoutes } from "../src/routes.js";
+import type { AgentSessionLike } from "../src/ws-handler.js";
+
+function createSession(overrides: Partial<AgentSessionLike> = {}): AgentSessionLike {
+	return {
+		prompt: async () => {},
+		steer: async () => {},
+		followUp: async () => {},
+		abort: async () => {},
+		compact: async () => ({ ok: true }),
+		setModel: async () => true,
+		setThinkingLevel: () => {},
+		subscribe: () => () => {},
+		isStreaming: false,
+		messages: [{ role: "user", content: "hello" }],
+		model: "openai/gpt-5-mini",
+		thinkingLevel: "medium",
+		sessionId: "session-1",
+		sessionFile: "/tmp/session-1.jsonl",
+		agent: { state: { systemPrompt: "You are helpful", tools: [] } },
+		newSession: async () => ({ cancelled: false }),
+		...overrides,
+	};
+}
+
+function createApp(session?: AgentSessionLike) {
+	return createRoutes({
+		token: "test-token",
+		instanceId: "instance-42",
+		startTime: Date.now() - 4_300,
+		getSession: () => session,
+		getConnectedClients: () => 3,
+	});
+}
+
+function authHeaders(token = "test-token") {
+	return { Authorization: `Bearer ${token}` };
+}
+
+describe("createRoutes", () => {
+	it("serves health checks without authentication", async () => {
+		const response = await createApp().request("/api/health");
+		const body = await response.json();
+
+		expect(response.status).toBe(200);
+		expect(body).toEqual({
+			status: "ok",
+			uptime: expect.any(Number),
+		});
+		expect(body.uptime).toBeGreaterThanOrEqual(4);
+	});
+
+	it("rejects missing or invalid bearer tokens", async () => {
+		const app = createApp();
+
+		const missing = await app.request("/api/instance");
+		expect(missing.status).toBe(401);
+		expect(await missing.json()).toEqual({ error: "Authorization required" });
+
+		const invalid = await app.request("/api/instance", {
+			headers: authHeaders("wrong-token"),
+		});
+		expect(invalid.status).toBe(401);
+		expect(await invalid.json()).toEqual({ error: "Invalid token" });
+	});
+
+	it("returns instance metadata when authenticated", async () => {
+		const response = await createApp().request("/api/instance", {
+			headers: authHeaders(),
+		});
+
+		expect(response.status).toBe(200);
+		expect(await response.json()).toEqual({
+			instanceId: "instance-42",
+			uptime: expect.any(Number),
+			connectedClients: 3,
+		});
+	});
+
+	it("returns 503 for session endpoints when no session is attached", async () => {
+		const app = createApp();
+
+		for (const pathname of ["/api/session/state", "/api/session/messages", "/api/session/stats", "/api/models"]) {
+			const response = await app.request(pathname, { headers: authHeaders() });
+			expect(response.status).toBe(503);
+			expect(await response.json()).toEqual({ error: "No session attached" });
+		}
+	});
+
+	it("returns session state, messages, stats, and models when a session is attached", async () => {
+		const session = createSession({
+			isStreaming: true,
+			messages: [
+				{ role: "user", content: "hello" },
+				{ role: "assistant", content: "hi" },
+			],
+		});
+		const app = createApp(session);
+
+		const state = await app.request("/api/session/state", { headers: authHeaders() });
+		expect(state.status).toBe(200);
+		expect(await state.json()).toEqual({
+			model: "openai/gpt-5-mini",
+			thinkingLevel: "medium",
+			isStreaming: true,
+			sessionId: "session-1",
+			messageCount: 2,
+		});
+
+		const messages = await app.request("/api/session/messages", { headers: authHeaders() });
+		expect(messages.status).toBe(200);
+		expect(await messages.json()).toEqual({ messages: session.messages });
+
+		const stats = await app.request("/api/session/stats", { headers: authHeaders() });
+		expect(stats.status).toBe(200);
+		expect(await stats.json()).toEqual({
+			sessionId: "session-1",
+			messageCount: 2,
+			isStreaming: true,
+		});
+
+		const models = await app.request("/api/models", { headers: authHeaders() });
+		expect(models.status).toBe(200);
+		expect(await models.json()).toEqual({
+			currentModel: "openai/gpt-5-mini",
+			thinkingLevel: "medium",
+		});
+	});
+});

--- a/packages/web-server/tests/server.test.ts
+++ b/packages/web-server/tests/server.test.ts
@@ -1,0 +1,182 @@
+import { once } from "node:events";
+import { createServer } from "node:http";
+import { afterEach, describe, expect, it, vi } from "vitest";
+import { WebSocket } from "ws";
+import { createPiWebServer, type PiWebServer } from "../src/server.js";
+import type { AgentSessionLike } from "../src/ws-handler.js";
+
+function createSession(): AgentSessionLike {
+	const listeners = new Set<(event: unknown) => void>();
+	return {
+		prompt: vi.fn(async () => {}),
+		steer: vi.fn(async () => {}),
+		followUp: vi.fn(async () => {}),
+		abort: vi.fn(async () => {}),
+		compact: vi.fn(async () => ({ compacted: true })),
+		setModel: vi.fn(async () => true),
+		setThinkingLevel: vi.fn(),
+		subscribe: vi.fn((listener) => {
+			listeners.add(listener);
+			return () => {
+				listeners.delete(listener);
+			};
+		}),
+		isStreaming: false,
+		messages: [{ role: "user", content: "hello" }],
+		model: "openai/gpt-5-mini",
+		thinkingLevel: "medium",
+		sessionId: "session-1",
+		sessionFile: "/tmp/session-1.jsonl",
+		agent: { state: { systemPrompt: "You are helpful", tools: [] } },
+		newSession: vi.fn(async () => ({ cancelled: false })),
+	};
+}
+
+async function findFreePort(): Promise<number> {
+	const probe = createServer();
+	await new Promise<void>((resolve, reject) => {
+		probe.listen(0, "127.0.0.1", () => resolve());
+		probe.once("error", reject);
+	});
+	const address = probe.address();
+	if (!address || typeof address === "string") {
+		throw new Error("Expected an ephemeral TCP port.");
+	}
+	const { port } = address;
+	await new Promise<void>((resolve, reject) => {
+		probe.close((error) => {
+			if (error) {
+				reject(error);
+				return;
+			}
+			resolve();
+		});
+	});
+	return port;
+}
+
+async function openAuthedClient(server: PiWebServer): Promise<{ ws: WebSocket; authMessage: any }> {
+	const ws = new WebSocket(server.url.replace("http://", "ws://"));
+	await once(ws, "open");
+	const authPromise = once(ws, "message").then(([message]) => JSON.parse(message.toString()));
+	ws.send(JSON.stringify({ type: "auth", token: server.token }));
+	const authMessage = await authPromise;
+	return { ws, authMessage };
+}
+
+afterEach(() => {
+	vi.restoreAllMocks();
+});
+
+describe.sequential("PiWebServer", () => {
+	it("starts, serves authenticated routes, and stops cleanly", async () => {
+		const session = createSession();
+		const server = createPiWebServer({ host: "127.0.0.1", port: await findFreePort(), token: "test-token" });
+		server.attachSession(session);
+		const started = await server.start();
+
+		try {
+			expect(started.url).toBe(server.url);
+			expect(server.isRunning).toBe(true);
+			expect(server.instanceId).toBeTruthy();
+			expect(server.connectedClients).toBe(0);
+
+			const health = await fetch(`${server.url}/api/health`);
+			expect(health.status).toBe(200);
+			expect(await health.json()).toEqual({ status: "ok", uptime: expect.any(Number) });
+
+			const state = await fetch(`${server.url}/api/session/state`, {
+				headers: { Authorization: `Bearer ${server.token}` },
+			});
+			expect(state.status).toBe(200);
+			expect(await state.json()).toEqual({
+				model: "openai/gpt-5-mini",
+				thinkingLevel: "medium",
+				isStreaming: false,
+				sessionId: "session-1",
+				messageCount: 1,
+			});
+
+			server.detachSession();
+			const detached = await fetch(`${server.url}/api/session/state`, {
+				headers: { Authorization: `Bearer ${server.token}` },
+			});
+			expect(detached.status).toBe(503);
+			expect(await detached.json()).toEqual({ error: "No session attached" });
+		} finally {
+			await server.stop();
+		}
+
+		expect(server.isRunning).toBe(false);
+	});
+
+	it("tracks authenticated websocket clients, enforces maxClients, and emits lifecycle events", async () => {
+		const session = createSession();
+		const server = createPiWebServer({
+			host: "127.0.0.1",
+			port: await findFreePort(),
+			token: "test-token",
+			maxClients: 1,
+		});
+		server.attachSession(session);
+		const onConnect = vi.fn();
+		const onDisconnect = vi.fn();
+		server.on("client_connect", onConnect);
+		server.on("client_disconnect", onDisconnect);
+		await server.start();
+
+		let firstClient: WebSocket | undefined;
+		let secondClient: WebSocket | undefined;
+		try {
+			const first = await openAuthedClient(server);
+			firstClient = first.ws;
+			expect(first.authMessage.type).toBe("auth_ok");
+			expect(server.connectedClients).toBe(1);
+			expect(onConnect).toHaveBeenCalledTimes(1);
+
+			secondClient = new WebSocket(server.url.replace("http://", "ws://"));
+			await once(secondClient, "open");
+			const closed = once(secondClient, "close");
+			secondClient.send(JSON.stringify({ type: "auth", token: server.token }));
+			const [code] = await closed;
+			expect(code).toBe(4002);
+			expect(server.connectedClients).toBe(1);
+
+			const disconnected = once(firstClient, "close");
+			firstClient.close(1000, "done");
+			await disconnected;
+			await vi.waitFor(() => {
+				expect(onDisconnect).toHaveBeenCalledTimes(1);
+				expect(server.connectedClients).toBe(0);
+			});
+		} finally {
+			if (secondClient?.readyState === WebSocket.OPEN) {
+				secondClient.close();
+			}
+			if (firstClient?.readyState === WebSocket.OPEN) {
+				firstClient.close();
+			}
+			await server.stop();
+		}
+	});
+
+	it("exposes tunnel metadata and closes connected clients during shutdown", async () => {
+		const session = createSession();
+		const server = createPiWebServer({ host: "127.0.0.1", port: await findFreePort(), token: "test-token" });
+		server.attachSession(session);
+		const tunnelStop = vi.fn();
+		server.setTunnel({ publicUrl: "https://example.trycloudflare.com", provider: "cloudflared", stop: tunnelStop });
+		await server.start();
+
+		const { ws } = await openAuthedClient(server);
+		const closed = once(ws, "close");
+
+		await server.stop();
+		const [code] = await closed;
+
+		expect(server.tunnelUrl).toBeUndefined();
+		expect(tunnelStop).toHaveBeenCalledTimes(1);
+		expect(code).toBe(1001);
+		ws.removeAllListeners();
+	});
+});

--- a/packages/web-server/tests/tunnel.test.ts
+++ b/packages/web-server/tests/tunnel.test.ts
@@ -1,0 +1,134 @@
+import { EventEmitter } from "node:events";
+import { afterEach, describe, expect, it, vi } from "vitest";
+
+const childProcess = vi.hoisted(() => ({
+	execFileSync: vi.fn(),
+	spawn: vi.fn(),
+}));
+
+vi.mock("node:child_process", () => childProcess);
+
+import { detectTunnelProvider, startTunnel } from "../src/tunnel.js";
+
+type MockProc = EventEmitter & {
+	stdout: EventEmitter;
+	stderr: EventEmitter;
+	kill: ReturnType<typeof vi.fn>;
+};
+
+function createMockProcess(): MockProc {
+	const proc = new EventEmitter() as MockProc;
+	proc.stdout = new EventEmitter();
+	proc.stderr = new EventEmitter();
+	proc.kill = vi.fn();
+	return proc;
+}
+
+afterEach(() => {
+	vi.restoreAllMocks();
+	vi.useRealTimers();
+});
+
+describe("detectTunnelProvider", () => {
+	it("prefers cloudflared when available", () => {
+		childProcess.execFileSync.mockImplementation((command: string) => {
+			if (command === "which") {
+				return "";
+			}
+			throw new Error("unexpected command");
+		});
+
+		expect(detectTunnelProvider()).toBe("cloudflared");
+		expect(childProcess.execFileSync).toHaveBeenCalledWith("which", ["cloudflared"], { stdio: "ignore" });
+	});
+
+	it("falls back to tailscale when cloudflared is unavailable", () => {
+		childProcess.execFileSync
+			.mockImplementationOnce(() => {
+				throw new Error("missing cloudflared");
+			})
+			.mockImplementationOnce(() => "");
+
+		expect(detectTunnelProvider()).toBe("tailscale");
+	});
+
+	it("returns undefined when no provider is installed", () => {
+		childProcess.execFileSync.mockImplementation(() => {
+			throw new Error("missing");
+		});
+
+		expect(detectTunnelProvider()).toBeUndefined();
+	});
+});
+
+describe("startTunnel", () => {
+	it("rejects when no tunnel provider is available", async () => {
+		childProcess.execFileSync.mockImplementation(() => {
+			throw new Error("missing");
+		});
+
+		await expect(startTunnel(3100)).rejects.toThrow("No tunnel provider found");
+	});
+
+	it("starts a cloudflared tunnel and returns a stop handle", async () => {
+		const proc = createMockProcess();
+		childProcess.spawn.mockReturnValue(proc);
+
+		const tunnelPromise = startTunnel(3100, "cloudflared");
+		proc.stderr.emit("data", Buffer.from("Visit https://quiet-river.trycloudflare.com now"));
+		const tunnel = await tunnelPromise;
+
+		expect(childProcess.spawn).toHaveBeenCalledWith("cloudflared", ["tunnel", "--url", "http://localhost:3100"], {
+			stdio: ["ignore", "pipe", "pipe"],
+		});
+		expect(tunnel).toEqual({
+			publicUrl: "https://quiet-river.trycloudflare.com",
+			provider: "cloudflared",
+			stop: expect.any(Function),
+		});
+
+		tunnel.stop();
+		expect(proc.kill).toHaveBeenCalledWith("SIGTERM");
+	});
+
+	it("starts a tailscale tunnel from stdout output", async () => {
+		const proc = createMockProcess();
+		childProcess.spawn.mockReturnValue(proc);
+
+		const tunnelPromise = startTunnel(4200, "tailscale");
+		proc.stdout.emit("data", Buffer.from("open https://pi.tailnet.example.ts.net for access"));
+		const tunnel = await tunnelPromise;
+
+		expect(childProcess.spawn).toHaveBeenCalledWith("tailscale", ["funnel", "4200"], {
+			stdio: ["ignore", "pipe", "pipe"],
+		});
+		expect(tunnel.publicUrl).toBe("https://pi.tailnet.example.ts.net");
+		expect(tunnel.provider).toBe("tailscale");
+	});
+
+	it("surfaces tunnel process failures", async () => {
+		const proc = createMockProcess();
+		childProcess.spawn.mockReturnValue(proc);
+
+		const cloudflaredFailure = startTunnel(3100, "cloudflared");
+		proc.emit("exit", 1);
+		await expect(cloudflaredFailure).rejects.toThrow("cloudflared exited with code 1");
+
+		const tailscaleProc = createMockProcess();
+		childProcess.spawn.mockReturnValue(tailscaleProc);
+		const tailscaleFailure = startTunnel(3100, "tailscale");
+		tailscaleProc.emit("error", new Error("spawn failed"));
+		await expect(tailscaleFailure).rejects.toThrow("spawn failed");
+	});
+
+	it("times out stalled tunnel startups", async () => {
+		vi.useFakeTimers();
+		const proc = createMockProcess();
+		childProcess.spawn.mockReturnValue(proc);
+
+		const tunnelPromise = startTunnel(3100, "cloudflared");
+		const rejection = expect(tunnelPromise).rejects.toThrow("Cloudflare tunnel timed out after 30s");
+		await vi.advanceTimersByTimeAsync(30_000);
+		await rejection;
+	});
+});

--- a/packages/web-server/tests/ws-handler.test.ts
+++ b/packages/web-server/tests/ws-handler.test.ts
@@ -1,0 +1,270 @@
+import { EventEmitter } from "node:events";
+import { afterEach, describe, expect, it, vi } from "vitest";
+import type { AgentSessionLike } from "../src/ws-handler.js";
+import { handleWebSocketConnection } from "../src/ws-handler.js";
+
+class MockWebSocket extends EventEmitter {
+	static OPEN = 1;
+	OPEN = 1;
+	readyState = MockWebSocket.OPEN;
+	sent: unknown[] = [];
+	closeCalls: Array<{ code: number; reason: string }> = [];
+
+	send(data: string): void {
+		this.sent.push(JSON.parse(data));
+	}
+
+	close(code = 1000, reason = ""): void {
+		this.readyState = 3;
+		this.closeCalls.push({ code, reason });
+		this.emit("close");
+	}
+
+	async emitMessage(data: unknown): Promise<void> {
+		for (const listener of this.listeners("message")) {
+			await listener(data);
+		}
+	}
+}
+
+function createSession(overrides: Partial<AgentSessionLike> = {}): AgentSessionLike {
+	return {
+		prompt: vi.fn(async () => {}),
+		steer: vi.fn(async () => {}),
+		followUp: vi.fn(async () => {}),
+		abort: vi.fn(async () => {}),
+		compact: vi.fn(async () => ({ compacted: true })),
+		setModel: vi.fn(async () => true),
+		setThinkingLevel: vi.fn(),
+		subscribe: vi.fn(() => vi.fn()),
+		isStreaming: false,
+		messages: [{ role: "user", content: "hello" }],
+		model: "openai/gpt-5-mini",
+		thinkingLevel: "medium",
+		sessionId: "session-1",
+		sessionFile: "/tmp/session-1.jsonl",
+		agent: { state: { systemPrompt: "You are helpful", tools: [] } },
+		newSession: vi.fn(async () => ({ cancelled: false })),
+		...overrides,
+	};
+}
+
+async function authenticateSocket(ws: MockWebSocket, token = "test-token") {
+	await ws.emitMessage(JSON.stringify({ type: "auth", token }));
+}
+
+afterEach(() => {
+	vi.restoreAllMocks();
+});
+
+describe("handleWebSocketConnection", () => {
+	it("rejects invalid JSON before authentication", async () => {
+		const ws = new MockWebSocket();
+		handleWebSocketConnection(ws as never, {
+			token: "test-token",
+			instanceId: "instance-1",
+			getSession: () => undefined,
+		});
+
+		await ws.emitMessage("not-json");
+
+		expect(ws.sent).toEqual([{ type: "error", error: "Invalid JSON" }]);
+		expect(ws.closeCalls).toEqual([]);
+	});
+
+	it("requires an auth handshake before processing commands", async () => {
+		const ws = new MockWebSocket();
+		handleWebSocketConnection(ws as never, {
+			token: "test-token",
+			instanceId: "instance-1",
+			getSession: () => undefined,
+		});
+
+		await ws.emitMessage(JSON.stringify({ type: "prompt", message: "hello" }));
+
+		expect(ws.sent).toEqual([{ type: "auth_error", reason: "auth_required" }]);
+		expect(ws.closeCalls).toEqual([{ code: 4001, reason: "Auth required" }]);
+	});
+
+	it("rejects invalid tokens", async () => {
+		const ws = new MockWebSocket();
+		handleWebSocketConnection(ws as never, {
+			token: "test-token",
+			instanceId: "instance-1",
+			getSession: () => undefined,
+		});
+
+		await authenticateSocket(ws, "wrong-token");
+
+		expect(ws.sent).toEqual([{ type: "auth_error", reason: "invalid_token" }]);
+		expect(ws.closeCalls).toEqual([{ code: 4001, reason: "Invalid token" }]);
+	});
+
+	it("authenticates, forwards session events, and disconnects cleanly", async () => {
+		const ws = new MockWebSocket();
+		const sessionEventListeners: Array<(event: unknown) => void> = [];
+		const unsubscribe = vi.fn();
+		const session = createSession({
+			subscribe: vi.fn((listener) => {
+				sessionEventListeners.push(listener);
+				return unsubscribe;
+			}),
+		});
+		const onClientConnect = vi.fn();
+		const onClientDisconnect = vi.fn();
+
+		handleWebSocketConnection(ws as never, {
+			token: "test-token",
+			instanceId: "instance-1",
+			getSession: () => session,
+			onClientConnect,
+			onClientDisconnect,
+		});
+
+		await authenticateSocket(ws);
+		expect(ws.sent[0]).toEqual({
+			type: "auth_ok",
+			instanceId: "instance-1",
+			session: {
+				sessionId: "session-1",
+				isStreaming: false,
+				model: "openai/gpt-5-mini",
+				thinkingLevel: "medium",
+			},
+		});
+		expect(onClientConnect).toHaveBeenCalledTimes(1);
+		const clientId = onClientConnect.mock.calls[0]?.[0];
+		expect(clientId).toEqual(expect.any(String));
+
+		sessionEventListeners[0]?.({ type: "agent_event", detail: "tick" });
+		expect(ws.sent.at(-1)).toEqual({ type: "agent_event", detail: "tick" });
+
+		ws.close(1000, "done");
+		expect(unsubscribe).toHaveBeenCalledTimes(1);
+		expect(onClientDisconnect).toHaveBeenCalledWith(clientId);
+	});
+
+	it("returns a structured error when authenticated but no session is attached", async () => {
+		const ws = new MockWebSocket();
+		handleWebSocketConnection(ws as never, {
+			token: "test-token",
+			instanceId: "instance-1",
+			getSession: () => undefined,
+		});
+
+		await authenticateSocket(ws);
+		await ws.emitMessage(JSON.stringify({ id: "cmd-1", type: "get_state" }));
+
+		expect(ws.sent.at(-1)).toEqual({
+			type: "response",
+			command: "get_state",
+			success: false,
+			error: "No session attached",
+			id: "cmd-1",
+		});
+	});
+
+	it("dispatches the supported command set once authenticated", async () => {
+		const ws = new MockWebSocket();
+		const session = createSession({ isStreaming: true });
+
+		handleWebSocketConnection(ws as never, {
+			token: "test-token",
+			instanceId: "instance-1",
+			getSession: () => session,
+		});
+
+		await authenticateSocket(ws);
+		await ws.emitMessage(
+			JSON.stringify({ id: "cmd-1", type: "prompt", message: "stream me", streamingBehavior: "steer" }),
+		);
+		await ws.emitMessage(JSON.stringify({ id: "cmd-2", type: "steer", message: "faster" }));
+		await ws.emitMessage(JSON.stringify({ id: "cmd-3", type: "follow_up", message: "more detail" }));
+		await ws.emitMessage(JSON.stringify({ id: "cmd-4", type: "abort" }));
+		await ws.emitMessage(JSON.stringify({ id: "cmd-5", type: "get_state" }));
+		await ws.emitMessage(JSON.stringify({ id: "cmd-6", type: "get_messages" }));
+		await ws.emitMessage(JSON.stringify({ id: "cmd-7", type: "set_thinking_level", level: "high" }));
+		await ws.emitMessage(JSON.stringify({ id: "cmd-8", type: "compact", customInstructions: "trim" }));
+		await ws.emitMessage(JSON.stringify({ id: "cmd-9", type: "new_session" }));
+		await ws.emitMessage(JSON.stringify({ id: "cmd-10", type: "extension_ui_response" }));
+		await ws.emitMessage(JSON.stringify({ id: "cmd-11", type: "unknown_command" }));
+
+		expect(session.prompt).toHaveBeenCalledWith("stream me", { streamingBehavior: "steer" });
+		expect(session.steer).toHaveBeenCalledWith("faster");
+		expect(session.followUp).toHaveBeenCalledWith("more detail");
+		expect(session.abort).toHaveBeenCalledTimes(1);
+		expect(session.setThinkingLevel).toHaveBeenCalledWith("high");
+		expect(session.compact).toHaveBeenCalledWith("trim");
+		expect(session.newSession).toHaveBeenCalledTimes(1);
+
+		expect(ws.sent).toContainEqual({ type: "response", command: "prompt", success: true, id: "cmd-1" });
+		expect(ws.sent).toContainEqual({
+			type: "response",
+			command: "get_state",
+			success: true,
+			data: {
+				model: "openai/gpt-5-mini",
+				thinkingLevel: "medium",
+				isStreaming: true,
+				sessionId: "session-1",
+				sessionFile: "/tmp/session-1.jsonl",
+				messageCount: 1,
+			},
+			id: "cmd-5",
+		});
+		expect(ws.sent).toContainEqual({
+			type: "response",
+			command: "get_messages",
+			success: true,
+			data: { messages: session.messages },
+			id: "cmd-6",
+		});
+		expect(ws.sent).toContainEqual({
+			type: "response",
+			command: "compact",
+			success: true,
+			data: { compacted: true },
+			id: "cmd-8",
+		});
+		expect(ws.sent).toContainEqual({
+			type: "response",
+			command: "new_session",
+			success: true,
+			data: { cancelled: false },
+			id: "cmd-9",
+		});
+		expect(ws.sent).toContainEqual({
+			type: "response",
+			command: "unknown_command",
+			success: false,
+			error: "Unknown command: unknown_command",
+			id: "cmd-11",
+		});
+	});
+
+	it("returns structured command errors when the session throws", async () => {
+		const ws = new MockWebSocket();
+		const session = createSession({
+			compact: vi.fn(() => Promise.reject(new Error("compact failed"))),
+		});
+
+		handleWebSocketConnection(ws as never, {
+			token: "test-token",
+			instanceId: "instance-1",
+			getSession: () => session,
+		});
+
+		await authenticateSocket(ws);
+		await ws.emitMessage(JSON.stringify({ id: "cmd-1", type: "compact" }));
+		expect(ws.sent.at(-1)).toEqual({
+			type: "response",
+			command: "compact",
+			success: false,
+			error: "compact failed",
+			id: "cmd-1",
+		});
+
+		ws.emit("error", new Error("socket error"));
+		expect((session.subscribe as ReturnType<typeof vi.fn>).mock.results[0]?.value).toHaveBeenCalledTimes(1);
+	});
+});

--- a/scripts/check-patch-coverage.mjs
+++ b/scripts/check-patch-coverage.mjs
@@ -1,0 +1,226 @@
+import fs from "node:fs";
+import path from "node:path";
+import { execFileSync } from "node:child_process";
+import { fileURLToPath } from "node:url";
+
+const DEFAULT_THRESHOLD = 100;
+const DEFAULT_LCOV_PATH = "coverage/lcov.info";
+
+export function parsePatchCoverageArgs(argv) {
+	const options = {
+		threshold: DEFAULT_THRESHOLD,
+		lcovPath: DEFAULT_LCOV_PATH,
+		base: process.env.BASE_SHA,
+		head: process.env.HEAD_SHA,
+	};
+
+	for (let index = 0; index < argv.length; index++) {
+		const arg = argv[index];
+		if (arg === "--threshold") {
+			options.threshold = Number(argv[++index]);
+			continue;
+		}
+		if (arg === "--lcov") {
+			options.lcovPath = argv[++index];
+			continue;
+		}
+		if (arg === "--base") {
+			options.base = argv[++index];
+			continue;
+		}
+		if (arg === "--head") {
+			options.head = argv[++index];
+		}
+	}
+
+	return options;
+}
+
+export function parseLcovByFile(lcovText) {
+	const coverage = new Map();
+	let currentFile;
+	let currentLines;
+
+	for (const rawLine of lcovText.split(/\r?\n/)) {
+		if (rawLine.startsWith("SF:")) {
+			currentFile = normalizeCoveragePath(rawLine.slice(3));
+			currentLines = new Map();
+			coverage.set(currentFile, currentLines);
+			continue;
+		}
+		if (rawLine.startsWith("DA:") && currentFile && currentLines) {
+			const [lineNumberRaw, hitsRaw] = rawLine.slice(3).split(",");
+			const lineNumber = Number(lineNumberRaw);
+			const hits = Number(hitsRaw);
+			if (Number.isInteger(lineNumber) && Number.isFinite(hits)) {
+				currentLines.set(lineNumber, hits);
+			}
+		}
+	}
+
+	return coverage;
+}
+
+export function parseChangedLinesFromDiff(diffText) {
+	const changedLines = new Map();
+	let currentFile;
+	let currentTarget;
+	let currentNewLine = 0;
+
+	for (const rawLine of diffText.split(/\r?\n/)) {
+		if (rawLine.startsWith("+++ b/")) {
+			currentFile = normalizeCoveragePath(rawLine.slice(6));
+			currentTarget = new Set();
+			changedLines.set(currentFile, currentTarget);
+			continue;
+		}
+		if (rawLine.startsWith("@@")) {
+			const match = /@@ -\d+(?:,\d+)? \+(\d+)(?:,(\d+))? @@/.exec(rawLine);
+			if (!match) {
+				throw new Error(`Unable to parse diff hunk: ${rawLine}`);
+			}
+			currentNewLine = Number(match[1]);
+			continue;
+		}
+		if (!currentFile || !currentTarget || rawLine.length === 0 || rawLine.startsWith("diff --git ")) {
+			continue;
+		}
+		if (rawLine.startsWith("+")) {
+			currentTarget.add(currentNewLine);
+			currentNewLine++;
+			continue;
+		}
+		if (rawLine.startsWith(" ")) {
+			currentNewLine++;
+			continue;
+		}
+		if (rawLine.startsWith("-")) {
+			continue;
+		}
+	}
+
+	for (const [file, lines] of [...changedLines.entries()]) {
+		if (lines.size === 0) {
+			changedLines.delete(file);
+		}
+	}
+
+	return changedLines;
+}
+
+export function calculatePatchCoverage(changedLines, coverageByFile) {
+	const perFile = [];
+	let covered = 0;
+	let total = 0;
+
+	for (const [file, changed] of changedLines.entries()) {
+		const coverageLines = coverageByFile.get(file);
+		if (!coverageLines) {
+			continue;
+		}
+		const executableLines = [...changed]
+			.filter((lineNumber) => coverageLines.has(lineNumber))
+			.sort((left, right) => left - right);
+		if (executableLines.length === 0) {
+			continue;
+		}
+
+		const coveredLines = executableLines.filter((lineNumber) => (coverageLines.get(lineNumber) ?? 0) > 0);
+		const uncoveredLines = executableLines.filter((lineNumber) => (coverageLines.get(lineNumber) ?? 0) === 0);
+		covered += coveredLines.length;
+		total += executableLines.length;
+		perFile.push({
+			file,
+			covered: coveredLines.length,
+			total: executableLines.length,
+			pct: (coveredLines.length / executableLines.length) * 100,
+			uncoveredLines,
+		});
+	}
+
+	perFile.sort((left, right) => {
+		const uncoveredDiff = right.uncoveredLines.length - left.uncoveredLines.length;
+		return uncoveredDiff !== 0 ? uncoveredDiff : left.file.localeCompare(right.file);
+	});
+
+	return {
+		covered,
+		total,
+		pct: total === 0 ? 100 : (covered / total) * 100,
+		perFile,
+	};
+}
+
+export function formatPatchCoverageReport(summary, threshold) {
+	const lines = [
+		`Patch coverage: ${summary.pct.toFixed(2)}% (${summary.covered}/${summary.total} changed executable lines covered)`,
+		`Required threshold: ${threshold.toFixed(2)}%`,
+	];
+
+	const uncoveredFiles = summary.perFile.filter((entry) => entry.uncoveredLines.length > 0);
+	if (uncoveredFiles.length > 0) {
+		lines.push("Uncovered changed lines:");
+		for (const entry of uncoveredFiles.slice(0, 20)) {
+			lines.push(`- ${entry.file}: ${entry.uncoveredLines.join(", ")}`);
+		}
+	}
+
+	return lines.join("\n");
+}
+
+export function normalizeCoveragePath(filePath) {
+	return filePath.replace(/^\.\//, "").split(path.sep).join("/");
+}
+
+export function getGitDiff(base, head) {
+	return execFileSync("git", ["diff", "--unified=0", "--no-color", `${base}...${head}`], {
+		encoding: "utf8",
+	});
+}
+
+export function runPatchCoverageCheck({ base, head, lcovPath, threshold }) {
+	if (!base || !head) {
+		console.log("Skipping patch coverage check because BASE_SHA or HEAD_SHA is missing.");
+		return { skipped: true, pct: 100, covered: 0, total: 0, perFile: [] };
+	}
+
+	const lcovText = fs.readFileSync(lcovPath, "utf8");
+	const diffText = getGitDiff(base, head);
+	const coverageByFile = parseLcovByFile(lcovText);
+	const changedLines = parseChangedLinesFromDiff(diffText);
+	const summary = calculatePatchCoverage(changedLines, coverageByFile);
+
+	if (summary.total === 0) {
+		console.log("Patch coverage: 100.00% (no changed executable lines found)");
+		return summary;
+	}
+
+	const report = formatPatchCoverageReport(summary, threshold);
+	console.log(report);
+	if (summary.pct < threshold) {
+		throw new Error(`Patch coverage ${summary.pct.toFixed(2)}% is below the required ${threshold.toFixed(2)}% threshold.`);
+	}
+
+	return summary;
+}
+
+export function main(argv = process.argv.slice(2)) {
+	const options = parsePatchCoverageArgs(argv);
+	if (!Number.isFinite(options.threshold)) {
+		throw new Error(`Invalid --threshold value: ${options.threshold}`);
+	}
+	return runPatchCoverageCheck(options);
+}
+
+const invokedPath = process.argv[1] ? path.resolve(process.argv[1]) : undefined;
+const modulePath = fileURLToPath(import.meta.url);
+/* v8 ignore start -- exercised via direct script execution in CI rather than unit tests */
+if (invokedPath && modulePath === invokedPath) {
+	try {
+		main();
+	} catch (error) {
+		console.error(error instanceof Error ? error.message : String(error));
+		process.exitCode = 1;
+	}
+}
+/* v8 ignore stop */

--- a/scripts/check-patch-coverage.test.ts
+++ b/scripts/check-patch-coverage.test.ts
@@ -1,0 +1,251 @@
+import fs from "node:fs";
+import os from "node:os";
+import path from "node:path";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+
+const childProcessMocks = vi.hoisted(() => ({
+	execFileSync: vi.fn(),
+}));
+
+vi.mock("node:child_process", () => ({
+	execFileSync: childProcessMocks.execFileSync,
+}));
+
+import {
+	calculatePatchCoverage,
+	formatPatchCoverageReport,
+	getGitDiff,
+	main,
+	normalizeCoveragePath,
+	parseChangedLinesFromDiff,
+	parseLcovByFile,
+	parsePatchCoverageArgs,
+	runPatchCoverageCheck,
+} from "./check-patch-coverage.mjs";
+
+const tempDirs: string[] = [];
+
+function createTempDir(): string {
+	const dir = fs.mkdtempSync(path.join(os.tmpdir(), "oh-pi-patch-coverage-"));
+	tempDirs.push(dir);
+	return dir;
+}
+
+describe("check-patch-coverage", () => {
+	beforeEach(() => {
+		vi.restoreAllMocks();
+		childProcessMocks.execFileSync.mockReset();
+	});
+
+	afterEach(() => {
+		for (const dir of tempDirs) {
+			fs.rmSync(dir, { recursive: true, force: true });
+		}
+		tempDirs.length = 0;
+	});
+
+	it("parses cli arguments with defaults and overrides", () => {
+		expect(parsePatchCoverageArgs([])).toMatchObject({ threshold: 100, lcovPath: "coverage/lcov.info" });
+		expect(
+			parsePatchCoverageArgs(["--threshold", "97.5", "--lcov", "tmp/lcov.info", "--base", "abc", "--head", "def"]),
+		).toEqual({
+			threshold: 97.5,
+			lcovPath: "tmp/lcov.info",
+			base: "abc",
+			head: "def",
+		});
+	});
+
+	it("parses changed lines across additions, context, deletions, and removes empty file entries", () => {
+		const changed = parseChangedLinesFromDiff(
+			[
+				"diff --git a/packages/demo.ts b/packages/demo.ts",
+				"+++ b/packages/demo.ts",
+				"@@ -10,1 +10,3 @@",
+				" context line",
+				"+const a = 1;",
+				"-const removed = 1;",
+				"+const b = 2;",
+				"diff --git a/packages/empty.ts b/packages/empty.ts",
+				"+++ b/packages/empty.ts",
+			].join("\n"),
+		);
+
+		expect(changed).toEqual(new Map([["packages/demo.ts", new Set([11, 12])]]));
+	});
+
+	it("throws on malformed diff hunks", () => {
+		expect(() => parseChangedLinesFromDiff("+++ b/packages/demo.ts\n@@ malformed @@\n+const a = 1;\n")).toThrow(
+			"Unable to parse diff hunk",
+		);
+	});
+
+	it("maps covered and uncovered changed executable lines from diff hunks", () => {
+		const coverage = parseLcovByFile(`TN:\nSF:packages/demo.ts\nDA:10,2\nDA:11,0\nDA:12,1\nend_of_record\n`);
+		const changed = parseChangedLinesFromDiff(
+			`diff --git a/packages/demo.ts b/packages/demo.ts\n+++ b/packages/demo.ts\n@@ -10,0 +10,3 @@\n+const a = 1;\n+const b = 2;\n+const c = 3;\n`,
+		);
+		const summary = calculatePatchCoverage(changed, coverage);
+
+		expect(summary).toMatchObject({ covered: 2, total: 3, pct: 66.66666666666666 });
+		expect(summary.perFile).toEqual([
+			{
+				file: "packages/demo.ts",
+				covered: 2,
+				total: 3,
+				pct: 66.66666666666666,
+				uncoveredLines: [11],
+			},
+		]);
+	});
+
+	it("ignores missing coverage files and non-executable changed lines", () => {
+		const changed = new Map([
+			["packages/missing.ts", new Set([1])],
+			["packages/demo.ts", new Set([19, 20, 21])],
+		]);
+		const coverage = parseLcovByFile(`TN:\nSF:packages/demo.ts\nDA:20,1\nend_of_record\n`);
+		const summary = calculatePatchCoverage(changed, coverage);
+
+		expect(summary).toMatchObject({ covered: 1, total: 1, pct: 100 });
+		expect(summary.perFile).toEqual([
+			{
+				file: "packages/demo.ts",
+				covered: 1,
+				total: 1,
+				pct: 100,
+				uncoveredLines: [],
+			},
+		]);
+	});
+
+	it("sorts uncovered files ahead of fully covered files", () => {
+		const changed = new Map([
+			["packages/b.ts", new Set([1, 2])],
+			["packages/a.ts", new Set([1])],
+		]);
+		const coverage = parseLcovByFile(
+			`TN:\nSF:packages/a.ts\nDA:1,1\nend_of_record\nTN:\nSF:packages/b.ts\nDA:1,1\nDA:2,0\nend_of_record\n`,
+		);
+		const summary = calculatePatchCoverage(changed, coverage);
+
+		expect(summary.perFile.map((entry) => entry.file)).toEqual(["packages/b.ts", "packages/a.ts"]);
+	});
+
+	it("formats readable reports with and without uncovered files", () => {
+		const failingReport = formatPatchCoverageReport(
+			{
+				covered: 19,
+				total: 20,
+				pct: 95,
+				perFile: [
+					{
+						file: "packages/demo.ts",
+						covered: 9,
+						total: 10,
+						pct: 90,
+						uncoveredLines: [42],
+					},
+				],
+			},
+			100,
+		);
+		expect(failingReport).toContain("Patch coverage: 95.00% (19/20 changed executable lines covered)");
+		expect(failingReport).toContain("Required threshold: 100.00%");
+		expect(failingReport).toContain("packages/demo.ts: 42");
+
+		const passingReport = formatPatchCoverageReport(
+			{
+				covered: 3,
+				total: 3,
+				pct: 100,
+				perFile: [{ file: "packages/demo.ts", covered: 3, total: 3, pct: 100, uncoveredLines: [] }],
+			},
+			100,
+		);
+		expect(passingReport).not.toContain("Uncovered changed lines:");
+	});
+
+	it("normalizes coverage paths and delegates git diff lookup", () => {
+		expect(normalizeCoveragePath(`./packages${path.sep}demo.ts`)).toBe("packages/demo.ts");
+
+		childProcessMocks.execFileSync.mockReturnValueOnce("diff output");
+		expect(getGitDiff("base", "head")).toBe("diff output");
+		expect(childProcessMocks.execFileSync).toHaveBeenCalledWith(
+			"git",
+			["diff", "--unified=0", "--no-color", "base...head"],
+			expect.objectContaining({ encoding: "utf8" }),
+		);
+	});
+
+	it("skips patch coverage checks when base or head is missing", () => {
+		const logSpy = vi.spyOn(console, "log").mockImplementation(() => {});
+
+		expect(runPatchCoverageCheck({ base: "", head: "head", lcovPath: "coverage/lcov.info", threshold: 100 })).toEqual({
+			skipped: true,
+			pct: 100,
+			covered: 0,
+			total: 0,
+			perFile: [],
+		});
+		expect(logSpy).toHaveBeenCalledWith("Skipping patch coverage check because BASE_SHA or HEAD_SHA is missing.");
+	});
+
+	it("reports 100% when no changed executable lines are found", () => {
+		const dir = createTempDir();
+		const lcovPath = path.join(dir, "lcov.info");
+		fs.writeFileSync(lcovPath, `TN:\nSF:packages/demo.ts\nDA:20,1\nend_of_record\n`, "utf8");
+		childProcessMocks.execFileSync.mockReturnValueOnce(
+			"diff --git a/packages/demo.ts b/packages/demo.ts\n+++ b/packages/demo.ts\n@@ -1,0 +1,1 @@\n+// comment\n",
+		);
+		const logSpy = vi.spyOn(console, "log").mockImplementation(() => {});
+
+		const summary = runPatchCoverageCheck({ base: "base", head: "head", lcovPath, threshold: 100 });
+
+		expect(summary).toMatchObject({ covered: 0, total: 0, pct: 100 });
+		expect(logSpy).toHaveBeenCalledWith("Patch coverage: 100.00% (no changed executable lines found)");
+	});
+
+	it("prints reports and throws when patch coverage is below the threshold", () => {
+		const dir = createTempDir();
+		const lcovPath = path.join(dir, "lcov.info");
+		fs.writeFileSync(lcovPath, `TN:\nSF:packages/demo.ts\nDA:10,1\nDA:11,0\nend_of_record\n`, "utf8");
+		childProcessMocks.execFileSync.mockReturnValueOnce(
+			"diff --git a/packages/demo.ts b/packages/demo.ts\n+++ b/packages/demo.ts\n@@ -10,0 +10,2 @@\n+const covered = true;\n+const uncovered = false;\n",
+		);
+		const logSpy = vi.spyOn(console, "log").mockImplementation(() => {});
+
+		expect(() => runPatchCoverageCheck({ base: "base", head: "head", lcovPath, threshold: 100 })).toThrow(
+			"Patch coverage 50.00% is below the required 100.00% threshold.",
+		);
+		expect(logSpy).toHaveBeenCalledWith(expect.stringContaining("Required threshold: 100.00%"));
+	});
+
+	it("validates threshold parsing through the exported main entry point", () => {
+		expect(() => main(["--threshold", "NaN"])).toThrow("Invalid --threshold value: NaN");
+	});
+
+	it("returns the summary when patch coverage meets the threshold", () => {
+		const dir = createTempDir();
+		const lcovPath = path.join(dir, "lcov.info");
+		fs.writeFileSync(lcovPath, `TN:\nSF:packages/demo.ts\nDA:10,1\nend_of_record\n`, "utf8");
+		childProcessMocks.execFileSync
+			.mockReturnValueOnce(
+				"diff --git a/packages/demo.ts b/packages/demo.ts\n+++ b/packages/demo.ts\n@@ -10,0 +10,1 @@\n+const covered = true;\n",
+			)
+			.mockReturnValueOnce(
+				"diff --git a/packages/demo.ts b/packages/demo.ts\n+++ b/packages/demo.ts\n@@ -10,0 +10,1 @@\n+const covered = true;\n",
+			);
+		const logSpy = vi.spyOn(console, "log").mockImplementation(() => {});
+
+		const summary = runPatchCoverageCheck({ base: "base", head: "head", lcovPath, threshold: 100 });
+
+		expect(summary).toMatchObject({ covered: 1, total: 1, pct: 100 });
+		expect(logSpy).toHaveBeenCalledWith(expect.stringContaining("Patch coverage: 100.00% (1/1 changed executable lines covered)"));
+		expect(main(["--base", "base", "--head", "head", "--threshold", "100", "--lcov", lcovPath])).toMatchObject({
+			covered: 1,
+			total: 1,
+			pct: 100,
+		});
+	});
+});

--- a/scripts/pi-source-switch.mts
+++ b/scripts/pi-source-switch.mts
@@ -658,8 +658,8 @@ function updatePiSources(pi: string, currentSources: ReadonlyMap<string, string>
 	}
 }
 
-function main() {
-	const options = parseArgs(process.argv);
+export function main(argv: string[] = process.argv) {
+	const options = parseArgs(argv);
 	const settingsPath = getSettingsPath(options.piLocal);
 	const settings = loadSettings(settingsPath);
 	const currentEntries = Array.isArray(settings.packages) ? settings.packages : [];

--- a/scripts/pi-source-switch.test.ts
+++ b/scripts/pi-source-switch.test.ts
@@ -1,7 +1,10 @@
-import { mkdtempSync, mkdirSync, rmSync, writeFileSync } from "node:fs";
+import { spawnSync } from "node:child_process";
+import { chmodSync, mkdtempSync, mkdirSync, readFileSync, realpathSync, rmSync, writeFileSync } from "node:fs";
 import { tmpdir } from "node:os";
 import path from "node:path";
+import { fileURLToPath } from "node:url";
 import { afterEach, describe, expect, it } from "vitest";
+import { SWITCHER_PACKAGES } from "../packages/oh-pi/bin/package-list.mjs";
 import {
 	buildPiExecutableCandidates,
 	dedupeManagedPackageEntries,
@@ -15,9 +18,110 @@ import {
 	rewriteManagedPackageSources,
 } from "./pi-source-switch.mts";
 
-describe("pi source switcher helpers", () => {
-	const tempDirs: string[] = [];
+const tempDirs: string[] = [];
+const scriptPath = fileURLToPath(new URL("./pi-source-switch.mts", import.meta.url));
 
+function createTempDir(prefix: string): string {
+	const dir = mkdtempSync(path.join(tmpdir(), prefix));
+	tempDirs.push(dir);
+	return dir;
+}
+
+function getPackageSource(entry: unknown): string | undefined {
+	if (typeof entry === "string") {
+		return entry;
+	}
+
+	if (entry && typeof entry === "object" && "source" in entry && typeof entry.source === "string") {
+		return entry.source;
+	}
+
+	return undefined;
+}
+
+function writeWorkspacePackage(
+	repoDir: string,
+	dirName: string,
+	packageName: string,
+	options: {
+		pi?: Record<string, string[]>;
+	} = {},
+): string {
+	const packageDir = path.join(repoDir, "packages", dirName);
+	mkdirSync(packageDir, { recursive: true });
+	writeFileSync(
+		path.join(packageDir, "package.json"),
+		JSON.stringify({ name: packageName, ...(options.pi ? { pi: options.pi } : {}) }),
+	);
+	return packageDir;
+}
+
+function createWorkspaceRepo(options: {
+	manifests?: Partial<Record<string, Record<string, string[]>>>;
+} = {}): Map<string, string> {
+	const repoDir = createTempDir("oh-pi-switcher-workspace-");
+	const packageDirs = new Map<string, string>();
+
+	for (const [index, packageName] of SWITCHER_PACKAGES.entries()) {
+		const dirName = `${index}-${packageName.replace(/[^a-z0-9]+/gi, "-").replace(/^-|-$/g, "")}`;
+		packageDirs.set(
+			packageName,
+			writeWorkspacePackage(repoDir, dirName, packageName, {
+				pi: options.manifests?.[packageName],
+			}),
+		);
+	}
+
+	return packageDirs;
+}
+
+function createFakePiExecutable(logPath: string): string {
+	const rootDir = createTempDir("oh-pi-switcher-pi-");
+	const binDir = path.join(rootDir, "bin");
+	mkdirSync(binDir, { recursive: true });
+
+	const executablePath = path.join(binDir, "pi");
+	writeFileSync(
+		executablePath,
+		[
+			"#!/usr/bin/env node",
+			"const fs = require('node:fs');",
+			"const logPath = process.env.PI_TEST_LOG_PATH;",
+			"if (logPath) {",
+			"  fs.appendFileSync(logPath, process.argv.slice(2).join(' ') + '\\n');",
+			"}",
+			"if (process.argv[2] === '--version') {",
+			"  process.stdout.write('0.0.0-test\\n');",
+			"  process.exit(0);",
+			"}",
+			"if (process.env.PI_TEST_FAIL_ON === process.argv[2]) {",
+			"  process.stderr.write(process.env.PI_TEST_FAIL_MESSAGE || 'sync failed');",
+			"  process.exit(1);",
+			"}",
+			"process.exit(0);",
+		].join("\n"),
+		"utf8",
+	);
+	chmodSync(executablePath, 0o755);
+
+	return binDir;
+}
+
+function runSwitcher(
+	args: string[],
+	options: {
+		cwd?: string;
+		env?: NodeJS.ProcessEnv;
+	} = {},
+) {
+	return spawnSync(process.execPath, ["--experimental-strip-types", scriptPath, ...args], {
+		cwd: options.cwd ?? process.cwd(),
+		env: { ...process.env, ...options.env },
+		encoding: "utf8",
+	});
+}
+
+describe("pi source switcher helpers", () => {
 	afterEach(() => {
 		for (const dir of tempDirs) {
 			rmSync(dir, { recursive: true, force: true });
@@ -71,8 +175,7 @@ describe("pi source switcher helpers", () => {
 	});
 
 	it("resolves workspace package directories from a repo checkout", () => {
-		const repoDir = mkdtempSync(path.join(tmpdir(), "oh-pi-switcher-"));
-		tempDirs.push(repoDir);
+		const repoDir = createTempDir("oh-pi-switcher-");
 		const packagesDir = path.join(repoDir, "packages");
 		mkdirSync(path.join(packagesDir, "extensions"), { recursive: true });
 		mkdirSync(path.join(packagesDir, "themes"), { recursive: true });
@@ -109,8 +212,7 @@ describe("pi source switcher helpers", () => {
 	});
 
 	it("reads workspace pi manifests for managed packages", () => {
-		const repoDir = mkdtempSync(path.join(tmpdir(), "oh-pi-switcher-manifest-"));
-		tempDirs.push(repoDir);
+		const repoDir = createTempDir("oh-pi-switcher-manifest-");
 		const packageDir = path.join(repoDir, "packages", "extensions");
 		mkdirSync(packageDir, { recursive: true });
 		writeFileSync(
@@ -145,8 +247,7 @@ describe("pi source switcher helpers", () => {
 	});
 
 	it("resolves local path sources back to workspace package names", () => {
-		const repoDir = mkdtempSync(path.join(tmpdir(), "oh-pi-switcher-source-"));
-		tempDirs.push(repoDir);
+		const repoDir = createTempDir("oh-pi-switcher-source-");
 		const packageDir = path.join(repoDir, "packages", "themes");
 		mkdirSync(packageDir, { recursive: true });
 		writeFileSync(path.join(packageDir, "package.json"), JSON.stringify({ name: "@ifi/oh-pi-themes" }));
@@ -173,5 +274,134 @@ describe("pi source switcher helpers", () => {
 		});
 
 		expect(resolved).toBe("/Users/tester/Library/pnpm/pi");
+	});
+
+	it("prints configured managed package status from user settings", () => {
+		const agentDir = createTempDir("oh-pi-switcher-agent-");
+		const settingsPath = path.join(agentDir, "settings.json");
+		writeFileSync(
+			settingsPath,
+			JSON.stringify({
+				packages: ["npm:@ifi/oh-pi-extensions@0.4.3", "npm:@ifi/oh-pi-themes@0.4.3", "npm:chalk@5.0.0"],
+			}),
+		);
+
+		const result = runSwitcher(["status"], {
+			env: {
+				PI_CODING_AGENT_DIR: agentDir,
+			},
+		});
+
+		expect(result.status).toBe(0);
+		expect(result.stderr).toBe("");
+		expect(result.stdout).toContain("oh-pi managed package sources (user settings)");
+		expect(result.stdout).toContain(`Settings: ${settingsPath}`);
+		expect(result.stdout).toContain("npm:@ifi/oh-pi-extensions@0.4.3");
+		expect(result.stdout).toContain("npm:@ifi/oh-pi-themes@0.4.3");
+		expect(result.stdout).toContain("@ifi/pi-provider-cursor");
+		expect(result.stdout).toContain("<not configured>");
+	});
+
+	it("prints local dry-run changes without mutating project settings", () => {
+		const projectDir = createTempDir("oh-pi-switcher-project-");
+		const settingsPath = path.join(projectDir, ".pi", "settings.json");
+		mkdirSync(path.dirname(settingsPath), { recursive: true });
+		const originalSettings = JSON.stringify(
+			{
+				packages: [{ source: "npm:@ifi/oh-pi-extensions", extensions: ["extensions/legacy.ts"] }, "npm:chalk@5.0.0"],
+			},
+			null,
+			2,
+		);
+		writeFileSync(settingsPath, `${originalSettings}\n`);
+
+		const workspacePackages = createWorkspaceRepo({
+			manifests: {
+				"@ifi/oh-pi-extensions": {
+					extensions: ["./extensions/custom-footer.ts", "./extensions/worktree.ts"],
+				},
+			},
+		});
+		const repoDir = path.dirname(path.dirname(workspacePackages.get("@ifi/oh-pi-extensions") ?? ""));
+
+		const result = runSwitcher(["local", "--pi-local", "--dry-run", "--path", repoDir], {
+			cwd: projectDir,
+		});
+		const resolvedSettingsPath = path.join(realpathSync.native(projectDir), ".pi", "settings.json");
+
+		expect(result.status).toBe(0);
+		expect(result.stderr).toBe("");
+		expect(result.stdout).toContain("Switching oh-pi packages to local mode (project settings)");
+		expect(result.stdout).toContain(`Settings: ${resolvedSettingsPath}`);
+		expect(result.stdout).toContain(`Repo: ${repoDir}`);
+		expect(result.stdout).toContain(workspacePackages.get("@ifi/oh-pi-extensions") ?? "");
+		expect(result.stdout).toContain("Dry run only — settings were not written");
+		expect(readFileSync(settingsPath, "utf8")).toBe(`${originalSettings}\n`);
+	});
+
+	it("writes remote package sources and syncs them through the discovered pi executable", () => {
+		const agentDir = createTempDir("oh-pi-switcher-agent-");
+		const settingsPath = path.join(agentDir, "settings.json");
+		writeFileSync(
+			settingsPath,
+			JSON.stringify(
+				{
+					packages: [{ source: "npm:@ifi/oh-pi-extensions@0.4.3", extensions: ["extensions/custom-footer.ts"] }, "npm:chalk@5.0.0"],
+				},
+				null,
+				2,
+			),
+		);
+
+		const logPath = path.join(agentDir, "pi.log");
+		const piBinDir = createFakePiExecutable(logPath);
+		const result = runSwitcher(["remote", "--version", "0.4.4"], {
+			env: {
+				PATH: [piBinDir, path.dirname(process.execPath), process.env.PATH ?? ""].join(path.delimiter),
+				PI_CODING_AGENT_DIR: agentDir,
+				PI_CODING_AGENT_BIN: piBinDir,
+				PI_TEST_LOG_PATH: logPath,
+			},
+		});
+
+		expect(result.status).toBe(0);
+		expect(result.stderr).toBe("");
+		expect(result.stdout).toContain("Switching oh-pi packages to remote mode (user settings)");
+		expect(result.stdout).toContain("Syncing packages with pi...");
+		expect(result.stdout).toContain("✅ Done. Fully restart pi to reload the switched packages.");
+
+		const savedSettings = JSON.parse(readFileSync(settingsPath, "utf8")) as { packages: unknown[] };
+		const savedSources = savedSettings.packages.map(getPackageSource).filter((value): value is string => Boolean(value));
+		const managedSources = savedSources.filter((value) => value.startsWith("npm:@ifi/"));
+		const extensionEntry = savedSettings.packages.find(
+			(entry) => getPackageSource(entry) === "npm:@ifi/oh-pi-extensions@0.4.4",
+		) as { source: string; extensions?: string[] } | undefined;
+
+		expect(managedSources).toHaveLength(SWITCHER_PACKAGES.length);
+		expect(savedSources).toContain("npm:@ifi/pi-provider-cursor@0.4.4");
+		expect(savedSources).toContain("npm:chalk@5.0.0");
+		expect(extensionEntry).toEqual({
+			source: "npm:@ifi/oh-pi-extensions@0.4.4",
+			extensions: ["extensions/custom-footer.ts"],
+		});
+
+		const piLog = readFileSync(logPath, "utf8");
+		expect(piLog).toContain("--version");
+		expect(piLog).toContain("update npm:@ifi/oh-pi-extensions@0.4.4");
+		expect(piLog).toContain("install npm:@ifi/pi-provider-cursor@0.4.4");
+	}, 20_000);
+
+	it("exits with an error when local mode cannot resolve the full managed workspace set", () => {
+		const repoDir = createTempDir("oh-pi-switcher-incomplete-");
+		writeWorkspacePackage(repoDir, "extensions", "@ifi/oh-pi-extensions");
+
+		const result = runSwitcher(["local", "--dry-run", "--path", repoDir], {
+			env: {
+				PI_CODING_AGENT_DIR: createTempDir("oh-pi-switcher-agent-"),
+			},
+		});
+
+		expect(result.status).toBe(1);
+		expect(result.stderr).toContain("Could not find workspace packages under");
 	});
 });

--- a/scripts/pi-source-switch.test.ts
+++ b/scripts/pi-source-switch.test.ts
@@ -1,8 +1,6 @@
-import { spawnSync } from "node:child_process";
 import { chmodSync, mkdtempSync, mkdirSync, readFileSync, realpathSync, rmSync, writeFileSync } from "node:fs";
 import { tmpdir } from "node:os";
 import path from "node:path";
-import { fileURLToPath } from "node:url";
 import { afterEach, describe, expect, it } from "vitest";
 import { SWITCHER_PACKAGES } from "../packages/oh-pi/bin/package-list.mjs";
 import {
@@ -16,10 +14,10 @@ import {
 	resolveWorkspacePackageManifests,
 	resolveWorkspacePackageSources,
 	rewriteManagedPackageSources,
+	main,
 } from "./pi-source-switch.mts";
 
 const tempDirs: string[] = [];
-const scriptPath = fileURLToPath(new URL("./pi-source-switch.mts", import.meta.url));
 
 function createTempDir(prefix: string): string {
 	const dir = mkdtempSync(path.join(tmpdir(), prefix));
@@ -114,11 +112,48 @@ function runSwitcher(
 		env?: NodeJS.ProcessEnv;
 	} = {},
 ) {
-	return spawnSync(process.execPath, ["--experimental-strip-types", scriptPath, ...args], {
-		cwd: options.cwd ?? process.cwd(),
-		env: { ...process.env, ...options.env },
-		encoding: "utf8",
-	});
+	const stdout: string[] = [];
+	const stderr: string[] = [];
+	const originalArgv = process.argv;
+	const originalEnv = process.env;
+	const originalCwd = process.cwd();
+	const originalLog = console.log;
+	const originalError = console.error;
+
+	const nextEnv = { ...process.env, ...options.env };
+	let status = 0;
+
+	console.log = (...values) => {
+		stdout.push(`${values.join(" ")}\n`);
+	};
+	console.error = (...values) => {
+		stderr.push(`${values.join(" ")}\n`);
+	};
+	process.argv = [process.execPath, "./scripts/pi-source-switch.mts", ...args];
+	process.env = nextEnv;
+
+	try {
+		if (options.cwd) {
+			process.chdir(options.cwd);
+		}
+		main(process.argv);
+	} catch (error) {
+		status = 1;
+		const message = error instanceof Error ? error.message : String(error);
+		console.error(`\nError: ${message}`);
+	} finally {
+		process.argv = originalArgv;
+		process.env = originalEnv;
+		process.chdir(originalCwd);
+		console.log = originalLog;
+		console.error = originalError;
+	}
+
+	return {
+		status,
+		stdout: stdout.join(""),
+		stderr: stderr.join(""),
+	};
 }
 
 describe("pi source switcher helpers", () => {


### PR DESCRIPTION
## Summary
- add meaningful, fast coverage across web server, web remote, core worktree, cursor, shared Q&A, subagents, plan, CLI, providers, and ant colony helpers
- keep the repo-wide coverage target honest by setting the Codecov project threshold to 60% for now
- raise patch coverage enforcement to 100% in CI and Codecov for all new PR changes

## Validation
- pnpm lint
- pnpm test
- pnpm test:coverage
- node ./scripts/check-patch-coverage.mjs --base origin/main --head HEAD --threshold 100 --lcov coverage/lcov.info
