### PR TITLE
fix(ollama): use runtime discovery state for cloud models, surface errors

### DIFF
--- a/.changeset/fix-ollama-cloud-model-refresh-stale-status.md
+++ b/.changeset/fix-ollama-cloud-model-refresh-stale-status.md
@@ -1,0 +1,26 @@
+---
+default: patch
+---
+
+Fix Ollama cloud models showing stale data after refresh and surface discovery errors
+
+The `/ollama:refresh-models` command and `/ollama:status` display always read
+cloud models from the stored OAuth credential when one exists, even after a
+successful discovery that updated the runtime state. This meant newly available
+models (like kimi-k2.6) would not appear until the credential was re-stored,
+and the "last refreshed" timestamp shown in status was the credential's
+`lastModelRefresh` — often hours or days stale.
+
+Changes:
+
+- Cloud model display now prefers the runtime discovery state
+  (`cloudEnvDiscoveryState.models`) over the stored credential. The credential
+  models are only used as fallback when the runtime state is empty (e.g. before
+  first discovery).
+- The "last refreshed" age shown in status now uses
+  `cloudEnvDiscoveryState.lastRefresh` (always set to `Date.now()` during
+  refresh) instead of the credential's `lastModelRefresh`.
+- Discovery errors are now surfaced in `/ollama:refresh-models`,
+  `/ollama:status`, and `/ollama-cloud status` output, making it obvious when
+  the cloud catalog couldn't be reached instead of silently falling back to
+  stale data.

--- a/packages/ollama/index.ts
+++ b/packages/ollama/index.ts
@@ -165,7 +165,14 @@ function registerOllamaCommands(pi: ExtensionAPI): void {
 				const cloudStatus = hasCloudAuth(credential)
 					? `${cloudModels.length} cloud available`
 					: `${cloudModels.length} public cloud discovered; run /login ollama-cloud to use them`;
-				ctx.ui.notify(`Refreshed Ollama models (${localModels.length} local installed, ${cloudStatus}).`, "info");
+				const parts = [`Refreshed Ollama models (${localModels.length} local installed, ${cloudStatus}).`];
+				if (cloudEnvDiscoveryState.lastError) {
+					parts.push(`Cloud discovery error: ${cloudEnvDiscoveryState.lastError}`);
+				}
+				if (localDiscoveryState.lastError) {
+					parts.push(`Local discovery error: ${localDiscoveryState.lastError}`);
+				}
+				ctx.ui.notify(parts.join(" "), parts.length > 1 ? "warning" : "info");
 				return;
 			}
 
@@ -245,7 +252,11 @@ function registerOllamaCommands(pi: ExtensionAPI): void {
 				const suffix = hasCloudAuth(credential)
 					? `${cloudModels.length} available`
 					: `${cloudModels.length} public models discovered; run /login ollama-cloud to use them`;
-				ctx.ui.notify(`Refreshed Ollama Cloud models (${suffix}).`, "info");
+				const parts = [`Refreshed Ollama Cloud models (${suffix}).`];
+				if (cloudEnvDiscoveryState.lastError) {
+					parts.push(`Discovery error: ${cloudEnvDiscoveryState.lastError}`);
+				}
+				ctx.ui.notify(parts.join(" "), parts.length > 1 ? "warning" : "info");
 				return;
 			}
 
@@ -503,39 +514,59 @@ function streamSimpleOllamaLocal(model: Model<any>, context: Context, options?: 
 	return streamSimpleOpenAICompletions(model as Model<"openai-completions">, context, options);
 }
 
+function getCloudModels(credential: OllamaCloudCredentials | null): OllamaProviderModel[] {
+	return cloudEnvDiscoveryState.models.length > 0
+		? cloudEnvDiscoveryState.models
+		: (credential ? getCredentialModels(credential) : getFallbackOllamaCloudModels());
+}
+
+function getCloudRefreshAge(credential: OllamaCloudCredentials | null): string {
+	return formatRefreshAge(cloudEnvDiscoveryState.lastRefresh ?? credential?.lastModelRefresh);
+}
+
 function renderUnifiedStatus(credential: OllamaCloudCredentials | null): string {
 	const localConfig = getOllamaLocalRuntimeConfig();
 	const cloudConfig = getOllamaCloudRuntimeConfig();
 	const localModels = getRegisteredLocalModels();
 	const downloadableLocalModels = localModels.filter((model) => model.localAvailability === "downloadable");
-	const cloudModels = credential ? getCredentialModels(credential) : cloudEnvDiscoveryState.models;
-	return [
+	const cloudModels = getCloudModels(credential);
+	const lines = [
 		`Ollama CLI: ${describeLocalCliStatus()}`,
 		`Ollama local: ${describeLocalRuntime()}`,
 		`Local installed: ${localDiscoveryState.models.length}${formatRefreshAge(localDiscoveryState.lastRefresh)}`,
 		`Local download candidates: ${downloadableLocalModels.length}`,
 		`Local base URL: ${localConfig.apiUrl}`,
 		`Ollama cloud auth: ${describeCloudAuth(credential)}`,
-		`Cloud models: ${cloudModels.length}${formatRefreshAge(credential?.lastModelRefresh ?? cloudEnvDiscoveryState.lastRefresh)}`,
+		`Cloud models: ${cloudModels.length}${getCloudRefreshAge(credential)}`,
+	];
+	if (cloudEnvDiscoveryState.lastError) {
+		lines.push(`Cloud discovery error: ${cloudEnvDiscoveryState.lastError}`);
+	}
+	lines.push(
 		`Cloud base URL: ${cloudConfig.apiUrl}`,
 		`Tip: prefer ollama-cloud/... for speed, and use /ollama pull <model> only when you need a local copy.`,
-	].join("\n");
+	);
+	return lines.join("\n");
 }
 
 function renderCloudStatus(credential: OllamaCloudCredentials | null): string {
 	const config = getOllamaCloudRuntimeConfig();
-	const cloudModels = credential ? getCredentialModels(credential) : cloudEnvDiscoveryState.models;
-	return [
+	const cloudModels = getCloudModels(credential);
+	const lines = [
 		`Ollama cloud auth: ${describeCloudAuth(credential)}`,
-		`Cloud models: ${cloudModels.length}${formatRefreshAge(credential?.lastModelRefresh ?? cloudEnvDiscoveryState.lastRefresh)}`,
-		`Cloud base URL: ${config.apiUrl}`,
-	].join("\n");
+		`Cloud models: ${cloudModels.length}${getCloudRefreshAge(credential)}`,
+	];
+	if (cloudEnvDiscoveryState.lastError) {
+		lines.push(`Discovery error: ${cloudEnvDiscoveryState.lastError}`);
+	}
+	lines.push(`Cloud base URL: ${config.apiUrl}`);
+	return lines.join("\n");
 }
 
 function collectOllamaModels(credential: OllamaCloudCredentials | null): CollectedOllamaModel[] {
 	const localConfig = getOllamaLocalRuntimeConfig();
 	const cloudConfig = getOllamaCloudRuntimeConfig();
-	const cloudModels = credential ? getCredentialModels(credential) : cloudEnvDiscoveryState.models;
+	const cloudModels = getCloudModels(credential);
 	return [
 		...cloudModels.map((model) => ({ ...model, provider: OLLAMA_CLOUD_PROVIDER, baseUrl: cloudConfig.apiUrl })),
 		...getRegisteredLocalModels().map((model) => ({ ...model, provider: OLLAMA_LOCAL_PROVIDER, baseUrl: localConfig.apiUrl })),


### PR DESCRIPTION
## Problem

After running `/ollama:refresh-models`, newly available cloud models like kimi-k2.6 would not appear. The `/ollama:status` display showed stale timestamps (e.g. "122h ago") even after a successful refresh.

## Root cause

The status and model listing code always preferred the stored OAuth credential models via `getCredentialModels(credential)` when a credential existed. This is stale data captured at login time. Even after `/ollama:refresh-models` successfully re-discovered all models and updated `cloudEnvDiscoveryState.models`, the display still read from the old stored credential.

Additionally, `cloudEnvDiscoveryState.lastError` was set when discovery failed but never shown to the user — so the refresh appeared successful even when it silently fell back to stale data.

## Changes

- **`getCloudModels()`**: New helper that prefers `cloudEnvDiscoveryState.models` (always updated during refresh) and only falls back to credential models when the runtime state is empty.
- **`getCloudRefreshAge()`**: New helper that uses `cloudEnvDiscoveryState.lastRefresh` (set to `Date.now()` on every refresh) instead of the credential's `lastModelRefresh`.
- **Error surfacing**: Discovery errors are now reported in `/ollama:refresh-models`, `/ollama:status`, and `/ollama-cloud status` output, making failures visible instead of silent.
- All three display functions (`renderUnifiedStatus`, `renderCloudStatus`, `collectOllamaModels`) now use the new helpers.

## Testing

All 25 existing tests pass. Typecheck passes.