### PR TITLE
fix(shared-qna): improve overlay popup contrast

### DIFF
--- a/.changeset/schedule-popup-contrast.md
+++ b/.changeset/schedule-popup-contrast.md
@@ -1,0 +1,5 @@
+---
+default: patch
+---
+
+improve the contrast of scrollable overlay popups like `/schedule` in dark terminal themes.

--- a/packages/shared-qna/scroll-select.ts
+++ b/packages/shared-qna/scroll-select.ts
@@ -77,6 +77,7 @@ type ScrollSelectUi = {
 
 type ScrollSelectTheme = {
 	fg: (color: string, text: string) => string;
+	bg?: (color: string, text: string) => string;
 	bold: (text: string) => string;
 };
 
@@ -128,12 +129,13 @@ class ScrollSelectComponent<T> {
 	render(width: number): string[] {
 		const { truncateToWidth, visibleWidth, wrapTextWithAnsi } = getPiTui();
 		const safeWidth = Math.max(20, width);
+		const contentWidth = Math.max(12, safeWidth - 2);
 		const lines: string[] = [];
-		const bodyWidth = Math.max(12, safeWidth - 2);
+		const selectedLineIndexes = new Set<number>();
 
 		for (const line of this.title.split("\n")) {
-			for (const wrapped of wrapTextWithAnsi(line, bodyWidth)) {
-				lines.push(truncateToWidth(wrapped, bodyWidth));
+			for (const wrapped of wrapTextWithAnsi(line, contentWidth)) {
+				lines.push(truncateToWidth(wrapped, contentWidth));
 			}
 		}
 
@@ -141,17 +143,17 @@ class ScrollSelectComponent<T> {
 
 		if (this.search) {
 			const filterText = this.searchQuery.trim().length > 0 ? `Filter: ${this.searchQuery}` : "Filter: all";
-			lines.push(truncateToWidth(this.theme.fg("dim", filterText), bodyWidth));
+			lines.push(truncateToWidth(this.theme.fg("dim", filterText), contentWidth));
 			lines.push("");
 		}
 
 		if (this.options.length === 0) {
-			lines.push(truncateToWidth(this.theme.fg("dim", this.emptyMessage), bodyWidth));
+			lines.push(truncateToWidth(this.theme.fg("dim", this.emptyMessage), contentWidth));
 		} else {
 			const { start, end } = this.getVisibleRange();
 
 			if (start > 0) {
-				lines.push(truncateToWidth(this.theme.fg("dim", `↑ ${start} more`), bodyWidth));
+				lines.push(truncateToWidth(this.theme.fg("dim", `↑ ${start} more`), contentWidth));
 			}
 
 			for (let index = start; index < end; index++) {
@@ -161,21 +163,28 @@ class ScrollSelectComponent<T> {
 				}
 
 				const prefix = index === this.cursorIndex ? this.theme.fg("accent", "→ ") : "  ";
-				const availableWidth = Math.max(4, bodyWidth - visibleWidth(prefix));
+				const availableWidth = Math.max(4, contentWidth - visibleWidth(prefix));
 				const label = truncateToWidth(option.label, availableWidth);
 				const line = `${prefix}${index === this.cursorIndex ? this.theme.fg("accent", label) : label}`;
-				lines.push(truncateToWidth(line, bodyWidth));
+				lines.push(truncateToWidth(line, contentWidth));
+				if (index === this.cursorIndex) {
+					selectedLineIndexes.add(lines.length - 1);
+				}
 			}
 
 			const hiddenBelow = this.options.length - end;
 			if (hiddenBelow > 0) {
-				lines.push(truncateToWidth(this.theme.fg("dim", `↓ ${hiddenBelow} more`), bodyWidth));
+				lines.push(truncateToWidth(this.theme.fg("dim", `↓ ${hiddenBelow} more`), contentWidth));
 			}
 		}
 
 		lines.push("");
-		lines.push(truncateToWidth(this.footerText(), bodyWidth));
-		return lines;
+		lines.push(truncateToWidth(this.footerText(), contentWidth));
+		return lines.map((line, index) =>
+			this.renderSurfaceLine(line, contentWidth, {
+				selected: selectedLineIndexes.has(index),
+			}),
+		);
 	}
 
 	handleInput(data: string): void {
@@ -209,6 +218,16 @@ class ScrollSelectComponent<T> {
 	invalidate(): void {}
 
 	dispose(): void {}
+
+	private renderSurfaceLine(line: string, contentWidth: number, options: { selected?: boolean } = {}): string {
+		const { visibleWidth } = getPiTui();
+		const paddedLine = `${line}${" ".repeat(Math.max(0, contentWidth - visibleWidth(line)))}`;
+		const boxedLine = ` ${paddedLine} `;
+		if (typeof this.theme.bg !== "function") {
+			return boxedLine;
+		}
+		return this.theme.bg(options.selected ? "selectedBg" : "customMessageBg", boxedLine);
+	}
 
 	private footerText(): string {
 		const parts = ["[↑↓/j/k] scroll", "[enter] select", "[esc] cancel"];

--- a/packages/shared-qna/tests/scroll-select.test.ts
+++ b/packages/shared-qna/tests/scroll-select.test.ts
@@ -25,10 +25,17 @@ type CustomFactory = (...args: any[]) => {
 	focused?: boolean;
 };
 
-function createTheme() {
+type TestTheme = {
+	fg: (color: string, text: string) => string;
+	bg?: (color: string, text: string) => string;
+	bold: (text: string) => string;
+};
+
+function createTheme(overrides: Partial<TestTheme> = {}): TestTheme {
 	return {
 		fg: (_color: string, text: string) => text,
 		bold: (text: string) => text,
+		...overrides,
 	};
 }
 
@@ -38,7 +45,7 @@ async function flushAsyncWork(turns = 4) {
 	}
 }
 
-function createFactoryRunner() {
+function createFactoryRunner(theme = createTheme()) {
 	const factories: CustomFactory[] = [];
 	const resolvers: Array<((value: unknown) => void) | undefined> = [];
 	const ui = {
@@ -60,7 +67,7 @@ function createFactoryRunner() {
 		if (!factory) {
 			throw new Error(`Expected custom factory at index ${index}.`);
 		}
-		return factory({ requestRender: vi.fn() }, createTheme(), {}, done ?? resolvers[index] ?? vi.fn());
+		return factory({ requestRender: vi.fn() }, theme, {}, done ?? resolvers[index] ?? vi.fn());
 	}
 
 	return { ui, buildComponent };
@@ -167,6 +174,47 @@ describe("openScrollableSelect", () => {
 		const later = component.render(60).join("\n");
 		expect(later).toContain("Option 10");
 		expect(later).toContain("↑ 7 more");
+	});
+
+	it("renders a contrasting surface background when background colors are available", async () => {
+		const { ui, buildComponent } = createFactoryRunner(
+			createTheme({
+				bg: (color: string, text: string) => `<${color}>${text}</${color}>`,
+			}),
+		);
+		await openScrollableSelect(ui, {
+			title: "Scheduled tasks",
+			options: [
+				{ value: "first", label: "First task" },
+				{ value: "second", label: "Second task" },
+			],
+		});
+
+		const lines = buildComponent().render(40);
+		expect(lines[0]).toContain("<customMessageBg>");
+		expect(lines.some((line) => line.includes("<selectedBg>"))).toBe(true);
+		expect(lines.every((line) => line.startsWith("<") && line.endsWith(">"))).toBe(true);
+	});
+
+	it("renders the empty message on the popup surface when options disappear", async () => {
+		const { ui, buildComponent } = createFactoryRunner(
+			createTheme({
+				bg: (color: string, text: string) => `<${color}>${text}</${color}>`,
+			}),
+		);
+		await openScrollableSelect(ui, {
+			title: "Scheduled tasks",
+			options: [
+				{ value: "first", label: "First task" },
+				{ value: "second", label: "Second task" },
+			],
+		});
+
+		const component = buildComponent() as any;
+		component.options = [];
+		const rendered = component.render(40).join("\n");
+		expect(rendered).toContain("No options available.");
+		expect(rendered).toContain("<customMessageBg>");
 	});
 
 	it("supports in-picker search without pager actions", async () => {


### PR DESCRIPTION
## Summary
- add a filled surface background to shared scrollable overlay popups
- highlight the active row with the selected background token
- improve the readability of `/schedule` and similar overlays in dark terminals

## Testing
- pnpm exec vitest run packages/shared-qna/tests/scroll-select.test.ts packages/extensions/extensions/scheduler-overlay.test.ts
