### PR TITLE
perf(worktree): reduce idle status churn

### DIFF
--- a/.changeset/worktree-status-idle-churn.md
+++ b/.changeset/worktree-status-idle-churn.md
@@ -1,0 +1,5 @@
+---
+default: patch
+---
+
+Reduce idle worktree status churn by removing the startup-time worktree status refresh and only updating the status badge during explicit worktree interactions.

--- a/docs/startup-performance-audit.md
+++ b/docs/startup-performance-audit.md
@@ -50,6 +50,11 @@ The benchmark suite currently covers:
 
 That work blocks the Node event loop completely.
 
+**Latest mitigation**
+
+- worktree startup no longer schedules a status-bar refresh during idle session boot
+- explicit `/worktree` commands still refresh the current worktree context and can surface a status badge when the user actually interacts with the worktree extension
+
 **Current benchmark coverage**
 
 - `worktree current context (single temp repo)`

--- a/packages/extensions/extensions/worktree.test.ts
+++ b/packages/extensions/extensions/worktree.test.ts
@@ -65,23 +65,16 @@ describe("worktree extension", () => {
 		expect(harness.commands.has("wt")).toBe(true);
 	});
 
-	it("defers status refresh on session start so startup avoids immediate git work", async () => {
-		vi.useFakeTimers();
-		try {
-			const harness = createExtensionHarness();
-			harness.ctx.cwd = "/repo";
-			worktreeShared.getRepoWorktreeContext.mockReturnValue(makeSnapshot());
+	it("does not probe or write worktree status on session start", () => {
+		const harness = createExtensionHarness();
+		harness.ctx.cwd = "/repo";
+		worktreeShared.getRepoWorktreeContext.mockReturnValue(makeSnapshot());
 
-			worktreeExtension(harness.pi as never);
-			harness.emit("session_start", {}, harness.ctx);
-			expect(worktreeShared.getRepoWorktreeContext).not.toHaveBeenCalled();
+		worktreeExtension(harness.pi as never);
+		harness.emit("session_start", {}, harness.ctx);
 
-			await vi.advanceTimersByTimeAsync(500);
-			expect(worktreeShared.getRepoWorktreeContext).toHaveBeenCalledWith("/repo");
-			expect(harness.statusMap.get("pi-worktree")).toContain("main checkout");
-		} finally {
-			vi.useRealTimers();
-		}
+		expect(worktreeShared.getRepoWorktreeContext).not.toHaveBeenCalled();
+		expect(harness.statusMap.has("pi-worktree")).toBe(false);
 	});
 
 	it("creates a pi-owned worktree and reports owner + purpose metadata", async () => {
@@ -114,6 +107,56 @@ describe("worktree extension", () => {
 		expect(harness.notifications.at(-1)?.msg).toContain("Created pi-owned worktree feat/footer-context");
 		expect(String(harness.messages.at(-1)?.content)).toContain("Owner instance: pi-test-instance");
 		expect(String(harness.messages.at(-1)?.content)).toContain("Purpose: Implement footer context");
+	});
+
+	it("shows a status badge for linked worktrees during explicit worktree commands", async () => {
+		const harness = createExtensionHarness();
+		harness.ctx.cwd = "/repo";
+		worktreeShared.getRepoWorktreeContext.mockReturnValue(
+			makeSnapshot({
+				isLinkedWorktree: true,
+				currentWorktreeRoot: "/tmp/pi/feat-footer",
+				currentBranch: "feat/footer-context",
+				current: {
+					path: "/tmp/pi/feat-footer",
+					branch: "feat/footer-context",
+					head: "abc",
+					bare: false,
+					detached: false,
+					lockedReason: null,
+					prunableReason: null,
+					isMain: false,
+					isCurrent: true,
+					isManaged: true,
+					metadata: { purpose: "Build worktree UX", owner: { instanceId: "pi-test-instance" } },
+				},
+			}),
+		);
+		worktreeShared.getRepoWorktreeSnapshot.mockReturnValue(
+			makeSnapshot({
+				isLinkedWorktree: true,
+				currentWorktreeRoot: "/tmp/pi/feat-footer",
+				currentBranch: "feat/footer-context",
+				current: {
+					path: "/tmp/pi/feat-footer",
+					branch: "feat/footer-context",
+					head: "abc",
+					bare: false,
+					detached: false,
+					lockedReason: null,
+					prunableReason: null,
+					isMain: false,
+					isCurrent: true,
+					isManaged: true,
+					metadata: { purpose: "Build worktree UX", owner: { instanceId: "pi-test-instance" } },
+				},
+			}),
+		);
+
+		worktreeExtension(harness.pi as never);
+		await harness.commands.get("worktree").handler("status", harness.ctx);
+
+		expect(harness.statusMap.get("pi-worktree")).toContain("pi wt feat/footer-context");
 	});
 
 	it("opens a matching worktree through the system opener helper", async () => {

--- a/packages/extensions/extensions/worktree.ts
+++ b/packages/extensions/extensions/worktree.ts
@@ -20,7 +20,6 @@ import {
 
 const COMMAND = "worktree";
 const COMMAND_ALIASES = [COMMAND, "Worktree", "wt"] as const;
-const WORKTREE_STATUS_REFRESH_DELAY_MS = 250;
 const instanceId = buildPaiInstanceId();
 
 function relativeDisplayPath(root: string, target: string): string {
@@ -253,7 +252,7 @@ function currentStatusText(snapshot: RepoWorktreeContext | null): string | undef
 	const repo = path.basename(snapshot.repoRoot);
 	const branch = snapshot.current?.branch ?? snapshot.currentBranch ?? "detached";
 	if (!snapshot.isLinkedWorktree) {
-		return `${repo} main checkout`;
+		return undefined;
 	}
 	if (snapshot.current?.isManaged && snapshot.current.metadata) {
 		return `${repo} · pi wt ${branch} · ${snapshot.current.metadata.purpose}`;
@@ -524,42 +523,6 @@ function buildCommandSpec(pi: ExtensionAPI) {
 }
 
 export default function worktreeExtension(pi: ExtensionAPI) {
-	let refreshTimer: ReturnType<typeof setTimeout> | null = null;
-
-	const scheduleStatusRefresh = (ctx: ExtensionContext, delayMs = WORKTREE_STATUS_REFRESH_DELAY_MS) => {
-		if (refreshTimer) {
-			clearTimeout(refreshTimer);
-		}
-
-		refreshTimer = setTimeout(
-			() => {
-				refreshTimer = null;
-				refreshStatus(ctx);
-			},
-			Math.max(0, delayMs),
-		);
-	};
-
-	const clearStatusRefresh = () => {
-		if (!refreshTimer) {
-			return;
-		}
-		clearTimeout(refreshTimer);
-		refreshTimer = null;
-	};
-
-	pi.on("session_start", (_event, ctx) => {
-		scheduleStatusRefresh(ctx);
-	});
-
-	pi.on("session_switch", (_event, ctx) => {
-		scheduleStatusRefresh(ctx);
-	});
-
-	pi.on("session_shutdown", () => {
-		clearStatusRefresh();
-	});
-
 	const spec = buildCommandSpec(pi);
 	for (const name of COMMAND_ALIASES) {
 		pi.registerCommand(name, spec);


### PR DESCRIPTION
## Summary
- stop scheduling a startup/session-switch worktree status refresh during idle boot
- keep explicit `/worktree` interactions refreshing the current worktree context and badge when the user actually uses the extension
- update worktree regression coverage and audit notes for the new on-demand behavior

## Why
After the usage-tracker fix, the latest runtime churn report showed `worktree` as the next remaining isolated offender at `0.92` status writes/min. That write came from the startup-time status refresh, even when the user had not interacted with the worktree extension.

## Benchmark impact
Using `OH_PI_BENCH_EXTENSION_FILTER=worktree pnpm bench:runtime` locally on this branch:
- isolated worktree idle status writes/min: `0.92` -> `0.00`
- full-stack mounted idle status writes/min: `2.77` -> `0.00`
- 4-instance full-stack mounted idle status writes/min: `11.08` -> `0.00`

## Validation
- `pnpm exec vitest run packages/extensions/extensions/worktree.test.ts`
- `OH_PI_BENCH_EXTENSION_FILTER=worktree pnpm bench:runtime`
- `pnpm lint`
- `pnpm typecheck`
- `pnpm test:coverage`
- `BASE_SHA=$(git merge-base main HEAD) HEAD_SHA=$(git rev-parse HEAD) node ./scripts/check-patch-coverage.mjs --threshold 100 --lcov coverage/lcov.info`

## Patch coverage
- `100.00% (1/1 changed executable lines covered)`