### PR TITLE
feat(docs): add docs:sync for MDT-integrated content pipeline

### DIFF
--- a/.changeset/add-docs-sync-mdt.md
+++ b/.changeset/add-docs-sync-mdt.md
@@ -1,0 +1,7 @@
+---
+default: patch
+---
+
+Add docs:sync script to derive MDX content from docs/*.md source files.
+Content now uses MDT markers and stays in sync with the repo's MDT
+documentation reuse system.

--- a/package.json
+++ b/package.json
@@ -68,6 +68,7 @@
     "mdt": "mdt",
     "docs:dev": "pnpm --filter @ifi/oh-pi-docs dev",
     "docs:build": "pnpm --filter @ifi/oh-pi-docs build",
+    "docs:sync": "pnpm --filter @ifi/oh-pi-docs docs:sync",
     "docs:list": "pnpm mdt list",
     "docs:update": "pnpm mdt update",
     "docs:check": "pnpm mdt check",

--- a/packages/docs/package.json
+++ b/packages/docs/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@ifi/oh-pi-docs",
   "version": "0.4.4",
-  "description": "Documentation site for oh-pi — Pi Coding Agent extensions and tools",
+  "description": "Documentation site for oh-pi \u2014 Pi Coding Agent extensions and tools",
   "type": "module",
   "private": true,
   "scripts": {
@@ -9,7 +9,8 @@
     "build": "vite build",
     "preview": "vite preview",
     "typecheck": "tsc --noEmit",
-    "lint": "biome check src/"
+    "lint": "biome check src/",
+    "docs:sync": "node scripts/sync-content.mjs"
   },
   "dependencies": {
     "clsx": "^2.1.1",

--- a/packages/docs/scripts/sync-content.mjs
+++ b/packages/docs/scripts/sync-content.mjs
@@ -1,0 +1,90 @@
+#!/usr/bin/env node
+/**
+ * Synchronize documentation content from docs/*.md into the docs site MDX files.
+ *
+ * This script:
+ * 1. Reads markdown files from the project's docs/ directory
+ * 2. Strips the first H1 title (handled by frontmatter/page title)
+ * 3. Converts HTML comments to MDX JSX comments
+ * 4. Prepends frontmatter with title extracted from the filename
+ * 5. Writes the result as MDX files in packages/docs/src/content/
+ *
+ * Run: pnpm docs:sync
+ */
+import { readFileSync, writeFileSync, mkdirSync, existsSync } from "node:fs";
+import { resolve, join } from "node:path";
+
+const REPO_ROOT = resolve(import.meta.dirname, "../../..");
+const DOCS_DIR = join(REPO_ROOT, "docs");
+const CONTENT_DIR = join(REPO_ROOT, "packages/docs/src/content");
+
+const TITLE_MAP = {
+	"01-overview": { title: "Overview", order: 1, description: "Project purpose, design philosophy, package architecture, install, run modes, providers, and auth." },
+	"02-interactive-mode": { title: "Interactive Mode", order: 2, description: "UI layout, editor features, command system, keybindings, message queue, terminal compatibility." },
+	"03-sessions": { title: "Session Management", order: 3, description: "JSONL tree structure, entry types, branching, context compaction, branch summaries." },
+	"04-extensions": { title: "Extension System", order: 4, description: "Extension API, event lifecycle, custom tools, UI interaction, state management." },
+	"05-skills-prompts-themes-packages": { title: "Skills, Prompts, Themes & Packages", order: 5, description: "Skill packs, prompt templates, theme customization, package management." },
+	"06-settings-sdk-rpc-tui": { title: "Settings, SDK, RPC & TUI", order: 6, description: "All settings, SDK programming interface, RPC protocol, TUI component system." },
+	"07-cli-reference": { title: "CLI Reference", order: 7, description: "Complete CLI options, directory structure, platform support." },
+	"feature-catalog": { title: "Feature Catalog", order: 8, description: "Package-by-package feature inventory." },
+};
+
+function convertHtmlCommentsToMdx(content) {
+	// Convert <!-- {=tagName} --> to {/* MDT: {=tagName} */}
+	content = content.replace(/<!--\s*\{=([^\}]+)\}\s*-->/g, "{/* MDT: {=$1} */}");
+	// Convert <!-- {/tagName} --> to {/* MDT: {/tagName} */}
+	content = content.replace(/<!--\s*\{\/([^\}]+)\}\s*-->/g, "{/* MDT: {/$1} */}");
+	// Convert <!-- {@tagName} --> (provider definitions) to {/* MDT: {@tagName} */}
+	content = content.replace(/<!--\s*\{@([^\}]+)\}\s*-->/g, "{/* MDT: {@$1} */}");
+	return content;
+}
+
+function stripFirstH1(content) {
+	return content.replace(/^# .+\n\n?/, "");
+}
+
+function syncDoc(baseName) {
+	const mdPath = join(DOCS_DIR, `${baseName}.md`);
+	const mdxPath = join(CONTENT_DIR, `${baseName}.mdx`);
+
+	if (!existsSync(mdPath)) {
+		console.warn(`Source file not found: ${mdPath}`);
+		return;
+	}
+
+	const meta = TITLE_MAP[baseName];
+	if (!meta) {
+		console.warn(`No metadata for: ${baseName}`);
+		return;
+	}
+
+	let source = readFileSync(mdPath, "utf-8");
+	source = stripFirstH1(source);
+	source = convertHtmlCommentsToMdx(source);
+
+	const frontmatter = [
+		"---",
+		`title: "${meta.title}"`,
+		`order: ${meta.order}`,
+		meta.description ? `description: "${meta.description}"` : null,
+		"---",
+		"",
+	].filter(Boolean).join("\n");
+
+	const output = `${frontmatter}\n${source.trim()}\n`;
+
+	if (!existsSync(mdxPath) || readFileSync(mdxPath, "utf-8") !== output) {
+		mkdirSync(CONTENT_DIR, { recursive: true });
+		writeFileSync(mdxPath, output, "utf-8");
+		console.log(`Synced: ${baseName}.mdx`);
+	} else {
+		console.log(`Unchanged: ${baseName}.mdx`);
+	}
+}
+
+// Sync all known docs
+for (const baseName of Object.keys(TITLE_MAP)) {
+	syncDoc(baseName);
+}
+
+console.log("\nDone! Run `pnpm docs:update` to sync MDT content with providers.");

--- a/packages/docs/src/content/01-overview.mdx
+++ b/packages/docs/src/content/01-overview.mdx
@@ -1,9 +1,8 @@
 ---
 title: "Overview"
 order: 1
+description: "Project purpose, design philosophy, package architecture, install, run modes, providers, and auth."
 ---
-
-
 ## 1. Project Overview
 
 - **Name**: `@mariozechner/pi-coding-agent`

--- a/packages/docs/src/content/02-interactive-mode.mdx
+++ b/packages/docs/src/content/02-interactive-mode.mdx
@@ -1,9 +1,8 @@
 ---
 title: "Interactive Mode"
 order: 2
+description: "UI layout, editor features, command system, keybindings, message queue, terminal compatibility."
 ---
-
-
 ## 1. UI Layout (Top to Bottom)
 
 1. **Startup Header** — Keybindings, loaded AGENTS.md, Prompt Templates, Skills, Extensions

--- a/packages/docs/src/content/03-sessions.mdx
+++ b/packages/docs/src/content/03-sessions.mdx
@@ -1,9 +1,8 @@
 ---
-title: "Sessions"
+title: "Session Management"
 order: 3
+description: "JSONL tree structure, entry types, branching, context compaction, branch summaries."
 ---
-
-
 ## 1. Session Storage
 
 Sessions are stored as JSONL (JSON Lines) files using a tree structure. Each entry has an `id` and

--- a/packages/docs/src/content/04-extensions.mdx
+++ b/packages/docs/src/content/04-extensions.mdx
@@ -1,9 +1,8 @@
 ---
-title: "Extensions"
+title: "Extension System"
 order: 4
+description: "Extension API, event lifecycle, custom tools, UI interaction, state management."
 ---
-
-
 ## 1. Overview
 
 Extensions are TypeScript modules loaded via jiti (no compilation needed). They can:

--- a/packages/docs/src/content/05-skills-prompts-themes-packages.mdx
+++ b/packages/docs/src/content/05-skills-prompts-themes-packages.mdx
@@ -1,9 +1,8 @@
 ---
 title: "Skills, Prompts, Themes & Packages"
 order: 5
+description: "Skill packs, prompt templates, theme customization, package management."
 ---
-
-
 ## 1. Skills
 
 Skills are on-demand capability packs following the [Agent Skills Standard](https://agentskills.io).

--- a/packages/docs/src/content/06-settings-sdk-rpc-tui.mdx
+++ b/packages/docs/src/content/06-settings-sdk-rpc-tui.mdx
@@ -1,9 +1,8 @@
 ---
 title: "Settings, SDK, RPC & TUI"
 order: 6
+description: "All settings, SDK programming interface, RPC protocol, TUI component system."
 ---
-
-
 ## 1. Settings
 
 ### File Locations

--- a/packages/docs/src/content/07-cli-reference.mdx
+++ b/packages/docs/src/content/07-cli-reference.mdx
@@ -1,9 +1,8 @@
 ---
 title: "CLI Reference"
 order: 7
+description: "Complete CLI options, directory structure, platform support."
 ---
-
-
 ## 1. CLI Usage
 
 ```bash

--- a/packages/docs/src/content/feature-catalog.mdx
+++ b/packages/docs/src/content/feature-catalog.mdx
@@ -1,9 +1,8 @@
 ---
 title: "Feature Catalog"
 order: 8
+description: "Package-by-package feature inventory."
 ---
-
-
 A package-by-package inventory of the features currently shipped in this repo.
 
 This document is the long-form companion to the root [README](../README.md). Use it when you want
@@ -15,7 +14,7 @@ one place that answers:
 - which content packs ship in the repo
 - which packages are mainly contributor-facing libraries
 
-{/* MDT: {repoStartHerePathDocs} */}
+{/* MDT: {=repoStartHerePathDocs} */}
 
 Use this reading path depending on what you are trying to do:
 
@@ -28,7 +27,7 @@ Use this reading path depending on what you are trying to do:
 
 ### Architecture at a glance
 
-{/* MDT: {repoArchitectureAtAGlanceDocs} */}
+{/* MDT: {=repoArchitectureAtAGlanceDocs} */}
 
 ```text
 oh-pi repo
@@ -63,7 +62,7 @@ oh-pi repo
 
 {/* MDT: {/repoArchitectureAtAGlanceDocs} */}
 
-{/* MDT: {repoContributorReadingPathDocs} */}
+{/* MDT: {=repoContributorReadingPathDocs} */}
 
 Suggested path for a new contributor:
 
@@ -79,7 +78,7 @@ Suggested path for a new contributor:
 
 ### Installed by `npx @ifi/oh-pi`
 
-{/* MDT: {repoDefaultInstallerPackagesDocs} */}
+{/* MDT: {=repoDefaultInstallerPackagesDocs} */}
 
 Default runtime/content packages installed by `npx @ifi/oh-pi`:
 
@@ -99,7 +98,7 @@ Default runtime/content packages installed by `npx @ifi/oh-pi`:
 
 ### Opt-in packages
 
-{/* MDT: {repoExperimentalPackagesDocs} */}
+{/* MDT: {=repoExperimentalPackagesDocs} */}
 
 Opt-in packages that stay separate from the default installer bundle:
 
@@ -115,7 +114,7 @@ Opt-in packages that stay separate from the default installer bundle:
 These are important parts of the codebase, but they are primarily consumed by other packages or by
 people extending oh-pi:
 
-{/* MDT: {repoContributorCompiledPackagesDocs} */}
+{/* MDT: {=repoContributorCompiledPackagesDocs} */}
 
 Most runtime packages in this repo ship raw TypeScript and can be loaded directly by pi. A smaller
 set of contributor-facing packages (`core`, `cli`, `web-client`, `web-server`) emit `dist/` output,

--- a/vitest.config.ts
+++ b/vitest.config.ts
@@ -33,6 +33,7 @@ const coverageExclude = [
 	"packages/docs/vite.config.ts",
 	"packages/docs/src/**/*.tsx",
 	"packages/docs/src/**/*.ts",
+	"packages/docs/scripts/*",
 ];
 
 export default defineConfig({


### PR DESCRIPTION
## What

Adds a `docs:sync` script that derives the docs site MDX content files from the `docs/*.md` source files, keeping everything in sync with the repo's MDT documentation reuse system.

### How it works
- `node packages/docs/scripts/sync-content.mjs` reads `docs/*.md` → writes `packages/docs/src/content/*.mdx`
- Strips duplicate H1 headings (page title comes from frontmatter)
- Converts HTML MDT comments (`<!-- {=tagName} -->`) to MDX JSX comments (`{/* MDT: {=tagName} */}`)
- Prepends frontmatter with `title`, `order`, and `description`

### Scripts
- `pnpm docs:sync` — re-sync all content from `docs/` to the docs site
- `pnpm docs:update` — update MDT providers then sync (existing MDT command)

### Why
Previously the MDX content files were manual copies, drifting from the `docs/*.md` source. Now they stay in sync automatically via `docs:sync`, and MDT markers in the source files flow through to the docs site.

## Test Plan
- [x] `pnpm docs:sync` — syncs all 8 pages
- [x] `pnpm --filter @ifi/oh-pi-docs build` — builds successfully
- [x] `pnpm lint` — passes
- [x] `pnpm typecheck` — passes