### PR TITLE
perf: eliminate redundant scans and intermediate allocations (round 2)

### DIFF
--- a/packages/ant-colony/extensions/ant-colony/queen.ts
+++ b/packages/ant-colony/extensions/ant-colony/queen.ts
@@ -553,18 +553,22 @@ function updateMetrics(nest: Nest): ColonyMetrics {
 	const now = Date.now();
 	const elapsed = (now - state.metrics.startTime) / 60000; // minutes
 
+	let totalCost = 0;
+	let totalTokens = 0;
+	for (const ant of state.ants) {
+		totalCost += ant.usage.cost;
+		totalTokens += ant.usage.input + ant.usage.output;
+	}
+	const doneCount = tasks.filter((t) => t.status === "done").length;
 	const metrics: ColonyMetrics = {
 		tasksTotal: tasks.length,
-		tasksDone: tasks.filter((t) => t.status === "done").length,
+		tasksDone: doneCount,
 		tasksFailed: tasks.filter((t) => t.status === "failed").length,
 		antsSpawned: state.ants.length,
-		totalCost: state.ants.reduce((s, a) => s + a.usage.cost, 0),
-		totalTokens: state.ants.reduce((s, a) => s + a.usage.input + a.usage.output, 0),
+		totalCost,
+		totalTokens,
 		startTime: state.metrics.startTime,
-		throughputHistory: [
-			...state.metrics.throughputHistory,
-			elapsed > 0 ? tasks.filter((t) => t.status === "done").length / elapsed : 0,
-		].slice(-20),
+		throughputHistory: [...state.metrics.throughputHistory, elapsed > 0 ? doneCount / elapsed : 0].slice(-20),
 	};
 
 	nest.updateState({ metrics });

--- a/packages/extensions/extensions/tool-metadata.ts
+++ b/packages/extensions/extensions/tool-metadata.ts
@@ -188,8 +188,9 @@ function sanitizeDetailsValue(
 
 	let changed = false;
 	const nextEntries: Array<[string, unknown]> = [];
-	const entries = Object.entries(value as Record<string, unknown>).slice(0, MAX_DETAIL_FIELDS);
-	if (entries.length !== Object.keys(value as Record<string, unknown>).length) {
+	const allEntries = Object.entries(value as Record<string, unknown>);
+	const entries = allEntries.slice(0, MAX_DETAIL_FIELDS);
+	if (entries.length !== allEntries.length) {
 		changed = true;
 	}
 	for (const [key, entryValue] of entries) {

--- a/packages/extensions/extensions/usage-tracker.ts
+++ b/packages/extensions/extensions/usage-tracker.ts
@@ -445,9 +445,7 @@ export default function usageTracker(pi: ExtensionAPI) {
 			if (!existsSync(dir)) {
 				mkdirSync(dir, { recursive: true });
 			}
-			const providers = Object.fromEntries(
-				Array.from(rateLimits.entries()).map(([provider, value]) => [provider, value]),
-			);
+			const providers = Object.fromEntries(rateLimits);
 			writeFileSync(rateLimitCachePath, `${JSON.stringify({ version: 1, providers }, null, 2)}\n`, "utf-8");
 		} catch {
 			// Non-critical. We can still rely on in-memory provider data.
@@ -1431,9 +1429,14 @@ export default function usageTracker(pi: ExtensionAPI) {
 		if (!provider) {
 			const externalSources = getExternalSources();
 			if (externalSources.length > 0) {
-				const externalTotalCost = externalSources.reduce((sum, source) => sum + source.costTotal, 0);
-				const externalTurns = externalSources.reduce((sum, source) => sum + source.turns, 0);
-				const externalTokens = externalSources.reduce((sum, source) => sum + source.input + source.output, 0);
+				let externalTotalCost = 0;
+				let externalTurns = 0;
+				let externalTokens = 0;
+				for (const source of externalSources) {
+					externalTotalCost += source.costTotal;
+					externalTurns += source.turns;
+					externalTokens += source.input + source.output;
+				}
 				lines.push(
 					`External inference: ${fmtCost(externalTotalCost)} across ${externalTurns} turns (${fmtTokens(externalTokens)} tokens)`,
 				);
@@ -1558,9 +1561,14 @@ export default function usageTracker(pi: ExtensionAPI) {
 		if (!provider) {
 			const externalSources = getExternalSources();
 			if (externalSources.length > 0) {
-				const externalTotalCost = externalSources.reduce((sum, source) => sum + source.costTotal, 0);
-				const externalTurns = externalSources.reduce((sum, source) => sum + source.turns, 0);
-				const externalTokens = externalSources.reduce((sum, source) => sum + source.input + source.output, 0);
+				let externalTotalCost = 0;
+				let externalTurns = 0;
+				let externalTokens = 0;
+				for (const source of externalSources) {
+					externalTotalCost += source.costTotal;
+					externalTurns += source.turns;
+					externalTokens += source.input + source.output;
+				}
 				lines.push(
 					`  ${theme.fg("accent", "External")}${sep}${theme.fg("warning", fmtCost(externalTotalCost))}${sep}${externalTurns} turns${sep}${fmtTokens(externalTokens)} tokens`,
 				);


### PR DESCRIPTION
Second performance pass following #241. Eliminates repeated array scans and intermediate array allocations across extensions and ant-colony.

## Changes

### Rule 4 (avoid unnecessary work)
- **tool-metadata.ts**: Cache  before  to avoid calling  then  on the same object
- **usage-tracker.ts**: Replace three repeated  passes on  with single  loops (2 locations)
- **usage-tracker.ts**: Replace  with direct 
- **queen.ts**: Replace two  passes on  with single  loop; deduplicate  count

### Test results
- 1,588 tests passed, 0 failures
- Biome lint/format clean across entire repo