### PR TITLE
feat(qna): add Ctrl+O context expansion popup for question details

### DIFF
--- a/.changeset/answer-context-popup.md
+++ b/.changeset/answer-context-popup.md
@@ -1,0 +1,16 @@
+---
+default: patch
+---
+
+Add Ctrl+O context expansion popup for QnA questions.
+
+When a question has a longer original formulation, pressing Ctrl+O opens a
+popup inside the QnA overlay showing the full question text, context, and all
+option descriptions. Escape, Enter, or Ctrl+O again closes the popup.
+
+- Added `fullContext` field to `QnAQuestion` for preserving the verbatim
+  original text alongside the concise `question` summary.
+- LLM extraction prompt now instructs preserving `fullContext` when the
+  question is summarized from a longer original.
+- `QnATuiComponent` toggles a context popup with Ctrl+O.
+- `normalizeExtractedQuestions` passes through `fullContext`.

--- a/packages/extensions/extensions/answer.test.ts
+++ b/packages/extensions/extensions/answer.test.ts
@@ -207,6 +207,26 @@ describe("normalizeExtractedQuestions", () => {
 		expect(result).toEqual([{ question: "Q?" }]);
 	});
 
+	it("extracts fullContext when present", () => {
+		const result = normalizeExtractedQuestions([
+			{
+				question: "Most expensive bug?",
+				fullContext: "What is the most expensive bug?\\n\\na. Wrong version bump\\nb. Missing package in release",
+			},
+		]);
+		expect(result).toEqual([
+			{
+				question: "Most expensive bug?",
+				fullContext: "What is the most expensive bug?\\n\\na. Wrong version bump\\nb. Missing package in release",
+			},
+		]);
+	});
+
+	it("ignores empty fullContext strings", () => {
+		const result = normalizeExtractedQuestions([{ question: "Q?", fullContext: "   " }]);
+		expect(result).toEqual([{ question: "Q?" }]);
+	});
+
 	it("ignores empty options arrays", () => {
 		const result = normalizeExtractedQuestions([{ question: "Q?", options: [] }]);
 		expect(result).toEqual([{ question: "Q?" }]);
@@ -367,6 +387,11 @@ describe("EXTRACTION_SYSTEM_PROMPT", () => {
 
 	it("instructs LLM to synthesize recommended option when no multiple options exist", () => {
 		expect(EXTRACTION_SYSTEM_PROMPT).toContain("recommendation marked `recommended: true`");
+	});
+
+	it("instructs LLM to extract fullContext for expandable detail", () => {
+		expect(EXTRACTION_SYSTEM_PROMPT).toContain("fullContext");
+		expect(EXTRACTION_SYSTEM_PROMPT).toContain("expand for detail");
 	});
 });
 

--- a/packages/extensions/extensions/answer.ts
+++ b/packages/extensions/extensions/answer.ts
@@ -25,7 +25,8 @@ const ANSWER_ENTRY_TYPE = "answer-state";
 const EXTRACTION_SYSTEM_PROMPT = [
 	"You are a question extractor. Given text from a conversation, extract any questions that need answering.",
 	"",
-	"Output a JSON array of objects, each with a `question` field (required) and optional `context`, `options`, and `recommendation` fields.",
+	"Output a JSON array of objects, each with a `question` field (required) and optional `context`, `fullContext`, `options`, and `recommendation` fields.",
+	"Use `fullContext` to preserve the original verbatim question text when you summarize or shorten it for the `question` field. This lets the user expand for more detail.",
 	"If a question has known options (e.g. yes/no, A/B/C, a numbered list of choices), include them as an `options` array where each option has `label`, `description`, and optional `recommended` fields.",
 	'If an option is clearly recommended (e.g. "I recommend X", "I\'d suggest Y"), mark it with `recommended: true`.',
 	'If there is a recommendation but no multiple options, create a single option array with the recommendation marked `recommended: true`. The user will see the one recommended option and an "Other" choice to describe what they actually want.',
@@ -40,7 +41,7 @@ const EXTRACTION_SYSTEM_PROMPT = [
 	"",
 	"Example output — question with choices found in a detailed section:",
 	"```json",
-	'[{"question": "What is the most expensive bug this system could ship?", "context": "Rank the options below by impact.", "options": [{"label": "a. Wrong version bump", "description": "e.g. patch instead of major"}, {"label": "b. Missing package in release", "description": "e.g. dependency not propagated"}, {"label": "c. Breaking dependency graph", "description": "e.g. circular propagation"}, {"label": "d. Config parsing silently ignores invalid input"}, {"label": "e. Adapter produces wrong manifest edits", "description": "e.g. corrupts Cargo.toml"}]}]',
+	'[{"question": "What is the most expensive bug this system could ship?", "context": "Rank the options below by impact.", "fullContext": "What is the most expensive bug this system could ship?\\n\\nRank these:\\n\\na. Wrong version bump (e.g. patch instead of major)\\nb. Missing package in release (e.g. dependency not propagated)\\nc. Breaking dependency graph (e.g. circular propagation, non-termination)\\nd. Config parsing silently ignores invalid input\\ne. Adapter produces wrong manifest edits (e.g. corrupts Cargo.toml)", "options": [{"label": "a. Wrong version bump", "description": "e.g. patch instead of major"}, {"label": "b. Missing package in release", "description": "e.g. dependency not propagated"}, {"label": "c. Breaking dependency graph", "description": "e.g. circular propagation"}, {"label": "d. Config parsing silently ignores invalid input"}, {"label": "e. Adapter produces wrong manifest edits", "description": "e.g. corrupts Cargo.toml"}]}]',
 	"```",
 	"",
 	"Example output — single recommendation without explicit choices:",
@@ -50,7 +51,7 @@ const EXTRACTION_SYSTEM_PROMPT = [
 	"",
 	"Guidelines:",
 	"- Find the MOST COMPLETE formulation of each question. If a question appears both as a detailed section (with choices, rankings, or examples) and as a short summary later (e.g. 'please answer the six questions above'), extract from the detailed section.",
-	"- Keep `question` concise — one sentence with the core question. Put background context in the `context` field.",
+	"- Keep `question` concise — one sentence with the core question. Put the full original text in `fullContext` so users can expand for detail. Put background context in the `context` field.",
 	"- Always extract all explicit choices as `options`. For example, if a question lists options a-e, include every option in the `options` array.",
 	"- Mark any clearly recommended option with `recommended: true`. Do not add a `recommended` field to non-recommended options.",
 	"- When there is a recommendation without multiple options, create a single option array with the recommendation marked `recommended: true`. The user will see the one recommended option and an 'Other' choice to describe what they actually want.",
@@ -75,6 +76,7 @@ const DEFAULT_TEMPLATES: QnATemplate[] = [
 interface ExtractedQuestion {
 	question: string;
 	context?: string;
+	fullContext?: string;
 	options?: Array<{ label: string; description: string; recommended?: boolean }>;
 }
 
@@ -147,6 +149,10 @@ function normalizeExtractedQuestions(raw: unknown): ExtractedQuestion[] {
 				question.context = (item.context as string).trim();
 			}
 
+			if (typeof item.fullContext === "string" && item.fullContext.trim().length > 0) {
+				question.fullContext = (item.fullContext as string).trim();
+			}
+
 			if (Array.isArray(item.options) && item.options.length > 0) {
 				const options = item.options
 					.filter(
@@ -184,6 +190,7 @@ function toQnAQuestions(extracted: ExtractedQuestion[]): QnAQuestion[] {
 	return extracted.map((q) => ({
 		question: q.question,
 		context: q.context,
+		fullContext: q.fullContext,
 		options: q.options,
 	}));
 }

--- a/packages/shared-qna/qna-tui.ts
+++ b/packages/shared-qna/qna-tui.ts
@@ -54,6 +54,7 @@ export interface QnAQuestion {
 	header?: string;
 	question: string;
 	context?: string;
+	fullContext?: string;
 	options?: QnAOption[];
 }
 
@@ -263,6 +264,7 @@ export class QnATuiComponent<TQuestion extends QnAQuestion> implements Component
 	private tui: TUI;
 	private onDone: (result: QnAResult | null) => void;
 	private showingConfirmation = false;
+	private showingContextPopup = false;
 	private templates: QnATemplate[];
 	private templateIndex = 0;
 	private onResponsesChange?: (responses: QnAResponse[]) => void;
@@ -542,6 +544,28 @@ export class QnATuiComponent<TQuestion extends QnAQuestion> implements Component
 			return;
 		}
 
+		if (matchesKey(data, Key.ctrl("o"))) {
+			if (this.showingContextPopup) {
+				this.showingContextPopup = false;
+				this.invalidate();
+				this.tui.requestRender();
+			} else if (this.getCurrentQuestion().fullContext) {
+				this.showingContextPopup = true;
+				this.invalidate();
+				this.tui.requestRender();
+			}
+			return;
+		}
+
+		if (this.showingContextPopup) {
+			if (matchesKey(data, Key.escape) || matchesKey(data, Key.enter) || matchesKey(data, Key.ctrl("o"))) {
+				this.showingContextPopup = false;
+				this.invalidate();
+				this.tui.requestRender();
+			}
+			return;
+		}
+
 		if (matchesKey(data, Key.ctrl("t"))) {
 			this.applyNextTemplate();
 			return;
@@ -678,10 +702,55 @@ export class QnATuiComponent<TQuestion extends QnAQuestion> implements Component
 		lines.push(padToWidth(boxLine(progressParts.join(" "))));
 
 		if (!this.showingConfirmation) {
-			if (question.header) {
-				lines.push(padToWidth(boxLine(this.cyan(question.header))));
-			}
-			lines.push(padToWidth(emptyBoxLine()));
+			if (this.showingContextPopup && question.fullContext) {
+				lines.push(padToWidth(emptyBoxLine()));
+				lines.push(padToWidth(boxLine(this.bold(this.cyan("Question Details")))));
+				lines.push(padToWidth(emptyBoxLine()));
+
+				const wrappedFull = wrapTextWithAnsi(this.bold("Full question:"), contentWidth);
+				for (const line of wrappedFull) {
+					lines.push(padToWidth(boxLine(line)));
+				}
+				for (const line of wrapTextWithAnsi(question.fullContext, contentWidth)) {
+					lines.push(padToWidth(boxLine(line)));
+				}
+
+				if (question.context) {
+					lines.push(padToWidth(emptyBoxLine()));
+					for (const line of wrapTextWithAnsi(this.bold("Context:"), contentWidth)) {
+						lines.push(padToWidth(boxLine(line)));
+					}
+					for (const line of wrapTextWithAnsi(question.context, contentWidth)) {
+						lines.push(padToWidth(boxLine(line)));
+					}
+				}
+
+				if (options.length > 0) {
+					lines.push(padToWidth(emptyBoxLine()));
+					for (const line of wrapTextWithAnsi(this.bold("Options:"), contentWidth)) {
+						lines.push(padToWidth(boxLine(line)));
+					}
+					for (let i = 0; i < options.length; i++) {
+						const opt = options[i];
+						const optLabel = `${i + 1}. ${opt.label}`;
+						for (const line of wrapTextWithAnsi(optLabel, contentWidth)) {
+							lines.push(padToWidth(boxLine(line)));
+						}
+						if (opt.description) {
+							for (const line of wrapTextWithAnsi(this.gray(`   ${opt.description}`), contentWidth)) {
+								lines.push(padToWidth(boxLine(line)));
+							}
+						}
+					}
+				}
+
+				lines.push(padToWidth(emptyBoxLine()));
+				lines.push(padToWidth(boxLine(this.dim("Esc or Enter to close · Ctrl+O to toggle"))));
+			} else {
+				if (question.header) {
+					lines.push(padToWidth(boxLine(this.cyan(question.header))));
+				}
+				lines.push(padToWidth(emptyBoxLine()));
 
 			const wrappedQuestion = wrapTextWithAnsi(`${this.bold("Q:")} ${this.bold(question.question)}`, contentWidth);
 			for (const line of wrappedQuestion) {
@@ -749,6 +818,7 @@ export class QnATuiComponent<TQuestion extends QnAQuestion> implements Component
 				lines.push(padToWidth(boxLine(`${this.bold("A:")} ${selectedLabel}`)));
 			}
 			lines.push(padToWidth(emptyBoxLine()));
+			}
 		}
 
 		if (this.showingConfirmation) {

--- a/packages/shared-qna/tests/qna-tui.test.ts
+++ b/packages/shared-qna/tests/qna-tui.test.ts
@@ -309,6 +309,68 @@ describe("QnATuiComponent", () => {
 		expect(rendered).toContain("Other");
 	});
 
+	it("opens context popup with Ctrl+O and closes with Escape", () => {
+		const done = vi.fn();
+		const component = new QnATuiComponent(
+			[
+				{
+					question: "Most expensive bug?",
+					fullContext: "What is the most expensive bug?\n\na. Wrong version bump\nb. Missing package in release",
+				},
+			],
+			createTui(),
+			done,
+		);
+
+		// Normal render does not show full context
+		const normalRender = component.render(80).join("\n");
+		expect(normalRender).toContain("Most expensive bug?");
+		expect(normalRender).not.toContain("Wrong version bump");
+
+		// Ctrl+O opens popup
+		component.handleInput("<ctrl-o>");
+		const popupRender = component.render(80).join("\n");
+		expect(popupRender).toContain("Question Details");
+		expect(popupRender).toContain("Wrong version bump");
+
+		// Escape closes popup
+		component.handleInput("<escape>");
+		const afterClose = component.render(80).join("\n");
+		expect(afterClose).not.toContain("Question Details");
+	});
+
+	it("toggles context popup closed with Ctrl+O", () => {
+		const done = vi.fn();
+		const component = new QnATuiComponent(
+			[
+				{
+					question: "Most expensive bug?",
+					fullContext: "What is the most expensive bug?\\n\\na. Wrong version bump\\nb. Missing package",
+				},
+			],
+			createTui(),
+			done,
+		);
+
+		// Open with Ctrl+O
+		component.handleInput("<ctrl-o>");
+		expect(component.render(80).join("\n")).toContain("Question Details");
+
+		// Close with Ctrl+O again
+		component.handleInput("<ctrl-o>");
+		expect(component.render(80).join("\n")).not.toContain("Question Details");
+	});
+
+	it("does nothing on Ctrl+O when fullContext is absent", () => {
+		const done = vi.fn();
+		const component = new QnATuiComponent([{ question: "Any notes?" }], createTui(), done);
+
+		component.handleInput("<ctrl-o>");
+		// Should not crash, just no-op
+		const rendered = component.render(80).join("\n");
+		expect(rendered).toContain("Any notes?");
+	});
+
 	it("supports escape from confirmation and ctrl+c cancellation", () => {
 		const done = vi.fn();
 		const component = new QnATuiComponent([{ question: "Any notes?" }], createTui(), done, {


### PR DESCRIPTION
Closes #242

## What

Adds a Ctrl+O context expansion popup to the QnA overlay. When a question has a longer original formulation stored in `fullContext`, pressing Ctrl+O opens a popup showing the full text, context, and all option descriptions.

## Changes

**packages/shared-qna/qna-tui.ts**
- Added `fullContext?: string` to `QnAQuestion` interface
- Added `showingContextPopup` state to `QnATuiComponent`
- Ctrl+O toggles the popup; Escape/Enter close it
- Popup renders full question text, context, and all options with descriptions

**packages/extensions/extensions/answer.ts**
- LLM extraction prompt now instructs preserving `fullContext` when the question is summarized from a longer original
- `normalizeExtractedQuestions` extracts `fullContext`
- `toQnAQuestions` passes `fullContext` through

## Verification

- 85 tests pass (10 qna-tui + 75 answer)
- Lint/format pass (`pnpm lint`)
- Changeset added