### PR TITLE
ci: run test matrix on node 22 and 24

### DIFF
--- a/.changeset/ci-node-22-24-tests.md
+++ b/.changeset/ci-node-22-24-tests.md
@@ -1,0 +1,5 @@
+---
+default: patch
+---
+
+Update the CI test matrix to run on Node 22 and Node 24, removing Node 20 from the test job.

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -259,7 +259,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        node: [20, 22]
+        node: [22, 24]
     steps:
       - uses: actions/checkout@v6.0.2
 


### PR DESCRIPTION
## Summary
- update the CI test matrix from Node 20/22 to Node 22/24
- remove Node 20 from the test job
- add the required changeset

## Validation
- pnpm test scripts/ci-workflow.test.ts