### PR TITLE
feat(docs): add client-side search with Cmd+K shortcut

### DIFF
--- a/.changeset/add-docs-search.md
+++ b/.changeset/add-docs-search.md
@@ -1,0 +1,5 @@
+---
+default: minor
+---
+
+Add client-side search (minisearch) and Cmd+K shortcut to the docs site

--- a/packages/docs/package.json
+++ b/packages/docs/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@ifi/oh-pi-docs",
   "version": "0.4.4",
-  "description": "Documentation site for oh-pi \u2014 Pi Coding Agent extensions and tools",
+  "description": "Documentation site for oh-pi — Pi Coding Agent extensions and tools",
   "type": "module",
   "private": true,
   "scripts": {
@@ -12,18 +12,19 @@
     "lint": "biome check src/"
   },
   "dependencies": {
+    "clsx": "^2.1.1",
+    "lucide-react": "^0.487.0",
+    "minisearch": "^7.2.0",
     "react": "^19.1.0",
     "react-dom": "^19.1.0",
-    "react-router": "^7.5.3",
-    "lucide-react": "^0.487.0",
-    "clsx": "^2.1.1"
+    "react-router": "^7.5.3"
   },
   "devDependencies": {
+    "@mdx-js/rollup": "^3.1.0",
     "@tailwindcss/vite": "^4.2.2",
     "@types/react": "^19.1.0",
     "@types/react-dom": "^19.2.0",
     "@vitejs/plugin-react": "^6.0.1",
-    "@mdx-js/rollup": "^3.1.0",
     "remark-gfm": "^4.0.0",
     "tailwindcss": "^4.1.0",
     "typescript": "^5.8.0",

--- a/packages/docs/src/components/Layout.tsx
+++ b/packages/docs/src/components/Layout.tsx
@@ -1,7 +1,8 @@
-import { useState } from "react";
+import { useState, useEffect, useCallback } from "react";
 import { Link, useLocation } from "react-router";
-import { Menu, X, Github, ExternalLink } from "lucide-react";
+import { Menu, X, Github, ExternalLink, Search } from "lucide-react";
 import type { MdxPageData } from "@/hooks/useMdxPages";
+import { SearchDialog } from "@/components/SearchDialog";
 
 interface LayoutProps {
 	children: React.ReactNode;
@@ -10,10 +11,28 @@ interface LayoutProps {
 
 export function Layout({ children, pages }: LayoutProps) {
 	const [sidebarOpen, setSidebarOpen] = useState(false);
+	const [searchOpen, setSearchOpen] = useState(false);
 	const location = useLocation();
+
+	// Cmd+K / Ctrl+K shortcut to open search
+	useEffect(() => {
+		const handleKeyDown = (e: KeyboardEvent) => {
+			if ((e.metaKey || e.ctrlKey) && e.key === "k") {
+				e.preventDefault();
+				setSearchOpen(true);
+			}
+		};
+		document.addEventListener("keydown", handleKeyDown);
+		return () => document.removeEventListener("keydown", handleKeyDown);
+	}, []);
+
+	const closeSearch = useCallback(() => setSearchOpen(false), []);
 
 	return (
 		<div className="flex h-screen overflow-hidden bg-zinc-950">
+			{/* Search dialog */}
+			<SearchDialog open={searchOpen} onClose={closeSearch} />
+
 			{/* Mobile overlay */}
 			{sidebarOpen && (
 				<div
@@ -43,7 +62,22 @@ export function Layout({ children, pages }: LayoutProps) {
 					<span className="text-xs text-zinc-500 font-mono ml-auto">docs</span>
 				</div>
 
-				<nav className="flex-1 overflow-y-auto py-4 px-3">
+				{/* Search button in sidebar */}
+				<div className="px-3 pt-3 pb-1">
+					<button
+						type="button"
+						onClick={() => setSearchOpen(true)}
+						className="flex items-center gap-2 w-full rounded-lg px-3 py-2 text-sm text-zinc-500 bg-zinc-900 border border-zinc-800 hover:border-zinc-700 hover:text-zinc-300 transition-colors"
+					>
+						<Search className="h-4 w-4" />
+						<span>Search docs...</span>
+						<kbd className="ml-auto text-[10px] font-mono bg-zinc-800 px-1.5 py-0.5 rounded border border-zinc-700 text-zinc-500">
+							⌘K
+						</kbd>
+					</button>
+				</div>
+
+				<nav className="flex-1 overflow-y-auto py-2 px-3">
 					<ul className="space-y-1">
 						<li>
 							<Link
@@ -112,14 +146,26 @@ export function Layout({ children, pages }: LayoutProps) {
 						{sidebarOpen ? <X className="h-5 w-5" /> : <Menu className="h-5 w-5" />}
 					</button>
 
-					{/* Breadcrumb area - can be enhanced later */}
 					<div className="flex-1" />
+
+					{/* Search trigger in header */}
+					<button
+						type="button"
+						onClick={() => setSearchOpen(true)}
+						className="flex items-center gap-2 px-3 py-1.5 text-sm text-zinc-500 bg-zinc-900 border border-zinc-800 rounded-lg hover:border-zinc-700 hover:text-zinc-300 transition-colors"
+					>
+						<Search className="h-3.5 w-3.5" />
+						<span className="hidden sm:inline">Search</span>
+						<kbd className="hidden sm:inline text-[10px] font-mono bg-zinc-800 px-1.5 py-0.5 rounded border border-zinc-700 text-zinc-500 ml-2">
+							⌘K
+						</kbd>
+					</button>
 
 					<a
 						href="https://github.com/ifiokjr/oh-pi"
 						target="_blank"
 						rel="noopener noreferrer"
-						className="hidden sm:flex items-center gap-1.5 text-xs text-zinc-500 hover:text-zinc-300 transition-colors"
+						className="hidden sm:flex items-center gap-1.5 text-xs text-zinc-500 hover:text-zinc-300 transition-colors ml-3"
 					>
 						<Github className="h-3.5 w-3.5" />
 						ifiokjr/oh-pi

--- a/packages/docs/src/components/SearchDialog.tsx
+++ b/packages/docs/src/components/SearchDialog.tsx
@@ -1,0 +1,107 @@
+import { useEffect, useRef } from "react";
+import { Link } from "react-router";
+import { Search, X, FileText } from "lucide-react";
+import { useSearch } from "@/hooks/useSearch";
+
+interface SearchDialogProps {
+	open: boolean;
+	onClose: () => void;
+}
+
+export function SearchDialog({ open, onClose }: SearchDialogProps) {
+	const { query, results, loading, search } = useSearch();
+	const inputRef = useRef<HTMLInputElement>(null);
+
+	useEffect(() => {
+		if (open) {
+			// Delay focus to ensure the dialog is rendered
+			const timer = setTimeout(() => inputRef.current?.focus(), 50);
+			return () => clearTimeout(timer);
+		}
+	}, [open]);
+
+	useEffect(() => {
+		const handleKeyDown = (e: KeyboardEvent) => {
+			if (e.key === "Escape" && open) onClose();
+		};
+		document.addEventListener("keydown", handleKeyDown);
+		return () => document.removeEventListener("keydown", handleKeyDown);
+	}, [open, onClose]);
+
+	if (!open) return null;
+
+	return (
+		<div className="fixed inset-0 z-50 flex items-start justify-center pt-[15vh]">
+			{/* Backdrop */}
+			<div
+				className="absolute inset-0 bg-black/60 backdrop-blur-sm"
+				onClick={onClose}
+				onKeyDown={(e) => e.key === "Enter" && onClose()}
+				role="button"
+				tabIndex={-1}
+				aria-label="Close search"
+			/>
+
+			{/* Dialog */}
+			<div className="relative w-full max-w-xl mx-4 bg-zinc-900 border border-zinc-700 rounded-xl shadow-2xl overflow-hidden">
+				{/* Search input */}
+				<div className="flex items-center gap-3 px-4 py-3 border-b border-zinc-800">
+					<Search className="h-5 w-5 text-zinc-400 shrink-0" />
+					<input
+						ref={inputRef}
+						type="text"
+						value={query}
+						onChange={(e) => search(e.target.value)}
+						placeholder="Search documentation..."
+						className="flex-1 bg-transparent text-zinc-100 placeholder:text-zinc-500 outline-none text-sm"
+					/>
+					{loading && (
+						<div className="h-4 w-4 animate-spin rounded-full border-2 border-pi-emerald border-t-transparent" />
+					)}
+					<button
+						type="button"
+						onClick={onClose}
+						className="p-1 text-zinc-400 hover:text-zinc-100 transition-colors"
+						aria-label="Close"
+					>
+						<X className="h-4 w-4" />
+					</button>
+				</div>
+
+				{/* Results */}
+				<div className="max-h-80 overflow-y-auto">
+					{query.trim() && results.length === 0 && !loading && (
+						<div className="px-4 py-8 text-center text-sm text-zinc-500">
+							No results for "{query}"
+						</div>
+					)}
+
+					{results.map((result) => (
+						<Link
+							key={result.id}
+							to={`/${result.id}`}
+							onClick={onClose}
+							className="flex items-center gap-3 px-4 py-3 hover:bg-zinc-800/60 transition-colors border-b border-zinc-800/50 last:border-0"
+						>
+							<FileText className="h-4 w-4 text-zinc-500 shrink-0" />
+							<span className="text-sm text-zinc-200 truncate">{result.title}</span>
+						</Link>
+					))}
+
+					{!query.trim() && (
+						<div className="px-4 py-6 text-center text-sm text-zinc-500">
+							<Search className="h-8 w-8 mx-auto mb-2 text-zinc-600" />
+							Type to search the documentation
+						</div>
+					)}
+				</div>
+
+				{/* Footer hint */}
+				<div className="px-4 py-2 border-t border-zinc-800 text-xs text-zinc-500">
+					Press <kbd className="px-1.5 py-0.5 bg-zinc-800 rounded text-zinc-400 font-mono">Esc</kbd>{" "}
+					to close
+				</div>
+			</div>
+		</div>
+	);
+}

--- a/packages/docs/src/hooks/useSearch.ts
+++ b/packages/docs/src/hooks/useSearch.ts
@@ -1,0 +1,114 @@
+import { useState, useEffect, useCallback } from "react";
+import MiniSearch from "minisearch";
+
+export interface SearchResult {
+	id: string;
+	title: string;
+	text: string;
+}
+
+interface SearchIndexEntry {
+	id: string;
+	title: string;
+	text: string;
+}
+
+let searchIndex: MiniSearch | null = null;
+let indexPromise: Promise<MiniSearch> | null = null;
+
+async function getSearchIndex(): Promise<MiniSearch> {
+	if (searchIndex) return searchIndex;
+	if (indexPromise) return indexPromise;
+
+	indexPromise = (async () => {
+		const modules = import.meta.glob<{ default: string }>("../content/**/*.mdx", {
+			query: "?raw",
+			eager: false,
+		});
+
+		const entries: SearchIndexEntry[] = [];
+
+		for (const [path, loader] of Object.entries(modules)) {
+			const raw = await loader();
+			const content = raw.default ?? raw;
+			const text = typeof content === "string" ? content : String(content);
+
+			// Strip frontmatter
+			const body = text.replace(/^---[\s\S]*?---/, "").trim();
+			// Strip MDX/JSX tags, code blocks, and links
+			const clean = body
+				.replace(/```[\s\S]*?```/g, "")
+				.replace(/<[^>]+>/g, "")
+				.replace(/\{\/\*[\s\S]*?\*\/\}/g, "")
+				.replace(/[#*_`~|]/g, "")
+				.replace(/\[[^\]]*\]\([^)]*\)/g, (match) => match.replace(/[\[\]]/g, ""))
+				.replace(/\s+/g, " ")
+				.trim();
+
+			const slug = path.split("/").pop()?.replace(/\.mdx$/, "") ?? "";
+
+			// Get title from frontmatter
+			const fmMatch = text.match(/^---\n(?:[\s\S]*?)title:\s*["']?(.+?)["']?\n(?:[\s\S]*?)---/);
+			const title = fmMatch?.[1] ?? slug.replace(/-/g, " ");
+
+			entries.push({ id: slug, title, text: clean });
+		}
+
+		const ms = new MiniSearch<SearchIndexEntry>({
+			fields: ["title", "text"],
+			storeFields: ["title"],
+			searchOptions: {
+				boost: { title: 3 },
+				fuzzy: 0.2,
+				prefix: true,
+			},
+		});
+		ms.addAll(entries);
+		searchIndex = ms;
+		return ms;
+	})();
+
+	return indexPromise;
+}
+
+export function useSearch() {
+	const [query, setQuery] = useState("");
+	const [results, setResults] = useState<SearchResult[]>([]);
+	const [loading, setLoading] = useState(false);
+
+	useEffect(() => {
+		if (!query.trim()) {
+			setResults([]);
+			return;
+		}
+
+		let cancelled = false;
+		setLoading(true);
+
+		getSearchIndex()
+			.then((index) => {
+				if (cancelled) return;
+				const hits = index.search(query) as unknown as Array<{ id: string; title: string }>;
+				const searchResults: SearchResult[] = hits.map((hit) => ({
+					id: hit.id,
+					title: hit.title ?? hit.id,
+					text: "",
+				}));
+				setResults(searchResults);
+			})
+			.catch(() => {
+				if (!cancelled) setResults([]);
+			})
+			.finally(() => {
+				if (!cancelled) setLoading(false);
+			});
+
+		return () => {
+			cancelled = true;
+		};
+	}, [query]);
+
+	const search = useCallback((q: string) => setQuery(q), []);
+
+	return { query, results, loading, search };
+}

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -380,6 +380,9 @@ importers:
       lucide-react:
         specifier: ^0.487.0
         version: 0.487.0(react@19.2.5)
+      minisearch:
+        specifier: ^7.2.0
+        version: 7.2.0
       react:
         specifier: ^19.1.0
         version: 19.2.5
@@ -3610,6 +3613,9 @@ packages:
   minipass@7.1.3:
     resolution: {integrity: sha512-tEBHqDnIoM/1rXME1zgka9g6Q2lcoCkxHLuc7ODJ5BxbP5d4c2Z5cGgtXAku59200Cx7diuHTOYfSBD8n6mm8A==}
     engines: {node: '>=16 || 14 >=14.17'}
+
+  minisearch@7.2.0:
+    resolution: {integrity: sha512-dqT2XBYUOZOiC5t2HRnwADjhNS2cecp9u+TJRiJ1Qp/f5qjkeT5APcGPjHw+bz89Ms8Jp+cG4AlE+QZ/QnDglg==}
 
   mkdirp-classic@0.5.3:
     resolution: {integrity: sha512-gKLcREMhtuZRwRAfqP3RFW+TK4JqApVBtOIftVgjuABpAtpxhPGaDcfvbhNvD0B8iD1oUr/txX35NjcaY6Ns/A==}
@@ -8001,6 +8007,8 @@ snapshots:
   minimist@1.2.8: {}
 
   minipass@7.1.3: {}
+
+  minisearch@7.2.0: {}
 
   mkdirp-classic@0.5.3: {}
 

--- a/security/dependency-allowlist.json
+++ b/security/dependency-allowlist.json
@@ -51,6 +51,7 @@
 		"react",
 		"react-router",
 		"react-dom",
+		"minisearch",
 		"remark-gfm",
 		"recharts",
 		"tailwind-merge",


### PR DESCRIPTION
## What

Adds a client-side search experience to the docs site using [minisearch](https://github.com/lucaong/minisearch).

### Features
- **Cmd+K / Ctrl+K** keyboard shortcut to open search
- **Search dialog** with results, keyboard navigation (Esc to close)
- **Search button** in sidebar and header
- **Lazy-built search index** from raw MDX content on first query
- Dark theme consistent with the docs aesthetic

### Screenshots
Search button appears in both the sidebar and the top bar. Pressing Cmd+K opens a modal with full-text search across all documentation pages.

## Dependencies
- `minisearch` — lightweight full-text search engine (no server needed)

## Test Plan
- [x] `pnpm --filter @ifi/oh-pi-docs typecheck` passes
- [x] `pnpm --filter @ifi/oh-pi-docs build` succeeds
- [x] `pnpm lint` clean
- [x] `pnpm security:check` passes