### PR TITLE
docs(git-workflow): commit-often, git-stash, and worktree-first principles

### DIFF
--- a/packages/skills/skills/git-workflow/SKILL.md
+++ b/packages/skills/skills/git-workflow/SKILL.md
@@ -9,6 +9,50 @@ description:
 
 Help with Git operations and workflow best practices.
 
+## Core Principles
+
+### 1. Commit early and often
+
+**Make small, frequent commits rather than accumulating large batches of changes.**
+
+- Commit after every logical unit of work — even if it's just "wip: explore approach" or "wip: add failing test"
+- A commit is cheap; losing work is expensive
+- Small commits make reviews easier, bisection faster, and rollbacks safer
+- Don't wait until everything is "perfect" — a messy commit history can be cleaned later with interactive rebase
+- Prefer `git commit -m "wip: <description>"` over leaving work uncommitted for long stretches
+
+### 2. Use `git stash` instead of discarding
+
+**When you need to clear or reset uncommitted work, never just delete it — stash it with an explanation.**
+
+- Use `git stash push -m "<reason>: <description>"` to preserve work and record *why* it was stashed
+- The stash remains in Git history and can be recovered via `git stash list` or `git reflog`
+- This protects against mistakes, dead ends that turn out to be useful later, or context lost during interruptions
+- If you later decide the stashed work is truly worthless — only then drop it explicitly with `git stash drop <stash>`
+- Explaining the stash in the message also helps future-you (or the next agent) understand what was happening
+
+Example:
+```bash
+# Bad: work is just gone
+rm -rf changed-files/
+git checkout -- .
+
+# Good: work is preserved with context
+git stash push -m "pivot: abandoning approach A for approach B after benchmark regression"
+git stash push -m "interrupted: switching to urgent bugfix PR #123"
+```
+
+### 3. Use worktrees for new work
+
+**Start new work in a fresh worktree rather than working directly on `main` or the current branch.**
+
+- Create a worktree for every distinct task or feature: `git worktree add -b feat/description ../worktrees/feat-description`
+- Keeps `main` clean and available for quick reference, hotfixes, or parallel reviews
+- Eliminates risk of accidentally committing work-in-progress to the trunk
+- Makes it safe to run tests, builds, and linting in isolation without polluting the main checkout
+- When done, remove the worktree: `git worktree remove <path>` — the branch remains for PR/merge
+- If the repo has the oh-pi worktree extension, prefer `/worktree create --purpose "..."`
+
 ## Capabilities
 
 ### Branch Strategy
@@ -37,6 +81,8 @@ git rev-parse --git-common-dir
 git worktree list --porcelain
 ```
 
+**Prefer worktrees for all new work.** See [Core Principle #3: Use worktrees for new work](#3-use-worktrees-for-new-work).
+
 If the oh-pi worktree extension is available, prefer:
 
 - `/worktree status` — show the current worktree, canonical repo root, and pi ownership metadata
@@ -49,9 +95,18 @@ For pi-owned worktrees:
 - only clean up pi-owned worktrees by default
 - do **not** clean external/manual worktrees unless the user explicitly asks
 
+When finishing work in a worktree:
+1. Push the branch: `git push origin <branch>`
+2. Open a PR from the worktree branch
+3. Remove the worktree after merge: `git worktree remove <path>`
+
 ### Commit Messages
 
-Follow Conventional Commits:
+Follow Conventional Commits
+
+Small commits are better than perfect commits. See [Core Principle #1: Commit early and often](#1-commit-early-and-often).
+
+Use these prefixes:
 
 ```
 feat(scope): add new feature
@@ -61,6 +116,21 @@ docs(scope): update documentation
 test(scope): add/update tests
 chore(scope): maintenance tasks
 ```
+
+For work-in-progress commits (which are encouraged!), use `wip:` prefix or `chore(wip):`:
+
+```bash
+git commit -am "wip: explore trie-based approach for tokenization"
+git commit -am "wip: failing test for edge case in parser"
+git commit -am "wip: checkpoint before attempting refactor"
+```
+
+Clean up before opening a PR:
+```bash
+git rebase -i main  # squash related wip commits
+```
+
+But **never leave work uncommitted for long** — stash or commit, don't let it sit dirty.
 
 ### PR Workflow
 


### PR DESCRIPTION
Updates the git-workflow skill to codify three practices that improve safety and traceability when agents work with Git.

## New core principles

### 1. Commit early and often
- Small, frequent commits are preferred over large batches
- WIP commits with "wip:" prefix are explicitly encouraged
- A commit is cheap; losing work is expensive
- History can always be cleaned with interactive rebase before opening a PR

### 2. Use git stash instead of discarding
- When clearing uncommitted work, stash it with an explanatory message
- Stashed work survives in Git history and is recoverable via stash list / reflog
- Useful for pivots, interruptions, and abandoned approaches that may prove useful later
- Drop explicitly only after confirming the stash is truly worthless

### 3. Use worktrees for new work
- Every new task starts in a fresh worktree, never on main/trunk
- Added finish steps: push branch → open PR → remove worktree after merge
- Cross-linked existing worktree section to the core principle

## Backward compatibility
- Purely additive — all existing content (branch strategy, conventional commits, conflict resolution, interactive rebase) remains unchanged
- New principles are placed at the top for visibility

## Checklist
- [x] Changeset added
- [x] Skill document updated