### PR TITLE
feat: remove explicit model overrides from ant_colony tool, use adaptive routing

### DIFF
--- a/.changeset/colony-adaptive-routing-models.md
+++ b/.changeset/colony-adaptive-routing-models.md
@@ -1,0 +1,5 @@
+---
+default: minor
+---
+
+Remove explicit model override parameters from ant_colony tool. Model selection now uses adaptive routing exclusively — scouts, workers, and soldiers each use the best available model for their task category (quick-discovery, implementation-default, review-critical). Configure via /route settings.

--- a/packages/ant-colony/extensions/ant-colony/index.ts
+++ b/packages/ant-colony/extensions/ant-colony/index.ts
@@ -1052,6 +1052,7 @@ export default function antColonyExtension(pi: ExtensionAPI) {
 			"Results are automatically injected when the colony finishes.",
 			"Scouts explore the codebase, workers execute tasks in parallel, soldiers review quality.",
 			"Use for multi-file changes, large refactors, or complex features.",
+			"Model selection is handled by adaptive routing — scouts, workers, and soldiers each use the best available model for their task category (quick-discovery, implementation-default, review-critical). Configure via /route settings.",
 		].join(" "),
 		parameters: Type.Object({
 			goal: Type.String({ description: "What the colony should accomplish" }),
@@ -1061,19 +1062,6 @@ export default function antColonyExtension(pi: ExtensionAPI) {
 			maxCost: Type.Optional(
 				Type.Number({ description: "Max cost budget in USD (default: unlimited)", minimum: 0.01 }),
 			),
-			scoutModel: Type.Optional(Type.String({ description: "Model for scout ants (default: current session model)" })),
-			workerModel: Type.Optional(
-				Type.String({ description: "Model for worker ants (default: current session model)" }),
-			),
-			soldierModel: Type.Optional(
-				Type.String({ description: "Model for soldier ants (default: current session model)" }),
-			),
-			designWorkerModel: Type.Optional(Type.String({ description: "Model override for design worker class" })),
-			multimodalWorkerModel: Type.Optional(
-				Type.String({ description: "Model override for multimodal worker class (cheap-first default route)" }),
-			),
-			backendWorkerModel: Type.Optional(Type.String({ description: "Model override for backend worker class" })),
-			reviewWorkerModel: Type.Optional(Type.String({ description: "Model override for review worker class" })),
 		}),
 
 		async execute(_toolCallId, params, _signal, _onUpdate, ctx) {
@@ -1085,35 +1073,12 @@ export default function antColonyExtension(pi: ExtensionAPI) {
 				};
 			}
 
-			const modelOverrides: Record<string, string> = {};
-			if (params.scoutModel) {
-				modelOverrides.scout = params.scoutModel;
-			}
-			if (params.workerModel) {
-				modelOverrides.worker = params.workerModel;
-			}
-			if (params.soldierModel) {
-				modelOverrides.soldier = params.soldierModel;
-			}
-			if (params.designWorkerModel) {
-				modelOverrides.design = params.designWorkerModel;
-			}
-			if (params.multimodalWorkerModel) {
-				modelOverrides.multimodal = params.multimodalWorkerModel;
-			}
-			if (params.backendWorkerModel) {
-				modelOverrides.backend = params.backendWorkerModel;
-			}
-			if (params.reviewWorkerModel) {
-				modelOverrides.review = params.reviewWorkerModel;
-			}
-
 			const colonyParams = {
 				goal: params.goal,
 				maxAnts: params.maxAnts,
 				maxCost: params.maxCost,
 				currentModel,
-				modelOverrides,
+				modelOverrides: {},
 				cwd: ctx.cwd,
 				modelRegistry: ctx.modelRegistry ?? undefined,
 				sessionFile: ctx.sessionManager?.getSessionFile?.() ?? null,


### PR DESCRIPTION
## Remove hardcoded model overrides from ant_colony tool

### Problem
The `ant_colony` tool accepted explicit model parameters (`scoutModel`, `workerModel`, `soldierModel`, etc.) that bypassed adaptive routing. When an unavailable model was specified (e.g., `anthropic/claude-sonnet-4`), the colony would crash with a "model not found" error instead of falling back gracefully.

### Solution
Remove all 7 explicit model override parameters from the tool schema. Model selection now exclusively uses adaptive routing via `resolveColonyCategoryModel`, which assigns each caste/worker-class the best available model for its task category:

| Caste/Class | Category | Typical Routing |
|------------|----------|----------------|
| Scout | `quick-discovery` | Fast, cheap models for exploration |
| Worker | `implementation-default` | Strong coding models |
| Soldier | `review-critical` | High-quality reasoning models |
| Design | `visual-engineering` | Models with design capability |
| Multimodal | `multimodal-default` | Image-capable models |
| Backend | `implementation-default` | Strong coding models |
| Review | `review-critical` | High-quality reasoning models |

Users configure these categories via `/route settings`. If no adaptive routing config exists, the colony falls back to the current session model.

### Changes
- Removed 7 model parameters from tool schema
- Removed modelOverrides construction from execute handler (now passes `{}`)
- Updated tool description to mention adaptive routing
- `ModelOverrides` type preserved internally for backward compatibility with persisted colonies
- Changeset: minor bump (changes tool API surface)

### Test Results
- ✅ All 264 ant-colony tests pass
- ✅ Biome lint passes