### PR TITLE
perf(custom-footer): reduce idle redraw churn

### DIFF
--- a/.changeset/custom-footer-idle-redraw-churn.md
+++ b/.changeset/custom-footer-idle-redraw-churn.md
@@ -1,0 +1,5 @@
+---
+default: patch
+---
+
+Reduce custom-footer idle redraw churn by letting the PR poll timer probe for changed PR state without forcing a footer rerender every minute when the visible footer content is unchanged.

--- a/docs/startup-performance-audit.md
+++ b/docs/startup-performance-audit.md
@@ -103,6 +103,7 @@ The footer caches totals after startup, but the aggregation path is still O(n) o
 **Latest mitigation**
 
 - footer PR polling now matches the 60-second GH probe cooldown instead of waking every 30 seconds
+- the poll timer now probes for PR changes without forcing a footer rerender every minute when the visible footer content is unchanged
 - PR probe completions request a redraw only when the visible PR list actually changes
 - watchdog and scheduler status-bar writes should stay deduplicated so periodic clean-state refreshes do not spam identical `setStatus(...)` calls
 

--- a/packages/extensions/extensions/custom-footer.test.ts
+++ b/packages/extensions/extensions/custom-footer.test.ts
@@ -249,8 +249,9 @@ describe("custom-footer extension", () => {
 			};
 
 			await pi._emit("session_start", {}, ctx);
+			const requestRender = vi.fn();
 			footerFactory(
-				{ requestRender: vi.fn() },
+				{ requestRender },
 				{ fg: (_color: string, text: string) => text },
 				{ onBranchChange: () => () => undefined, getGitBranch: () => "main" },
 			);
@@ -258,8 +259,10 @@ describe("custom-footer extension", () => {
 			await vi.advanceTimersByTimeAsync(500);
 			expect(refreshRepoWorktreeContext).toHaveBeenCalledTimes(1);
 
+			requestRender.mockClear();
 			await vi.advanceTimersByTimeAsync(60_000);
 			expect(refreshRepoWorktreeContext).toHaveBeenCalledTimes(1);
+			expect(requestRender).not.toHaveBeenCalled();
 		} finally {
 			getCachedRepoWorktreeContext.mockRestore();
 			refreshRepoWorktreeContext.mockRestore();

--- a/packages/extensions/extensions/custom-footer.ts
+++ b/packages/extensions/extensions/custom-footer.ts
@@ -281,7 +281,6 @@ export default function (pi: ExtensionAPI) {
 			const unsubSafeMode = subscribeSafeMode(() => tui.requestRender());
 			const timer = setInterval(() => {
 				probeActivePrs();
-				tui.requestRender();
 			}, FOOTER_POLL_INTERVAL_MS);
 			probeActivePrs();
 


### PR DESCRIPTION
## Summary
- stop the footer PR poll timer from forcing a rerender every minute when the visible footer content has not changed
- keep PR probing active so visible PR links still refresh when probe results change
- extend the footer regression test to assert the idle poll window no longer drives no-op rerenders

## Why
After the diagnostics fix, the runtime churn benchmark showed `custom-footer` as the next clearest isolated always-on redraw source. The footer was waking once per minute even when nothing visible changed.

## Benchmark impact
Using `pnpm bench:runtime` locally after the diagnostics fix:
- isolated custom-footer idle footer redraws/min: `0.92` -> `0.00`
- full-stack mounted idle footer redraws/min: `1.85` -> `0.92`
- 4-instance full-stack mounted idle footer redraws/min: `7.38` -> `3.69`

## Validation
- `pnpm lint`
- `pnpm test`
- `pnpm typecheck`
- `pnpm exec vitest run packages/extensions/extensions/custom-footer.test.ts`
- `OH_PI_BENCH_EXTENSION_FILTER=custom-footer pnpm bench:runtime`