### PR TITLE
perf(usage-tracker): reduce startup rerender churn

### DIFF
--- a/.changeset/usage-tracker-startup-rerender.md
+++ b/.changeset/usage-tracker-startup-rerender.md
@@ -1,0 +1,5 @@
+---
+default: patch
+---
+
+Reduce usage-tracker idle startup churn by skipping widget redraw requests when deferred startup probe or persisted-state work does not change the widget's visible content.

--- a/docs/startup-performance-audit.md
+++ b/docs/startup-performance-audit.md
@@ -122,6 +122,7 @@ The usage tracker hydrates from session history near startup and also schedules 
 
 - usage widget redraws should now be event-driven from usage/probe/session changes instead of a fixed 15-second timer
 - widget rendering should follow the latest active session context after `session_switch` without requiring a remount
+- deferred startup probe/cache work now skips requesting a widget redraw when the visible widget state stays unchanged, which removes the remaining idle startup no-op rerender from the runtime churn report
 
 ### 5. `packages/ant-colony/extensions/ant-colony/*`
 

--- a/packages/extensions/extensions/usage-tracker.test.ts
+++ b/packages/extensions/extensions/usage-tracker.test.ts
@@ -280,6 +280,7 @@ function stripAnsiForTest(text: string): string {
 // ─── Import ──────────────────────────────────────────────────────────────────
 
 import { existsSync, promises as fsPromises, mkdirSync, readFileSync, writeFileSync } from "node:fs";
+import { resetSafeModeStateForTests, setSafeModeState } from "./runtime-mode";
 import usageTracker from "./usage-tracker.js";
 
 // ─── Tests ───────────────────────────────────────────────────────────────────
@@ -324,6 +325,7 @@ describe("usage-tracker extension", () => {
 	});
 
 	afterEach(() => {
+		resetSafeModeStateForTests();
 		vi.useRealTimers();
 	});
 
@@ -1245,6 +1247,61 @@ describe("usage-tracker extension", () => {
 			requestRender.mockClear();
 
 			vi.advanceTimersByTime(60_000);
+
+			expect(requestRender).not.toHaveBeenCalled();
+		});
+
+		it("clears widget render tracking on dispose and on hidden widget updates", async () => {
+			usageTracker(pi as any);
+			pi._emit("session_start", { type: "session_start" }, ctx);
+
+			const widgetFactory = ctx._widgets.get("usage-tracker") as
+				| ((
+						tui: { requestRender: () => void },
+						theme: { fg: (_color: string, text: string) => string },
+				  ) => {
+						dispose: () => void;
+						render: (width: number) => string[];
+				  })
+				| undefined;
+			expect(widgetFactory).toBeDefined();
+			const requestRender = vi.fn();
+			const component = widgetFactory?.({ requestRender }, { fg: (_color: string, text: string) => text });
+
+			await pi._commands.get("usage-toggle").handler("", ctx);
+			component?.dispose();
+			requestRender.mockClear();
+
+			pi._emit("model_select", { type: "model_select" }, ctx);
+			await Promise.resolve();
+
+			expect(requestRender).not.toHaveBeenCalled();
+		});
+
+		it("switches to a safe-mode widget signature without repeated rerenders", async () => {
+			usageTracker(pi as any);
+			pi._emit("session_start", { type: "session_start" }, ctx);
+
+			const widgetFactory = ctx._widgets.get("usage-tracker") as
+				| ((
+						tui: { requestRender: () => void },
+						theme: { fg: (_color: string, text: string) => string },
+				  ) => {
+						dispose: () => void;
+						render: (width: number) => string[];
+				  })
+				| undefined;
+			expect(widgetFactory).toBeDefined();
+			const requestRender = vi.fn();
+			widgetFactory?.({ requestRender }, { fg: (_color: string, text: string) => text });
+			requestRender.mockClear();
+
+			setSafeModeState(true, { source: "manual" });
+			expect(requestRender).toHaveBeenCalledTimes(1);
+
+			requestRender.mockClear();
+			pi._emit("model_select", { type: "model_select" }, ctx);
+			await Promise.resolve();
 
 			expect(requestRender).not.toHaveBeenCalled();
 		});

--- a/packages/extensions/extensions/usage-tracker.test.ts
+++ b/packages/extensions/extensions/usage-tracker.test.ts
@@ -1200,6 +1200,33 @@ describe("usage-tracker extension", () => {
 			expect(requestRender).toHaveBeenCalledTimes(1);
 		});
 
+		it("does not re-render for deferred startup work when the widget stays visually empty", async () => {
+			(existsSync as ReturnType<typeof vi.fn>).mockReturnValue(false);
+			(readFileSync as ReturnType<typeof vi.fn>).mockReturnValue("{}");
+			mockFetch.mockResolvedValue(makeFetchResponse({ body: {} }));
+			ctx.model = { id: "claude-sonnet-4-20250514", provider: "anthropic" } as any;
+			usageTracker(pi as any);
+			pi._emit("session_start", { type: "session_start" }, ctx);
+
+			const widgetFactory = ctx._widgets.get("usage-tracker") as
+				| ((
+						tui: { requestRender: () => void },
+						theme: { fg: (_color: string, text: string) => string },
+				  ) => {
+						render: (width: number) => string[];
+				  })
+				| undefined;
+			expect(widgetFactory).toBeDefined();
+			const requestRender = vi.fn();
+			widgetFactory?.({ requestRender }, { fg: (_color: string, text: string) => text });
+			requestRender.mockClear();
+
+			await vi.advanceTimersByTimeAsync(2_000);
+			await Promise.resolve();
+
+			expect(requestRender).not.toHaveBeenCalled();
+		});
+
 		it("does not rely on a periodic widget timer while idle", () => {
 			usageTracker(pi as any);
 			pi._emit("session_start", { type: "session_start" }, ctx);

--- a/packages/extensions/extensions/usage-tracker.ts
+++ b/packages/extensions/extensions/usage-tracker.ts
@@ -154,8 +154,50 @@ export default function usageTracker(pi: ExtensionAPI) {
 	let persistedStateLoadTimer: ReturnType<typeof setTimeout> | null = null;
 	let startupRefreshTimer: ReturnType<typeof setTimeout> | null = null;
 	let requestWidgetRender: (() => void) | null = null;
+	let lastWidgetSignature: string | null = null;
 
-	const requestUsageWidgetRender = () => {
+	const getUsageWidgetSignature = (ctx: ExtensionContext | null | undefined = activeCtx): string => {
+		if (!widgetVisible) {
+			return "hidden";
+		}
+		if (getSafeModeState().enabled) {
+			return "safe-mode";
+		}
+
+		const activeProvider = getActiveProvider(ctx);
+		const totals = getTotals(activeProvider);
+		const visibleTotals =
+			activeProvider && totals.turns > 0
+				? {
+						cost: totals.cost,
+						input: totals.input,
+						output: totals.output,
+					}
+				: null;
+		const visibleRateLimits = getRateLimitEntries(activeProvider)
+			.filter((rl) => !(rl.error || rl.windows.length === 0))
+			.map((rl) => ({
+				provider: rl.provider,
+				windows: rl.windows.map((window) => ({
+					label: window.label,
+					percentLeft: window.percentLeft,
+					resetDescription: window.resetDescription,
+				})),
+			}));
+
+		return JSON.stringify({
+			activeProvider,
+			visibleTotals,
+			visibleRateLimits,
+		});
+	};
+
+	const requestUsageWidgetRender = (ctx: ExtensionContext | null | undefined = activeCtx) => {
+		const nextSignature = getUsageWidgetSignature(ctx);
+		if (nextSignature === lastWidgetSignature) {
+			return;
+		}
+		lastWidgetSignature = nextSignature;
 		requestWidgetRender?.();
 	};
 
@@ -1536,11 +1578,13 @@ export default function usageTracker(pi: ExtensionAPI) {
 		ctx.ui.setWidget("usage-tracker", (tui, theme) => {
 			const componentRequestRender = () => tui.requestRender();
 			requestWidgetRender = componentRequestRender;
-			const unsubSafeMode = subscribeSafeMode(() => requestUsageWidgetRender());
+			lastWidgetSignature = getUsageWidgetSignature(activeCtx ?? ctx);
+			const unsubSafeMode = subscribeSafeMode(() => requestUsageWidgetRender(activeCtx ?? ctx));
 			return {
 				dispose() {
 					if (requestWidgetRender === componentRequestRender) {
 						requestWidgetRender = null;
+						lastWidgetSignature = null;
 					}
 					unsubSafeMode();
 				},
@@ -1619,6 +1663,7 @@ export default function usageTracker(pi: ExtensionAPI) {
 				mountWidget(ctx);
 				ctx.ui.notify("Usage widget shown.", "info");
 			} else {
+				lastWidgetSignature = null;
 				ctx.ui.setWidget("usage-tracker", undefined);
 				ctx.ui.notify("Usage widget hidden. Run /usage-toggle to show.", "info");
 			}


### PR DESCRIPTION
## Summary
- dedupe usage-tracker widget redraw requests by comparing the widget's visible signature before requesting a rerender
- skip deferred startup probe and persisted-state redraws when they do not change what the widget shows
- add regression coverage for empty startup states that previously caused a no-op widget rerender

## Why
After the status-cache fix, the latest runtime churn report showed `usage-tracker` as the next isolated idle offender at `0.92` widget renders/min. The remaining churn came from deferred startup work requesting a widget redraw even when the widget stayed visually empty.

## Benchmark impact
Using `pnpm bench:runtime` locally on this branch:
- isolated usage-tracker idle widget renders/min: `0.92` -> `0.00`
- full-stack mounted idle widget renders/min: `0.92` -> `0.00`
- 4-instance full-stack mounted idle widget renders/min: `3.69` -> `0.00`
- next remaining isolated offender: `worktree` at `0.92` status writes/min

## Validation
- `pnpm exec vitest run packages/extensions/extensions/usage-tracker.test.ts`
- `OH_PI_BENCH_EXTENSION_FILTER=usage-tracker pnpm bench:runtime`
- `pnpm bench:runtime`
- `pnpm lint`
- `pnpm typecheck`
- `pnpm test`