### PR TITLE
fix(ollama): prefer runtime discovery state in modifyModels for /scoped-models

### DIFF
--- a/.changeset/fix-ollama-scoped-models-registry-modifymodels.md
+++ b/.changeset/fix-ollama-scoped-models-registry-modifymodels.md
@@ -1,0 +1,17 @@
+---
+default: patch
+---
+
+Fix Ollama cloud models not appearing in /scoped-models after refresh
+
+The `modifyModels` OAuth callback in `createOllamaCloudOAuthProvider` always
+used `getCredentialModels(credentials)` — the stale models stored with the
+login credential — over the freshly discovered runtime state. This meant that
+even after `/ollama:refresh-models` successfully re-discovered all models, the
+model registry (used by `/scoped-models`) would overwrite them with the old
+credential models on the next registry refresh.
+
+Now `modifyModels` prefers `cloudEnvDiscoveryState.models` (the runtime
+discovery state that is always updated during refresh) and only falls back to
+credential models when the runtime state is empty (e.g. before first
+discovery).

--- a/packages/ollama/auth.ts
+++ b/packages/ollama/auth.ts
@@ -6,7 +6,7 @@ import {
 	OLLAMA_CLOUD_PROVIDER,
 	getOllamaCloudRuntimeConfig,
 } from "./config.js";
-import { enrichOllamaCloudCredentials, getCredentialModels, type OllamaCloudCredentials } from "./models.js";
+import { enrichOllamaCloudCredentials, getCredentialModels, type OllamaCloudCredentials, type OllamaProviderModel } from "./models.js";
 
 const STATIC_CREDENTIAL_TTL_MS = 365 * 24 * 60 * 60 * 1000;
 
@@ -44,7 +44,11 @@ export async function refreshOllamaCloudCredentialModels(credentials: OllamaClou
 	return enrichOllamaCloudCredentials(createStaticCredential(credentials.access), { previous: credentials });
 }
 
-export function createOllamaCloudOAuthProvider(): Omit<OAuthProviderInterface, "id"> {
+export type CloudModelsGetter = () => OllamaProviderModel[];
+
+export function createOllamaCloudOAuthProvider(
+	getActiveCloudModels: CloudModelsGetter,
+): Omit<OAuthProviderInterface, "id"> {
 	return {
 		name: "Ollama Cloud",
 		async login(callbacks) {
@@ -58,7 +62,10 @@ export function createOllamaCloudOAuthProvider(): Omit<OAuthProviderInterface, "
 		},
 		modifyModels(models, credentials) {
 			const config = getOllamaCloudRuntimeConfig();
-			const current = getCredentialModels(credentials as OllamaCloudCredentials);
+			const runtimeModels = getActiveCloudModels();
+			const current = runtimeModels.length > 0
+				? runtimeModels
+				: getCredentialModels(credentials as OllamaCloudCredentials);
 			return [
 				...models.filter((model) => model.provider !== OLLAMA_CLOUD_PROVIDER),
 				...current.map((model) => ({

--- a/packages/ollama/index.ts
+++ b/packages/ollama/index.ts
@@ -8,6 +8,7 @@ import {
 } from "@mariozechner/pi-ai";
 import {
 	createOllamaCloudOAuthProvider,
+	type CloudModelsGetter,
 	loginOllamaCloud,
 	refreshOllamaCloudCredential,
 	refreshOllamaCloudCredentialModels,
@@ -102,7 +103,7 @@ function registerOllamaCloudProvider(pi: ExtensionAPI): void {
 		api: OLLAMA_API,
 		apiKey: OLLAMA_CLOUD_API_KEY_ENV,
 		baseUrl: getOllamaCloudRuntimeConfig().apiUrl,
-		oauth: createOllamaCloudOAuthProvider(),
+		oauth: createOllamaCloudOAuthProvider(() => cloudEnvDiscoveryState.models),
 		models: toProviderModels(cloudEnvDiscoveryState.models),
 		streamSimple: streamSimpleOllama,
 	});
@@ -581,7 +582,7 @@ function findLocalModelForQuery(query: string, credential: OllamaCloudCredential
 		return localMatch;
 	}
 
-	const cloudModels = (credential ? getCredentialModels(credential) : cloudEnvDiscoveryState.models).map((model) => ({
+	const cloudModels = getCloudModels(credential).map((model) => ({
 		...model,
 		provider: OLLAMA_CLOUD_PROVIDER,
 		baseUrl: getOllamaCloudRuntimeConfig().apiUrl,
@@ -842,6 +843,7 @@ export {
 	getFallbackOllamaCloudModels,
 	loginOllamaCloud,
 	refreshOllamaCloudCredential,
+	type CloudModelsGetter,
 };
 export { toOllamaModel, toOllamaCloudModel, type OllamaCloudCredentials, type OllamaProviderModel } from "./models.js";
 

--- a/packages/ollama/tests/auth.test.ts
+++ b/packages/ollama/tests/auth.test.ts
@@ -54,8 +54,28 @@ describe("ollama cloud auth", () => {
 		await backend.close();
 	});
 
-	it("modifies provider models from credential-discovered models", () => {
-		const provider = createOllamaCloudOAuthProvider();
+	it("modifies provider models using runtime cloud models when available", () => {
+		const runtimeModels = [
+			{ id: "kimi-k2.6", name: "Kimi K2.6", reasoning: true, input: ["text", "image"] as const, cost: { input: 0, output: 0, cacheRead: 0, cacheWrite: 0 }, contextWindow: 262144, maxTokens: 32768, source: "cloud" as const },
+		];
+		const provider = createOllamaCloudOAuthProvider(() => runtimeModels as never);
+		const modified = provider.modifyModels?.(
+			[
+				{ id: "placeholder", name: "Placeholder", api: "openai-completions", provider: "ollama-cloud", baseUrl: "https://example.com/v1", reasoning: false, input: ["text"], cost: { input: 0, output: 0, cacheRead: 0, cacheWrite: 0 }, contextWindow: 1, maxTokens: 1 },
+			],
+			{
+				refresh: "r",
+				access: "a",
+				expires: Date.now() + 1000,
+				models: [{ id: "gpt-oss:120b", name: "GPT OSS 120B", reasoning: true, input: ["text"], cost: { input: 0, output: 0, cacheRead: 0, cacheWrite: 0 }, contextWindow: 131072, maxTokens: 16384, source: "cloud" }],
+			} as never,
+		);
+
+		expect(modified?.map((model) => model.id)).toEqual(["kimi-k2.6"]);
+	});
+
+	it("falls back to credential models when runtime state is empty", () => {
+		const provider = createOllamaCloudOAuthProvider(() => []);
 		const modified = provider.modifyModels?.(
 			[
 				{ id: "placeholder", name: "Placeholder", api: "openai-completions", provider: "ollama-cloud", baseUrl: "https://example.com/v1", reasoning: false, input: ["text"], cost: { input: 0, output: 0, cacheRead: 0, cacheWrite: 0 }, contextWindow: 1, maxTokens: 1 },


### PR DESCRIPTION
## Problem

After running `/ollama:refresh-models`, newly available cloud models like `kimi-k2.6` appear in `/ollama:status` and `/ollama:models` (fixed in #232), but still don't appear in `/scoped-models`.

## Root cause

The `modifyModels` OAuth callback in `createOllamaCloudOAuthProvider` always used `getCredentialModels(credentials)` — the stale models stored with the login credential — over the freshly discovered runtime state. When pi's model registry calls `modifyModels` during a refresh, it overwrites the provider's current models (which include newly discovered ones) with the stale credential models.

This is a different code path from the status/model list display (fixed in #232). The model registry uses `modifyModels` to reconcile OAuth provider models, and this was still reading from the stale credential.

## Changes

- **`auth.ts`**: `createOllamaCloudOAuthProvider` now accepts a `getActiveCloudModels` getter function. The `modifyModels` callback prefers the runtime discovery state (`cloudEnvDiscoveryState.models`) when non-empty, falling back to credential models only before first discovery.
- **`index.ts`**: Pass `() => cloudEnvDiscoveryState.models` as the getter to `createOllamaCloudOAuthProvider`. Also use `getCloudModels()` in `findLocalModelForQuery` (consistent with #232 fixes).
- **`auth.test.ts`**: Split the single modifyModels test into two: one asserting runtime models are preferred, one asserting credential models are the fallback. Added kimi-k2.6 as the test model for the runtime-preference case.

## Testing

All 26 tests pass (1 new test added). Typecheck passes.