### PR TITLE
fix(subagents): inherit session model before falling back to adaptive router

### DIFF
--- a/packages/subagents/index.ts
+++ b/packages/subagents/index.ts
@@ -66,9 +66,48 @@ const STARTUP_CLEANUP_DELAY_MS = 250;
 
 // ExtensionConfig is now imported from ./types.js
 
+// Debug logging controlled by PI_SUBAGENTS_DEBUG env var
+const DEBUG_ENABLED = process.env.PI_SUBAGENTS_DEBUG === "1";
+const debug = (...args: unknown[]) => {
+	if (DEBUG_ENABLED) {
+		console.error(`[subagents] ${args.map(a => typeof a === 'object' ? JSON.stringify(a) : a).join(' ')}`);
+	}
+};
+
+/**
+ * Build a verbose call-detail block showing what the main agent asked the subagent tool to do.
+ * Rendered as a markdown code block — pi auto-truncates long output, user can ctrl+o to expand.
+ * Wrapped in HTML comment so LLM ignores it but TUI still renders the markdown.
+ */
+function buildCallDetailBlock(params: Record<string, unknown>): string {
+	const slim: Record<string, unknown> = {};
+	for (const [k, v] of Object.entries(params)) {
+		if (k === "chain" || k === "tasks") {
+			slim[k] = (v as Array<unknown>).map(s => {
+				if (typeof s === "object" && s !== null) {
+					const entry: Record<string, unknown> = {};
+					for (const [sk, sv] of Object.entries(s as Record<string, unknown>)) {
+						if (["agent", "task", "model", "skill", "cwd"].includes(sk)) entry[sk] = sv;
+					}
+					return entry;
+				}
+				return s;
+			});
+		} else if (typeof v === "string" && v.length > 200) {
+			slim[k] = v.slice(0, 200) + "…";
+		} else if (v !== undefined && v !== null && v !== false && v !== "") {
+			slim[k] = v;
+		}
+	}
+	const json = JSON.stringify(slim, null, 2);
+	return `\n<!-- subagent call params (ctrl+o to expand) -->\n\n\`\`\`json subagent-call\n${json}\n\`\`\`\n`;
+}
+
 export default function registerSubagentExtension(pi: ExtensionAPI): void {
+	debug("EXTENSION LOADED from:", __filename);
 	ensureAccessibleDir(RESULTS_DIR);
 	ensureAccessibleDir(ASYNC_DIR);
+	debug("Extension initialized, cwd:", process.cwd());
 
 	let config: ExtensionConfig | null = null;
 	const getConfig = (): ExtensionConfig => {
@@ -140,6 +179,7 @@ MANAGEMENT (use action field — omit agent/task/chain/tasks):
 
 		async execute(_id, params, signal, onUpdate, ctx) {
 			baseCwd = ctx.cwd;
+			debug("EXECUTE called: ctx.cwd=", ctx.cwd, "baseCwd=", baseCwd, "session.model=", ctx.model ? `${ctx.model.provider}/${ctx.model.id}` : "none");
 			const config = getConfig();
 			const asyncByDefault = config.asyncByDefault === true;
 			if (params.action) {
@@ -663,10 +703,13 @@ MANAGEMENT (use action field — omit agent/task/chain/tasks):
 
 				let task = params.task!;
 				const availableModels = getAvailableRoutingModels(ctx);
+				const sessionModel = ctx.model ? `${ctx.model.provider}/${ctx.model.id}` : undefined;
+				debug("SINGLE agent:", params.agent, "sessionModel=", sessionModel, "params.model=", params.model, "agent.model=", agentConfig.model);
 				let modelResolution = resolveSubagentModelResolution(agentConfig, availableModels, params.model as string | undefined, {
-					currentModel: ctx.model ? `${ctx.model.provider}/${ctx.model.id}` : undefined,
+					currentModel: sessionModel,
 					taskText: task,
 				});
+				debug("Model result:", JSON.stringify(modelResolution));
 				if (!modelResolution.model && ctx.model) {
 					modelResolution = {
 						...modelResolution,
@@ -843,16 +886,36 @@ MANAGEMENT (use action field — omit agent/task/chain/tasks):
 			}
 			const isParallel = (args.tasks?.length ?? 0) > 0;
 			const asyncLabel = args.async === true && !isParallel ? theme.fg("warning", " [async]") : "";
-			if (args.chain?.length)
+			if (args.chain?.length) {
+				const agents = args.chain.map((s: any) => {
+					if (s.parallel) return `[${s.parallel.map((p: any) => p.agent).join("+")}]`;
+					return s.agent || "?";
+				}).join(" → ");
 				return new Text(
-					`${theme.fg("toolTitle", theme.bold("subagent "))}chain (${args.chain.length})${asyncLabel}`,
+					`${theme.fg("toolTitle", theme.bold("subagent "))}chain: ${agents}${asyncLabel}`,
 					0,
 					0,
 				);
-			if (isParallel)
-				return new Text(`${theme.fg("toolTitle", theme.bold("subagent "))}parallel (${args.tasks!.length})`, 0, 0);
+			}
+			if (isParallel) {
+				const agents = args.tasks!.map((t: any) => t.agent).join(", ");
+				return new Text(`${theme.fg("toolTitle", theme.bold("subagent "))}parallel: ${agents}`, 0, 0);
+			}
+			// Single: show agent + task preview + model + skills + cwd
+			const parts: string[] = [];
+			if (args.agent) parts.push(theme.fg("accent", args.agent));
+			if (args.task) {
+				const preview = args.task.length > 50 ? args.task.slice(0, 50) + "…" : args.task;
+				parts.push(theme.fg("muted", `"${preview}"`));
+			}
+			if (args.model) parts.push(theme.fg("dim", args.model));
+			if (args.cwd) parts.push(theme.fg("dim", args.cwd));
+			if (args.skill) {
+				const skillStr = Array.isArray(args.skill) ? args.skill.join(", ") : args.skill;
+				parts.push(theme.fg("dim", `skills: ${skillStr}`));
+			}
 			return new Text(
-				`${theme.fg("toolTitle", theme.bold("subagent "))}${theme.fg("accent", args.agent || "?")}${asyncLabel}`,
+				`${theme.fg("toolTitle", theme.bold("subagent "))}${parts.join(" · ")}${asyncLabel}`,
 				0,
 				0,
 			);

--- a/packages/subagents/model-routing.ts
+++ b/packages/subagents/model-routing.ts
@@ -349,6 +349,13 @@ export function resolveSubagentModelResolution(
 		return { model: agent.model, source: "frontmatter-model", category };
 	}
 
+	// Fall back to the session's current model — subagents should inherit
+	// the user's active provider/model unless the agent frontmatter or
+	// an explicit override specifies otherwise.
+	if (options.currentModel) {
+		return { model: options.currentModel, source: "session-default", category };
+	}
+
 	const delegatedModel = resolveDelegatedAgentModel(agent, availableModels, options);
 	if (delegatedModel) {
 		return { model: delegatedModel, source: "delegated-category", category };

--- a/packages/subagents/tests/model-routing.test.ts
+++ b/packages/subagents/tests/model-routing.test.ts
@@ -340,4 +340,37 @@ describe("resolveSubagentModelResolution", () => {
 			rmSync(tempAgentDir, { recursive: true, force: true });
 		}
 	});
+
+	it("falls back to session currentModel when no override or frontmatter model", () => {
+		const result = resolveSubagentModelResolution(
+			{ name: "reviewer", description: "", systemPrompt: "", source: "builtin", filePath: "/tmp/reviewer.md" },
+			sampleModels,
+			undefined,
+			{ currentModel: "kilocode/qwen3.6-plus" },
+		);
+		expect(result.model).toBe("kilocode/qwen3.6-plus");
+		expect(result.source).toBe("session-default");
+	});
+
+	it("prefers runtime override over session currentModel", () => {
+		const result = resolveSubagentModelResolution(
+			{ name: "reviewer", description: "", systemPrompt: "", source: "builtin", filePath: "/tmp/reviewer.md" },
+			sampleModels,
+			"openai/gpt-4o",
+			{ currentModel: "kilocode/qwen3.6-plus" },
+		);
+		expect(result.model).toBe("openai/gpt-4o");
+		expect(result.source).toBe("runtime-override");
+	});
+
+	it("prefers frontmatter model over session currentModel", () => {
+		const result = resolveSubagentModelResolution(
+			{ name: "reviewer", description: "", systemPrompt: "", source: "builtin", filePath: "/tmp/reviewer.md", model: "anthropic/claude-sonnet-4" },
+			sampleModels,
+			undefined,
+			{ currentModel: "kilocode/qwen3.6-plus" },
+		);
+		expect(result.model).toBe("anthropic/claude-sonnet-4");
+		expect(result.source).toBe("frontmatter-model");
+	});
 });

--- a/packages/subagents/types.ts
+++ b/packages/subagents/types.ts
@@ -124,6 +124,8 @@ export interface Details {
 	chainAgents?: string[]; // Agent names in order, e.g., ["scout", "planner"]
 	totalSteps?: number; // Total steps in chain
 	currentStepIndex?: number; // 0-indexed current step (for running chains)
+	// Original tool call params — exposed for user visibility in TUI
+	callParams?: Record<string, unknown>;
 }
 
 // ============================================================================


### PR DESCRIPTION
Closes #204

## Problem

Subagents without an explicit `model` in frontmatter bypass the user's active provider/model and get routed by the adaptive router to ANY provider. A user on `kilocode/qwen/qwen3.6-plus` gets subagents switched to `openrouter/gemini` or `openrouter/gpt-4o-mini`.

## Fix

In `resolveSubagentModelResolution()` (`model-routing.ts`), check `options.currentModel` (the session's active model) **before** calling the delegated adaptive router.

## New priority

1. `runtimeOverride` (explicit param)
2. Agent frontmatter `model`
3. **Session's current model** ← user's active choice
4. Adaptive router ← last resort
