### PR TITLE
docs(repo): expand feature docs and local dev guidance

### DIFF
--- a/.changeset/docs-feature-catalog-and-local-dev.md
+++ b/.changeset/docs-feature-catalog-and-local-dev.md
@@ -1,0 +1,10 @@
+---
+default: patch
+---
+
+Improve the repo documentation to better cover the full oh-pi feature surface.
+
+- add a package-by-package feature catalog covering runtime packages, content packs, and contributor libraries
+- expand the root README with missing extension coverage such as scheduler, BTW/QQ, watchdog, and tool metadata
+- add a clearer running-locally guide that explains how `pnpm pi:local` works for local feature testing and development
+- refresh package lists and package counts to include newer additions like `pi-web-remote` and the expanded skills pack

--- a/.changeset/docs-feature-catalog-and-local-dev.md
+++ b/.changeset/docs-feature-catalog-and-local-dev.md
@@ -8,3 +8,4 @@ Improve the repo documentation to better cover the full oh-pi feature surface.
 - expand the root README with missing extension coverage such as scheduler, BTW/QQ, watchdog, and tool metadata
 - add a clearer running-locally guide that explains how `pnpm pi:local` works for local feature testing and development
 - refresh package lists and package counts to include newer additions like `pi-web-remote` and the expanded skills pack
+- update transitive dependency overrides so security audit checks pass again on the branch

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -12,6 +12,53 @@ pnpm build
 pnpm test
 ```
 
+<!-- {=repoContributorReadingPathDocs} -->
+
+Suggested path for a new contributor:
+
+1. skim the root `README.md` for the package map and the local dev loop
+2. read `docs/feature-catalog.md` to understand which package owns which feature
+3. run `pnpm install` and `pnpm pi:local`
+4. restart `pi` and exercise the feature in a real session
+5. open the package README for the area you are changing, then run the relevant build/test commands
+
+<!-- {/repoContributorReadingPathDocs} -->
+
+<!-- {=repoContributorCompiledPackagesDocs} -->
+
+Most runtime packages in this repo ship raw TypeScript and can be loaded directly by pi. A smaller
+set of contributor-facing packages (`core`, `cli`, `web-client`, `web-server`) emit `dist/` output,
+so build those when you are working on them directly.
+
+<!-- {/repoContributorCompiledPackagesDocs} -->
+
+### Running the repo in a real pi session
+
+<!-- {=repoPiLocalSwitcherOverviewDocs} -->
+
+The `pnpm pi:local` workflow points a real pi install at this checkout instead of the published npm
+packages. It is the normal local development loop for testing unpublished oh-pi changes in a real
+interactive pi session.
+
+<!-- {/repoPiLocalSwitcherOverviewDocs} -->
+
+<!-- {=repoPiLocalQuickstartDocs} -->
+
+```bash
+pnpm install
+pnpm pi:local
+pi
+```
+
+<!-- {/repoPiLocalQuickstartDocs} -->
+
+<!-- {=repoPiSourceSwitchRestartDocs} -->
+
+After switching package sources, fully restart `pi`. Do not rely on `/reload` for source switches,
+because it can keep previously loaded package modules alive.
+
+<!-- {/repoPiSourceSwitchRestartDocs} -->
+
 ## Commit Convention
 
 Use [Conventional Commits](https://www.conventionalcommits.org/):

--- a/README.md
+++ b/README.md
@@ -54,6 +54,7 @@ oh-pi repo
 │   └── @ifi/oh-pi
 ├── default runtime packages
 │   ├── extensions
+│   ├── background-tasks
 │   ├── diagnostics
 │   ├── ant-colony
 │   ├── subagents
@@ -740,6 +741,7 @@ That is the normal developer loop for oh-pi feature work.
 Managed local switching covers these packages:
 
 - `@ifi/oh-pi-extensions`
+- `@ifi/pi-background-tasks`
 - `@ifi/oh-pi-ant-colony`
 - `@ifi/pi-diagnostics`
 - `@ifi/pi-extension-subagents`
@@ -850,6 +852,7 @@ oh-pi/
 │   ├── core/                   Shared types, registries, icons, i18n, and path helpers (compiled)
 │   ├── cli/                    Interactive TUI configurator (compiled)
 │   ├── extensions/             13 core pi extensions (raw .ts)
+│   ├── background-tasks/       Reactive background shell task package (raw .ts)
 │   ├── diagnostics/            Prompt completion timing extension (raw .ts)
 │   ├── ant-colony/             Multi-agent swarm extension (raw .ts)
 │   ├── subagents/              Subagent orchestration package (raw .ts)

--- a/README.md
+++ b/README.md
@@ -24,12 +24,61 @@ npx @ifi/oh-pi
 ## 30-Second Start
 
 ```bash
-npx @ifi/oh-pi       # install all extensions, themes, prompts, and skills
+npx @ifi/oh-pi       # install the default oh-pi bundle
 pi                    # start coding
 ```
 
 oh-pi installs the full bundle into pi in one command. See [Installer Options](#installer-options)
 for project-scoped installs and version pinning.
+
+## Start Here
+
+<!-- {=repoStartHerePathDocs} -->
+
+Use this reading path depending on what you are trying to do:
+
+- **I just want to use oh-pi** → start in the root `README.md`, then jump into `docs/feature-catalog.md` for package-by-package detail
+- **I want to try the latest local changes** → run `pnpm install`, `pnpm pi:local`, restart `pi`, then exercise the feature in a real session
+- **I want to contribute** → read `CONTRIBUTING.md`, then the package README for the area you are changing
+- **I want to understand ownership** → use `docs/feature-catalog.md` to see which package owns which runtime feature, content pack, or library surface
+
+<!-- {/repoStartHerePathDocs} -->
+
+### Architecture at a glance
+
+<!-- {=repoArchitectureAtAGlanceDocs} -->
+
+```text
+oh-pi repo
+├── installer
+│   └── @ifi/oh-pi
+├── default runtime packages
+│   ├── extensions
+│   ├── diagnostics
+│   ├── ant-colony
+│   ├── subagents
+│   ├── plan
+│   ├── spec
+│   └── web-remote
+├── content packs
+│   ├── themes
+│   ├── prompts
+│   ├── skills
+│   └── agents
+├── opt-in extras
+│   ├── adaptive-routing
+│   ├── provider-catalog
+│   ├── provider-cursor
+│   └── provider-ollama
+└── contributor libraries
+    ├── core
+    ├── cli
+    ├── shared-qna
+    ├── web-client
+    └── web-server
+```
+
+<!-- {/repoArchitectureAtAGlanceDocs} -->
 
 ### Fork-based Git install
 
@@ -48,29 +97,40 @@ Published npm installs remain the better default for stable releases.
 
 This is a monorepo. Install everything at once with `npx @ifi/oh-pi`, or pick individual packages.
 
-| Package                                          | Description                        | Install                                |
-| ------------------------------------------------ | ---------------------------------- | -------------------------------------- |
-| [`@ifi/oh-pi`](./packages/oh-pi)                 | One-command installer for all pkgs | `npx @ifi/oh-pi`                       |
-| [`@ifi/oh-pi-core`](./packages/core)             | Shared types, registries, i18n     | (library, not installed directly)      |
-| [`@ifi/oh-pi-extensions`](./packages/extensions)          | Core extension pack (see below)             | `pi install npm:@ifi/oh-pi-extensions`      |
-| [`@ifi/pi-extension-adaptive-routing`](./packages/adaptive-routing) | Optional adaptive + delegated routing       | `pi install npm:@ifi/pi-extension-adaptive-routing` |
-| [`@ifi/oh-pi-ant-colony`](./packages/ant-colony)          | Multi-agent swarm extension                 | `pi install npm:@ifi/oh-pi-ant-colony`      |
-| [`@ifi/pi-diagnostics`](./packages/diagnostics)           | Prompt completion timing extension          | `pi install npm:@ifi/pi-diagnostics`         |
-| [`@ifi/pi-extension-subagents`](./packages/subagents)     | Full-featured subagent delegation extension | `pi install npm:@ifi/pi-extension-subagents` |
-| [`@ifi/pi-plan`](./packages/plan)                         | Branch-aware planning mode extension        | `pi install npm:@ifi/pi-plan`               |
-| [`@ifi/pi-shared-qna`](./packages/shared-qna)             | Shared Q&A TUI helpers                      | (library, not installed directly)           |
-| [`@ifi/pi-spec`](./packages/spec)                         | Native spec-driven workflow with `/spec`    | `pi install npm:@ifi/pi-spec`               |
-| [`@ifi/pi-provider-catalog`](./packages/providers)        | Experimental OpenCode-backed provider catalog | `pi install npm:@ifi/pi-provider-catalog` |
-| [`@ifi/pi-provider-cursor`](./packages/cursor)            | Experimental Cursor OAuth provider            | `pi install npm:@ifi/pi-provider-cursor`  |
-| [`@ifi/pi-provider-ollama`](./packages/ollama)            | Experimental Ollama local + cloud provider    | `pi install npm:@ifi/pi-provider-ollama`  |
-| [`@ifi/oh-pi-themes`](./packages/themes)                  | 6 color themes                              | `pi install npm:@ifi/oh-pi-themes`          |
-| [`@ifi/oh-pi-prompts`](./packages/prompts)                | 10 prompt templates                         | `pi install npm:@ifi/oh-pi-prompts`         |
-| [`@ifi/oh-pi-skills`](./packages/skills)                  | 12 skill packs                              | `pi install npm:@ifi/oh-pi-skills`          |
-| [`@ifi/oh-pi-agents`](./packages/agents)                  | 5 AGENTS.md templates                       | (used by CLI only)                          |
+| Package | Role | Install |
+| ------- | ---- | ------- |
+| [`@ifi/oh-pi`](./packages/oh-pi) | Meta-installer for the default oh-pi bundle | `npx @ifi/oh-pi` |
+| [`@ifi/oh-pi-cli`](./packages/cli) | Interactive TUI configurator | `npx @ifi/oh-pi-cli` |
+| [`@ifi/oh-pi-core`](./packages/core) | Shared types, registries, icons, i18n, and path helpers | (library, not installed directly) |
+| [`@ifi/oh-pi-extensions`](./packages/extensions) | Core extension pack with 13 session features | `pi install npm:@ifi/oh-pi-extensions` |
+| [`@ifi/pi-background-tasks`](./packages/background-tasks) | Reactive background shell tasks with `/bg`, `Ctrl+Shift+B`, and `bg_task` | `pi install npm:@ifi/pi-background-tasks` |
+| [`@ifi/pi-diagnostics`](./packages/diagnostics) | Prompt completion timing extension | `pi install npm:@ifi/pi-diagnostics` |
+| [`@ifi/oh-pi-ant-colony`](./packages/ant-colony) | Multi-agent swarm extension | `pi install npm:@ifi/oh-pi-ant-colony` |
+| [`@ifi/pi-extension-subagents`](./packages/subagents) | Full-featured subagent delegation runtime | `pi install npm:@ifi/pi-extension-subagents` |
+| [`@ifi/pi-plan`](./packages/plan) | Branch-aware planning mode extension | `pi install npm:@ifi/pi-plan` |
+| [`@ifi/pi-spec`](./packages/spec) | Native spec-driven workflow with `/spec` | `pi install npm:@ifi/pi-spec` |
+| [`@ifi/pi-web-remote`](./packages/web-remote) | `/remote` session sharing extension | `pi install npm:@ifi/pi-web-remote` |
+| [`@ifi/pi-extension-adaptive-routing`](./packages/adaptive-routing) | Optional adaptive + delegated routing | `pi install npm:@ifi/pi-extension-adaptive-routing` |
+| [`@ifi/pi-provider-catalog`](./packages/providers) | Experimental OpenCode-backed provider catalog | `pi install npm:@ifi/pi-provider-catalog` |
+| [`@ifi/pi-provider-cursor`](./packages/cursor) | Experimental Cursor OAuth provider | `pi install npm:@ifi/pi-provider-cursor` |
+| [`@ifi/pi-provider-ollama`](./packages/ollama) | Experimental Ollama local + cloud provider | `pi install npm:@ifi/pi-provider-ollama` |
+| [`@ifi/oh-pi-themes`](./packages/themes) | 6 color themes | `pi install npm:@ifi/oh-pi-themes` |
+| [`@ifi/oh-pi-prompts`](./packages/prompts) | 10 prompt templates | `pi install npm:@ifi/oh-pi-prompts` |
+| [`@ifi/oh-pi-skills`](./packages/skills) | 17 skill packs | `pi install npm:@ifi/oh-pi-skills` |
+| [`@ifi/oh-pi-agents`](./packages/agents) | 5 AGENTS.md templates | (used by CLI/templates) |
+| [`@ifi/pi-shared-qna`](./packages/shared-qna) | Shared Q&A TUI helpers | (library, not installed directly) |
+| [`@ifi/pi-web-client`](./packages/web-client) | Platform-agnostic remote session client library | `pnpm add @ifi/pi-web-client` |
+| [`@ifi/pi-web-server`](./packages/web-server) | Embeddable remote session server | `pnpm add @ifi/pi-web-server` |
 
 `@ifi/pi-extension-adaptive-routing`, `@ifi/pi-provider-catalog`, `@ifi/pi-provider-cursor`, and
 `@ifi/pi-provider-ollama` stay opt-in for now and are **not** installed by `npx @ifi/oh-pi`.
 They are intentionally shipped as separate optional packages.
+
+### Full Feature Catalog
+
+For a package-by-package inventory of everything in the repo — including every extension, runtime
+package, prompt, skill, theme, AGENTS template, and contributor-facing library — see
+[docs/feature-catalog.md](./docs/feature-catalog.md).
 
 ### Native `/spec` Workflow
 
@@ -242,6 +302,18 @@ how long it took, and how each assistant turn progressed.
 `before_agent_start`, `turn_end`, and `agent_end`, then emits a custom diagnostic message when the
 agent goes idle for that prompt.
 
+### 🧾 Tool Metadata (`tool-metadata`) — **default: on**
+
+Enriches tool results with execution metadata so pi can show when a tool started, when it finished,
+how long it took, and roughly how much text went in or out.
+
+**Adds:** start/end timestamps, duration, approximate input/output sizing, and a context snapshot at
+completion. It also sanitizes oversized tool output/details payloads so the TUI stays stable even
+when tools return huge text blobs.
+
+**How it works:** Hooks tool calls/results centrally and appends structured metadata to tool result
+`details`, which other features like diagnostics can reuse for consistent timing displays.
+
 ### ⚡ Compact Header (`compact-header`) — **default: on**
 
 Replaces the verbose default startup header with a dense one-liner showing model, provider, thinking
@@ -276,6 +348,33 @@ purpose metadata for pi-created worktrees.
 **Behavior:** pi-owned worktrees are created under shared pi storage, namespaced by the canonical
 repo root. Cleanup focuses on pi-owned worktrees only and leaves external/manual worktrees alone
 unless you explicitly intervene.
+
+### 📅 Scheduler (`scheduler`) — **default: on**
+
+Adds first-class reminders, recurring follow-ups, and future check-ins to pi.
+
+**Commands:** `/remind in 45m <prompt>` | `/loop 5m <prompt>` | `/loop cron '*/5 * * * *' <prompt>` |
+`/schedule` | `/schedule:tui` | `/schedule:list` | `/schedule:enable <id>` |
+`/schedule:disable <id>` | `/schedule:delete <id>` | `/schedule:clear` |
+`/schedule:clear-other` | `/schedule:adopt <id|all>` | `/schedule:release <id|all>` |
+`/schedule:clear-foreign`
+
+**Tool:** `schedule_prompt`
+
+**Behavior:** tasks run only while pi is active and idle, persist under shared pi storage, default
+to instance scope, and can opt into workspace scope for shared CI/build/deploy monitors. Use
+`continueUntilComplete` when a follow-up should keep retrying until a success marker appears.
+
+### 💬 BTW / QQ (`btw`) — **default: on**
+
+Creates a side-conversation widget above the editor so you can ask follow-up questions, think in
+parallel, or park a tangent without interrupting the main thread.
+
+**Commands:** `/btw` | `/btw:new` | `/btw:clear` | `/btw:inject` | `/btw:summarize` and the alias
+set `/qq`, `/qq:new`, `/qq:clear`, `/qq:inject`, `/qq:summarize`
+
+**Behavior:** keep a lightweight parallel thread, then either inject the full exchange into the main
+agent or inject a generated summary instead.
 
 ### ⏳ Background Process (`bg-process`) — **default: off**
 
@@ -367,6 +466,18 @@ Key usage-tracker surfaces:
 - `usage_report` so the agent can answer quota and spend questions directly
 
 <!-- {/extensionsUsageTrackerCommandsDocs} -->
+
+### 🛡️ Watchdog + Safe Mode (`watchdog`) — **default: on**
+
+Continuously samples runtime health so heavy sessions stay usable.
+
+**Commands:** `/watchdog` | `/watchdog:status` | `/watchdog:startup` | `/watchdog:overlay` |
+`/watchdog:dashboard` | `/watchdog:config` | `/watchdog:reset` | `/watchdog:on` |
+`/watchdog:off` | `/watchdog:sample` | `/watchdog:blame` | `/safe-mode [on|off|status]`
+
+**Behavior:** tracks CPU, memory, and event-loop lag; records recent samples and alerts; and can
+escalate into safe mode when repeated alerts suggest sustained UI churn. The optional config file
+lives at `~/.pi/agent/extensions/watchdog/config.json`.
 
 ### 🐜 Ant Colony (`ant-colony`) — **default: off**
 
@@ -470,6 +581,10 @@ Anthropic · OpenAI · Google Gemini · Groq · OpenRouter · xAI · Mistral
 
 ## Skills
 
+The tables below highlight the most commonly reached-for skills. For the full list of all 17 skills,
+plus the 5 AGENTS.md templates that ship in this repo, see
+[docs/feature-catalog.md](./docs/feature-catalog.md).
+
 ### 🔧 Tool Skills
 
 | Skill        | What it does                               |
@@ -541,6 +656,14 @@ cd oh-pi
 pnpm install
 ```
 
+<!-- {=repoContributorCompiledPackagesDocs} -->
+
+Most runtime packages in this repo ship raw TypeScript and can be loaded directly by pi. A smaller
+set of contributor-facing packages (`core`, `cli`, `web-client`, `web-server`) emit `dist/` output,
+so build those when you are working on them directly.
+
+<!-- {/repoContributorCompiledPackagesDocs} -->
+
 See [CONTRIBUTING.md](./CONTRIBUTING.md) for contributor workflow, changeset requirements, and PR guidelines.
 
 ### Commands
@@ -572,10 +695,68 @@ That keeps the repo-wide floor honest while still requiring new code paths in a 
 covered. CI uses the same `pnpm test:patch-coverage` command on pull requests, so local results and
 CI results stay aligned.
 
-### Test a local checkout in pi
+### Running locally & local development
 
-Use the repo-local source switcher to flip pi between the published npm packages and the packages in
-whatever checkout or worktree you want to test.
+<!-- {=repoPiLocalSwitcherOverviewDocs} -->
+
+The `pnpm pi:local` workflow points a real pi install at this checkout instead of the published npm
+packages. It is the normal local development loop for testing unpublished oh-pi changes in a real
+interactive pi session.
+
+<!-- {/repoPiLocalSwitcherOverviewDocs} -->
+
+#### Quick start
+
+<!-- {=repoPiLocalQuickstartDocs} -->
+
+```bash
+pnpm install
+pnpm pi:local
+pi
+```
+
+<!-- {/repoPiLocalQuickstartDocs} -->
+
+That is the normal developer loop for oh-pi feature work.
+
+#### What `pnpm pi:local` does
+
+<!-- {=repoPiLocalWhatItDoesDocs} -->
+
+`pnpm pi:local` runs the repo-local source switcher in `local` mode. It:
+
+- rewrites only the managed oh-pi package sources in your pi settings
+- points those package sources at the workspace packages in this checkout
+- preserves package-specific config objects already present in `settings.json`
+- refreshes package manifest paths so newly added extensions/prompts/skills/themes are picked up
+- runs `pi install` for newly added managed packages and `pi update` for packages you already had configured
+- manages the default installer set and the opt-in experimental packages used for local feature development
+- lets you validate unpublished changes from a branch, worktree, or detached checkout before release
+
+<!-- {/repoPiLocalWhatItDoesDocs} -->
+
+<!-- {=repoPiLocalManagedPackagesDocs} -->
+
+Managed local switching covers these packages:
+
+- `@ifi/oh-pi-extensions`
+- `@ifi/oh-pi-ant-colony`
+- `@ifi/pi-diagnostics`
+- `@ifi/pi-extension-subagents`
+- `@ifi/pi-plan`
+- `@ifi/pi-spec`
+- `@ifi/pi-web-remote`
+- `@ifi/oh-pi-themes`
+- `@ifi/oh-pi-prompts`
+- `@ifi/oh-pi-skills`
+- `@ifi/pi-extension-adaptive-routing`
+- `@ifi/pi-provider-catalog`
+- `@ifi/pi-provider-cursor`
+- `@ifi/pi-provider-ollama`
+
+<!-- {/repoPiLocalManagedPackagesDocs} -->
+
+#### Common commands
 
 ```bash
 pnpm pi:local                             # point pi at this checkout
@@ -586,23 +767,38 @@ pnpm pi:switch local -- --pi-local        # write into the current project's .pi
 pnpm pi:switch status                     # show the current managed package sources
 ```
 
-What it does:
+#### Typical local workflow
 
-- rewrites only the managed oh-pi package sources in your pi settings
-- preserves package-specific config objects already in `settings.json`, while refreshing local package manifests so newly added extensions like `worktree` are picked up
-- runs `pi install` for newly added managed packages and `pi update` for packages you already had configured
-- includes the experimental provider packages in addition to the main installer set, including `@ifi/pi-provider-catalog`
-- lets you validate a branch or detached worktree before you publish
+1. `pnpm install`
+2. `pnpm pi:local`
+3. Fully restart `pi`
+4. Exercise the feature in a real pi session
+5. Make changes in this repo
+6. Restart `pi` again when the package source or loaded modules need a clean reload
+7. Switch back with `pnpm pi:published` when you want the published packages again
 
-After switching, fully restart `pi`. Do not rely on `/reload` for source switches because it can
-keep previously loaded package modules alive.
+#### Important restart note
+
+<!-- {=repoPiSourceSwitchRestartDocs} -->
+
+After switching package sources, fully restart `pi`. Do not rely on `/reload` for source switches,
+because it can keep previously loaded package modules alive.
+
+<!-- {/repoPiSourceSwitchRestartDocs} -->
+
+#### When to re-run installs or builds
+
+<!-- {=repoPiLocalInstallFreshnessDocs} -->
 
 If you recently pulled, rebased, or switched branches in the checkout you pointed `pi` at, run
 `pnpm install --frozen-lockfile` there before restarting `pi`. Local source mode loads workspace
 files directly, so stale `node_modules` can surface missing internal `@ifi/*` package errors.
 
-This is intended to be the normal development loop for testing a branch locally before cutting a
-release.
+<!-- {/repoPiLocalInstallFreshnessDocs} -->
+
+If you are changing one of the compiled contributor packages (`@ifi/oh-pi-core`, `@ifi/oh-pi-cli`,
+`@ifi/pi-web-client`, or `@ifi/pi-web-server`), also run the relevant build command or `pnpm build`
+so their emitted `dist/` output stays current.
 
 ### Changesets
 
@@ -651,27 +847,33 @@ calling `knope release`. Use `--dry-run` to preview without making changes.
 ```
 oh-pi/
 ├── packages/
-│   ├── core/                   Shared types, registry, i18n (compiled)
-│   ├── cli/                    TUI configurator binary (compiled)
-│   ├── extensions/             9 pi extensions (raw .ts)
+│   ├── core/                   Shared types, registries, icons, i18n, and path helpers (compiled)
+│   ├── cli/                    Interactive TUI configurator (compiled)
+│   ├── extensions/             13 core pi extensions (raw .ts)
+│   ├── diagnostics/            Prompt completion timing extension (raw .ts)
 │   ├── ant-colony/             Multi-agent swarm extension (raw .ts)
 │   ├── subagents/              Subagent orchestration package (raw .ts)
-│   ├── shared-qna/             Shared Q&A TUI helper library (raw .ts)
 │   ├── plan/                   Planning mode extension (raw .ts)
 │   ├── spec/                   Native spec-driven workflow package (raw .ts)
+│   ├── adaptive-routing/       Optional adaptive/delegated routing package (raw .ts)
+│   ├── providers/              Experimental provider catalog package (raw .ts)
 │   ├── cursor/                 Experimental Cursor OAuth provider package (raw .ts)
 │   ├── ollama/                 Experimental Ollama local + cloud provider package (raw .ts)
+│   ├── web-remote/             `/remote` session sharing extension (raw .ts)
+│   ├── web-client/             Remote session client library (compiled)
+│   ├── web-server/             Remote session server library (compiled)
+│   ├── shared-qna/             Shared Q&A TUI helper library (raw .ts)
 │   ├── themes/                 6 JSON theme files
 │   ├── prompts/                10 markdown prompt templates
-│   ├── skills/                 12 skill directories
+│   ├── skills/                 17 skill directories
 │   ├── agents/                 5 AGENTS.md templates
 │   └── oh-pi/                  Installer CLI (npx @ifi/oh-pi)
-├── docs/                  Full documentation
-├── benchmarks/            Performance benchmarks
-├── .changeset/            Pending changesets (knope)
-├── CHANGELOG.md           Release history
-├── knope.toml             Release automation config
-└── biome.json             Linter + formatter config
+├── docs/                       Full documentation
+├── benchmarks/                 Performance benchmarks
+├── .changeset/                 Pending changesets (knope)
+├── CHANGELOG.md                Release history
+├── knope.toml                  Release automation config
+└── biome.json                  Linter + formatter config
 ```
 
 ## License

--- a/docs/00-index.md
+++ b/docs/00-index.md
@@ -106,6 +106,7 @@ oh-pi repo
 │   └── @ifi/oh-pi
 ├── default runtime packages
 │   ├── extensions
+│   ├── background-tasks
 │   ├── diagnostics
 │   ├── ant-colony
 │   ├── subagents

--- a/docs/00-index.md
+++ b/docs/00-index.md
@@ -13,6 +13,7 @@
 | 05  | [Skills/Prompts/Themes/Packages](05-skills-prompts-themes-packages.md) | Skill packs, prompt templates, theme customization, package management and distribution        |
 | 06  | [Settings/SDK/RPC/TUI](06-settings-sdk-rpc-tui.md)                     | All settings, SDK programming interface, RPC protocol, TUI component system, custom models     |
 | 07  | [CLI Reference](07-cli-reference.md)                                   | Complete CLI options, directory structure, platform support, key numbers                       |
+| 08  | [oh-pi Feature Catalog](feature-catalog.md)                            | Package-by-package feature inventory, local dev loop, runtime/content package ownership        |
 
 ## Core Concepts Quick Reference
 
@@ -81,6 +82,69 @@ CLI flags > project .pi/settings.json > global ~/.pi/agent/settings.json
 ```
 --api-key > auth.json > environment variables > models.json
 ```
+
+## Start here
+
+<!-- {=repoStartHerePathDocs} -->
+
+Use this reading path depending on what you are trying to do:
+
+- **I just want to use oh-pi** → start in the root `README.md`, then jump into `docs/feature-catalog.md` for package-by-package detail
+- **I want to try the latest local changes** → run `pnpm install`, `pnpm pi:local`, restart `pi`, then exercise the feature in a real session
+- **I want to contribute** → read `CONTRIBUTING.md`, then the package README for the area you are changing
+- **I want to understand ownership** → use `docs/feature-catalog.md` to see which package owns which runtime feature, content pack, or library surface
+
+<!-- {/repoStartHerePathDocs} -->
+
+### Architecture at a glance
+
+<!-- {=repoArchitectureAtAGlanceDocs} -->
+
+```text
+oh-pi repo
+├── installer
+│   └── @ifi/oh-pi
+├── default runtime packages
+│   ├── extensions
+│   ├── diagnostics
+│   ├── ant-colony
+│   ├── subagents
+│   ├── plan
+│   ├── spec
+│   └── web-remote
+├── content packs
+│   ├── themes
+│   ├── prompts
+│   ├── skills
+│   └── agents
+├── opt-in extras
+│   ├── adaptive-routing
+│   ├── provider-catalog
+│   ├── provider-cursor
+│   └── provider-ollama
+└── contributor libraries
+    ├── core
+    ├── cli
+    ├── shared-qna
+    ├── web-client
+    └── web-server
+```
+
+<!-- {/repoArchitectureAtAGlanceDocs} -->
+
+## Suggested contributor reading path
+
+<!-- {=repoContributorReadingPathDocs} -->
+
+Suggested path for a new contributor:
+
+1. skim the root `README.md` for the package map and the local dev loop
+2. read `docs/feature-catalog.md` to understand which package owns which feature
+3. run `pnpm install` and `pnpm pi:local`
+4. restart `pi` and exercise the feature in a real session
+5. open the package README for the area you are changing, then run the relevant build/test commands
+
+<!-- {/repoContributorReadingPathDocs} -->
 
 ## Value for oh-pi
 

--- a/docs/feature-catalog.md
+++ b/docs/feature-catalog.md
@@ -1,0 +1,548 @@
+# oh-pi Feature Catalog
+
+A package-by-package inventory of the features currently shipped in this repo.
+
+This document is the long-form companion to the root [README](../README.md). Use it when you want
+one place that answers:
+
+- what `npx @ifi/oh-pi` installs by default
+- which features are opt-in add-ons
+- which commands, tools, shortcuts, and workflows each package adds
+- which content packs ship in the repo
+- which packages are mainly contributor-facing libraries
+
+<!-- {=repoStartHerePathDocs} -->
+
+Use this reading path depending on what you are trying to do:
+
+- **I just want to use oh-pi** → start in the root `README.md`, then jump into `docs/feature-catalog.md` for package-by-package detail
+- **I want to try the latest local changes** → run `pnpm install`, `pnpm pi:local`, restart `pi`, then exercise the feature in a real session
+- **I want to contribute** → read `CONTRIBUTING.md`, then the package README for the area you are changing
+- **I want to understand ownership** → use `docs/feature-catalog.md` to see which package owns which runtime feature, content pack, or library surface
+
+<!-- {/repoStartHerePathDocs} -->
+
+### Architecture at a glance
+
+<!-- {=repoArchitectureAtAGlanceDocs} -->
+
+```text
+oh-pi repo
+├── installer
+│   └── @ifi/oh-pi
+├── default runtime packages
+│   ├── extensions
+│   ├── diagnostics
+│   ├── ant-colony
+│   ├── subagents
+│   ├── plan
+│   ├── spec
+│   └── web-remote
+├── content packs
+│   ├── themes
+│   ├── prompts
+│   ├── skills
+│   └── agents
+├── opt-in extras
+│   ├── adaptive-routing
+│   ├── provider-catalog
+│   ├── provider-cursor
+│   └── provider-ollama
+└── contributor libraries
+    ├── core
+    ├── cli
+    ├── shared-qna
+    ├── web-client
+    └── web-server
+```
+
+<!-- {/repoArchitectureAtAGlanceDocs} -->
+
+<!-- {=repoContributorReadingPathDocs} -->
+
+Suggested path for a new contributor:
+
+1. skim the root `README.md` for the package map and the local dev loop
+2. read `docs/feature-catalog.md` to understand which package owns which feature
+3. run `pnpm install` and `pnpm pi:local`
+4. restart `pi` and exercise the feature in a real session
+5. open the package README for the area you are changing, then run the relevant build/test commands
+
+<!-- {/repoContributorReadingPathDocs} -->
+
+## Install tiers at a glance
+
+### Installed by `npx @ifi/oh-pi`
+
+<!-- {=repoDefaultInstallerPackagesDocs} -->
+
+Default runtime/content packages installed by `npx @ifi/oh-pi`:
+
+- `@ifi/oh-pi-extensions`
+- `@ifi/oh-pi-ant-colony`
+- `@ifi/pi-diagnostics`
+- `@ifi/pi-extension-subagents`
+- `@ifi/pi-plan`
+- `@ifi/pi-spec`
+- `@ifi/pi-web-remote`
+- `@ifi/oh-pi-themes`
+- `@ifi/oh-pi-prompts`
+- `@ifi/oh-pi-skills`
+
+<!-- {/repoDefaultInstallerPackagesDocs} -->
+
+### Opt-in packages
+
+<!-- {=repoExperimentalPackagesDocs} -->
+
+Opt-in packages that stay separate from the default installer bundle:
+
+- `@ifi/pi-extension-adaptive-routing`
+- `@ifi/pi-provider-catalog`
+- `@ifi/pi-provider-cursor`
+- `@ifi/pi-provider-ollama`
+
+<!-- {/repoExperimentalPackagesDocs} -->
+
+### Contributor-facing/internal packages
+
+These are important parts of the codebase, but they are primarily consumed by other packages or by
+people extending oh-pi:
+
+<!-- {=repoContributorCompiledPackagesDocs} -->
+
+Most runtime packages in this repo ship raw TypeScript and can be loaded directly by pi. A smaller
+set of contributor-facing packages (`core`, `cli`, `web-client`, `web-server`) emit `dist/` output,
+so build those when you are working on them directly.
+
+<!-- {/repoContributorCompiledPackagesDocs} -->
+
+- [`@ifi/oh-pi-cli`](../packages/cli)
+- [`@ifi/oh-pi-core`](../packages/core)
+- [`@ifi/pi-shared-qna`](../packages/shared-qna)
+- [`@ifi/pi-web-client`](../packages/web-client)
+- [`@ifi/pi-web-server`](../packages/web-server)
+- [`@ifi/oh-pi-agents`](../packages/agents)
+
+## Runtime feature map
+
+| Package | Installs by default | Primary surfaces | What it gives you |
+| --- | --- | --- | --- |
+| [`@ifi/oh-pi-extensions`](../packages/extensions) | Yes | commands, tools, widgets, footer, tool interception | The core QoL extension pack: git safety, session naming, status UI, backgrounding, scheduling, usage, watchdog, worktrees, side-conversations, and more |
+| [`@ifi/pi-diagnostics`](../packages/diagnostics) | Yes | widget, session messages, `/diagnostics`, `Ctrl+Shift+D` | Prompt start/end timestamps, total duration, and per-turn timing |
+| [`@ifi/oh-pi-ant-colony`](../packages/ant-colony) | Yes | `ant_colony` tool, `/colony*`, `Ctrl+Shift+A` | Multi-agent swarm with scouts/workers/soldiers, isolated worktrees, pheromones, adaptive concurrency, and review passes |
+| [`@ifi/pi-extension-subagents`](../packages/subagents) | Yes | `subagent`, `subagent_status`, `/run`, `/chain`, `/parallel`, `/agents`, `Ctrl+Shift+A` | Rich delegated execution with built-in agents, reusable chains, background runs, and a TUI manager |
+| [`@ifi/pi-plan`](../packages/plan) | Yes | `/plan`, `Alt+P`, plan-mode tools | Branch-aware planning workflow with persistent plan files and delegated research tasks |
+| [`@ifi/pi-spec`](../packages/spec) | Yes | `/spec` and `spec:*` subcommands | Native spec-first workflow with deterministic `.specify/` and `specs/###-feature-name/` artifacts |
+| [`@ifi/pi-web-remote`](../packages/web-remote) | Yes | `/remote` | Share the current pi session through a remote web UI |
+| [`@ifi/pi-extension-adaptive-routing`](../packages/adaptive-routing) | No | `/route*` | Adaptive/shadow routing and delegated startup categories for colonies and subagents |
+| [`@ifi/pi-provider-catalog`](../packages/providers) | No | `/providers*` | Multi-provider catalog and lazy API-key login backed by `models.dev` |
+| [`@ifi/pi-provider-cursor`](../packages/cursor) | No | `/login cursor`, `/cursor*` | Experimental Cursor OAuth provider with model discovery and direct AgentService streaming |
+| [`@ifi/pi-provider-ollama`](../packages/ollama) | No | `/login ollama-cloud`, `/ollama*`, `/model` | Experimental Ollama local + cloud provider integration |
+
+## `@ifi/oh-pi-extensions`: core extension pack
+
+This package is where most of the day-to-day ergonomics live.
+
+### Included extensions
+
+| Feature | Primary surfaces | What it does |
+| --- | --- | --- |
+| `git-guard` | automatic stash checkpoints, guarded git invocations | Reduces accidental code loss and blocks interactive git commands that would hang an agent session |
+| `auto-session-name` | automatic session titles, better compaction continuity | Names sessions from user intent, keeps titles fresh as focus changes, and emits clearer resume hints |
+| `custom-footer` | live footer, `/status` overlay | Shows model, thinking level, token usage, cost, context %, cwd, branch, worktree state, and extension statuses |
+| `compact-header` | startup UI | Replaces the default startup banner with a denser one-line header |
+| `tool-metadata` | tool result details | Adds start/end timestamps, duration, approximate I/O sizing, and context snapshots to tool results; also sanitizes huge outputs for UI safety |
+| `auto-update` | startup notification | Checks npm asynchronously and tells you when a newer oh-pi release is available |
+| `external-editor` | `/external-editor`, `Ctrl+Shift+E` | Opens the current draft in `$VISUAL` or `$EDITOR`, then syncs the saved text back into pi |
+| `worktree` | `/worktree`, `/worktree list`, `/worktree create`, `/worktree cleanup` | Gives oh-pi first-class git worktree awareness and managed pi-owned worktrees under shared storage |
+| `bg-process` | `bash` override, `bg_status` tool | Automatically detaches long-running commands after a timeout and lets the agent inspect/stop them later |
+| `scheduler` | `/remind`, `/loop`, `/schedule*`, `schedule_prompt` tool | Schedules one-time reminders and recurring follow-ups for builds, CI, deploys, PRs, and long-running checks |
+| `usage-tracker` | widget, `/usage`, `/usage-toggle`, `/usage-refresh`, `Ctrl+U`, `usage_report` | Tracks provider quotas, rolling cost history, and per-model/session usage |
+| `btw` / `qq` | `/btw*`, `/qq*` | Runs side conversations in a widget above the editor, then injects the full thread or a summary back into the main agent |
+| `watchdog` / `safe-mode` | `/watchdog*`, `/safe-mode` | Samples runtime health, records alerts, shows startup/blame dashboards, and can reduce UI churn when the session gets too heavy |
+
+### Scheduler details
+
+The scheduler is one of the most important workflow additions because it turns pi into something that
+can check back later instead of requiring you to babysit every long-running task.
+
+Key behaviors:
+
+- one-time reminders with `/remind in 45m ...`
+- recurring checks with `/loop 5m ...` or cron expressions
+- shared `schedule_prompt` tool so the agent can set reminders or monitors for you
+- instance-scoped tasks by default, with explicit workspace-scoped tasks for shared CI/build/deploy monitors
+- adopt/release/clear-foreign flows so multiple pi instances do not silently fight over the same scheduler state
+- persisted scheduler state under shared pi storage using a workspace-mirrored path
+- `continueUntilComplete` support for retries until a completion signal is detected
+
+### Usage tracker details
+
+The usage tracker is designed to answer both quick and deep questions about cost and quota.
+
+It provides:
+
+- an always-visible widget above the editor
+- a full dashboard overlay via `/usage`
+- provider quota probes for Anthropic, OpenAI, and Google when pi-managed auth is available
+- rolling 30-day persisted history so the view survives restarts
+- session totals and per-model breakdowns
+- agent-callable `usage_report` output for quota/cost questions
+- integration with ant-colony usage streams so colony cost is visible too
+
+### Watchdog details
+
+The watchdog focuses on keeping interactive pi sessions usable as more extensions and UI surfaces are
+loaded.
+
+It includes:
+
+- periodic CPU, memory, and event-loop sampling
+- a config file under `~/.pi/agent/extensions/watchdog/config.json`
+- capped alerting so the UI does not spam you when the system is already under stress
+- startup breakdown reporting
+- blame reporting to understand recent pressure
+- safe-mode toggles to reduce nonessential UI churn when repeated alerts occur
+
+## `@ifi/pi-diagnostics`: prompt timing
+
+`@ifi/pi-diagnostics` adds prompt-level completion timing on top of the lower-level tool timing that
+`tool-metadata` already records.
+
+Primary surfaces:
+
+- widget below the editor
+- diagnostic session log entry after each prompt completes
+- per-turn timing breakdown when a prompt took multiple assistant turns
+- `/diagnostics [status|toggle|on|off]`
+- `Ctrl+Shift+D`
+
+Use it when you want to answer questions like:
+
+- “When did this prompt actually start?”
+- “Did the slowdown happen in one long turn or several short turns?”
+- “How long did this full interaction take end-to-end?”
+
+## `@ifi/oh-pi-ant-colony`: autonomous swarm execution
+
+Ant-colony is the flagship large-task execution feature.
+
+### Core behaviors
+
+- scout/worker/soldier castes with different responsibilities
+- adaptive concurrency instead of a fixed worker count
+- shared pheromone communication instead of direct ant-to-ant chat
+- per-task file locking so conflicting edits do not happen simultaneously
+- optional isolated git worktrees by default, with shared-cwd fallback
+- resumable colony state under shared storage
+- auto-triggering for large multi-file or parallelizable tasks
+- streaming usage into the usage tracker
+- delegated routing categories when adaptive routing is installed
+
+### Primary surfaces
+
+- `ant_colony` tool
+- `/colony <goal>`
+- `/colony-count`
+- `/colony-status [id]`
+- `/colony-stop [id|all]`
+- `/colony-resume [colonyId]`
+- `Ctrl+Shift+A` colony panel
+
+### Best-fit use cases
+
+Use ant-colony for:
+
+- multi-file refactors
+- migrations
+- parallelizable test-writing sweeps
+- coordinated review/rework loops
+- large feature additions that benefit from scouting + implementation + review phases
+
+## `@ifi/pi-extension-subagents`: delegated execution runtime
+
+Subagents is the other major execution system, but it is more explicit and user-directed than
+ant-colony.
+
+### Major capabilities
+
+- single-agent runs via `subagent` or `/run`
+- sequential chains via `subagent.chain` or `/chain`
+- parallel fan-out via `subagent.tasks` or `/parallel`
+- reusable agent definitions stored as markdown with YAML frontmatter
+- reusable `.chain.md` pipelines
+- background execution with async status inspection
+- built-in agents such as `scout`, `planner`, `worker`, `reviewer`, `researcher`, `artist`, and `frontend-designer`
+- TUI-based create/edit/browse/run flows in the Agents Manager
+- management actions for creating, updating, and deleting agents/chains
+- project-scope agent storage in shared pi storage by default, with legacy repo-local mode available as an opt-in
+- optional delegated routing categories via adaptive routing
+- optional direct MCP tools when frontmatter explicitly asks for them
+
+### Primary surfaces
+
+- `subagent`
+- `subagent_status`
+- `/run <agent> <task>`
+- `/chain ...`
+- `/parallel ...`
+- `/agents`
+- `Ctrl+Shift+A`
+
+### When to prefer subagents over ant-colony
+
+Prefer subagents when you want:
+
+- explicit named specialists
+- reusable pipelines
+- a controlled chain of reasoning between steps
+- agent definitions you can version and tweak directly
+- background execution that you can inspect as a single run
+
+## `@ifi/pi-plan`: plan mode
+
+Plan mode turns planning into a first-class session state instead of an informal prompt style.
+
+### What it adds
+
+- `/plan` to enter/exit plan mode
+- `Alt+P` shortcut
+- persistent plan file handling per session
+- branch-aware start location choices (`Empty branch` or `Current branch` when available)
+- resume/start-fresh flows when a plan already exists
+- an active plan banner while plan mode is enabled
+- end-of-plan summary with the plan file path and preview
+
+### Plan-only tools
+
+While active, plan mode exposes tools that are not available the rest of the time:
+
+- `task_agents` — read-only delegated research tasks
+- `steer_task_agent` — rerun a specific research task with extra guidance
+- `request_user_input` — gather structured clarification from the user
+- `set_plan` — overwrite the canonical plan file with the latest full plan
+
+Plan mode is best when you want structured planning without jumping directly into implementation.
+
+## `@ifi/pi-spec`: native spec-first workflow
+
+`@ifi/pi-spec` adapts spec-kit ideas to pi as a native TypeScript extension package.
+
+### Canonical `/spec` subcommands
+
+- `status`
+- `help`
+- `init`
+- `constitution`
+- `specify`
+- `clarify`
+- `checklist`
+- `plan`
+- `tasks`
+- `analyze`
+- `implement`
+- `list`
+- `next`
+
+### Filesystem contract
+
+The public API is not just the command surface. It is also the file layout created in the repo:
+
+- `.specify/` for reusable workflow state and editable templates
+- `specs/###-feature-name/` for per-feature artifacts such as `spec.md`, `plan.md`, `tasks.md`, research notes, data models, quickstart notes, contracts, and checklists
+
+### Why it matters
+
+Use `@ifi/pi-spec` when you want:
+
+- requirements before implementation
+- visible workflow state in git
+- deterministic scaffolding
+- project-owned templates you can customize after initialization
+- a spec/plan/tasks flow that feels native inside pi instead of shell-script-driven
+
+## `@ifi/pi-web-remote`: remote session sharing
+
+This package adds `/remote` so a pi session can be shared through a browser-oriented remote UI.
+
+Primary actions:
+
+- start remote access for the current session
+- expose a connection URL or tunnel-backed URL
+- inspect connection status
+- stop remote sharing via `/remote stop`
+
+This package sits on top of the lower-level `@ifi/pi-web-server` and `@ifi/pi-web-client`
+libraries.
+
+## Optional routing and provider packages
+
+### `@ifi/pi-extension-adaptive-routing`
+
+Purpose:
+
+- shadow-routing or auto-routing decisions for prompts
+- delegated startup categories for subagents and ant-colony when no explicit model override is set
+- telemetry and explainability around why a model/provider was picked
+
+Primary commands:
+
+- `/route status`
+- `/route auto`
+- `/route shadow`
+- `/route off`
+- `/route explain`
+- `/route assignments`
+- `/route why <category|role-override> [task text]`
+- `/route stats`
+- `/route lock`
+- `/route unlock`
+- `/route refresh`
+- `/route feedback`
+
+### `@ifi/pi-provider-catalog`
+
+Purpose:
+
+- register a large catalog of API-key providers from OpenCode `models.dev`
+- avoid dumping every possible provider into pi's global login picker up front
+- let users lazily enable the ones they actually want
+
+Primary commands:
+
+- `/providers:status`
+- `/providers:list [query]`
+- `/providers:login [provider]`
+- `/providers:info <provider>`
+- `/providers:models <provider>`
+- `/providers:refresh-models [provider|all]`
+
+### `@ifi/pi-provider-cursor`
+
+Purpose:
+
+- Cursor OAuth login from pi
+- model discovery and refresh
+- direct streaming from Cursor's AgentService transport
+- continued tool-call bridging across pi tool rounds
+
+Primary commands:
+
+- `/login cursor`
+- `/cursor status`
+- `/cursor refresh-models`
+- `/cursor clear-state`
+
+### `@ifi/pi-provider-ollama`
+
+Purpose:
+
+- local Ollama daemon discovery
+- cloud Ollama login and catalog discovery
+- model metadata, browsing, and pulling from inside pi
+
+Primary commands:
+
+- `/ollama:status`
+- `/ollama:refresh-models`
+- `/ollama:models`
+- `/ollama:info <model>`
+- `/ollama:pull <model>`
+- `/login ollama-cloud`
+
+## Content packs
+
+## `@ifi/oh-pi-prompts`
+
+The prompt template pack ships 10 ready-made slash commands.
+
+| Prompt | Purpose |
+| --- | --- |
+| `/review` | Review code for bugs, security issues, missing error handling, performance issues, and readability problems |
+| `/fix` | Fix a bug with minimal changes and explain the root cause |
+| `/explain` | Explain code or a concept from one-line summary through trade-offs and edge cases |
+| `/refactor` | Refactor while preserving behavior |
+| `/test` | Generate tests using the project's existing framework |
+| `/commit` | Generate a Conventional Commit message from staged changes |
+| `/document` | Generate or update technical documentation |
+| `/optimize` | Analyze and improve performance without premature micro-optimization |
+| `/security` | Run an OWASP-style security audit |
+| `/pr` | Draft a pull request description |
+
+## `@ifi/oh-pi-skills`
+
+The skills pack currently ships 17 skills.
+
+| Skill | What it is for |
+| --- | --- |
+| `btw` | Use the `/btw` or `/qq` side-conversation workflow effectively |
+| `claymorphism` | Build soft, puffy clay-like interfaces |
+| `context7` | Query up-to-date library and framework docs through Context7 |
+| `debug-helper` | Analyze errors, logs, crashes, and performance issues |
+| `flutter-serverpod-mvp` | Scaffold and evolve Flutter + Serverpod MVPs |
+| `git-workflow` | Branching, commits, PRs, and merge/conflict workflow help |
+| `glassmorphism` | Build frosted-glass style interfaces |
+| `grill-me` | Stress-test a plan or design through adversarial questioning |
+| `improve-codebase-architecture` | Find architecture improvements that deepen modules and improve testability |
+| `liquid-glass` | Build Apple Liquid Glass-inspired interfaces |
+| `neubrutalism` | Build bold, thick-bordered, offset-shadow interfaces |
+| `quick-setup` | Detect project type and generate `.pi/` config |
+| `request-refactor-plan` | Interview the user, create a tiny-commit refactor plan, and file it as a GitHub issue |
+| `rust-workspace-bootstrap` | Scaffold a production Rust workspace with knope, devenv, and CI/release workflows |
+| `web-fetch` | Fetch a web page and extract readable content |
+| `web-search` | Search the web via DuckDuckGo |
+| `write-a-skill` | Author new pi-compatible skills correctly |
+
+## `@ifi/oh-pi-themes`
+
+The theme pack currently ships 6 themes.
+
+| Theme | Style |
+| --- | --- |
+| `oh-p-dark` | First-party cyan/purple dark theme |
+| `cyberpunk` | Neon magenta + electric cyan |
+| `nord` | Arctic blue palette |
+| `catppuccin-mocha` | Pastel-on-dark palette |
+| `tokyo-night` | Blue/purple twilight palette |
+| `gruvbox-dark` | Warm retro dark palette |
+
+## `@ifi/oh-pi-agents`
+
+The AGENTS template pack currently ships 5 templates.
+
+| Template | Focus |
+| --- | --- |
+| `general-developer` | Safe default project guidelines for everyday development |
+| `fullstack-developer` | Full-stack application architecture, quality, and git conventions |
+| `security-researcher` | Security testing/reporting workflow and ethics |
+| `data-ai-engineer` | Data pipelines, AI/ML reproducibility, and infra discipline |
+| `colony-operator` | When and how to delegate work to ant-colony |
+
+## Contributor-facing packages and libraries
+
+| Package | Role |
+| --- | --- |
+| [`@ifi/oh-pi`](../packages/oh-pi) | Meta-installer that registers the default bundle with pi |
+| [`@ifi/oh-pi-cli`](../packages/cli) | Interactive setup/configuration TUI with provider/model/routing/package selection flows |
+| [`@ifi/oh-pi-core`](../packages/core) | Shared registries, icons, i18n helpers, and path helpers for the pi agent directory and shared storage |
+| [`@ifi/pi-shared-qna`](../packages/shared-qna) | Reusable TUI Q&A helpers and shared `pi-tui` loading logic |
+| [`@ifi/pi-web-client`](../packages/web-client) | Platform-agnostic TypeScript client for custom remote session UIs |
+| [`@ifi/pi-web-server`](../packages/web-server) | Embeddable HTTP + WebSocket remote session server |
+
+## Which feature should I reach for?
+
+- **Safer day-to-day pi sessions** → `@ifi/oh-pi-extensions`
+- **Timing and completion visibility** → `@ifi/pi-diagnostics`
+- **Large parallel work** → `@ifi/oh-pi-ant-colony`
+- **Named specialists and reusable pipelines** → `@ifi/pi-extension-subagents`
+- **Structured planning without implementing yet** → `@ifi/pi-plan`
+- **Spec-first product development** → `@ifi/pi-spec`
+- **Remote access from a browser UI** → `@ifi/pi-web-remote`
+- **Automatic or explainable model routing** → `@ifi/pi-extension-adaptive-routing`
+- **Extra API-key providers** → `@ifi/pi-provider-catalog`
+- **Cursor integration** → `@ifi/pi-provider-cursor`
+- **Ollama local/cloud integration** → `@ifi/pi-provider-ollama`
+
+For the local development loop that points a real pi install at this checkout, see the root
+[README running locally section](../README.md#running-locally--local-development).

--- a/docs/feature-catalog.md
+++ b/docs/feature-catalog.md
@@ -32,6 +32,7 @@ oh-pi repo
 │   └── @ifi/oh-pi
 ├── default runtime packages
 │   ├── extensions
+│   ├── background-tasks
 │   ├── diagnostics
 │   ├── ant-colony
 │   ├── subagents
@@ -79,6 +80,7 @@ Suggested path for a new contributor:
 Default runtime/content packages installed by `npx @ifi/oh-pi`:
 
 - `@ifi/oh-pi-extensions`
+- `@ifi/pi-background-tasks`
 - `@ifi/oh-pi-ant-colony`
 - `@ifi/pi-diagnostics`
 - `@ifi/pi-extension-subagents`
@@ -128,7 +130,8 @@ so build those when you are working on them directly.
 
 | Package | Installs by default | Primary surfaces | What it gives you |
 | --- | --- | --- | --- |
-| [`@ifi/oh-pi-extensions`](../packages/extensions) | Yes | commands, tools, widgets, footer, tool interception | The core QoL extension pack: git safety, session naming, status UI, backgrounding, scheduling, usage, watchdog, worktrees, side-conversations, and more |
+| [`@ifi/oh-pi-extensions`](../packages/extensions) | Yes | commands, tools, widgets, footer, tool interception | The core QoL extension pack: git safety, session naming, status UI, scheduling, usage, watchdog, worktrees, side-conversations, and more |
+| [`@ifi/pi-background-tasks`](../packages/background-tasks) | Yes | `bg_task`, `bg_status`, `/bg`, `Ctrl+Shift+B` | Reactive background shell task management with log tails, watches, wakeups, and a richer tracked-task model |
 | [`@ifi/pi-diagnostics`](../packages/diagnostics) | Yes | widget, session messages, `/diagnostics`, `Ctrl+Shift+D` | Prompt start/end timestamps, total duration, and per-turn timing |
 | [`@ifi/oh-pi-ant-colony`](../packages/ant-colony) | Yes | `ant_colony` tool, `/colony*`, `Ctrl+Shift+A` | Multi-agent swarm with scouts/workers/soldiers, isolated worktrees, pheromones, adaptive concurrency, and review passes |
 | [`@ifi/pi-extension-subagents`](../packages/subagents) | Yes | `subagent`, `subagent_status`, `/run`, `/chain`, `/parallel`, `/agents`, `Ctrl+Shift+A` | Rich delegated execution with built-in agents, reusable chains, background runs, and a TUI manager |
@@ -204,6 +207,26 @@ It includes:
 - startup breakdown reporting
 - blame reporting to understand recent pressure
 - safe-mode toggles to reduce nonessential UI churn when repeated alerts occur
+
+## `@ifi/pi-background-tasks`: reactive background shell tasks
+
+This package promotes long-running shell commands from an implementation detail into a first-class pi workflow.
+
+### Primary surfaces
+
+- `bg_task`
+- `bg_status`
+- `/bg`
+- `Ctrl+Shift+B`
+- `/bg watch --follow <id>`
+
+### What it adds beyond the older `bg-process` shim
+
+- tracked tasks with stable ids in addition to PID-based compatibility status
+- persistent log files for every spawned task
+- reactive follow-ups so pi can wake itself up when watched tasks emit new output or exit
+- richer manual management through `/bg` and the dashboard overlay
+- compatibility with the old `bg_status` flow while offering a more capable `bg_task` tool for the agent
 
 ## `@ifi/pi-diagnostics`: prompt timing
 
@@ -533,6 +556,7 @@ The AGENTS template pack currently ships 5 templates.
 ## Which feature should I reach for?
 
 - **Safer day-to-day pi sessions** → `@ifi/oh-pi-extensions`
+- **Long-running shell commands, watches, and log tails** → `@ifi/pi-background-tasks`
 - **Timing and completion visibility** → `@ifi/pi-diagnostics`
 - **Large parallel work** → `@ifi/oh-pi-ant-colony`
 - **Named specialists and reusable pipelines** → `@ifi/pi-extension-subagents`

--- a/docs/mdt/oh-pi-docs.t.md
+++ b/docs/mdt/oh-pi-docs.t.md
@@ -337,6 +337,7 @@ oh-pi repo
 │   └── @ifi/oh-pi
 ├── default runtime packages
 │   ├── extensions
+│   ├── background-tasks
 │   ├── diagnostics
 │   ├── ant-colony
 │   ├── subagents
@@ -368,6 +369,7 @@ oh-pi repo
 Default runtime/content packages installed by `npx @ifi/oh-pi`:
 
 - `@ifi/oh-pi-extensions`
+- `@ifi/pi-background-tasks`
 - `@ifi/oh-pi-ant-colony`
 - `@ifi/pi-diagnostics`
 - `@ifi/pi-extension-subagents`
@@ -436,6 +438,7 @@ pi
 Managed local switching covers these packages:
 
 - `@ifi/oh-pi-extensions`
+- `@ifi/pi-background-tasks`
 - `@ifi/oh-pi-ant-colony`
 - `@ifi/pi-diagnostics`
 - `@ifi/pi-extension-subagents`

--- a/docs/mdt/oh-pi-docs.t.md
+++ b/docs/mdt/oh-pi-docs.t.md
@@ -317,3 +317,164 @@ kept visible in the status bar and the `/watchdog` overlay instead of repeatedly
 terminal.
 
 <!-- {/extensionsWatchdogAlertBehaviorDocs} -->
+
+<!-- {@repoStartHerePathDocs} -->
+
+Use this reading path depending on what you are trying to do:
+
+- **I just want to use oh-pi** → start in the root `README.md`, then jump into `docs/feature-catalog.md` for package-by-package detail
+- **I want to try the latest local changes** → run `pnpm install`, `pnpm pi:local`, restart `pi`, then exercise the feature in a real session
+- **I want to contribute** → read `CONTRIBUTING.md`, then the package README for the area you are changing
+- **I want to understand ownership** → use `docs/feature-catalog.md` to see which package owns which runtime feature, content pack, or library surface
+
+<!-- {/repoStartHerePathDocs} -->
+
+<!-- {@repoArchitectureAtAGlanceDocs} -->
+
+```text
+oh-pi repo
+├── installer
+│   └── @ifi/oh-pi
+├── default runtime packages
+│   ├── extensions
+│   ├── diagnostics
+│   ├── ant-colony
+│   ├── subagents
+│   ├── plan
+│   ├── spec
+│   └── web-remote
+├── content packs
+│   ├── themes
+│   ├── prompts
+│   ├── skills
+│   └── agents
+├── opt-in extras
+│   ├── adaptive-routing
+│   ├── provider-catalog
+│   ├── provider-cursor
+│   └── provider-ollama
+└── contributor libraries
+    ├── core
+    ├── cli
+    ├── shared-qna
+    ├── web-client
+    └── web-server
+```
+
+<!-- {/repoArchitectureAtAGlanceDocs} -->
+
+<!-- {@repoDefaultInstallerPackagesDocs} -->
+
+Default runtime/content packages installed by `npx @ifi/oh-pi`:
+
+- `@ifi/oh-pi-extensions`
+- `@ifi/oh-pi-ant-colony`
+- `@ifi/pi-diagnostics`
+- `@ifi/pi-extension-subagents`
+- `@ifi/pi-plan`
+- `@ifi/pi-spec`
+- `@ifi/pi-web-remote`
+- `@ifi/oh-pi-themes`
+- `@ifi/oh-pi-prompts`
+- `@ifi/oh-pi-skills`
+
+<!-- {/repoDefaultInstallerPackagesDocs} -->
+
+<!-- {@repoExperimentalPackagesDocs} -->
+
+Opt-in packages that stay separate from the default installer bundle:
+
+- `@ifi/pi-extension-adaptive-routing`
+- `@ifi/pi-provider-catalog`
+- `@ifi/pi-provider-cursor`
+- `@ifi/pi-provider-ollama`
+
+<!-- {/repoExperimentalPackagesDocs} -->
+
+<!-- {@repoContributorCompiledPackagesDocs} -->
+
+Most runtime packages in this repo ship raw TypeScript and can be loaded directly by pi. A smaller
+set of contributor-facing packages (`core`, `cli`, `web-client`, `web-server`) emit `dist/` output,
+so build those when you are working on them directly.
+
+<!-- {/repoContributorCompiledPackagesDocs} -->
+
+<!-- {@repoPiLocalSwitcherOverviewDocs} -->
+
+The `pnpm pi:local` workflow points a real pi install at this checkout instead of the published npm
+packages. It is the normal local development loop for testing unpublished oh-pi changes in a real
+interactive pi session.
+
+<!-- {/repoPiLocalSwitcherOverviewDocs} -->
+
+<!-- {@repoPiLocalQuickstartDocs} -->
+
+```bash
+pnpm install
+pnpm pi:local
+pi
+```
+
+<!-- {/repoPiLocalQuickstartDocs} -->
+
+<!-- {@repoPiLocalWhatItDoesDocs} -->
+
+`pnpm pi:local` runs the repo-local source switcher in `local` mode. It:
+
+- rewrites only the managed oh-pi package sources in your pi settings
+- points those package sources at the workspace packages in this checkout
+- preserves package-specific config objects already present in `settings.json`
+- refreshes package manifest paths so newly added extensions/prompts/skills/themes are picked up
+- runs `pi install` for newly added managed packages and `pi update` for packages you already had configured
+- manages the default installer set and the opt-in experimental packages used for local feature development
+- lets you validate unpublished changes from a branch, worktree, or detached checkout before release
+
+<!-- {/repoPiLocalWhatItDoesDocs} -->
+
+<!-- {@repoPiLocalManagedPackagesDocs} -->
+
+Managed local switching covers these packages:
+
+- `@ifi/oh-pi-extensions`
+- `@ifi/oh-pi-ant-colony`
+- `@ifi/pi-diagnostics`
+- `@ifi/pi-extension-subagents`
+- `@ifi/pi-plan`
+- `@ifi/pi-spec`
+- `@ifi/pi-web-remote`
+- `@ifi/oh-pi-themes`
+- `@ifi/oh-pi-prompts`
+- `@ifi/oh-pi-skills`
+- `@ifi/pi-extension-adaptive-routing`
+- `@ifi/pi-provider-catalog`
+- `@ifi/pi-provider-cursor`
+- `@ifi/pi-provider-ollama`
+
+<!-- {/repoPiLocalManagedPackagesDocs} -->
+
+<!-- {@repoPiSourceSwitchRestartDocs} -->
+
+After switching package sources, fully restart `pi`. Do not rely on `/reload` for source switches,
+because it can keep previously loaded package modules alive.
+
+<!-- {/repoPiSourceSwitchRestartDocs} -->
+
+<!-- {@repoPiLocalInstallFreshnessDocs} -->
+
+If you recently pulled, rebased, or switched branches in the checkout you pointed `pi` at, run
+`pnpm install --frozen-lockfile` there before restarting `pi`. Local source mode loads workspace
+files directly, so stale `node_modules` can surface missing internal `@ifi/*` package errors.
+
+<!-- {/repoPiLocalInstallFreshnessDocs} -->
+
+<!-- {@repoContributorReadingPathDocs} -->
+
+Suggested path for a new contributor:
+
+1. skim the root `README.md` for the package map and the local dev loop
+2. read `docs/feature-catalog.md` to understand which package owns which feature
+3. run `pnpm install` and `pnpm pi:local`
+4. restart `pi` and exercise the feature in a real session
+5. open the package README for the area you are changing, then run the relevant build/test commands
+
+<!-- {/repoContributorReadingPathDocs} -->

--- a/packages/oh-pi/README.md
+++ b/packages/oh-pi/README.md
@@ -43,6 +43,7 @@ oh-pi repo
 │   └── @ifi/oh-pi
 ├── default runtime packages
 │   ├── extensions
+│   ├── background-tasks
 │   ├── diagnostics
 │   ├── ant-colony
 │   ├── subagents

--- a/packages/oh-pi/README.md
+++ b/packages/oh-pi/README.md
@@ -1,6 +1,6 @@
 # @ifi/oh-pi
 
-> All-in-one setup for pi-coding-agent — extensions, themes, prompts, skills, and ant-colony swarm.
+> All-in-one setup for pi-coding-agent — extensions, prompts, skills, themes, remote sharing, and ant-colony workflows.
 
 ## Install
 
@@ -20,27 +20,84 @@ npx @ifi/oh-pi --local              # install to project .pi/settings.json
 npx @ifi/oh-pi --remove             # uninstall all oh-pi packages from pi
 ```
 
+## Start Here
+
+<!-- {=repoStartHerePathDocs} -->
+
+Use this reading path depending on what you are trying to do:
+
+- **I just want to use oh-pi** → start in the root `README.md`, then jump into `docs/feature-catalog.md` for package-by-package detail
+- **I want to try the latest local changes** → run `pnpm install`, `pnpm pi:local`, restart `pi`, then exercise the feature in a real session
+- **I want to contribute** → read `CONTRIBUTING.md`, then the package README for the area you are changing
+- **I want to understand ownership** → use `docs/feature-catalog.md` to see which package owns which runtime feature, content pack, or library surface
+
+<!-- {/repoStartHerePathDocs} -->
+
+### Architecture at a glance
+
+<!-- {=repoArchitectureAtAGlanceDocs} -->
+
+```text
+oh-pi repo
+├── installer
+│   └── @ifi/oh-pi
+├── default runtime packages
+│   ├── extensions
+│   ├── diagnostics
+│   ├── ant-colony
+│   ├── subagents
+│   ├── plan
+│   ├── spec
+│   └── web-remote
+├── content packs
+│   ├── themes
+│   ├── prompts
+│   ├── skills
+│   └── agents
+├── opt-in extras
+│   ├── adaptive-routing
+│   ├── provider-catalog
+│   ├── provider-cursor
+│   └── provider-ollama
+└── contributor libraries
+    ├── core
+    ├── cli
+    ├── shared-qna
+    ├── web-client
+    └── web-server
+```
+
+<!-- {/repoArchitectureAtAGlanceDocs} -->
+
 ## Packages
 
-| Package                 | Contents                                                                                    |
-| ----------------------- | ------------------------------------------------------------------------------------------- |
-| `@ifi/oh-pi-extensions`      | git-guard, auto-session, custom-footer, compact-header, external-editor, auto-update, bg-process, watchdog, worktree |
-| `@ifi/oh-pi-ant-colony`       | Multi-agent swarm extension (`/colony`, colony commands)                                     |
-| `@ifi/pi-diagnostics`         | Prompt completion timestamps, durations, per-turn timing, widget, and `/diagnostics`         |
-| `@ifi/pi-extension-subagents` | Subagent orchestration extension (`subagent`, `subagent_status`, `/run`, `/chain`, `/parallel`) |
-| `@ifi/pi-plan`                | Planning mode extension (`/plan`, `Alt+P`, `task_agents`, `set_plan`)                       |
-| `@ifi/pi-spec`                | Native spec-driven workflow package with `/spec` and local `.specify/` scaffolding          |
-| `@ifi/oh-pi-themes`           | cyberpunk, nord, gruvbox, tokyo-night, catppuccin, oh-p-dark                                 |
-| `@ifi/oh-pi-prompts`          | review, fix, explain, refactor, test, commit, pr, and more                                  |
-| `@ifi/oh-pi-skills`          | web-search, debug-helper, git-workflow, rust-workspace-bootstrap, and more                  |
-| `@ifi/oh-pi-agents`          | AGENTS.md templates for common roles                                                        |
+| Package | Contents |
+| ------- | -------- |
+| `@ifi/oh-pi-extensions` | 13 core session features including git-guard, auto-session-name, custom-footer, tool-metadata, scheduler, usage-tracker, btw/qq, watchdog, bg-process, external-editor, and worktree |
+| `@ifi/pi-background-tasks` | Reactive background shell tasks with `/bg`, `Ctrl+Shift+B`, log tails, and the `bg_task` tool |
+| `@ifi/oh-pi-ant-colony` | Multi-agent swarm extension (`ant_colony`, `/colony*`, colony panel, isolated worktrees, pheromone/task orchestration) |
+| `@ifi/pi-diagnostics` | Prompt completion timestamps, durations, per-turn timing, widget, and `/diagnostics` |
+| `@ifi/pi-extension-subagents` | Subagent orchestration runtime (`subagent`, `subagent_status`, `/run`, `/chain`, `/parallel`, `/agents`) |
+| `@ifi/pi-plan` | Planning mode extension (`/plan`, `Alt+P`, `task_agents`, `steer_task_agent`, `set_plan`) |
+| `@ifi/pi-spec` | Native spec-driven workflow package with `/spec` and local `.specify/` scaffolding |
+| `@ifi/pi-web-remote` | `/remote` session sharing for browser-oriented remote access |
+| `@ifi/oh-pi-themes` | 6 themes: cyberpunk, nord, gruvbox, tokyo-night, catppuccin-mocha, oh-p-dark |
+| `@ifi/oh-pi-prompts` | 10 prompt templates including review, fix, explain, refactor, test, commit, pr, and document |
+| `@ifi/oh-pi-skills` | 17 skills including web-search, web-fetch, context7, debug-helper, git-workflow, quick-setup, and more |
+| `@ifi/oh-pi-agents` | 5 AGENTS.md templates for common roles |
 
 Optional packages that stay opt-in:
 
-- `@ifi/pi-extension-adaptive-routing` — install separately when you want `/route`, delegated startup routing, and provider assignment categories
+<!-- {=repoExperimentalPackagesDocs} -->
+
+Opt-in packages that stay separate from the default installer bundle:
+
+- `@ifi/pi-extension-adaptive-routing`
 - `@ifi/pi-provider-catalog`
 - `@ifi/pi-provider-cursor`
 - `@ifi/pi-provider-ollama`
+
+<!-- {/repoExperimentalPackagesDocs} -->
 
 ## Getting Started
 
@@ -48,3 +105,6 @@ Optional packages that stay opt-in:
 npx @ifi/oh-pi
 pi
 ```
+
+For the full package-by-package feature inventory and the local development workflow, see the repo
+README and `docs/feature-catalog.md` in GitHub.


### PR DESCRIPTION
## Summary
- add a full feature catalog with clearer package ownership and reader wayfinding
- expand the root and package READMEs with missing feature coverage and a stronger running-locally guide
- reuse shared MDT blocks across docs and code comments for installer, routing, and local-dev guidance

## Validation
- pnpm mdt update
- pnpm mdt check

## Notes
- docs-only change; no full lint/test/build run in this PR