### PR TITLE
fix(extensions): return Widget from worktree renderCall/renderResult

### DIFF
--- a/.changeset/fix-worktree-render-string-not-widget.md
+++ b/.changeset/fix-worktree-render-string-not-widget.md
@@ -1,0 +1,9 @@
+---
+default: patch
+---
+
+Fix worktree tool renderCall/renderResult returning strings instead of Widget instances
+
+The worktree tool's `renderCall` and `renderResult` returned plain strings
+instead of TUI `Widget` instances. `Box.render` calls `child.render()` on
+every child, so a bare string caused `TypeError: child.render is not a function`.

--- a/packages/extensions/extensions/worktree.ts
+++ b/packages/extensions/extensions/worktree.ts
@@ -2,6 +2,7 @@
 import path from "node:path";
 import process from "node:process";
 import type { ExtensionAPI, ExtensionContext } from "@mariozechner/pi-coding-agent";
+import { Text } from "@mariozechner/pi-tui";
 import { Type } from "@sinclair/typebox";
 import { recordRuntimeSample } from "./watchdog-runtime-diagnostics";
 import {
@@ -805,7 +806,7 @@ function registerWorktreeTool(pi: ExtensionAPI) {
 			const action = args.action ?? "?";
 			const detail =
 				action === "create" ? `${args.branch ?? "?"}` : action === "cleanup" ? `${args.target ?? "?"}` : "";
-			return `${theme.fg("toolTitle", theme.bold("⌥ worktree"))} ${action} ${detail}`;
+			return new Text(`${theme.fg("toolTitle", theme.bold("⌥ worktree"))} ${action} ${detail}`, 0, 0);
 		},
 
 		renderResult(result, _options, theme) {
@@ -813,10 +814,10 @@ function registerWorktreeTool(pi: ExtensionAPI) {
 				result.content?.find((e): e is { type: "text"; text: string } => typeof e === "object" && e?.type === "text")
 					?.text ?? "";
 			if (result.isError) {
-				return `${theme.fg("error", text)}`;
+				return new Text(theme.fg("error", text), 0, 0);
 			}
 			const firstLine = text.split("\n")[0] ?? "";
-			return `${theme.fg("success", "✓ ")}${theme.fg("muted", firstLine)}`;
+			return new Text(`${theme.fg("success", "✓ ")}${theme.fg("muted", firstLine)}`, 0, 0);
 		},
 	});
 }


### PR DESCRIPTION
## Problem

The worktree tool's `renderCall` and `renderResult` returned plain strings instead of TUI Widget instances. `Box.render` calls `child.render()` on every child, so a bare string caused:

```
TypeError: child.render is not a function
    at Box.render (pi-tui/dist/components/box.js:62:33)
    at ToolExecutionComponent.render (...)
```

This crash occurs whenever the worktree tool renders (e.g. creating a worktree).

## Fix

- Import `Text` from `@mariozechner/pi-tui`
- Wrap all return values in `new Text(..., 0, 0)` to match the expected Widget interface

## Changeset

`patch` — bug fix