### PR TITLE
feat(extensions/qna): highlight recommended options in QnA overlay

### DIFF
--- a/.changeset/answer-recommendation-options.md
+++ b/.changeset/answer-recommendation-options.md
@@ -1,0 +1,24 @@
+---
+default: patch
+---
+
+Highlight recommended options in answer extension QnA overlay.
+
+The QnA TUI now renders recommended options with bold text and a `(recommended)` postfix so the user's preferred choice stands out visually.
+
+LLM extraction prompt changes:
+- Instructs the model to mark clearly recommended options with `recommended: true`
+- When there is a recommendation without multiple explicit choices, the model creates a single synthetic recommended option; the TUI already presents an `Other` choice so the user can describe what they actually want.
+- Added example showing single-recommendation extraction
+
+Shared QnA component (`qna-tui.ts`):
+- Added `recommended?: boolean` to `QnAOption` interface
+- Render loop appends `(recommended)` postfix and applies bold styling when `recommended` is true
+
+Answer extension (`answer.ts`):
+- Updated `ExtractedQuestion` option type to carry `recommended`
+- `normalizeExtractedQuestions` passes through the flag and synthesizes a recommended option from a `recommendation` string when no explicit options exist
+
+Tests:
+- Added coverage for recommended flag extraction, defaulting to false, synthesis from recommendation string, and preference for explicit options
+- Updated prompt assertion tests for new recommendation guidelines

--- a/packages/extensions/extensions/answer.test.ts
+++ b/packages/extensions/extensions/answer.test.ts
@@ -181,8 +181,8 @@ describe("normalizeExtractedQuestions", () => {
 			{
 				question: "Database?",
 				options: [
-					{ label: "PostgreSQL", description: "Relational" },
-					{ label: "MongoDB", description: "Document" },
+					{ label: "PostgreSQL", description: "Relational", recommended: false },
+					{ label: "MongoDB", description: "Document", recommended: false },
 				],
 			},
 		]);
@@ -192,7 +192,9 @@ describe("normalizeExtractedQuestions", () => {
 		const result = normalizeExtractedQuestions([
 			{ question: "Pick one?", options: [{ label: "A", description: "First" }, { description: "No label" }] },
 		]);
-		expect(result).toEqual([{ question: "Pick one?", options: [{ label: "A", description: "First" }] }]);
+		expect(result).toEqual([
+			{ question: "Pick one?", options: [{ label: "A", description: "First", recommended: false }] },
+		]);
 	});
 
 	it("strips options entirely when none remain after filtering", () => {
@@ -214,12 +216,67 @@ describe("normalizeExtractedQuestions", () => {
 		const result = normalizeExtractedQuestions([
 			{ question: "Q?", options: [{ label: "  A  ", description: "  desc  " }] },
 		]);
-		expect(result).toEqual([{ question: "Q?", options: [{ label: "A", description: "desc" }] }]);
+		expect(result).toEqual([{ question: "Q?", options: [{ label: "A", description: "desc", recommended: false }] }]);
 	});
 
 	it("uses empty string for non-string description in options", () => {
 		const result = normalizeExtractedQuestions([{ question: "Q?", options: [{ label: "A", description: 123 }] }]);
-		expect(result).toEqual([{ question: "Q?", options: [{ label: "A", description: "" }] }]);
+		expect(result).toEqual([{ question: "Q?", options: [{ label: "A", description: "", recommended: false }] }]);
+	});
+
+	it("preserves recommended flag on options", () => {
+		const result = normalizeExtractedQuestions([
+			{
+				question: "Pick one?",
+				options: [
+					{ label: "A", description: "First", recommended: true },
+					{ label: "B", description: "Second" },
+				],
+			},
+		]);
+		expect(result).toEqual([
+			{
+				question: "Pick one?",
+				options: [
+					{ label: "A", description: "First", recommended: true },
+					{ label: "B", description: "Second", recommended: false },
+				],
+			},
+		]);
+	});
+
+	it("defaults recommended to false when omitted", () => {
+		const result = normalizeExtractedQuestions([{ question: "Q?", options: [{ label: "A", description: "Only" }] }]);
+		expect(result).toEqual([{ question: "Q?", options: [{ label: "A", description: "Only", recommended: false }] }]);
+	});
+
+	it("synthesizes recommended option from recommendation string", () => {
+		const result = normalizeExtractedQuestions([
+			{ question: "Which tool?", context: "I recommend Kani.", recommendation: "Start with Kani" },
+		]);
+		expect(result).toEqual([
+			{
+				question: "Which tool?",
+				context: "I recommend Kani.",
+				options: [{ label: "Start with Kani", description: "", recommended: true }],
+			},
+		]);
+	});
+
+	it("prefers explicit options over recommendation string", () => {
+		const result = normalizeExtractedQuestions([
+			{
+				question: "Which tool?",
+				options: [{ label: "Kani", description: "Verifier", recommended: true }],
+				recommendation: "Use Kani",
+			},
+		]);
+		expect(result).toEqual([
+			{
+				question: "Which tool?",
+				options: [{ label: "Kani", description: "Verifier", recommended: true }],
+			},
+		]);
 	});
 });
 
@@ -293,9 +350,23 @@ describe("EXTRACTION_SYSTEM_PROMPT", () => {
 		expect(EXTRACTION_SYSTEM_PROMPT).toContain("Put background context in the `context` field");
 	});
 
-	it("instructs LLM to always extract explicit choices as options", () => {
+	it("instructs LLM to extract explicit choices as options", () => {
 		expect(EXTRACTION_SYSTEM_PROMPT).toContain("Always extract all explicit choices");
 		expect(EXTRACTION_SYSTEM_PROMPT).toContain("include every option");
+	});
+
+	it("instructs LLM to mark recommended options", () => {
+		expect(EXTRACTION_SYSTEM_PROMPT).toContain("mark it with `recommended: true`");
+		expect(EXTRACTION_SYSTEM_PROMPT).toContain("recommended: true");
+	});
+
+	it("includes single-recommendation example", () => {
+		expect(EXTRACTION_SYSTEM_PROMPT).toContain("single recommendation without explicit choices");
+		expect(EXTRACTION_SYSTEM_PROMPT).toContain("Proptest");
+	});
+
+	it("instructs LLM to synthesize recommended option when no multiple options exist", () => {
+		expect(EXTRACTION_SYSTEM_PROMPT).toContain("recommendation marked `recommended: true`");
 	});
 });
 
@@ -398,8 +469,8 @@ describe("extractQuestions", () => {
 			{
 				question: "Database?",
 				options: [
-					{ label: "PostgreSQL", description: "Relational" },
-					{ label: "SQLite", description: "Embedded" },
+					{ label: "PostgreSQL", description: "Relational", recommended: false },
+					{ label: "SQLite", description: "Embedded", recommended: false },
 				],
 			},
 		]);

--- a/packages/extensions/extensions/answer.ts
+++ b/packages/extensions/extensions/answer.ts
@@ -25,14 +25,16 @@ const ANSWER_ENTRY_TYPE = "answer-state";
 const EXTRACTION_SYSTEM_PROMPT = [
 	"You are a question extractor. Given text from a conversation, extract any questions that need answering.",
 	"",
-	"Output a JSON array of objects, each with a `question` field (required) and optional `context` and `options` fields.",
-	"If a question has known options (e.g. yes/no, A/B/C, a numbered list of choices), include them as an `options` array where each option has `label` and `description` fields.",
+	"Output a JSON array of objects, each with a `question` field (required) and optional `context`, `options`, and `recommendation` fields.",
+	"If a question has known options (e.g. yes/no, A/B/C, a numbered list of choices), include them as an `options` array where each option has `label`, `description`, and optional `recommended` fields.",
+	'If an option is clearly recommended (e.g. "I recommend X", "I\'d suggest Y"), mark it with `recommended: true`.',
+	'If there is a recommendation but no multiple options, create a single option array with the recommendation marked `recommended: true`. The user will see the one recommended option and an "Other" choice to describe what they actually want.',
 	"If no questions are found, output an empty array: []",
 	"",
 	"Example output — simple options:",
 	"```json",
 	'[{"question": "What is your preferred database?", "options": [{"label": "PostgreSQL", "description": "Relational, mature"}, {"label": "MongoDB", "description": "Document store, flexible schema"}, {"label": "SQLite", "description": "Lightweight, embedded"}]},',
-	' {"question": "Should we use TypeScript or JavaScript?", "options": [{"label": "TypeScript", "description": "Static typing, better DX"}, {"label": "JavaScript", "description": "Simpler, no build step"}]},',
+	' {"question": "Should we use TypeScript or JavaScript?", "options": [{"label": "TypeScript", "description": "Static typing, better DX", "recommended": true}, {"label": "JavaScript", "description": "Simpler, no build step"}]},',
 	' {"question": "Any additional context or preferences?"}]',
 	"```",
 	"",
@@ -41,10 +43,17 @@ const EXTRACTION_SYSTEM_PROMPT = [
 	'[{"question": "What is the most expensive bug this system could ship?", "context": "Rank the options below by impact.", "options": [{"label": "a. Wrong version bump", "description": "e.g. patch instead of major"}, {"label": "b. Missing package in release", "description": "e.g. dependency not propagated"}, {"label": "c. Breaking dependency graph", "description": "e.g. circular propagation"}, {"label": "d. Config parsing silently ignores invalid input"}, {"label": "e. Adapter produces wrong manifest edits", "description": "e.g. corrupts Cargo.toml"}]}]',
 	"```",
 	"",
+	"Example output — single recommendation without explicit choices:",
+	"```json",
+	'[{"question": "Which testing strategy should we use first?", "context": "Based on the current codebase state.", "options": [{"label": "Proptest", "description": "Property-based testing finds more bugs per hour and integrates easily.", "recommended": true}]}]',
+	"```",
+	"",
 	"Guidelines:",
 	"- Find the MOST COMPLETE formulation of each question. If a question appears both as a detailed section (with choices, rankings, or examples) and as a short summary later (e.g. 'please answer the six questions above'), extract from the detailed section.",
 	"- Keep `question` concise — one sentence with the core question. Put background context in the `context` field.",
 	"- Always extract all explicit choices as `options`. For example, if a question lists options a-e, include every option in the `options` array.",
+	"- Mark any clearly recommended option with `recommended: true`. Do not add a `recommended` field to non-recommended options.",
+	"- When there is a recommendation without multiple options, create a single option array with the recommendation marked `recommended: true`. The user will see the one recommended option and an 'Other' choice to describe what they actually want.",
 	"- Only extract genuine questions that need a response, not rhetorical questions",
 	"- Include free-text questions without options when the answer is open-ended",
 	"- Output only the JSON array, nothing else",
@@ -66,7 +75,7 @@ const DEFAULT_TEMPLATES: QnATemplate[] = [
 interface ExtractedQuestion {
 	question: string;
 	context?: string;
-	options?: Array<{ label: string; description: string }>;
+	options?: Array<{ label: string; description: string; recommended?: boolean }>;
 }
 
 interface AnswerState {
@@ -147,12 +156,24 @@ function normalizeExtractedQuestions(raw: unknown): ExtractedQuestion[] {
 					.map((opt) => ({
 						label: (opt.label as string).trim(),
 						description: typeof opt.description === "string" ? opt.description.trim() : "",
+						recommended: opt.recommended === true,
 					}))
 					.filter((opt) => opt.label.length > 0);
 
 				if (options.length > 0) {
 					question.options = options;
 				}
+			}
+
+			// Synthesize a recommended option if the LLM provided a recommendation text without options
+			if (!question.options && typeof item.recommendation === "string" && item.recommendation.trim().length > 0) {
+				question.options = [
+					{
+						label: (item.recommendation as string).trim(),
+						description: "",
+						recommended: true,
+					},
+				];
 			}
 
 			return question;

--- a/packages/shared-qna/qna-tui.ts
+++ b/packages/shared-qna/qna-tui.ts
@@ -47,6 +47,7 @@ function getPiTui() {
 export interface QnAOption {
 	label: string;
 	description: string;
+	recommended?: boolean;
 }
 
 export interface QnAQuestion {
@@ -698,17 +699,22 @@ export class QnATuiComponent<TQuestion extends QnAQuestion> implements Component
 				lines.push(padToWidth(emptyBoxLine()));
 				for (let i = 0; i <= options.length; i++) {
 					const isOther = i === options.length;
-					const optionLabel = isOther ? "Other" : options[i].label;
+					const rawLabel = isOther ? "Other" : options[i].label;
+					const isRecommended = !isOther && options[i].recommended;
+					const optionLabel = isRecommended ? `${rawLabel} (recommended)` : rawLabel;
 					const description = isOther ? "Type your own answer" : options[i].description;
 					const selected = response.selectedOptionIndex === i;
 					const marker = selected ? "▶" : " ";
 					const optionPrefix = `${marker} ${i + 1}. `;
 					const line = `${optionPrefix}${optionLabel}`;
-					const styledLine = selected
-						? response.selectionTouched
-							? this.green(line)
-							: this.cyan(line)
-						: line;
+					let styledLine: string;
+					if (selected) {
+						styledLine = response.selectionTouched ? this.green(line) : this.cyan(line);
+					} else if (isRecommended) {
+						styledLine = this.bold(line);
+					} else {
+						styledLine = line;
+					}
 					lines.push(padToWidth(boxLine(truncateToWidth(styledLine, contentWidth))));
 
 					if (selected && description && description.trim().length > 0) {

--- a/packages/shared-qna/tests/qna-tui.test.ts
+++ b/packages/shared-qna/tests/qna-tui.test.ts
@@ -267,6 +267,48 @@ describe("QnATuiComponent", () => {
 		expect(rendered).toContain("A: Bun");
 	});
 
+	it("renders recommended options with bold '(recommended)' postfix", () => {
+		const done = vi.fn();
+		const component = new QnATuiComponent(
+			[
+				{
+					question: "Which strategy?",
+					options: [
+						{ label: "Kani", description: "Formal verification" },
+						{ label: "Proptest", description: "Finds more bugs per hour", recommended: true },
+					],
+				},
+			],
+			createTui(),
+			done,
+			{ initialResponses: [{ selectedOptionIndex: 0, selectionTouched: true, committed: false }] },
+		);
+
+		const rendered = component.render(80).join("\n");
+		expect(rendered).toContain("Proptest (recommended)");
+		// The selected option (Kani) should be green/blue, not bold
+		expect(rendered).toContain("Kani");
+		expect(rendered).not.toContain("Kani (recommended)");
+	});
+
+	it("synthesizes single recommended option with implicit Other from UI", () => {
+		const done = vi.fn();
+		const component = new QnATuiComponent(
+			[
+				{
+					question: "Which tool?",
+					options: [{ label: "Start with Kani", description: "Recommended approach", recommended: true }],
+				},
+			],
+			createTui(),
+			done,
+		);
+
+		const rendered = component.render(80).join("\n");
+		expect(rendered).toContain("Start with Kani (recommended)");
+		expect(rendered).toContain("Other");
+	});
+
 	it("supports escape from confirmation and ctrl+c cancellation", () => {
 		const done = vi.fn();
 		const component = new QnATuiComponent([{ question: "Any notes?" }], createTui(), done, {


### PR DESCRIPTION
## What

Surfaces recommended options in the answer extension's QnA TUI so the user's preferred choice stands out visually.

## Changes

**Shared QnA ()**
- Added  to  interface
- Render loop appends  postfix and applies bold styling to recommended options

**Answer extension ()**
- LLM prompt teaches extraction of  on clearly preferred options
- When there is a recommendation without explicit choices, the prompt instructs synthesizing a single recommended option
-  passes through  flag and synthesizes an option from a  string when no explicit options exist
-  forwards options as-is (including )

**Tests**
- Recommended flag extraction and defaulting
- Synthetic option creation from recommendation string
- Prompt assertions for new recommendation guidelines

## Verification

- 72 tests pass in 
- 6 tests pass in 
- Lint/format pass (
> @ lint /Users/ifiokjr/Developer/projects/aipi/oh-pi
> biome check --error-on-warnings .

Checked 225 files in 126ms. No fixes applied.)
