### PR TITLE
fix(pi-local): warn about stale workspace installs

### DIFF
--- a/.changeset/pi-local-install-hint.md
+++ b/.changeset/pi-local-install-hint.md
@@ -1,0 +1,5 @@
+---
+default: patch
+---
+
+Add a clearer local-source-mode reminder to run `pnpm install --frozen-lockfile` after pulling, rebasing, or switching branches so pi does not fail to resolve internal workspace packages from a stale install.

--- a/README.md
+++ b/README.md
@@ -597,6 +597,10 @@ What it does:
 After switching, fully restart `pi`. Do not rely on `/reload` for source switches because it can
 keep previously loaded package modules alive.
 
+If you recently pulled, rebased, or switched branches in the checkout you pointed `pi` at, run
+`pnpm install --frozen-lockfile` there before restarting `pi`. Local source mode loads workspace
+files directly, so stale `node_modules` can surface missing internal `@ifi/*` package errors.
+
 This is intended to be the normal development loop for testing a branch locally before cutting a
 release.
 

--- a/scripts/pi-source-switch.mts
+++ b/scripts/pi-source-switch.mts
@@ -598,6 +598,12 @@ function printChangeSummary(mode: Mode, changes: readonly Change[], settingsPath
 	}
 }
 
+function printLocalInstallHint(repoPath: string) {
+	console.log("");
+	console.log(`Reminder: if you recently pulled, rebased, or switched branches in ${repoPath}, run \`pnpm install --frozen-lockfile\` before restarting pi.`);
+	console.log("Local source mode loads workspace files directly, so stale node_modules can surface missing internal @ifi/* package errors.");
+}
+
 function printStatus(currentSources: ReadonlyMap<string, string>, settingsPath: string, piLocal: boolean) {
 	const scope = piLocal ? "project" : "user";
 	console.log(`\noh-pi managed package sources (${scope} settings)`);
@@ -683,6 +689,9 @@ export function main(argv: string[] = process.argv) {
 	const nextSettings: SettingsFile = { ...settings, packages: nextEntries };
 	if (options.dryRun) {
 		console.log("\nDry run only — settings were not written and pi install/update was not run.");
+		if (options.mode === "local") {
+			printLocalInstallHint(options.repoPath);
+		}
 		console.log("When you apply this switch, fully restart pi; /reload can keep old package modules alive.");
 		return;
 	}
@@ -690,6 +699,9 @@ export function main(argv: string[] = process.argv) {
 	writeSettings(settingsPath, nextSettings);
 	const pi = findPi();
 	updatePiSources(pi, currentSources, desiredSources);
+	if (options.mode === "local") {
+		printLocalInstallHint(options.repoPath);
+	}
 	console.log("\n✅ Done. Fully restart pi to reload the switched packages.");
 	console.log("⚠️  Avoid /reload after switching sources; it can keep previously loaded package modules alive.");
 }

--- a/scripts/pi-source-switch.test.ts
+++ b/scripts/pi-source-switch.test.ts
@@ -371,6 +371,8 @@ describe("pi source switcher helpers", () => {
 		expect(result.stdout).toContain(`Repo: ${repoDir}`);
 		expect(result.stdout).toContain(workspacePackages.get("@ifi/oh-pi-extensions") ?? "");
 		expect(result.stdout).toContain("Dry run only — settings were not written");
+		expect(result.stdout).toContain("run `pnpm install --frozen-lockfile` before restarting pi");
+		expect(result.stdout).toContain("stale node_modules can surface missing internal @ifi/* package errors");
 		expect(readFileSync(settingsPath, "utf8")).toBe(`${originalSettings}\n`);
 	});
 
@@ -425,6 +427,34 @@ describe("pi source switcher helpers", () => {
 		expect(piLog).toContain("update npm:@ifi/oh-pi-extensions@0.4.4");
 		expect(piLog).toContain("install npm:@ifi/pi-provider-cursor@0.4.4");
 	}, 20_000);
+
+	it("prints a workspace install reminder after switching to local mode", () => {
+		const agentDir = createTempDir("oh-pi-switcher-agent-");
+		const settingsPath = path.join(agentDir, "settings.json");
+		writeFileSync(settingsPath, JSON.stringify({ packages: ["npm:@ifi/oh-pi-extensions@0.4.3"] }, null, 2));
+
+		const workspacePackages = createWorkspaceRepo();
+		const repoDir = path.dirname(path.dirname(workspacePackages.get("@ifi/oh-pi-extensions") ?? ""));
+		const logPath = path.join(agentDir, "pi.log");
+		const piBinDir = createFakePiExecutable(logPath);
+
+		const result = runSwitcher(["local", "--path", repoDir], {
+			env: {
+				PATH: [piBinDir, path.dirname(process.execPath), process.env.PATH ?? ""].join(path.delimiter),
+				PI_CODING_AGENT_DIR: agentDir,
+				PI_CODING_AGENT_BIN: piBinDir,
+				PI_TEST_LOG_PATH: logPath,
+			},
+		});
+
+		const savedSettings = JSON.parse(readFileSync(settingsPath, "utf8")) as { packages: unknown[] };
+		const savedSources = savedSettings.packages.map(getPackageSource).filter((value): value is string => Boolean(value));
+
+		expect(result.status).toBe(0);
+		expect(result.stdout).toContain("run `pnpm install --frozen-lockfile` before restarting pi");
+		expect(result.stdout).toContain("stale node_modules can surface missing internal @ifi/* package errors");
+		expect(savedSources).toContain(workspacePackages.get("@ifi/oh-pi-extensions") ?? "");
+	});
 
 	it("exits with an error when local mode cannot resolve the full managed workspace set", () => {
 		const repoDir = createTempDir("oh-pi-switcher-incomplete-");


### PR DESCRIPTION
## Summary
- print a clearer `pnpm install --frozen-lockfile` reminder when switching pi to local workspace sources
- cover the new reminder in the source switcher tests
- document the stale-workspace-install gotcha in the local checkout workflow docs

## Validation
- pnpm exec vitest run scripts/pi-source-switch.test.ts
- pnpm lint
