### PR TITLE
perf(status-cache): reduce idle clear churn

### DIFF
--- a/.changeset/status-cache-noop-clears.md
+++ b/.changeset/status-cache-noop-clears.md
@@ -1,0 +1,5 @@
+---
+default: patch
+---
+
+Reduce idle startup status churn by skipping initial no-op status clear writes for unseen status-bar keys while preserving real clears after visible status text has been shown.

--- a/docs/startup-performance-audit.md
+++ b/docs/startup-performance-audit.md
@@ -84,9 +84,9 @@ This is the most expensive focused startup-adjacent benchmark today and maps dir
 - `scheduler persisted store load (50 tasks)`
 - included indirectly by the full-stack startup cases
 
-**What to watch**
+**Latest mitigation**
 
-The scheduler store is capped, so this path is not the largest benchmark today, but it is on the hot startup path and should stay small. The runtime heartbeat also updates footer status, so repeated identical `pi-scheduler` status text should stay coalesced instead of being re-sent on every periodic tick.
+The shared status-bar cache now skips initial no-op `setStatus(key, undefined)` clears for unseen keys. That removes the idle startup status writes that still showed up in the runtime churn report for scheduler and watchdog while preserving real clears after a visible status had been shown.
 
 ### 3. `packages/extensions/extensions/custom-footer.ts`
 

--- a/packages/extensions/extensions/ui-status-cache.test.ts
+++ b/packages/extensions/extensions/ui-status-cache.test.ts
@@ -1,0 +1,51 @@
+import { describe, expect, it, vi } from "vitest";
+
+import { createStatusBarState } from "./ui-status-cache";
+
+describe("createStatusBarState", () => {
+	it("skips initial undefined clears for unseen keys", () => {
+		const setStatus = vi.fn();
+		const statusBar = createStatusBarState();
+		const target = {
+			hasUI: true,
+			ui: { setStatus },
+		};
+
+		expect(statusBar.set(target, "watchdog", undefined)).toBe(false);
+		expect(setStatus).not.toHaveBeenCalled();
+	});
+
+	it("still clears keys after a value was previously written", () => {
+		const setStatus = vi.fn();
+		const statusBar = createStatusBarState();
+		const target = {
+			hasUI: true,
+			ui: { setStatus },
+		};
+
+		expect(statusBar.set(target, "watchdog", "lag p99 80ms")).toBe(true);
+		expect(statusBar.set(target, "watchdog", undefined)).toBe(true);
+		expect(setStatus).toHaveBeenNthCalledWith(1, "watchdog", "lag p99 80ms");
+		expect(setStatus).toHaveBeenNthCalledWith(2, "watchdog", undefined);
+	});
+
+	it("keeps targets isolated when the active UI target changes", () => {
+		const firstSetStatus = vi.fn();
+		const secondSetStatus = vi.fn();
+		const statusBar = createStatusBarState();
+		const firstTarget = {
+			hasUI: true,
+			ui: { setStatus: firstSetStatus },
+		};
+		const secondTarget = {
+			hasUI: true,
+			ui: { setStatus: secondSetStatus },
+		};
+
+		expect(statusBar.set(firstTarget, "watchdog", "active")).toBe(true);
+		expect(statusBar.set(secondTarget, "watchdog", undefined)).toBe(false);
+		expect(statusBar.set(secondTarget, "watchdog", "active")).toBe(true);
+		expect(firstSetStatus).toHaveBeenCalledTimes(1);
+		expect(secondSetStatus).toHaveBeenCalledTimes(1);
+	});
+});

--- a/packages/extensions/extensions/ui-status-cache.ts
+++ b/packages/extensions/extensions/ui-status-cache.ts
@@ -34,6 +34,10 @@ export function createStatusBarState() {
 				return false;
 			}
 
+			if (!lastValues.has(key) && value === undefined) {
+				return false;
+			}
+
 			if (lastValues.has(key) && lastValues.get(key) === value) {
 				return false;
 			}

--- a/packages/extensions/extensions/watchdog.test.ts
+++ b/packages/extensions/extensions/watchdog.test.ts
@@ -336,7 +336,7 @@ describe("watchdog extension", () => {
 		expect(ctx._statuses.get("safe-mode")).toBeUndefined();
 	});
 
-	it("coalesces repeated clean watchdog status clears", async () => {
+	it("skips repeated clean watchdog status clears when nothing was shown", async () => {
 		const pi = createMockPi();
 		const ctx = createMockCtx();
 		watchdogExtension(pi as any);
@@ -352,7 +352,7 @@ describe("watchdog extension", () => {
 		await vi.advanceTimersByTimeAsync(10_000);
 
 		const watchdogCalls = ctx._statusCalls.filter((call) => call.key === "watchdog");
-		expect(watchdogCalls).toEqual([{ key: "watchdog", value: undefined }]);
+		expect(watchdogCalls).toEqual([]);
 	});
 
 	it("resets watchdog history and clears alert status", async () => {


### PR DESCRIPTION
## Summary
- skip initial no-op `setStatus(key, undefined)` writes for unseen status-bar keys
- keep real status clears after visible text has been shown
- add cache regression coverage and update the watchdog expectation around clean idle startup

## Why
After `custom-footer`, the latest runtime churn report showed `scheduler` and `watchdog` as the next clearest isolated idle offenders at `1.85` status writes/min each. Inspection showed those writes were coming from startup-time no-op clears rather than visible state changes, so the shared status cache is the narrowest fix.

## Benchmark impact
Using `pnpm bench:runtime` locally on this branch:
- isolated scheduler idle status writes/min: `1.85` -> `0.00`
- isolated watchdog idle status writes/min: `1.85` -> `0.00`
- full-stack mounted idle status writes/min: `5.54` -> `2.77`
- 4-instance full-stack mounted idle status writes/min: `22.15` -> `11.08`

## Validation
- `pnpm lint`
- `pnpm test`
- `pnpm typecheck`
- `pnpm exec vitest run packages/extensions/extensions/ui-status-cache.test.ts packages/extensions/extensions/scheduler.test.ts packages/extensions/extensions/watchdog.test.ts`
- `pnpm bench:runtime`