### PR TITLE
feat(subagents): add idle timeout watchdog for stuck subagents

### DIFF
--- a/packages/subagents/agents.ts
+++ b/packages/subagents/agents.ts
@@ -23,6 +23,9 @@ export interface AgentConfig {
 	mcpDirectTools?: string[];
 	model?: string;
 	thinking?: string;
+	/** Idle timeout in ms — kill the agent if it produces no output for this long.
+	 *  Default: 15 min (from DEFAULT_IDLE_TIMEOUT_MS). Set to 0 to disable. */
+	idleTimeoutMs?: number;
 	systemPrompt: string;
 	source: AgentSource;
 	filePath: string;
@@ -172,6 +175,7 @@ function loadAgentsFromDir(dir: string, source: AgentSource): AgentConfig[] {
 			mcpDirectTools: mcpDirectTools.length > 0 ? mcpDirectTools : undefined,
 			model: frontmatter.model,
 			thinking: frontmatter.thinking,
+			idleTimeoutMs: frontmatter.idleTimeoutMs ? Number(frontmatter.idleTimeoutMs) : undefined,
 			systemPrompt: body,
 			source,
 			filePath,

--- a/packages/subagents/execution.ts
+++ b/packages/subagents/execution.ts
@@ -15,6 +15,7 @@ import {
 	type RunSyncOptions,
 	type SingleResult,
 	DEFAULT_MAX_OUTPUT,
+	DEFAULT_IDLE_TIMEOUT_MS,
 	truncateOutput,
 	getSubagentDepthEnv,
 } from "./types.js";
@@ -49,7 +50,7 @@ export async function runSync(
 	task: string,
 	options: RunSyncOptions,
 ): Promise<SingleResult> {
-	const { cwd, signal, onUpdate, maxOutput, artifactsDir, artifactConfig, runId, index, modelOverride } = options;
+	const { cwd, signal, onUpdate, maxOutput, artifactsDir, artifactConfig, runId, index, modelOverride, idleTimeoutMs } = options;
 	const agent = agents.find((a) => a.name === agentName);
 	if (!agent) {
 		return {
@@ -211,6 +212,27 @@ export async function runSync(
 		let processClosed = false;
 		const UPDATE_THROTTLE_MS = 50; // Reduced from 75ms for faster responsiveness
 
+		// Idle-timeout watchdog — kills the process if no activity for N ms.
+		// Default 15 min; 0 disables. Agent frontmatter can override: `idleTimeoutMs: 1800000`
+		const idleTimeout = idleTimeoutMs ?? DEFAULT_IDLE_TIMEOUT_MS;
+		let idleTimer: ReturnType<typeof setTimeout> | null = null;
+		let idleKilled = false;
+		const resetIdleTimer = () => {
+			if (idleTimeout <= 0 || processClosed) return;
+			if (idleTimer) clearTimeout(idleTimer);
+			idleTimer = setTimeout(() => {
+				if (processClosed) return;
+				idleKilled = true;
+				result.error = `Idle timeout: no activity for ${Math.round(idleTimeout / 60000)} min`;
+				progress.error = result.error;
+				progress.status = "failed";
+				proc.kill("SIGTERM");
+				setTimeout(() => !proc.killed && proc.kill("SIGKILL"), 3000);
+			}, idleTimeout);
+		};
+		// Start the initial idle timer (first activity will reset it)
+		resetIdleTimer();
+
 		const scheduleUpdate = () => {
 			if (!onUpdate || processClosed) return;
 			const now = Date.now();
@@ -262,6 +284,7 @@ export async function runSync(
 					progress.currentToolArgs = extractToolArgsPreview((evt.args || {}) as Record<string, unknown>);
 					// Tool start is important - update immediately by forcing throttle reset
 					lastUpdateTime = 0;
+					resetIdleTimer();
 					scheduleUpdate();
 				}
 
@@ -278,6 +301,7 @@ export async function runSync(
 					}
 					progress.currentTool = undefined;
 					progress.currentToolArgs = undefined;
+					resetIdleTimer();
 					scheduleUpdate();
 				}
 
@@ -310,6 +334,7 @@ export async function runSync(
 							}
 						}
 					}
+					resetIdleTimer();
 					scheduleUpdate();
 				}
 				if (evt.type === "tool_result_end" && evt.message) {
@@ -327,6 +352,7 @@ export async function runSync(
 							progress.recentOutput.splice(0, progress.recentOutput.length - 50);
 						}
 					}
+					resetIdleTimer();
 					scheduleUpdate();
 				}
 			} catch {
@@ -344,6 +370,7 @@ export async function runSync(
 			lines.forEach(processLine);
 
 			// Also schedule an update on data received (handles streaming output)
+			resetIdleTimer();
 			scheduleUpdate();
 		});
 		proc.stderr.on("data", (d) => {
@@ -354,6 +381,10 @@ export async function runSync(
 			if (pendingTimer) {
 				clearTimeout(pendingTimer);
 				pendingTimer = null;
+			}
+			if (idleTimer) {
+				clearTimeout(idleTimer);
+				idleTimer = null;
 			}
 			if (buf.trim()) processLine(buf);
 			if (code !== 0 && stderrBuf.trim() && !result.error) {

--- a/packages/subagents/index.ts
+++ b/packages/subagents/index.ts
@@ -582,6 +582,7 @@ MANAGEMENT (use action field — omit agent/task/chain/tasks):
 						modelOverride: modelResolutions[i]?.model,
 						modelSource: modelResolutions[i]?.source,
 						modelCategory: modelResolutions[i]?.category,
+						idleTimeoutMs: agentConfigs[i]?.idleTimeoutMs,
 						skills: effectiveSkills === false ? [] : effectiveSkills,
 						onUpdate: onUpdate
 							? (p) => {
@@ -786,6 +787,7 @@ MANAGEMENT (use action field — omit agent/task/chain/tasks):
 					modelOverride,
 					modelSource: modelResolution.source,
 					modelCategory: modelResolution.category,
+					idleTimeoutMs: agentConfig?.idleTimeoutMs,
 					skills: effectiveSkills,
 				});
 				recordRun(params.agent!, cleanTask, r.exitCode, r.progressSummary?.durationMs ?? 0);

--- a/packages/subagents/types.ts
+++ b/packages/subagents/types.ts
@@ -221,6 +221,9 @@ export interface RunSyncOptions {
 	modelCategory?: string;
 	/** Skills to inject (overrides agent default if provided) */
 	skills?: string[];
+	/** Idle timeout in ms — kill the agent if it produces no output for this long.
+	 *  Default: 15 min. Set to 0 to disable. Override per-agent via frontmatter: `idleTimeoutMs: 1800000`. */
+	idleTimeoutMs?: number;
 }
 
 export interface ExtensionConfig {
@@ -250,6 +253,12 @@ export const DEFAULT_ARTIFACT_CONFIG: ArtifactConfig = {
 
 export const MAX_PARALLEL = 8;
 export const MAX_CONCURRENCY = 4;
+
+/** Default idle timeout: kill a subagent if it produces no output for this long.
+ *  15 min — enough for slow OCR/vision tasks but catches truly stuck agents.
+ *  Override per-agent via frontmatter: `idleTimeoutMs: 1200000` (20 min). */
+export const DEFAULT_IDLE_TIMEOUT_MS = 15 * 60 * 1000;
+
 export const RESULTS_DIR = path.join(os.tmpdir(), "pi-async-subagent-results");
 export const ASYNC_DIR = path.join(os.tmpdir(), "pi-async-subagent-runs");
 export const WIDGET_KEY = "subagent-async";


### PR DESCRIPTION
## Problem

During parallel sync execution (`tasks: [...]`), the main agent is completely blocked — it cannot call tools, check status, or kill stuck subagents. The TUI shows progress to the user, but the LLM orchestrator is blind.

A subagent that gets stuck (infinite loop, dead API call, OCR hanging on a corrupt PDF) will run indefinitely with no way for the orchestrator to intervene.

## Solution

Add an **idle-timeout watchdog** that auto-kills agents producing no output for a configurable duration.

### How it works

- Timer starts when the subagent process spawns
- **Resets on every activity**: tool call start/end, assistant message, stdout data
- If idle for N ms → `SIGTERM` → `SIGKILL` after 3s grace
- Result includes error: `"Idle timeout: no activity for 15 min"`

### Configuration

| Level | How | Default |
|---|---|---|
| Global constant | `DEFAULT_IDLE_TIMEOUT_MS` in `types.ts` | 15 min |
| Per-agent | `idleTimeoutMs` in agent frontmatter | inherits default |
| Disable | `idleTimeoutMs: 0` | — |

```yaml
---
name: ecsc-highlight-authorities
idleTimeoutMs: 1800000  # 30 min for slow OCR/vision tasks
---
```

### Why 15 min default?

OCR/vision tasks on legal PDFs can legitimately take 10-20 min per document. 15 min is generous enough for slow tasks but catches truly stuck agents.

### Files changed

| File | Lines |
|---|---|
| `packages/subagents/types.ts` | +9 (constant + `idleTimeoutMs` in `RunSyncOptions`) |
| `packages/subagents/agents.ts` | +4 (field in `AgentConfig` + frontmatter parsing) |
| `packages/subagents/execution.ts` | +32/-1 (watchdog logic + cleanup on close) |
| `packages/subagents/index.ts` | +2 (wire through for single + parallel) |

Total: **4 files, 47 insertions, 1 deletion**