### PR TITLE
fix(subagents): validate resolved models against available model registry

### DIFF
--- a/.changeset/subagent-model-validation.md
+++ b/.changeset/subagent-model-validation.md
@@ -1,0 +1,5 @@
+---
+default: patch
+---
+
+Validate subagent models against available models before passing to spawned pi process. Previously, subagents inherited the parent session model (e.g. `github-models/openai/gpt-4o-mini`) without checking whether it was actually available, causing "No models match pattern" warnings. Now, runtime overrides, frontmatter models, and session-default fallbacks are all validated against the available model registry. Invalid models are silently skipped, allowing fallback to delegated category routing or no model override.

--- a/packages/subagents/async-execution.ts
+++ b/packages/subagents/async-execution.ts
@@ -167,9 +167,6 @@ export function executeAsyncChain(id: string, params: AsyncChainParams): AsyncEx
 			currentModel: ctx.currentModel,
 			taskText: s.task,
 		});
-		if (!modelResolution.model && ctx.currentModel) {
-			modelResolution = { ...modelResolution, model: ctx.currentModel, source: "session-default" };
-		}
 
 		return {
 			agent: s.agent,
@@ -285,9 +282,6 @@ export function executeAsyncSingle(id: string, params: AsyncSingleParams): Async
 		currentModel: ctx.currentModel,
 		taskText: params.task,
 	});
-	if (!modelResolution.model && ctx.currentModel) {
-		modelResolution = { ...modelResolution, model: ctx.currentModel, source: "session-default" };
-	}
 	const pid = spawnRunner(
 		{
 			id,

--- a/packages/subagents/chain-execution.ts
+++ b/packages/subagents/chain-execution.ts
@@ -47,8 +47,6 @@ import {
 /** Resolve a model name to its full provider/model format */
 function resolveModelFullId(modelName: string | undefined, availableModels: ModelInfo[]): string | undefined {
 	if (!modelName) return undefined;
-	// If already in provider/model format, return as-is
-	if (modelName.includes("/")) return modelName;
 
 	// Handle thinking level suffixes (e.g., "claude-sonnet-4-5:high")
 	// Strip the suffix for lookup, then add it back
@@ -57,13 +55,12 @@ function resolveModelFullId(modelName: string | undefined, availableModels: Mode
 	const thinkingSuffix = colonIdx !== -1 ? modelName.substring(colonIdx) : "";
 
 	// Look up base model in available models to find provider
-	const match = availableModels.find((m) => m.id === baseModel);
+	const match = availableModels.find((m) => m.id === baseModel || m.fullId === baseModel);
 	if (match) {
 		return thinkingSuffix ? `${match.fullId}${thinkingSuffix}` : match.fullId;
 	}
 
-	// Fallback: return as-is
-	return modelName;
+	return undefined;
 }
 
 export interface ChainExecutionParams {
@@ -341,13 +338,6 @@ export async function executeChain(params: ChainExecutionParams): Promise<ChainE
 						taskText: taskStr,
 					})
 					: { model: explicitModel, source: explicitModel ? ("runtime-override" as const) : ("session-default" as const) };
-				if (!modelResolution.model && inheritedModel) {
-					modelResolution = {
-						...modelResolution,
-						model: resolveModelFullId(inheritedModel, availableModels),
-						source: "session-default",
-					};
-				}
 
 				const r = await runSync(ctx.cwd, agents, task.agent, taskStr, {
 					cwd: task.cwd ?? cwd,
@@ -505,13 +495,6 @@ export async function executeChain(params: ChainExecutionParams): Promise<ChainE
 				currentModel: inheritedModel,
 				taskText: stepTask,
 			});
-			if (!modelResolution.model && inheritedModel) {
-				modelResolution = {
-					...modelResolution,
-					model: resolveModelFullId(inheritedModel, availableModels),
-					source: "session-default",
-				};
-			}
 
 			// Run step
 			const r = await runSync(ctx.cwd, agents, seqStep.agent, stepTask, {

--- a/packages/subagents/index.ts
+++ b/packages/subagents/index.ts
@@ -451,18 +451,14 @@ MANAGEMENT (use action field — omit agent/task/chain/tasks):
 				let tasks = params.tasks.map((t) => t.task);
 				const inheritedModel = ctx.model ? `${ctx.model.provider}/${ctx.model.id}` : undefined;
 				const availableModels = getAvailableRoutingModels(ctx);
-				const modelResolutions = agentConfigs.map((config, i) => {
-					const resolution = resolveSubagentModelResolution(
+				const modelResolutions = agentConfigs.map((config, i) =>
+					resolveSubagentModelResolution(
 						config,
 						availableModels,
 						(params.tasks?.[i] as { model?: string } | undefined)?.model,
 						{ currentModel: inheritedModel, taskText: tasks[i] },
-					);
-					if (!resolution.model && inheritedModel) {
-						return { ...resolution, model: inheritedModel, source: "session-default" as const };
-					}
-					return resolution;
-				});
+					),
+				);
 				// Initialize skill overrides from task-level skill params (may be overridden by TUI)
 				const skillOverrides: (string[] | false | undefined)[] = params.tasks.map((t) =>
 					normalizeSkillInput((t as { skill?: string | string[] | boolean }).skill),
@@ -663,17 +659,15 @@ MANAGEMENT (use action field — omit agent/task/chain/tasks):
 
 				let task = params.task!;
 				const availableModels = getAvailableRoutingModels(ctx);
-				let modelResolution = resolveSubagentModelResolution(agentConfig, availableModels, params.model as string | undefined, {
-					currentModel: ctx.model ? `${ctx.model.provider}/${ctx.model.id}` : undefined,
-					taskText: task,
-				});
-				if (!modelResolution.model && ctx.model) {
-					modelResolution = {
-						...modelResolution,
-						model: `${ctx.model.provider}/${ctx.model.id}`,
-						source: "session-default",
-					};
-				}
+				let modelResolution = resolveSubagentModelResolution(
+					agentConfig,
+					availableModels,
+					params.model as string | undefined,
+					{
+						currentModel: ctx.model ? `${ctx.model.provider}/${ctx.model.id}` : undefined,
+						taskText: task,
+					},
+				);
 				let modelOverride: string | undefined = modelResolution.model;
 				let skillOverride: string[] | false | undefined = normalizeSkillInput(params.skill);
 				// Normalize output: true means "use default" (same as undefined), false means disable

--- a/packages/subagents/model-routing.ts
+++ b/packages/subagents/model-routing.ts
@@ -335,6 +335,37 @@ export function toAvailableModelRefs(models: DelegatedAvailableModel[]): Availab
 	}));
 }
 
+/**
+ * Check whether a model string is available in the given models list.
+ * Accepts fullId (provider/id), bare id, or id with thinking suffix.
+ * Returns the canonical fullId if available, otherwise undefined.
+ */
+export function findAvailableModel(
+	modelName: string | undefined,
+	availableModels: AvailableModelRef[],
+): string | undefined {
+	if (!modelName) return undefined;
+
+	// Strip thinking suffix for lookup
+	const colonIdx = modelName.lastIndexOf(":");
+	const baseName = colonIdx !== -1 ? modelName.substring(0, colonIdx) : modelName;
+	const thinkingSuffix = colonIdx !== -1 ? modelName.substring(colonIdx) : "";
+
+	// Try exact fullId match first
+	const exactMatch = availableModels.find((m) => m.fullId === baseName);
+	if (exactMatch) {
+		return thinkingSuffix ? `${exactMatch.fullId}${thinkingSuffix}` : exactMatch.fullId;
+	}
+
+	// Try bare id match
+	const idMatch = availableModels.find((m) => m.id === baseName);
+	if (idMatch) {
+		return thinkingSuffix ? `${idMatch.fullId}${thinkingSuffix}` : idMatch.fullId;
+	}
+
+	return undefined;
+}
+
 export function resolveSubagentModelResolution(
 	agent: AgentConfig,
 	availableModels: AvailableModelRef[],
@@ -343,15 +374,27 @@ export function resolveSubagentModelResolution(
 ): SubagentModelResolution {
 	const category = categoryForAgent(agent);
 	if (runtimeOverride) {
-		return { model: runtimeOverride, source: "runtime-override", category };
+		const validated = findAvailableModel(runtimeOverride, availableModels);
+		if (validated) {
+			return { model: validated, source: "runtime-override", category };
+		}
 	}
 	if (agent.model) {
-		return { model: agent.model, source: "frontmatter-model", category };
+		const validated = findAvailableModel(agent.model, availableModels);
+		if (validated) {
+			return { model: validated, source: "frontmatter-model", category };
+		}
 	}
 
 	const delegatedModel = resolveDelegatedAgentModel(agent, availableModels, options);
 	if (delegatedModel) {
 		return { model: delegatedModel, source: "delegated-category", category };
+	}
+
+	// Fall back to current session model if it's available
+	const sessionModel = findAvailableModel(options.currentModel, availableModels);
+	if (sessionModel) {
+		return { model: sessionModel, source: "session-default", category };
 	}
 
 	return { source: "session-default", category };

--- a/packages/subagents/tests/async-execution.test.ts
+++ b/packages/subagents/tests/async-execution.test.ts
@@ -137,11 +137,15 @@ beforeEach(() => {
 		missing: [],
 	}));
 	asyncMocks.resolveSubagentModelResolution.mockImplementation(
-		(_agent: any, _models: any[], explicitModel?: string) => ({
-			model: explicitModel,
-			source: explicitModel ? "runtime-override" : "agent-default",
-			category: explicitModel ? "explicit" : undefined,
-		}),
+		(_agent: any, _models: any[], explicitModel?: string, options?: { currentModel?: string }) => {
+			if (explicitModel) {
+				return { model: explicitModel, source: "runtime-override", category: "explicit" };
+			}
+			if (options?.currentModel) {
+				return { model: options.currentModel, source: "session-default", category: undefined };
+			}
+			return { model: undefined, source: "agent-default", category: undefined };
+		},
 	);
 });
 
@@ -240,7 +244,7 @@ describe("async execution helpers", () => {
 		const ctx = createCtx();
 		asyncMocks.resolveSubagentModelResolution
 			.mockReturnValueOnce({ model: "openai/gpt-5", source: "runtime-override", category: "explicit" })
-			.mockReturnValue({ model: undefined, source: "agent-default", category: undefined });
+			.mockReturnValue({ model: "anthropic/claude-sonnet-4", source: "session-default", category: undefined });
 
 		const result = executeAsyncChain("chain-2", {
 			chain: [

--- a/packages/subagents/tests/index-entrypoint.test.ts
+++ b/packages/subagents/tests/index-entrypoint.test.ts
@@ -288,11 +288,17 @@ beforeEach(() => {
 		truncation: undefined,
 		progressSummary: { durationMs: 12 },
 	});
-	mocks.resolveSubagentModelResolution.mockReturnValue({
-		model: undefined,
-		source: "agent-default",
-		category: undefined,
-	});
+	mocks.resolveSubagentModelResolution.mockImplementation(
+		(_agent: any, _models: any[], explicitModel?: string, options?: { currentModel?: string }) => {
+			if (explicitModel) {
+				return { model: explicitModel, source: "runtime-override", category: "explicit" };
+			}
+			if (options?.currentModel) {
+				return { model: options.currentModel, source: "session-default", category: undefined };
+			}
+			return { model: undefined, source: "agent-default", category: undefined };
+		},
+	);
 	mocks.finalizeSingleOutput.mockImplementation(({ truncatedOutput, fullOutput }: any) => ({
 		displayOutput: truncatedOutput || fullOutput || "(no output)",
 	}));

--- a/packages/subagents/tests/model-routing.test.ts
+++ b/packages/subagents/tests/model-routing.test.ts
@@ -12,7 +12,7 @@ vi.mock("@ifi/oh-pi-core", async () => {
 	return await import("../../core/src/model-intelligence.ts");
 });
 
-import { resolveSubagentModelResolution, toAvailableModelRefs } from "../model-routing.js";
+import { findAvailableModel, resolveSubagentModelResolution, toAvailableModelRefs } from "../model-routing.js";
 
 const sampleModels = [
 	{
@@ -339,5 +339,96 @@ describe("resolveSubagentModelResolution", () => {
 		} finally {
 			rmSync(tempAgentDir, { recursive: true, force: true });
 		}
+	});
+
+	describe("findAvailableModel", () => {
+		it("resolves full IDs that exist in available models", () => {
+			expect(findAvailableModel("openai/gpt-5-mini", sampleModels)).toBe("openai/gpt-5-mini");
+		});
+
+		it("resolves bare IDs to full IDs when available", () => {
+			expect(findAvailableModel("gpt-5-mini", sampleModels)).toBe("openai/gpt-5-mini");
+		});
+
+		it("preserves thinking suffixes when resolving", () => {
+			expect(findAvailableModel("gpt-5-mini:high", sampleModels)).toBe("openai/gpt-5-mini:high");
+		});
+
+		it("returns undefined for unavailable models", () => {
+			expect(findAvailableModel("github-models/openai/gpt-4o-mini", sampleModels)).toBeUndefined();
+			expect(findAvailableModel("nonexistent-model", sampleModels)).toBeUndefined();
+		});
+
+		it("returns undefined for undefined input", () => {
+			expect(findAvailableModel(undefined, sampleModels)).toBeUndefined();
+		});
+	});
+
+	describe("model validation in resolution", () => {
+		it("rejects unavailable runtime overrides and falls through", () => {
+			const result = resolveSubagentModelResolution(
+				{
+					name: "scout",
+					description: "Scout",
+					systemPrompt: "Prompt",
+					source: "builtin",
+					filePath: "/tmp/scout.md",
+				},
+				[],
+				"github-models/openai/gpt-4o-mini",
+			);
+			expect(result.source).toBe("session-default");
+			expect(result.model).toBeUndefined();
+		});
+
+		it("rejects unavailable frontmatter models and falls through", () => {
+			const result = resolveSubagentModelResolution(
+				{
+					name: "scout",
+					description: "Scout",
+					systemPrompt: "Prompt",
+					source: "builtin",
+					filePath: "/tmp/scout.md",
+					model: "github-models/openai/gpt-4o-mini",
+				},
+				[],
+			);
+			expect(result.source).not.toBe("frontmatter-model");
+			expect(result.model).toBeUndefined();
+		});
+
+		it("falls back to available session-default currentModel", () => {
+			const result = resolveSubagentModelResolution(
+				{
+					name: "scout",
+					description: "Scout",
+					systemPrompt: "Prompt",
+					source: "builtin",
+					filePath: "/tmp/scout.md",
+				},
+				sampleModels,
+				undefined,
+				{ currentModel: "google/gemini-2.5-flash" },
+			);
+			expect(result.model).toBe("google/gemini-2.5-flash");
+			expect(result.category).toBeUndefined();
+		});
+
+		it("rejects unavailable session-default currentModel", () => {
+			const result = resolveSubagentModelResolution(
+				{
+					name: "scout",
+					description: "Scout",
+					systemPrompt: "Prompt",
+					source: "builtin",
+					filePath: "/tmp/scout.md",
+				},
+				[],
+				undefined,
+				{ currentModel: "github-models/openai/gpt-4o-mini" },
+			);
+			expect(result.source).toBe("session-default");
+			expect(result.model).toBeUndefined();
+		});
 	});
 });


### PR DESCRIPTION
---
"@ifi/pi-extension-subagents": patch
---

Validate subagent models against available models before passing to spawned pi process. Previously, subagents inherited the parent session model (e.g. `github-models/openai/gpt-4o-mini`) without checking whether it was actually available, causing "No models match pattern" warnings. Now, runtime overrides, frontmatter models, and session-default fallbacks are all validated against the available model registry. Invalid models are silently skipped, allowing fallback to delegated category routing or no model override.