### PR TITLE
test(policy): align local and ci patch coverage checks

### DIFF
--- a/.changeset/test-policy-tranche-docs.md
+++ b/.changeset/test-policy-tranche-docs.md
@@ -1,0 +1,5 @@
+---
+default: patch
+---
+
+Document the current coverage policy more clearly for contributors and add a `pnpm test:patch-coverage` shortcut for running the local 100% patch-coverage gate.

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -309,7 +309,7 @@ jobs:
         env:
           BASE_SHA: ${{ github.event.pull_request.base.sha }}
           HEAD_SHA: ${{ github.event.pull_request.head.sha }}
-        run: node ./scripts/check-patch-coverage.mjs --threshold 100 --lcov coverage/lcov.info
+        run: pnpm test:patch-coverage
 
       - name: Upload coverage artifact
         uses: actions/upload-artifact@v4.6.2

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -74,13 +74,15 @@ frontmatter, knope will ignore that changeset in this repo.
 4. Create and commit a changeset: `knope document-change`
 5. Ensure the build passes: `pnpm build`
 6. Ensure lint passes: `pnpm lint`
-7. Push and create a PR
+7. For code changes, run `pnpm test`. If the PR changes executable code, also run `pnpm test:coverage && pnpm test:patch-coverage`
+8. Push and create a PR
 
 ### PR Requirements
 
 - Title follows Conventional Commits format
 - Description clearly explains the change and rationale
 - A changeset file is included for every non-release change
+- New executable PR changes keep patch coverage at 100%
 - One PR addresses one issue
 - No unrelated code changes
 

--- a/README.md
+++ b/README.md
@@ -546,15 +546,31 @@ See [CONTRIBUTING.md](./CONTRIBUTING.md) for contributor workflow, changeset req
 ### Commands
 
 ```bash
-pnpm build          # Build every workspace package that exposes a build script
-pnpm typecheck      # Type check with tsgo (fast)
-pnpm test           # Run all tests
-pnpm test:coverage  # Run tests with repo-wide coverage reporting
-pnpm lint           # Biome lint + format check
-pnpm security:check # Dependency allowlist + vulnerability audits
-pnpm lint:fix       # Auto-fix lint issues
-pnpm format         # Format all files
+pnpm build               # Build every workspace package that exposes a build script
+pnpm typecheck           # Type check with tsgo (fast)
+pnpm test                # Run all tests
+pnpm test:coverage       # Run tests with repo-wide coverage reporting
+pnpm test:patch-coverage # Enforce 100% patch coverage from coverage/lcov.info
+pnpm lint                # Biome lint + format check
+pnpm security:check      # Dependency allowlist + vulnerability audits
+pnpm lint:fix            # Auto-fix lint issues
+pnpm format              # Format all files
 ```
+
+### Coverage policy
+
+- Overall/project coverage is currently enforced at **60%**.
+- Patch coverage for new PR changes is enforced at **100%**.
+- The local contributor loop for coverage-sensitive work is:
+
+```bash
+pnpm test:coverage
+pnpm test:patch-coverage
+```
+
+That keeps the repo-wide floor honest while still requiring new code paths in a PR to be fully
+covered. CI uses the same `pnpm test:patch-coverage` command on pull requests, so local results and
+CI results stay aligned.
 
 ### Test a local checkout in pi
 

--- a/package.json
+++ b/package.json
@@ -42,6 +42,7 @@
 		"security:check": "pnpm security:allowlist && pnpm security:audit:prod && pnpm security:audit:dev",
 		"test": "vitest run",
 		"test:coverage": "vitest run --coverage",
+		"test:patch-coverage": "node ./scripts/check-patch-coverage.mjs --threshold 100 --lcov coverage/lcov.info",
 		"bench": "pnpm bench:startup && pnpm bench:runtime && pnpm bench:extensions-render && pnpm bench:live-runtime",
 		"bench:startup": "OH_PI_RUN_BENCHMARKS=1 pnpm exec vitest run benchmarks/startup/startup-bench.test.ts",
 		"bench:runtime": "OH_PI_RUN_BENCHMARKS=1 pnpm exec vitest run benchmarks/runtime/runtime-bench.test.ts",


### PR DESCRIPTION
## Summary
- add a `pnpm test:patch-coverage` script for the local 100% patch-coverage gate
- document the current 60% overall / 100% patch coverage policy in README and CONTRIBUTING
- make CI call the same patch-coverage script contributors run locally

## Validation
- pnpm lint
