### PR TITLE
fix: preserve manual pi session names

### DIFF
--- a/.changeset/auto-session-name-manual-lock.md
+++ b/.changeset/auto-session-name-manual-lock.md
@@ -1,0 +1,5 @@
+---
+default: patch
+---
+
+fix: stop auto session renames after a manual /name override

--- a/packages/extensions/extensions/auto-session-name.test.ts
+++ b/packages/extensions/extensions/auto-session-name.test.ts
@@ -52,6 +52,59 @@ describe("auto-session-name extension", () => {
 		expect(harness.sessionName).toContain("Implement auto-continue after compaction");
 	});
 
+	it("stops auto renaming after the user sets a custom session name", async () => {
+		const harness = createExtensionHarness();
+		autoSessionNameExtension(harness.pi as never);
+
+		harness.emit("session_start", { type: "session_start" }, harness.ctx);
+		await harness.emitAsync(
+			"agent_end",
+			{
+				type: "agent_end",
+				messages: [{ role: "user", content: "Investigate scheduler ownership handling" }],
+			},
+			harness.ctx,
+		);
+
+		harness.pi.setSessionName("My locked custom name");
+
+		await harness.emitAsync(
+			"agent_end",
+			{
+				type: "agent_end",
+				messages: [
+					{ role: "user", content: "Investigate scheduler ownership handling" },
+					{
+						role: "user",
+						content: "Implement auto-continue after compaction and improve resume hints for shutdown",
+					},
+				],
+			},
+			harness.ctx,
+		);
+
+		expect(harness.sessionName).toBe("My locked custom name");
+	});
+
+	it("does not auto-name after the user sets a custom session name before the first rename", async () => {
+		const harness = createExtensionHarness();
+		autoSessionNameExtension(harness.pi as never);
+
+		harness.emit("session_start", { type: "session_start" }, harness.ctx);
+		harness.pi.setSessionName("Pinned session name");
+
+		await harness.emitAsync(
+			"agent_end",
+			{
+				type: "agent_end",
+				messages: [{ role: "user", content: "Refactor scheduler startup ownership checks and notifications" }],
+			},
+			harness.ctx,
+		);
+
+		expect(harness.sessionName).toBe("Pinned session name");
+	});
+
 	it("queues a continue message when compaction finishes", () => {
 		const harness = createExtensionHarness();
 		autoSessionNameExtension(harness.pi as never);

--- a/packages/extensions/extensions/auto-session-name.ts
+++ b/packages/extensions/extensions/auto-session-name.ts
@@ -105,6 +105,7 @@ function chooseName(messages: MessageLike[], currentName: string): string | unde
 
 export default function autoSessionNameExtension(pi: ExtensionAPI) {
 	let lastAutoName = "";
+	let manualNameLocked = false;
 	let compactContinuationQueued = false;
 
 	const emitResumeHint = (reason: "shutdown" | "switch", sessionFile: string | undefined) => {
@@ -128,11 +129,16 @@ export default function autoSessionNameExtension(pi: ExtensionAPI) {
 
 	pi.on("agent_end", async (event) => {
 		const messages = (event as { messages?: MessageLike[] }).messages ?? [];
-		if (messages.length === 0) {
+		if (messages.length === 0 || manualNameLocked) {
 			return;
 		}
 
 		const current = (pi.getSessionName?.() ?? "").trim();
+		if (current && current !== lastAutoName) {
+			manualNameLocked = true;
+			return;
+		}
+
 		const next = chooseName(messages, current);
 		if (!(next && next !== current && next !== lastAutoName)) {
 			return;


### PR DESCRIPTION
## Summary
- stop auto-session-name from overwriting manual `/name` updates
- treat any session name that diverges from the last auto-generated name as locked
- add regression coverage for manual names set before and after auto naming

## Testing
- pnpm vitest packages/extensions/extensions/auto-session-name.test.ts