### PR TITLE
fix(providers): use native mistral conversations api

### DIFF
--- a/.changeset/fix-mistral-native-api.md
+++ b/.changeset/fix-mistral-native-api.md
@@ -1,0 +1,5 @@
+---
+default: patch
+---
+
+fix the provider catalog to route native Mistral providers through the Mistral conversations API.

--- a/packages/providers/config.ts
+++ b/packages/providers/config.ts
@@ -1,6 +1,11 @@
 import { SUPPORTED_PROVIDER_DATA } from "./supported-providers.generated.js";
 
-export type ProviderApiKind = "anthropic-messages" | "google-generative-ai" | "openai-completions" | "openai-responses";
+export type ProviderApiKind =
+	| "anthropic-messages"
+	| "google-generative-ai"
+	| "openai-completions"
+	| "openai-responses"
+	| "mistral-conversations";
 
 export interface SupportedProviderDefinition {
 	id: string;
@@ -34,7 +39,7 @@ export const SUPPORTED_PROVIDERS: SupportedProviderDefinition[] = SUPPORTED_PROV
 	id: provider.id,
 	name: provider.name,
 	env: [...provider.env],
-	baseUrl: normalizeProviderBaseUrl(provider.baseUrl),
+	baseUrl: resolveProviderBaseUrl(provider.id, provider.baseUrl),
 	npm: provider.npm,
 	api: resolveProviderApi(provider.id, provider.npm),
 	authUrl: resolveProviderAuthUrl(provider.id, provider.baseUrl),
@@ -71,9 +76,21 @@ export function normalizeProviderBaseUrl(baseUrl: string): string {
 		.replace(/\/(?:chat\/completions|responses|messages|completions|models)$/i, "");
 }
 
+function resolveProviderBaseUrl(providerId: string, baseUrl: string): string {
+	const normalized = normalizeProviderBaseUrl(baseUrl);
+	if (providerId === "mistral") {
+		return normalized.replace(/\/v\d+(?:beta)?$/i, "");
+	}
+	return normalized;
+}
+
 function resolveProviderApi(providerId: string, npm: string): ProviderApiKind {
 	if (providerId === "openai") {
 		return "openai-responses";
+	}
+
+	if (providerId === "mistral") {
+		return "mistral-conversations";
 	}
 
 	if (npm === "@ai-sdk/google") {

--- a/packages/providers/tests/catalog.test.ts
+++ b/packages/providers/tests/catalog.test.ts
@@ -63,6 +63,12 @@ describe("provider catalog", () => {
 		expect(ids.has("ollama-cloud")).toBe(false);
 	});
 
+	it("maps native Mistral to the Mistral conversations API", () => {
+		const provider = getSupportedProvider("mistral");
+		expect(provider.api).toBe("mistral-conversations");
+		expect(provider.baseUrl).toBe("https://api.mistral.ai");
+	});
+
 	it("filters the models.dev catalog down to pi-usable text models", async () => {
 		vi.stubGlobal(
 			"fetch",


### PR DESCRIPTION
## Summary
- route the native Mistral provider through the `mistral-conversations` API
- normalize the native Mistral base URL to the SDK root instead of `/v1`
- add a regression test for the Mistral provider mapping

## Testing
- pnpm exec vitest run packages/providers/tests/catalog.test.ts packages/providers/tests/index.test.ts packages/providers/tests/auth.test.ts
- pnpm typecheck

Closes #191
Supersedes #192