### PR TITLE
feat(skills): add devenv skill for devenv.nix task runner

### DIFF
--- a/.changeset/add-devenv-skill.md
+++ b/.changeset/add-devenv-skill.md
@@ -1,0 +1,8 @@
+---
+default: patch
+---
+
+Add a devenv skill for using devenv.nix as the task runner and development environment.
+
+- add `packages/skills/skills/devenv/SKILL.md` with activation rules, core commands, and script conventions
+- add `packages/skills/skills/devenv/REFERENCE.md` with the recommended devenv.nix layout, script options, git hooks, processes, and troubleshooting

--- a/packages/skills/skills/devenv/REFERENCE.md
+++ b/packages/skills/skills/devenv/REFERENCE.md
@@ -1,0 +1,233 @@
+# devenv Reference
+
+## Recommended `devenv.nix` layout
+
+This is the preferred structure, adapted from the monochange project. Adjust packages,
+scripts, and hooks for each project's needs.
+
+```nix
+{
+  pkgs,
+  lib,
+  config,
+  inputs,
+  ...
+}:
+
+let
+  extra = inputs.ifiokjr-nixpkgs.packages.${pkgs.stdenv.system};
+in
+{
+  packages =
+    with pkgs;
+    [
+      # Add project-specific packages here
+    ]
+    ++ lib.optionals stdenv.isDarwin [
+      coreutils
+    ];
+
+  enterShell = ''
+    # Keep shell entry fast. Only bootstrap missing toolchains here;
+    # explicit updates happen via install/update tasks instead of every shell.
+    export PATH="$DEVENV_ROOT/scripts:$PATH"
+  '';
+
+  # Disable dotenv if using direnv
+  dotenv.disableHint = true;
+
+  git-hooks = {
+    hooks = {
+      # Add pre-commit and pre-push hooks here
+    };
+  };
+
+  scripts = {
+    # Colon-namespaced scripts: build:*, test:*, lint:*, fix:*, etc.
+    "build:all" = {
+      exec = ''
+        set -e
+        # Project-specific build commands
+      '';
+      description = "Build everything.";
+      binary = "bash";
+    };
+
+    "test:all" = {
+      exec = ''
+        set -e
+        # Project-specific test commands
+      '';
+      description = "Run all tests.";
+      binary = "bash";
+    };
+
+    "lint:all" = {
+      exec = ''
+        set -e
+        # Project-specific lint commands
+      '';
+      description = "Run all checks.";
+      binary = "bash";
+    };
+
+    "fix:all" = {
+      exec = ''
+        set -e
+        # Project-specific autofix commands
+      '';
+      description = "Fix all autofixable problems.";
+      binary = "bash";
+    };
+
+    "docs:check" = {
+      exec = ''
+        set -e
+        mdt check
+      '';
+      description = "Check that shared documentation blocks are synchronized.";
+      binary = "bash";
+    };
+
+    "docs:update" = {
+      exec = ''
+        set -e
+        mdt update
+      '';
+      description = "Update shared documentation blocks.";
+      binary = "bash";
+    };
+  };
+}
+```
+
+## Script definition options
+
+Each script in the `scripts` block accepts:
+
+| Field | Required | Description |
+|-------|----------|-------------|
+| `exec` | Yes | Shell command body. Use `"$@"` to forward arguments. |
+| `description` | Recommended | Short description shown by `devenv scan`. |
+| `binary` | Optional | Shell binary (default: `bash`). |
+
+## Key variables available in `exec`
+
+- `$DEVENV_ROOT` — project root directory
+- `$DEVENV_PROFILE` — path to the devenv profile (contains `bin/`)
+- `$PWD` — current working directory
+
+## `enterShell` best practices
+
+- Keep it fast. Avoid expensive operations like full installs.
+- Only bootstrap missing toolchains (e.g. `rustup toolchain list | grep`).
+- Add custom script directories to PATH: `export PATH="$DEVENV_ROOT/scripts:$PATH"`.
+- Shell activation happens on every `devenv test` or `direnv` reload.
+
+## Git hooks in devenv
+
+Git hooks are defined under `git-hooks.hooks`. Each hook accepts:
+
+| Field | Description |
+|-------|-------------|
+| `enable` | Whether the hook is active |
+| `verbose` | Print hook output |
+| `pass_filenames` | Pass staged filenames to the entry command |
+| `name` | Display name |
+| `description` | What the hook does |
+| `entry` | Command to run (can reference `${pkgs.tool}/bin/tool`) |
+| `stages` | `pre-commit` or `pre-push` |
+
+### Common hook patterns
+
+```nix
+"lint:all" = {
+  enable = true;
+  verbose = true;
+  pass_filenames = false;
+  name = "lint and test";
+  description = "Run lint and test before push.";
+  entry = "${config.env.DEVENV_PROFILE}/bin/lint:all && ${config.env.DEVENV_PROFILE}/bin/test:all";
+  stages = [ "pre-push" ];
+};
+
+"gitleaks" = {
+  enable = true;
+  verbose = true;
+  pass_filenames = true;
+  name = "secrets";
+  description = "Scan for leaked secrets.";
+  entry = "${pkgs.gitleaks}/bin/gitleaks protect --staged --verbose --redact";
+  stages = [ "pre-commit" ];
+};
+```
+
+## Processes and services
+
+devenv can manage background processes:
+
+```nix
+processes = {
+  server.exec = "cargo run --bin my-server";
+};
+
+services.postgres = {
+  enable = true;
+  package = pkgs.postgresql_16;
+  initialDatabases = [{ name = "myapp"; }];
+};
+```
+
+Run with:
+
+```bash
+devenv up            # Start all processes and services
+```
+
+## `devenv.yaml` inputs
+
+Use `devenv.yaml` to declare external flake inputs:
+
+```yaml
+inputs:
+  nixpkgs:
+    url: github:NixOS/nixpkgs/nixpkgs-unstable
+  ifiokjr-nixpkgs:
+    url: github:ifiokjr/nixpkgs
+```
+
+Then reference them in `devenv.nix` as `inputs.ifiokjr-nixpkgs.packages.${pkgs.stdenv.system}`.
+
+## Common commands reference
+
+| Command | Purpose |
+|---------|---------|
+| `devenv test` | Enter the development shell |
+| `devenv shell <cmd>` | Run a single command in the shell |
+| `devenv up` | Start processes and services |
+| `devenv update` | Update flake inputs |
+| `devenv gc` | Garbage collect old generations |
+| `devenv processes status` | Show running processes |
+| `devenv scan` | List available scripts |
+
+## Troubleshooting
+
+### Command not found outside the shell
+
+If `pnpm`, `cargo`, or other tools are not available on your system PATH, always prefix:
+
+```bash
+devenv shell pnpm install
+devenv shell cargo build
+```
+
+### Stale environment
+
+```bash
+devenv test   # Re-enters the shell, re-evaluating enterShell
+```
+
+### Shell activation is slow
+
+Check that `enterShell` doesn't run expensive operations. Move one-time setup into named
+scripts like `install:toolchains` instead.

--- a/packages/skills/skills/devenv/SKILL.md
+++ b/packages/skills/skills/devenv/SKILL.md
@@ -1,0 +1,123 @@
+---
+name: devenv
+description:
+  Use devenv as the task runner and development environment when devenv.nix is present in the
+  project. Run scripts via `devenv test` to enter the shell, or `devenv shell <command>` when
+  commands aren't available outside the shell. Prefer devenv scripts over ad-hoc commands. Use when
+  devenv.nix exists, or when the user asks about devenv setup, scripts, processes, or Nix-based
+  dev environments.
+---
+
+# devenv Skill
+
+## Activation
+
+Load this skill when `devenv.nix` exists in the project root, or when the user mentions devenv,
+Nix shells, or project task runners.
+
+## Quick start
+
+```bash
+# Enter the development shell (sets up PATH, env, git hooks)
+devenv test
+
+# Run a one-off command inside the shell
+devenv shell <command>
+
+# Run a named script
+devenv shell <script-name>
+# Example: devenv shell lint:all
+```
+
+## Core rules
+
+1. **Prefer devenv scripts over raw commands.** When a `scripts` block exists in `devenv.nix`,
+   always use the script name instead of the underlying command.
+
+   ```bash
+   # ✅ Preferred
+   devenv shell lint:all
+   devenv shell test:all
+
+   # ❌ Avoid
+   cargo clippy --workspace --all-features -- -D warnings
+   pnpm test
+   ```
+
+2. **Use `devenv shell <command>` when direct commands fail.** If `pnpm`, `cargo`, or other
+   project tools are not on PATH, prefix with `devenv shell`:
+
+   ```bash
+   devenv shell pnpm install
+   devenv shell cargo build --workspace
+   ```
+
+3. **Use `devenv test` to enter the shell** for interactive work or to verify the environment
+   is correctly set up.
+
+4. **Check `devenv.nix` scripts before inventing commands.** Always read the `scripts` block to
+   find existing task names before running raw commands.
+
+## Common patterns
+
+### Running project tasks
+
+```bash
+devenv shell build:all       # Build everything
+devenv shell test:all        # Run all tests
+devenv shell lint:all        # Run all lints
+devenv shell fix:all         # Fix all autofixable problems
+devenv shell docs:check      # Check documentation
+devenv shell docs:update     # Update shared docs
+```
+
+### Managing the environment
+
+```bash
+devenv test                  # Enter the shell (sets up env + hooks)
+devenv update                # Update flake inputs
+devenv gc                    # Garbage collect old generations
+```
+
+### Running processes
+
+```bash
+devenv up                    # Start all processes (postgres, redis, etc.)
+devenv processes status      # Check running processes
+```
+
+## When scripts aren't on PATH
+
+Some devenv configurations set `enterShell` to add scripts to PATH via:
+
+```nix
+enterShell = ''
+  export PATH="$DEVENV_ROOT/scripts:$PATH"
+'';
+```
+
+In those cases, scripts may be available directly inside `devenv test`. Outside the shell, always
+use `devenv shell <script-name>`.
+
+## Script naming conventions
+
+The user's preferred `devenv.nix` layout uses colon-separated namespaced scripts:
+
+- `build:*` — build tasks
+- `test:*` — test tasks
+- `lint:*` — lint and check tasks
+- `fix:*` — autofix tasks
+- `install:*` — dependency installation tasks
+- `update:*` — update tasks
+- `docs:*` — documentation tasks
+- `coverage:*` — coverage tasks
+- `snapshot:*` — snapshot update/review tasks
+- `setup:*` — editor/tool setup tasks
+- `clean:*` — cleanup tasks
+- `deny:check` — security/license checks
+- `publish:check` — publication dry-run checks
+
+## See also
+
+For the recommended `devenv.nix` layout, script structure, and git-hooks configuration, see
+[REFERENCE.md](REFERENCE.md).


### PR DESCRIPTION
## Summary

Add a new `devenv` skill for projects that use `devenv.nix` as their development environment and task runner.

## What the skill does

- **Activates** when `devenv.nix` is present in the project
- **Uses `devenv test`** to enter the shell environment
- **Uses `devenv shell <command>`** when tools aren't available outside the shell
- **Prefers devenv scripts** over raw commands (e.g. `devenv shell lint:all` instead of `cargo clippy ...`)
- **Documents colon-namespaced script conventions**: `build:*`, `test:*`, `lint:*`, `fix:*`, `install:*`, `update:*`, `docs:*`, etc.

## Files added

- `packages/skills/skills/devenv/SKILL.md` — activation rules, core commands, script naming conventions
- `packages/skills/skills/devenv/REFERENCE.md` — recommended `devenv.nix` layout, script options, git-hooks config, processes/services, troubleshooting

## Local checks

- `pnpm mdt check` ✅
- `pnpm lint` ✅

## Style

The skill is based on the devenv.nix layout used in the monochange project, with colon-namespaced scripts, `enterShell` that adds `$DEVENV_ROOT/scripts` to PATH, and git-hooks configured for pre-commit/pre-push.
