### PR TITLE
feat(ollama): add kimi-k2.6 to cloud fallback model catalog

### DIFF
--- a/.changeset/add-kimi-k2.6-fallback.md
+++ b/.changeset/add-kimi-k2.6-fallback.md
@@ -1,0 +1,5 @@
+---
+default: patch
+---
+
+Add kimi-k2.6 to Ollama cloud fallback model catalog

--- a/packages/ollama/models.ts
+++ b/packages/ollama/models.ts
@@ -88,6 +88,7 @@ const FALLBACK_OLLAMA_CLOUD_MODELS: OllamaProviderModel[] = [
 	toOllamaModel({ id: "gpt-oss:20b", source: "cloud", reasoning: true, input: ["text"], contextWindow: 131_072, maxTokens: 16_384 }),
 	toOllamaModel({ id: "kimi-k2-thinking", source: "cloud", reasoning: true, input: ["text"], contextWindow: 262_144, maxTokens: 32_768 }),
 	toOllamaModel({ id: "kimi-k2.5", source: "cloud", reasoning: true, input: ["text", "image"], contextWindow: 262_144, maxTokens: 32_768 }),
+	toOllamaModel({ id: "kimi-k2.6", source: "cloud", reasoning: true, input: ["text", "image"], contextWindow: 262_144, maxTokens: 32_768 }),
 	toOllamaModel({ id: "kimi-k2:1t", source: "cloud", reasoning: false, input: ["text"], contextWindow: 262_144, maxTokens: 32_768 }),
 	toOllamaModel({ id: "minimax-m2", source: "cloud", reasoning: false, input: ["text"], contextWindow: 204_800, maxTokens: 25_600 }),
 	toOllamaModel({ id: "minimax-m2.1", source: "cloud", reasoning: true, input: ["text"], contextWindow: 204_800, maxTokens: 25_600 }),

--- a/packages/ollama/tests/models.test.ts
+++ b/packages/ollama/tests/models.test.ts
@@ -25,6 +25,7 @@ describe("ollama models", () => {
 		expect(models.some((model) => model.id === "gpt-oss:120b")).toBe(true);
 		expect(models.some((model) => model.id === "qwen3-vl:235b")).toBe(true);
 		expect(models.some((model) => model.id === "glm-5.1")).toBe(true);
+		expect(models.some((model) => model.id === "kimi-k2.6")).toBe(true);
 	});
 
 	it("normalizes model defaults", () => {


### PR DESCRIPTION
## Problem

`kimi-k2.6` was recently announced as GA on Ollama Cloud, but running `/ollama:refresh-models` would not surface it when the fallback catalog is used (offline discovery, individual model metadata failures).

The live Ollama API at `https://ollama.com/v1/models` correctly returns `kimi-k2.6` and its `/api/show` endpoint confirms `vision` + `thinking` capabilities (262k context, reasoning model with image support). So online discovery finds it fine — the gap was only in the hardcoded fallback list.

## Changes

- **`packages/ollama/models.ts`**: Added `kimi-k2.6` entry to `FALLBACK_OLLAMA_CLOUD_MODELS` with `reasoning: true`, `input: ["text", "image"]`, `contextWindow: 262_144`, `maxTokens: 32_768`
- **`packages/ollama/tests/models.test.ts`**: Added assertion that `kimi-k2.6` is present in the fallback catalog
- **`.changeset/add-kimi-k2.6-fallback.md`**: Patch changeset