### PR TITLE
perf(diagnostics): reduce idle widget redraw churn

### DIFF
--- a/.changeset/diagnostics-widget-idle-churn.md
+++ b/.changeset/diagnostics-widget-idle-churn.md
@@ -1,0 +1,5 @@
+---
+default: patch
+---
+
+Reduce diagnostics widget idle redraw churn by only running its elapsed-time refresh timer while a prompt is actively in progress. This removes the always-on one-second idle redraw loop that could multiply across several pi instances and contribute to watchdog event-loop warnings.

--- a/docs/startup-performance-audit.md
+++ b/docs/startup-performance-audit.md
@@ -154,9 +154,11 @@ The diagnostics package mounts an always-on widget and currently drives it with 
 
 The new runtime suite mounts widgets/footers and advances an idle 65-second window, so diagnostics now shows up directly in the isolated extension ranking instead of only as an anecdotal suspect.
 
-**What to watch**
+**Latest mitigation**
 
-If diagnostics stays near the top of the isolated runtime churn report, it is a strong candidate for the first follow-up fix because it is both always-on and instance-multiplying.
+- the diagnostics widget now refreshes its elapsed-time timer only while a prompt is actively running
+- idle and completed diagnostics states no longer keep a fixed one-second redraw timer alive
+- this should remove the largest isolated always-on widget redraw source from the runtime churn report and reduce multi-instance watchdog noise
 
 ### 7. `packages/subagents/*`
 

--- a/packages/diagnostics/index.ts
+++ b/packages/diagnostics/index.ts
@@ -366,17 +366,41 @@ export default function diagnosticsExtension(pi: ExtensionAPI): void {
 			WIDGET_KEY,
 			(tui, theme) => {
 				requestWidgetRender = () => tui.requestRender();
-				const timer = setInterval(() => tui.requestRender(), WIDGET_REFRESH_MS);
+				let timer: ReturnType<typeof setInterval> | null = null;
+
+				const stopTimer = () => {
+					if (!timer) {
+						return;
+					}
+					clearInterval(timer);
+					timer = null;
+				};
+
+				const syncTimer = () => {
+					if (!currentPrompt) {
+						stopTimer();
+						return;
+					}
+
+					if (timer) {
+						return;
+					}
+
+					timer = setInterval(() => tui.requestRender(), WIDGET_REFRESH_MS);
+					timer.unref?.();
+				};
+
 				return {
 					dispose() {
 						if (requestWidgetRender) {
 							requestWidgetRender = null;
 						}
-						clearInterval(timer);
+						stopTimer();
 					},
 					// biome-ignore lint/suspicious/noEmptyBlockStatements: Required by the widget component interface.
 					invalidate() {},
 					render(width: number) {
+						syncTimer();
 						return renderWidgetLines(theme).map((line) => truncateToWidth(line, width));
 					},
 				};

--- a/packages/diagnostics/tests/diagnostics.test.ts
+++ b/packages/diagnostics/tests/diagnostics.test.ts
@@ -254,6 +254,9 @@ describe("diagnostics extension", () => {
 		const widget = widgetFactory?.({ requestRender }, theme);
 		expect(widget?.render(200).join("\n")).toContain("waiting for next prompt");
 
+		await vi.advanceTimersByTimeAsync(1_000);
+		expect(requestRender).not.toHaveBeenCalled();
+
 		harness.emit(
 			"before_agent_start",
 			{ type: "before_agent_start", prompt: "Investigate the flaky test timeout in CI.", images: [] },
@@ -322,10 +325,14 @@ describe("diagnostics extension", () => {
 		expect(message.details.durationMs).toBe(7_250);
 		expect(message.details.turnCount).toBe(2);
 		expect(message.details.toolCount).toBe(1);
-		expect(message.details.turns[0]?.completedAtLabel).toMatch(/2026-04-16 \d{2}:00:01/);
+		expect(message.details.turns[0]?.completedAtLabel).toMatch(/2026-04-16 \d{2}:00:0[12]/);
 		expect(message.details.turns[0]?.toolCount).toBe(1);
 		expect(message.details.turns[1]?.responsePreview).toContain("Done.");
 		expect(widget?.render(200).join("\n")).toContain("completed");
+
+		requestRender.mockClear();
+		await vi.advanceTimersByTimeAsync(1_000);
+		expect(requestRender).not.toHaveBeenCalled();
 
 		widget?.dispose();
 		expect(appendEntry).not.toHaveBeenCalled();


### PR DESCRIPTION
## Summary
- stop the diagnostics widget's one-second timer when no prompt is actively running
- keep the elapsed-time refresh only for active prompts, where the timer is actually useful
- update diagnostics tests and audit notes for the new event-driven idle behavior

## Why
The new runtime churn benchmark showed `diagnostics` as the clearest isolated always-on redraw source at about 60 widget redraws/minute, and the 4-instance scenario amplified that churn sharply. This was a strong match for the reported post-startup watchdog noise.

## Benchmark impact
Using `OH_PI_BENCH_EXTENSION_FILTER=diagnostics pnpm bench:runtime` locally:
- isolated diagnostics idle widget redraws/min: `60.00` -> `0.00`
- full-stack mounted idle widget redraws/min: `60.92` -> `0.92`
- 4-instance full-stack mounted idle widget redraws/min: `243.69` -> `3.69`

## Validation
- `pnpm lint`
- `pnpm test`
- `pnpm typecheck`
- `pnpm exec vitest run packages/diagnostics/tests/diagnostics.test.ts`
- `OH_PI_BENCH_EXTENSION_FILTER=diagnostics pnpm bench:runtime`