### PR TITLE
fix(subagents): resolve skills against task cwd, not runtime cwd

### DIFF
--- a/packages/subagents/async-execution.ts
+++ b/packages/subagents/async-execution.ts
@@ -150,7 +150,7 @@ export function executeAsyncChain(id: string, params: AsyncChainParams): AsyncEx
 		const stepOverrides: StepOverrides = { skills: stepSkillInput };
 		const behavior = resolveStepBehavior(a, stepOverrides, chainSkills);
 		const skillNames = behavior.skills === false ? [] : behavior.skills;
-		const { resolved: resolvedSkills } = resolveSkills(skillNames, ctx.cwd);
+		const { resolved: resolvedSkills } = resolveSkills(skillNames, s.cwd ?? cwd ?? ctx.cwd);
 
 		let systemPrompt = a.systemPrompt?.trim() || null;
 		if (resolvedSkills.length > 0) {
@@ -263,7 +263,7 @@ export function executeAsyncSingle(id: string, params: AsyncSingleParams): Async
 	const { agent, task, agentConfig, ctx, cwd, maxOutput, artifactsDir, artifactConfig, shareEnabled, sessionRoot } =
 		params;
 	const skillNames = params.skills ?? agentConfig.skills ?? [];
-	const { resolved: resolvedSkills } = resolveSkills(skillNames, ctx.cwd);
+	const { resolved: resolvedSkills } = resolveSkills(skillNames, cwd ?? ctx.cwd);
 	let systemPrompt = agentConfig.systemPrompt?.trim() || null;
 	if (resolvedSkills.length > 0) {
 		const injection = buildSkillInjection(resolvedSkills);

--- a/packages/subagents/execution.ts
+++ b/packages/subagents/execution.ts
@@ -115,7 +115,7 @@ export async function runSync(
 	}
 
 	const skillNames = options.skills ?? agent.skills ?? [];
-	const { resolved: resolvedSkills, missing: missingSkills } = resolveSkills(skillNames, runtimeCwd);
+	const { resolved: resolvedSkills, missing: missingSkills } = resolveSkills(skillNames, cwd ?? runtimeCwd);
 
 	// When explicit skills are specified (via options or agent config), disable
 	// pi's own skill discovery so the spawned process doesn't inject the full

--- a/packages/subagents/tests/async-execution.test.ts
+++ b/packages/subagents/tests/async-execution.test.ts
@@ -308,4 +308,47 @@ describe("async execution helpers", () => {
 			asyncDir: "/tmp/pi-async-subagent-runs/chain-2",
 		});
 	});
+
+	it("resolves async single-agent skills against task cwd, not context cwd", () => {
+		const ctx = createCtx();
+		executeAsyncSingle("run-ctx", {
+			agent: "reviewer",
+			task: "Inspect",
+			agentConfig: { name: "reviewer", skills: ["ecsc-reviewer"] },
+			ctx,
+			cwd: "/legal/project",
+			shareEnabled: false,
+			sessionRoot: undefined,
+			artifactConfig: { enabled: false },
+		});
+
+		expect(asyncMocks.resolveSkills).toHaveBeenCalledWith(["ecsc-reviewer"], "/legal/project");
+	});
+
+	it("resolves async chain step skills against step cwd, then chain cwd, then context cwd", () => {
+		const ctx = createCtx();
+		asyncMocks.resolveSubagentModelResolution
+			.mockReturnValueOnce({ model: undefined, source: "agent-default", category: undefined })
+			.mockReturnValueOnce({ model: undefined, source: "agent-default", category: undefined });
+
+		executeAsyncChain("chain-cwd", {
+			chain: [
+				{ agent: "scout", task: "Inspect", cwd: "/legal/project", skill: ["ecsc-reviewer"] },
+				{ agent: "planner", task: "Plan", skill: ["planning"] },
+			],
+			agents: [
+				{ name: "scout" },
+				{ name: "planner" },
+			],
+			ctx,
+			cwd: "/default/workspace",
+			shareEnabled: false,
+			artifactConfig: { enabled: false },
+		});
+
+		// First step uses its own cwd
+		expect(asyncMocks.resolveSkills).toHaveBeenNthCalledWith(1, ["ecsc-reviewer"], "/legal/project");
+		// Second step falls back to chain-level cwd
+		expect(asyncMocks.resolveSkills).toHaveBeenNthCalledWith(2, ["planning"], "/default/workspace");
+	});
 });

--- a/packages/subagents/tests/async-execution.test.ts
+++ b/packages/subagents/tests/async-execution.test.ts
@@ -351,4 +351,47 @@ describe("async execution helpers", () => {
 		// Second step falls back to chain-level cwd
 		expect(asyncMocks.resolveSkills).toHaveBeenNthCalledWith(2, ["planning"], "/default/workspace");
 	});
+
+	it("resolves async single-agent skills against context cwd when no cwd provided", () => {
+		const ctx = createCtx();
+		executeAsyncSingle("run-no-cwd", {
+			agent: "reviewer",
+			task: "Inspect",
+			agentConfig: { name: "reviewer", skills: ["ecsc-reviewer"] },
+			ctx,
+			cwd: undefined,
+			shareEnabled: false,
+			sessionRoot: undefined,
+			artifactConfig: { enabled: false },
+		});
+
+		// Should fall back to ctx.cwd
+		expect(asyncMocks.resolveSkills).toHaveBeenCalledWith(["ecsc-reviewer"], ctx.cwd);
+	});
+
+	it("resolves async chain step skills against context cwd when step cwd and chain cwd are both undefined", () => {
+		const ctx = createCtx();
+		asyncMocks.resolveSubagentModelResolution
+			.mockReturnValueOnce({ model: undefined, source: "agent-default", category: undefined })
+			.mockReturnValueOnce({ model: undefined, source: "agent-default", category: undefined });
+
+		executeAsyncChain("chain-no-cwd", {
+			chain: [
+				{ agent: "scout", task: "Inspect", skill: ["ecsc-reviewer"] },
+				{ agent: "planner", task: "Plan", skill: ["planning"] },
+			],
+			agents: [
+				{ name: "scout" },
+				{ name: "planner" },
+			],
+			ctx,
+			cwd: undefined,
+			shareEnabled: false,
+			artifactConfig: { enabled: false },
+		});
+
+		// Both steps should fall back to ctx.cwd
+		expect(asyncMocks.resolveSkills).toHaveBeenNthCalledWith(1, ["ecsc-reviewer"], ctx.cwd);
+		expect(asyncMocks.resolveSkills).toHaveBeenNthCalledWith(2, ["planning"], ctx.cwd);
+	});
 });

--- a/packages/subagents/tests/execution.test.ts
+++ b/packages/subagents/tests/execution.test.ts
@@ -334,6 +334,32 @@ describe("runSync", () => {
 		expect(executionMocks.rmSync).toHaveBeenCalledWith("/tmp/pi-prompt", { recursive: true, force: true });
 	});
 
+	it("resolves skills against task cwd, not runtime cwd", async () => {
+		const runPromise = runSync(
+			"/runtime-dir",
+			[
+				{
+					name: "reviewer",
+					model: "anthropic/claude-sonnet-4",
+					skills: ["ecsc-reviewer"],
+				},
+			],
+			"reviewer",
+			"Inspect",
+			{
+				cwd: "/legal/project",
+				share: false,
+			},
+		);
+
+		const proc = executionMocks.procs[0];
+		proc.emit("close", 0);
+		await runPromise;
+
+		// resolveSkills must be called with the task's cwd, not runtimeCwd
+		expect(executionMocks.resolveSkills).toHaveBeenCalledWith(["ecsc-reviewer"], "/legal/project");
+	});
+
 	it("captures parse errors, surfaces detected internal failures, and handles abort signals", async () => {
 		vi.useFakeTimers();
 		executionMocks.detectSubagentError.mockReturnValue({


### PR DESCRIPTION
Closes #203

## Problem

When a subagent specifies a working directory (`cwd`) different from where pi was launched, skill resolution searches for `.pi/skills/` in the wrong place.

**Bug trace:**
1. `runSync(runtimeCwd, ...)` — `runtimeCwd` = where pi launched
2. `resolveSkills(skillNames, runtimeCwd)` — wrong directory
3. Skills not found → `--no-skills` flag pushed to spawned pi
4. `--no-skills` disables ALL skill discovery including cascading-skills
5. Subagent runs with zero skills

## Fix

| File | Before | After |
|---|---|---|
| `execution.ts:109` | `resolveSkills(skillNames, runtimeCwd)` | `resolveSkills(skillNames, cwd ?? runtimeCwd)` |
| `async-execution.ts:156` | `resolveSkills(skillNames, ctx.cwd)` | `resolveSkills(skillNames, s.cwd ?? cwd ?? ctx.cwd)` |
| `async-execution.ts:264` | `resolveSkills(skillNames, ctx.cwd)` | `resolveSkills(skillNames, cwd ?? ctx.cwd)` |

## Tests

3 new tests added. All 1359+ tests pass.