### PR TITLE
feat: reduce context noise, add bg task expiry, label scheduled runs

### DIFF
--- a/.changeset/reduce-context-noise-scheduled-labels-bg-expiry.md
+++ b/.changeset/reduce-context-noise-scheduled-labels-bg-expiry.md
@@ -1,0 +1,9 @@
+---
+default: minor
+---
+
+Reduce context noise from watchdog/safe-mode messages, add bg task default expiry, and label scheduled task runs
+
+- **Background tasks**: Add a default 10-minute expiry to all background tasks. Expired tasks are automatically stopped and logged. Set `expiresAt: null` to disable. The expiry is displayed in the dashboard and spawn output.
+- **Background task output events**: No longer trigger agent turns (only exit events do), reducing unnecessary LLM context consumption from routine output notifications.
+- **Scheduler dispatches**: Use `sendMessage` with a custom type (`pi-scheduler:dispatched`) instead of `sendUserMessage`. Scheduled task runs now render with a distinct "⏰ Scheduled run" label in the TUI, showing the task ID, mode, and run count, instead of appearing as regular user messages.

--- a/packages/background-tasks/background-tasks-shared.ts
+++ b/packages/background-tasks/background-tasks-shared.ts
@@ -12,6 +12,7 @@ export const BG_OUTPUT_ALERT_MAX_CHARS = 3_000;
 export const BG_LOG_TAIL_MAX_CHARS = 5_000;
 export const BG_DASHBOARD_WIDTH = 96;
 export const BG_DASHBOARD_MAX_HEIGHT = "80%";
+export const BG_DEFAULT_TIMEOUT_MS = 10 * 60_000;
 export const BG_INSTALL_SYMBOL = Symbol.for("oh-pi.background-tasks.installed");
 
 export type BackgroundTaskStatus = "running" | "completed" | "failed" | "stopped";
@@ -26,6 +27,7 @@ export interface BackgroundTaskSnapshot {
 	startedAt: number;
 	updatedAt: number;
 	lastOutputAt: number | null;
+	expiresAt: number | null;
 	status: BackgroundTaskStatus;
 	exitCode: number | null;
 	reactToOutput: boolean;

--- a/packages/background-tasks/index.ts
+++ b/packages/background-tasks/index.ts
@@ -16,6 +16,7 @@ import {
 	BG_COMMAND,
 	BG_DASHBOARD_MAX_HEIGHT,
 	BG_DASHBOARD_WIDTH,
+	BG_DEFAULT_TIMEOUT_MS,
 	BG_INSTALL_SYMBOL,
 	BG_LOG_TAIL_MAX_CHARS,
 	BG_MESSAGE_TYPE,
@@ -60,6 +61,7 @@ type SpawnTaskOptions = {
 	initialOutput?: string;
 	initialLastAlertLength?: number;
 	logFile?: string;
+	expiresAt?: number | null;
 };
 
 type ThemeLike = Theme;
@@ -77,6 +79,7 @@ function taskSnapshot(task: ManagedTask): BackgroundTaskSnapshot {
 		startedAt: task.startedAt,
 		updatedAt: task.updatedAt,
 		lastOutputAt: task.lastOutputAt,
+		expiresAt: task.expiresAt,
 		status: task.status,
 		exitCode: task.exitCode,
 		reactToOutput: task.reactToOutput,
@@ -99,9 +102,16 @@ function buildTaskEventLines(details: BackgroundTaskEventDetails, theme: ThemeLi
 		`${theme.fg("muted", "Task")}: ${details.task.id} · ${taskDisplayName(details.task)}`,
 		`${theme.fg("muted", "Status")}: ${summarizeTaskStatus(details.task.status, details.task.exitCode)} · pid ${details.task.pid}`,
 		`${theme.fg("muted", "Started")}: ${formatRelativeTime(details.task.startedAt, details.eventAt)} · ${formatDuration(details.eventAt - details.task.startedAt)} elapsed`,
+	];
+
+	if (details.task.expiresAt != null) {
+		lines.push(`${theme.fg("muted", "Expiry")}: ${formatRelativeTime(details.task.expiresAt, details.eventAt)} (${formatDuration(details.task.expiresAt - details.eventAt)} remaining)`);
+	}
+
+	lines.push(
 		`${theme.fg("muted", "Command")}: ${details.task.command}`,
 		`${theme.fg("muted", "Log")}: ${details.task.logFile}`,
-	];
+	);
 
 	if (details.matchedPattern) {
 		lines.push(`${theme.fg("muted", "Pattern")}: ${details.matchedPattern}`);
@@ -185,6 +195,23 @@ export default function backgroundTasksExtension(pi: ExtensionAPI): void {
 		}
 		clearTimeout(task.outputTimer);
 		task.outputTimer = null;
+	};
+
+	const checkExpiredTasks = () => {
+		const now = Date.now();
+		for (const task of tasks.values()) {
+			if (task.status !== "running") {
+				continue;
+			}
+			if (task.expiresAt != null && now >= task.expiresAt) {
+				const remaining = getTaskOutput(task);
+				if (remaining.trim()) {
+					appendFileSync(task.logFile, `\n[expired] Background task timed out after ${formatDuration(task.expiresAt! - task.startedAt)}.\n`);
+				}
+				finalizeTask(task, task.exitCode, "stopped");
+				sendTaskEvent("exit", task);
+			}
+		}
 	};
 
 	const clearFinishedTasks = (): number => {
@@ -274,6 +301,7 @@ export default function backgroundTasksExtension(pi: ExtensionAPI): void {
 	};
 
 	const refreshUi = () => {
+		checkExpiredTasks();
 		if (activeCtx) {
 			syncWidget(activeCtx);
 		}
@@ -305,7 +333,7 @@ export default function backgroundTasksExtension(pi: ExtensionAPI): void {
 				display: true,
 				details,
 			},
-			{ triggerTurn: true, deliverAs: "followUp" },
+			eventType === "exit" ? { triggerTurn: true, deliverAs: "followUp" } : { triggerTurn: false },
 		);
 	};
 
@@ -399,6 +427,7 @@ export default function backgroundTasksExtension(pi: ExtensionAPI): void {
 		const title = options.title?.trim() || command;
 		const reactToOutput = options.reactToOutput ?? true;
 		const notifyPattern = options.notifyPattern?.trim() || undefined;
+		const expiresAt = options.expiresAt !== undefined ? options.expiresAt : Date.now() + BG_DEFAULT_TIMEOUT_MS;
 		const child =
 			options.child ??
 			(() => {
@@ -424,6 +453,7 @@ export default function backgroundTasksExtension(pi: ExtensionAPI): void {
 			startedAt: Date.now(),
 			updatedAt: Date.now(),
 			lastOutputAt: initialOutput.trim().length > 0 ? Date.now() : null,
+			expiresAt,
 			status: "running",
 			exitCode: null,
 			reactToOutput,
@@ -656,6 +686,9 @@ export default function backgroundTasksExtension(pi: ExtensionAPI): void {
 						);
 						right.push(`${theme.fg("muted", "Status")}: ${summarizeTaskStatus(selected.status, selected.exitCode)} · pid ${selected.pid}`);
 						right.push(`${theme.fg("muted", "Started")}: ${formatRelativeTime(selected.startedAt)} · ${formatDuration(Date.now() - selected.startedAt)} elapsed`);
+						if (selected.expiresAt != null) {
+							right.push(`${theme.fg("muted", "Expiry")}: ${formatRelativeTime(selected.expiresAt)} (${formatDuration(selected.expiresAt - Date.now())} remaining)`);
+						}
 						right.push(`${theme.fg("muted", "Command")}: ${selected.command}`);
 						right.push(`${theme.fg("muted", "Cwd")}: ${selected.cwd}`);
 						right.push(`${theme.fg("muted", "Log")}: ${selected.logFile}`);
@@ -875,7 +908,7 @@ export default function backgroundTasksExtension(pi: ExtensionAPI): void {
 	pi.registerTool({
 		name: "bash",
 		label: "Bash",
-		description: `Execute a bash command. Output is truncated to 2000 lines or 50KB. If a command runs longer than ${BG_TIMEOUT_MS / 1000}s, it is automatically moved into the background task runtime and you get the task id, PID, and log file. Use bg_status or bg_task to inspect it later.`,
+		description: `Execute a bash command. Output is truncated to 2000 lines or 50KB. If a command runs longer than ${BG_TIMEOUT_MS / 1000}s, it is automatically moved into the background task runtime and you get the task id, PID, and log file. Background tasks expire after 10 minutes by default. Use bg_status or bg_task to inspect it later.`,
 		parameters: Type.Object({
 			command: Type.String({ description: "Bash command to execute" }),
 			timeout: Type.Optional(Type.Number({ description: "Timeout in seconds before auto-backgrounding" })),
@@ -922,7 +955,7 @@ export default function backgroundTasksExtension(pi: ExtensionAPI): void {
 					});
 					const preview = tailText((stdout + stderr).trim(), 500) || "(no output yet)";
 					finish({
-						text: `Command still running after ${timeoutMs / 1000}s, moved to the background.\nTask: ${task.id}\nPID: ${task.pid}\nLog: ${task.logFile}\n\nOutput so far:\n${preview}\n\nPi will watch for new output and notify you when the task exits.`,
+						text: `Command still running after ${timeoutMs / 1000}s, moved to the background.\nTask: ${task.id}\nPID: ${task.pid}\nLog: ${task.logFile}\nExpiry: ${task.expiresAt != null ? formatRelativeTime(task.expiresAt) : "none"}\n\nOutput so far:\n${preview}\n\nPi will watch for new output and notify you when the task exits.`,
 						details: { task: taskSnapshot(task) },
 					});
 				}, timeoutMs);
@@ -996,7 +1029,7 @@ export default function backgroundTasksExtension(pi: ExtensionAPI): void {
 		name: "bg_task",
 		label: "Background Task",
 		description:
-			"Spawn, inspect, and stop background shell tasks. Tasks keep running after the tool returns, append output to a log file, and can wake the agent up when new output arrives or when the task exits.",
+			"Spawn, inspect, and stop background shell tasks. Tasks keep running after the tool returns, append output to a log file, and can wake the agent up when new output arrives or when the task exits. Background tasks expire after 10 minutes by default to prevent indefinite runs. Pass expiresAt=null to disable the expiry.",
 		parameters: Type.Object({
 			action: StringEnum(["spawn", "list", "log", "stop", "clear"] as const, {
 				description: "spawn=start a new task, list=show tasks, log=view task output, stop=terminate, clear=remove finished tasks",
@@ -1041,7 +1074,7 @@ export default function backgroundTasksExtension(pi: ExtensionAPI): void {
 				});
 
 				return makeToolResult(
-					`Started ${task.id} (pid ${task.pid}) in the background.\nCommand: ${task.command}\nCwd: ${task.cwd}\nLog: ${task.logFile}\nWakeups: ${task.reactToOutput ? task.notifyPattern ?? "on output" : "exit only"}`,
+					`Started ${task.id} (pid ${task.pid}) in the background.\nCommand: ${task.command}\nCwd: ${task.cwd}\nLog: ${task.logFile}\nExpiry: ${task.expiresAt != null ? formatRelativeTime(task.expiresAt) : "none"}\nWakeups: ${task.reactToOutput ? task.notifyPattern ?? "on output" : "exit only"}`,
 					{ details: { task: taskSnapshot(task) } },
 				);
 			}

--- a/packages/background-tasks/tests/background-tasks-shared.test.ts
+++ b/packages/background-tasks/tests/background-tasks-shared.test.ts
@@ -89,6 +89,7 @@ describe("background task shared helpers", () => {
 				startedAt: Date.now() - 10_000,
 				updatedAt: Date.now() - 1_000,
 				lastOutputAt: Date.now() - 2_000,
+				expiresAt: Date.now() + 590_000,
 				status: "running",
 				exitCode: null,
 				reactToOutput: true,

--- a/packages/extensions/extensions/scheduler-shared.ts
+++ b/packages/extensions/extensions/scheduler-shared.ts
@@ -16,6 +16,7 @@ export const MAX_DISPATCHES_PER_WINDOW = 6;
 export const SCHEDULER_LEASE_HEARTBEAT_MS = 1_000;
 export const SCHEDULER_SAFE_MODE_HEARTBEAT_MS = 5_000;
 export const SCHEDULER_LEASE_STALE_AFTER_MS = 10_000;
+export const SCHEDULER_DISPATCHED_MESSAGE_TYPE = "pi-scheduler:dispatched";
 export const MAX_DISPATCH_TIMESTAMPS = 64;
 
 export type TaskKind = "recurring" | "once";

--- a/packages/extensions/extensions/scheduler.test.ts
+++ b/packages/extensions/extensions/scheduler.test.ts
@@ -92,6 +92,9 @@ function createMockPi() {
 		registerCommand(name: string, opts: any) {
 			commands.set(name, opts);
 		},
+		registerMessageRenderer(_customType: string, _renderer: any) {
+			// No-op in tests
+		},
 		sendMessage(msg: any) {
 			messages.push(msg);
 		},
@@ -182,6 +185,7 @@ import schedulerExtension, {
 	parseDuration,
 	parseLoopScheduleArgs,
 	parseRemindScheduleArgs,
+	SCHEDULER_DISPATCHED_MESSAGE_TYPE,
 	SCHEDULER_SAFE_MODE_HEARTBEAT_MS,
 	SchedulerRuntime,
 	THREE_DAYS,
@@ -189,6 +193,12 @@ import schedulerExtension, {
 } from "./scheduler.js";
 
 // ─── Duration parsing ────────────────────────────────────────────────────────
+
+// Helper to extract dispatched scheduler prompt content from mocked messages.
+const getDispatchedPrompts = (pi: ReturnType<typeof createPi>) =>
+	pi._messages
+		.filter((m: any) => m.customType === SCHEDULER_DISPATCHED_MESSAGE_TYPE)
+		.map((m: any) => m.content as string);
 
 describe("parseDuration", () => {
 	it("parses seconds with short unit", () => {
@@ -1048,7 +1058,7 @@ describe("SchedulerRuntime", () => {
 			task.pending = true;
 			runtime.dispatchTask(task);
 
-			expect(pi._userMessages).toEqual(["check ci"]);
+			expect(getDispatchedPrompts(pi)).toEqual(["check ci"]);
 			expect(task.runCount).toBe(1);
 			expect(task.lastStatus).toBe("success");
 			expect(task.pending).toBe(false);
@@ -1062,7 +1072,7 @@ describe("SchedulerRuntime", () => {
 			task.pending = true;
 			runtime.dispatchTask(task);
 
-			expect(pi._userMessages).toEqual(["remind me"]);
+			expect(getDispatchedPrompts(pi)).toEqual(["remind me"]);
 			expect(runtime.taskCount).toBe(0);
 		});
 
@@ -1126,7 +1136,7 @@ describe("SchedulerRuntime", () => {
 				runtime.dispatchTask(task);
 			}
 
-			expect(pi._userMessages).toHaveLength(MAX_DISPATCHES_PER_WINDOW);
+			expect(getDispatchedPrompts(pi)).toHaveLength(MAX_DISPATCHES_PER_WINDOW);
 			expect(tasks[MAX_DISPATCHES_PER_WINDOW].pending).toBe(true);
 			expect(ctx._notifications.some((n: any) => n.msg.includes("Scheduler throttled"))).toBe(true);
 		});
@@ -1140,7 +1150,7 @@ describe("SchedulerRuntime", () => {
 				task.pending = true;
 				runtime.dispatchTask(task);
 			}
-			expect(pi._userMessages).toHaveLength(MAX_DISPATCHES_PER_WINDOW);
+			expect(getDispatchedPrompts(pi)).toHaveLength(MAX_DISPATCHES_PER_WINDOW);
 
 			vi.advanceTimersByTime(DISPATCH_RATE_LIMIT_WINDOW_MS + 1_000);
 
@@ -1148,7 +1158,7 @@ describe("SchedulerRuntime", () => {
 			nextTask.pending = true;
 			runtime.dispatchTask(nextTask);
 
-			expect(pi._userMessages).toHaveLength(MAX_DISPATCHES_PER_WINDOW + 1);
+			expect(getDispatchedPrompts(pi)).toHaveLength(MAX_DISPATCHES_PER_WINDOW + 1);
 		});
 
 		it("does not dispatch disabled task", () => {
@@ -1160,14 +1170,14 @@ describe("SchedulerRuntime", () => {
 			task.pending = true;
 			runtime.dispatchTask(task);
 
-			expect(pi._userMessages).toHaveLength(0);
+			expect(getDispatchedPrompts(pi)).toHaveLength(0);
 		});
 
-		it("marks task as error if sendUserMessage throws", () => {
+		it("marks task as error if sendMessage throws", () => {
 			const ctx = createMockCtx();
 			runtime.setRuntimeContext(ctx as any);
 
-			pi.sendUserMessage = () => {
+			pi.sendMessage = () => {
 				throw new Error("send failed");
 			};
 
@@ -1195,7 +1205,7 @@ describe("SchedulerRuntime", () => {
 			vi.advanceTimersByTime(150);
 			await Promise.resolve();
 
-			expect(pi._userMessages).toEqual(["check ci"]);
+			expect(getDispatchedPrompts(pi)).toEqual(["check ci"]);
 			expect(runtime.getTask(task.id)).toBeUndefined();
 		});
 	});
@@ -1423,7 +1433,7 @@ describe("SchedulerRuntime", () => {
 			runtime.setTaskEnabled("overdue2", true);
 			await runtime.tickScheduler();
 
-			expect(pi._userMessages).toEqual(["check build"]);
+			expect(getDispatchedPrompts(pi)).toEqual(["check build"]);
 		});
 
 		it("skips expired tasks when loading from disk", () => {
@@ -2456,7 +2466,7 @@ describe("event wiring", () => {
 		pi._emit("session_shutdown", { type: "session_shutdown" }, otherCtx);
 		await vi.advanceTimersByTimeAsync(ONE_MINUTE + 2_000);
 
-		expect(pi._userMessages).toContain("check build");
+		expect(getDispatchedPrompts(pi)).toContain("check build");
 	});
 
 	it("stops scheduler and clears status when the last session shuts down", () => {
@@ -2518,8 +2528,8 @@ describe("safe mode", () => {
 		vi.advanceTimersByTime(SCHEDULER_SAFE_MODE_HEARTBEAT_MS + 1_000 + 100);
 		await runtime.tickScheduler();
 
-		expect(pi._userMessages.length).toBe(1);
-		expect(pi._userMessages[0]).toBe("run this");
+		expect(getDispatchedPrompts(pi).length).toBe(1);
+		expect(getDispatchedPrompts(pi)[0]).toBe("run this");
 	});
 
 	it("suppresses rate limit notifications in safe mode", () => {
@@ -2938,7 +2948,7 @@ describe("edge cases", () => {
 		});
 
 		runtime.dispatchTask(task);
-		expect(pi._userMessages.at(-1)).toBe("check build status");
+		expect(getDispatchedPrompts(pi).at(-1)).toBe("check build status");
 		expect(runtime.getTask(task.id)?.awaitingCompletion).toBe(true);
 		expect(runtime.getTask(task.id)?.lastStatus).toBe("pending");
 

--- a/packages/extensions/extensions/scheduler.ts
+++ b/packages/extensions/extensions/scheduler.ts
@@ -28,6 +28,7 @@ import * as fs from "node:fs";
 import * as path from "node:path";
 import { openScrollableSelect, type ScrollSelectOption } from "@ifi/pi-shared-qna";
 import type { ExtensionAPI, ExtensionContext } from "@mariozechner/pi-coding-agent";
+import { Text } from "@mariozechner/pi-tui";
 import {
 	computeNextCronRunAt,
 	formatDurationShort,
@@ -53,6 +54,7 @@ import {
 	ONE_HOUR,
 	ONE_MINUTE,
 	type ResumeReason,
+	SCHEDULER_DISPATCHED_MESSAGE_TYPE,
 	SCHEDULER_LEASE_HEARTBEAT_MS,
 	SCHEDULER_LEASE_STALE_AFTER_MS,
 	SCHEDULER_SAFE_MODE_HEARTBEAT_MS,
@@ -103,6 +105,7 @@ export {
 	MIN_RECURRING_INTERVAL,
 	ONE_HOUR,
 	ONE_MINUTE,
+	SCHEDULER_DISPATCHED_MESSAGE_TYPE,
 	SCHEDULER_LEASE_HEARTBEAT_MS,
 	SCHEDULER_LEASE_STALE_AFTER_MS,
 	SCHEDULER_SAFE_MODE_HEARTBEAT_MS,
@@ -1173,7 +1176,15 @@ export class SchedulerRuntime {
 		}
 
 		try {
-			this.pi.sendUserMessage(task.prompt);
+			this.pi.sendMessage(
+				{
+					customType: SCHEDULER_DISPATCHED_MESSAGE_TYPE,
+					content: task.prompt,
+					display: true,
+					details: { taskId: task.id, taskMode: this.taskMode(task), runCount: task.runCount + 1 },
+				},
+				{ triggerTurn: true },
+			);
 			this.recordDispatch(now);
 		} catch {
 			task.pending = true;
@@ -1997,6 +2008,20 @@ storage using a workspace-mirrored path.
 */
 export default function schedulerExtension(pi: ExtensionAPI) {
 	const runtime = new SchedulerRuntime(pi);
+
+	pi.registerMessageRenderer(SCHEDULER_DISPATCHED_MESSAGE_TYPE, (message, _options, theme) => {
+		const details = message.details as { taskId?: string; taskMode?: string; runCount?: number } | undefined;
+		const prefix = theme.bold(theme.fg("accent", "⏰ Scheduled run"));
+		const taskInfo = details?.taskId ? ` \u00B7 ${details.taskId}` : "";
+		const modeInfo = details?.taskMode ? ` \u00B7 ${details.taskMode}` : "";
+		const runInfo = details?.runCount ? ` \u00B7 run #${details.runCount}` : "";
+		const label = `${prefix}${taskInfo}${modeInfo}${runInfo}`;
+		const body = typeof message.content === "string" ? message.content : "";
+		return new Text(`${label}\n${theme.fg("dim", body)}`, 1, 0, (segment: string) =>
+			theme.bg("customMessageBg", segment),
+		);
+	});
+
 	registerEvents(pi, runtime);
 	registerCommands(pi, runtime);
 	registerTools(pi, runtime);


### PR DESCRIPTION
## Summary

Three changes to reduce LLM context noise and improve background task management:

### 1. Background task default expiry (10 minutes)
- All background tasks now have a default 10-minute expiry (`BG_DEFAULT_TIMEOUT_MS`)
- Expired tasks are automatically stopped and logged with an expiry message
- Expiry info is displayed in the dashboard detail pane and spawn output
- Pass `expiresAt: null` to disable the expiry (e.g., for long-running watchers)
- New `expiresAt` field on `BackgroundTaskSnapshot`

### 2. Background task output events no longer trigger agent turns
- Previously, every background task output notification triggered an agent turn, consuming LLM context unnecessarily
- Now only exit events trigger a turn; output events are still displayed in the TUI but don't force the LLM to process them
- This significantly reduces context consumption from chatty background processes

### 3. Scheduler dispatches labeled as scheduled runs
- Scheduler task dispatches now use `sendMessage` with a custom type (`pi-scheduler:dispatched`) instead of `sendUserMessage`
- A custom message renderer shows **⏰ Scheduled run** with the task ID, mode, and run count in the TUI
- This makes it clearly distinguishable from user-typed messages in the conversation tree
- Added `SCHEDULER_DISPATCHED_MESSAGE_TYPE` constant

## Test plan
- [x] `pnpm typecheck` passes
- [x] `pnpm lint` passes
- [x] `pnpm --filter @ifi/pi-background-tasks test:worktree` passes (17/17)
- [ ] Manual: start a bg task and verify expiry appears in dashboard
- [ ] Manual: schedule a task and verify scheduled run label in TUI
- [ ] Manual: run a chatty bg task and verify output events don't trigger turns