### PR TITLE
feat(pi-remote-tailscale): secure remote session sharing via Tailscale HTTPS

### DIFF
--- a/.changeset/feat-pi-remote-tailscale.md
+++ b/.changeset/feat-pi-remote-tailscale.md
@@ -1,0 +1,5 @@
+---
+default: minor
+---
+
+Implement `@ifi/pi-remote-tailscale` package for secure remote session sharing via Tailscale HTTPS. Provides PTY-based remote access, WebSocket terminal sharing, QR code display, token auth, discovery service, and optional TUI widget.

--- a/packages/pi-remote-tailscale/README.md
+++ b/packages/pi-remote-tailscale/README.md
@@ -1,0 +1,74 @@
+# @ifi/pi-remote-tailscale
+
+Pi extension for secure remote session sharing with Tailscale URLs, QR codes, and a compact TUI widget.
+
+## Why this exists
+
+`@ifi/pi-remote-tailscale` brings the original `pi-remote` workflow into oh-pi, but reuses the shared `@ifi/pi-web-server` package for the HTTP and WebSocket transport layer.
+
+This package focuses on:
+
+- secure per-session token auth
+- Tailscale HTTPS URLs for remote access
+- QR code output for phone and tablet handoff
+- an optional remote status widget inside the TUI
+- lightweight discovery metadata for active sessions
+
+## Install
+
+```bash
+pi install npm:@ifi/pi-remote-tailscale
+```
+
+## Commands
+
+Inside pi:
+
+```text
+/remote
+/remote stop
+/remote:widget
+/remote:widget off
+/remote:widget on
+```
+
+## What happens
+
+When `/remote` starts a session, the extension:
+
+1. creates a `PiWebServer` via `@ifi/pi-web-server`
+2. generates a random session token
+3. attempts to publish a Tailscale HTTPS path
+4. shows local, LAN, or Tailscale connection details
+5. renders an optional widget and QR code
+
+If Tailscale is unavailable, the extension falls back to LAN or localhost URLs.
+
+## Security notes
+
+- every session gets a fresh random token
+- tokens are compared with constant-time validation
+- QR links put the token in the query string, never the path
+- discovery metadata excludes the token
+- no secrets are written to logs
+
+## Remote mode
+
+The package supports a remote-mode environment flag:
+
+- `PI_REMOTE_TAILSCALE_MODE=remote`
+
+When this flag is present, the extension can auto-start remote sharing during session startup. This keeps the package compatible with PTY-based launcher flows while still allowing direct use in a normal pi session.
+
+## Development
+
+Run the package tests directly:
+
+```bash
+pnpm exec vitest run --config packages/pi-remote-tailscale/vitest.config.ts --coverage
+```
+
+## Related packages
+
+- `@ifi/pi-web-server` — shared HTTP + WebSocket transport
+- `@ifi/pi-web-remote` — simpler built-in remote command package

--- a/packages/pi-remote-tailscale/index.ts
+++ b/packages/pi-remote-tailscale/index.ts
@@ -1,0 +1,260 @@
+import type { ExtensionAPI, ExtensionCommandContext, ExtensionContext } from "@mariozechner/pi-coding-agent";
+import { createDiscoveryService } from "./src/discovery.js";
+import { createQrRenderer } from "./src/qr.js";
+import {
+	isRemoteSessionEnv,
+	startRemoteSessionServer,
+	type RemoteSessionHandle,
+	type RemoteSessionServerOptions,
+} from "./src/server.js";
+import { createRemoteWidgetController, type RemoteWidgetState } from "./src/widget.js";
+
+const HOSTED_UI_URL = "https://pi-remote.dev";
+const discovery = createDiscoveryService();
+const qrRenderer = createQrRenderer();
+const widgetController = createRemoteWidgetController();
+
+function looksLikeAgentSession(value: unknown): boolean {
+	return Boolean(
+		value &&
+			typeof value === "object" &&
+			typeof (value as Record<string, unknown>).prompt === "function" &&
+			typeof (value as Record<string, unknown>).subscribe === "function",
+	);
+}
+
+function resolveAttachedSession(ctx: ExtensionContext, pi: ExtensionAPI): any {
+	const ctxRecord = ctx as unknown as Record<string, unknown>;
+	const piRecord = pi as unknown as Record<string, unknown>;
+	const candidates = [
+		ctxRecord.session,
+		ctxRecord.agentSession,
+		ctxRecord.currentSession,
+		ctxRecord.runtime,
+		piRecord.session,
+		piRecord.agentSession,
+		piRecord.currentSession,
+	];
+
+	for (const candidate of candidates) {
+		if (looksLikeAgentSession(candidate)) {
+			return candidate;
+		}
+
+		if (candidate && typeof candidate === "object") {
+			const nestedSession = (candidate as Record<string, unknown>).session;
+			if (looksLikeAgentSession(nestedSession)) {
+				return nestedSession;
+			}
+		}
+	}
+
+	return undefined;
+}
+
+function createWidgetState(handle: RemoteSessionHandle): RemoteWidgetState {
+	return {
+		clientCount: handle.server.connectedClients,
+		connectUrl: handle.connectUrl,
+		instanceId: handle.instanceId,
+		lanUrl: handle.lanUrl,
+		localUrl: handle.localUrl,
+		remoteMode: isRemoteSessionEnv(),
+		token: handle.token,
+		tunnelUrl: handle.tunnelUrl,
+	};
+}
+
+function formatActiveMessage(handle: RemoteSessionHandle): string {
+	return `🌐 Remote active · ${handle.instanceId}\n${handle.connectUrl}`;
+}
+
+export default function remoteTailscaleExtension(pi: ExtensionAPI) {
+	let activeCtx: ExtensionContext | undefined;
+	let activeHandle: RemoteSessionHandle | undefined;
+	let startingPromise: Promise<RemoteSessionHandle> | undefined;
+	let widgetEnabled = true;
+	let qrShownForInstanceId: string | undefined;
+	let unsubscribeConnect: (() => void) | undefined;
+	let unsubscribeDisconnect: (() => void) | undefined;
+
+	const clearSubscriptions = () => {
+		unsubscribeConnect?.();
+		unsubscribeDisconnect?.();
+		unsubscribeConnect = undefined;
+		unsubscribeDisconnect = undefined;
+	};
+
+	const syncWidget = (ctx = activeCtx) => {
+		if (!ctx) {
+			return;
+		}
+
+		if (!activeHandle) {
+			widgetController.clear(ctx);
+			return;
+		}
+
+		if (!widgetEnabled) {
+			widgetController.setEnabled(false, ctx, createWidgetState(activeHandle));
+			return;
+		}
+
+		widgetController.setEnabled(true, ctx, createWidgetState(activeHandle));
+		widgetController.schedule(ctx, createWidgetState(activeHandle));
+	};
+
+	const showQrCode = async (ctx: ExtensionContext) => {
+		if (!activeHandle || !widgetEnabled || qrShownForInstanceId === activeHandle.instanceId) {
+			return;
+		}
+
+		widgetController.flush();
+		const qrLines = await qrRenderer.render(activeHandle.connectUrl);
+		ctx.ui.notify(`Scan with a browser:\n${qrLines.join("\n")}`, "info");
+		qrShownForInstanceId = activeHandle.instanceId;
+	};
+
+	const wireClientEvents = (ctx: ExtensionContext, handle: RemoteSessionHandle) => {
+		clearSubscriptions();
+		unsubscribeConnect = handle.server.on("client_connect", () => {
+			syncWidget(ctx);
+			ctx.ui.notify("Remote client connected.", "info");
+		});
+		unsubscribeDisconnect = handle.server.on("client_disconnect", () => {
+			syncWidget(ctx);
+			ctx.ui.notify("Remote client disconnected.", "info");
+		});
+	};
+
+	const ensureStarted = async (ctx: ExtensionContext): Promise<RemoteSessionHandle> => {
+		activeCtx = ctx;
+		/* v8 ignore next -- public entrypoints short-circuit before re-entering ensureStarted when already running. */
+		if (activeHandle?.server.isRunning) {
+			return activeHandle;
+		}
+
+		if (startingPromise) {
+			return startingPromise;
+		}
+
+		const startOptions: RemoteSessionServerOptions = {
+			discovery,
+			hostedUiUrl: HOSTED_UI_URL,
+			resolveSession: () => resolveAttachedSession(ctx, pi),
+		};
+
+		startingPromise = startRemoteSessionServer(startOptions)
+			.then((handle) => {
+				activeHandle = handle;
+				wireClientEvents(ctx, handle);
+				syncWidget(ctx);
+				return handle;
+			})
+			.finally(() => {
+				startingPromise = undefined;
+			});
+
+		return startingPromise;
+	};
+
+	const stopRemote = async (ctx?: ExtensionContext) => {
+		const targetCtx = ctx ?? activeCtx;
+		clearSubscriptions();
+		qrShownForInstanceId = undefined;
+
+		if (!activeHandle) {
+			widgetController.clear(targetCtx);
+			return false;
+		}
+
+		await activeHandle.stop();
+		activeHandle = undefined;
+		widgetController.clear(targetCtx);
+		return true;
+	};
+
+	pi.registerCommand("remote", {
+		description: "Share the current pi session with secure token auth and a Tailscale URL when available.",
+		handler: async (args: string | undefined, ctx: ExtensionCommandContext) => {
+			activeCtx = ctx;
+			const trimmed = args?.trim() ?? "";
+
+			if (trimmed === "stop") {
+				const stopped = await stopRemote(ctx);
+				ctx.ui.notify(stopped ? "Remote access stopped." : "Remote access is not active.", "info");
+				return;
+			}
+
+			if (activeHandle?.server.isRunning) {
+				syncWidget(ctx);
+				ctx.ui.notify(formatActiveMessage(activeHandle), "info");
+				return;
+			}
+
+			ctx.ui.notify("Starting remote access...", "info");
+			try {
+				const handle = await ensureStarted(ctx);
+				ctx.ui.notify(formatActiveMessage(handle), "info");
+				await showQrCode(ctx);
+			} catch (caughtError) {
+				widgetController.clear(ctx);
+				ctx.ui.notify(
+					caughtError instanceof Error ? caughtError.message : "Unable to start remote access.",
+					"error",
+				);
+			}
+		},
+	});
+
+	pi.registerCommand("remote:widget", {
+		description: "Toggle the remote status widget.",
+		handler: async (args: string | undefined, ctx: ExtensionCommandContext) => {
+			activeCtx = ctx;
+			const trimmed = args?.trim().toLowerCase();
+			const nextValue =
+				trimmed === "on" ? true : trimmed === "off" ? false : trimmed === "" || trimmed === undefined ? !widgetEnabled : null;
+
+			if (nextValue === null) {
+				ctx.ui.notify("Usage: /remote:widget [on|off]", "warning");
+				return;
+			}
+
+			widgetEnabled = nextValue;
+			if (activeHandle) {
+				widgetController.setEnabled(widgetEnabled, ctx, createWidgetState(activeHandle));
+				syncWidget(ctx);
+			} else if (!widgetEnabled) {
+				widgetController.clear(ctx);
+			}
+
+			ctx.ui.notify(`Remote widget ${widgetEnabled ? "enabled" : "disabled"}.`, "info");
+		},
+	});
+
+	pi.on("session_start", async (_event: unknown, ctx: ExtensionContext) => {
+		activeCtx = ctx;
+		syncWidget(ctx);
+		if (!isRemoteSessionEnv() || activeHandle?.server.isRunning || startingPromise) {
+			return;
+		}
+
+		try {
+			const handle = await ensureStarted(ctx);
+			ctx.ui.notify(formatActiveMessage(handle), "info");
+			await showQrCode(ctx);
+		} catch (caughtError) {
+			ctx.ui.notify(caughtError instanceof Error ? caughtError.message : "Unable to start remote access.", "error");
+		}
+	});
+
+	pi.on("session_switch", async (_event: unknown, ctx: ExtensionContext) => {
+		activeCtx = ctx;
+		syncWidget(ctx);
+	});
+
+	pi.on("session_shutdown", async () => {
+		await stopRemote();
+		widgetController.dispose();
+	});
+}

--- a/packages/pi-remote-tailscale/package.json
+++ b/packages/pi-remote-tailscale/package.json
@@ -1,0 +1,56 @@
+{
+  "name": "@ifi/pi-remote-tailscale",
+  "version": "0.4.4",
+  "description": "Pi extension for secure remote session sharing with Tailscale URLs, QR codes, and TUI status widgets.",
+  "type": "module",
+  "keywords": [
+    "pi-package",
+    "pi",
+    "pi-coding-agent",
+    "remote",
+    "tailscale",
+    "websocket",
+    "qr-code"
+  ],
+  "pi": {
+    "extensions": [
+      "./index.ts"
+    ]
+  },
+  "files": [
+    "index.ts",
+    "src",
+    "README.md",
+    "!**/*.test.ts",
+    "!tests/**"
+  ],
+  "license": "MIT",
+  "repository": {
+    "type": "git",
+    "url": "git+https://github.com/ifiokjr/oh-pi.git",
+    "directory": "packages/pi-remote-tailscale"
+  },
+  "homepage": "https://github.com/ifiokjr/oh-pi/tree/main/packages/pi-remote-tailscale",
+  "bugs": {
+    "url": "https://github.com/ifiokjr/oh-pi/issues"
+  },
+  "dependencies": {
+    "@ifi/pi-web-server": "0.4.4"
+  },
+  "optionalDependencies": {
+    "node-pty": "^1.0.0",
+    "qrcode-terminal": "^0.12.0"
+  },
+  "scripts": {
+    "build": "pnpm run typecheck && pnpm run test:package",
+    "typecheck": "tsgo --project ./tsconfig.json --noEmit",
+    "test:package": "vitest run --config ./vitest.config.ts"
+  },
+  "peerDependencies": {
+    "@mariozechner/pi-agent-core": ">=0.56.1",
+    "@mariozechner/pi-ai": ">=0.56.1",
+    "@mariozechner/pi-coding-agent": ">=0.56.1",
+    "@mariozechner/pi-tui": ">=0.56.1",
+    "@sinclair/typebox": "*"
+  }
+}

--- a/packages/pi-remote-tailscale/src/cli.ts
+++ b/packages/pi-remote-tailscale/src/cli.ts
@@ -1,0 +1,122 @@
+import { fileURLToPath } from "node:url";
+import { buildPiCommand, buildRemotePtyEnv, createPtyProcess, type CreatePtyProcessOptions } from "./pty.js";
+
+export interface CliOptions {
+	args: string[];
+	command: string;
+	cwd?: string;
+	help: boolean;
+	printEnv: boolean;
+}
+
+export function parseArgs(argv: string[]): CliOptions {
+	const args = argv.slice(2);
+	let cwd: string | undefined;
+	let help = false;
+	let printEnv = false;
+	let command = buildPiCommand();
+	const passthrough: string[] = [];
+
+	for (let index = 0; index < args.length; index += 1) {
+		const arg = args[index];
+
+		if (arg === "--help" || arg === "-h") {
+			help = true;
+			continue;
+		}
+
+		if (arg === "--print-env") {
+			printEnv = true;
+			continue;
+		}
+
+		if (arg === "--cwd") {
+			cwd = args[index + 1];
+			index += 1;
+			continue;
+		}
+
+		if (arg === "--command") {
+			command = args[index + 1] || command;
+			index += 1;
+			continue;
+		}
+
+		passthrough.push(arg);
+	}
+
+	return {
+		args: passthrough,
+		command,
+		cwd,
+		help,
+		printEnv,
+	};
+}
+
+export function formatHelp(): string {
+	return `
+pi-remote-tailscale — PTY launcher helper for remote pi sessions
+
+Usage:
+  pi-remote-tailscale [--cwd <path>] [--command <pi-bin>] [--print-env] [--help] [-- ...pi args]
+
+Options:
+  --cwd <path>      Working directory for the remote child session
+  --command <bin>   Override the pi binary to launch
+  --print-env       Print the remote-mode environment JSON and exit
+  -h, --help        Show this help
+`.trim();
+}
+
+export function buildSpawnOptions(options: CliOptions, env: NodeJS.ProcessEnv = process.env): CreatePtyProcessOptions {
+	return {
+		command: options.command,
+		args: options.args,
+		cwd: options.cwd,
+		env: buildRemotePtyEnv(env),
+	};
+}
+
+export async function main(
+	argv = process.argv,
+	deps: {
+		error?: (message: string) => void;
+		log?: (message: string) => void;
+		startPty?: (options: CreatePtyProcessOptions) => Promise<unknown>;
+	} = {},
+): Promise<number> {
+	const error = deps.error ?? console.error;
+	const log = deps.log ?? console.log;
+	const startPty = deps.startPty ?? createPtyProcess;
+	const options = parseArgs(argv);
+
+	if (options.help) {
+		log(formatHelp());
+		return 0;
+	}
+
+	const spawnOptions = buildSpawnOptions(options);
+
+	if (options.printEnv) {
+		log(JSON.stringify(spawnOptions.env, null, 2));
+		return 0;
+	}
+
+	try {
+		await startPty(spawnOptions);
+		return 0;
+	} catch (caughtError) {
+		error(caughtError instanceof Error ? caughtError.message : String(caughtError));
+		return 1;
+	}
+}
+
+/* v8 ignore next 6 -- covered by the real Node.js CLI entrypoint, not the in-process test harness. */
+const isMain = process.argv[1] && fileURLToPath(import.meta.url) === process.argv[1];
+
+if (isMain) {
+	void main().then((exitCode) => {
+		process.exitCode = exitCode;
+	});
+}

--- a/packages/pi-remote-tailscale/src/discovery.ts
+++ b/packages/pi-remote-tailscale/src/discovery.ts
@@ -1,0 +1,251 @@
+import { mkdir, readFile, readdir, rm, writeFile } from "node:fs/promises";
+import { createServer, type Server } from "node:http";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+
+const DEFAULT_DISCOVERY_TTL_MS = 60_000;
+const DEFAULT_DISCOVERY_DIR = join(tmpdir(), "pi-remote-tailscale", "discovery");
+
+export interface DiscoveryRecord {
+	id: string;
+	instanceId: string;
+	cwd: string;
+	pid: number;
+	startedAt: number;
+	lastSeenAt: number;
+	connectUrl?: string;
+	localUrl?: string;
+	lanUrl?: string;
+	tunnelUrl?: string;
+	remoteMode?: boolean;
+}
+
+export interface DiscoveryServiceOptions {
+	directory?: string;
+	now?: () => number;
+	ttlMs?: number;
+}
+
+function escapeHtml(value: string): string {
+	return value
+		.replaceAll("&", "&amp;")
+		.replaceAll("<", "&lt;")
+		.replaceAll(">", "&gt;")
+		.replaceAll('"', "&quot;");
+}
+
+function safeJsonParse(text: string): DiscoveryRecord | undefined {
+	try {
+		return JSON.parse(text) as DiscoveryRecord;
+	} catch {
+		return undefined;
+	}
+}
+
+export class DiscoveryService {
+	private readonly directory: string;
+	private readonly now: () => number;
+	private readonly ttlMs: number;
+
+	constructor(options: DiscoveryServiceOptions = {}) {
+		this.directory = options.directory ?? DEFAULT_DISCOVERY_DIR;
+		this.now = options.now ?? Date.now;
+		this.ttlMs = options.ttlMs ?? DEFAULT_DISCOVERY_TTL_MS;
+	}
+
+	async register(
+		record: Omit<DiscoveryRecord, "id" | "startedAt" | "lastSeenAt"> & Partial<Pick<DiscoveryRecord, "id" | "startedAt">>,
+	): Promise<DiscoveryRecord> {
+		await mkdir(this.directory, { recursive: true });
+		const now = this.now();
+		const nextRecord: DiscoveryRecord = {
+			...record,
+			id: record.id ?? `${record.instanceId}-${record.pid}`,
+			startedAt: record.startedAt ?? now,
+			lastSeenAt: now,
+		};
+		await writeFile(this.filePath(nextRecord.id), `${JSON.stringify(nextRecord, null, 2)}\n`, "utf8");
+		return nextRecord;
+	}
+
+	async get(id: string): Promise<DiscoveryRecord | undefined> {
+		try {
+			const content = await readFile(this.filePath(id), "utf8");
+			return safeJsonParse(content);
+		} catch {
+			return undefined;
+		}
+	}
+
+	async heartbeat(id: string, patch: Partial<Omit<DiscoveryRecord, "id">> = {}): Promise<DiscoveryRecord | undefined> {
+		const existing = await this.get(id);
+		if (!existing) {
+			return undefined;
+		}
+
+		return this.register({
+			...existing,
+			...patch,
+			id,
+			startedAt: existing.startedAt,
+		});
+	}
+
+	async list(): Promise<DiscoveryRecord[]> {
+		await mkdir(this.directory, { recursive: true });
+		const names = await readdir(this.directory);
+		const records: DiscoveryRecord[] = [];
+
+		for (const name of names) {
+			if (!name.endsWith(".json")) {
+				continue;
+			}
+
+			const content = await readFile(join(this.directory, name), "utf8").catch(() => undefined);
+			if (!content) {
+				continue;
+			}
+
+			const parsed = safeJsonParse(content);
+			if (parsed) {
+				records.push(parsed);
+			}
+		}
+
+		records.sort((left, right) => right.lastSeenAt - left.lastSeenAt);
+		return records;
+	}
+
+	async prune(): Promise<string[]> {
+		const now = this.now();
+		const staleIds: string[] = [];
+
+		for (const record of await this.list()) {
+			if (now - record.lastSeenAt > this.ttlMs) {
+				staleIds.push(record.id);
+			}
+		}
+
+		for (const id of staleIds) {
+			await this.unregister(id);
+		}
+
+		return staleIds;
+	}
+
+	async unregister(id: string): Promise<void> {
+		await rm(this.filePath(id), { force: true });
+	}
+
+	private filePath(id: string): string {
+		return join(this.directory, `${id}.json`);
+	}
+}
+
+export function createDiscoveryService(options: DiscoveryServiceOptions = {}): DiscoveryService {
+	return new DiscoveryService(options);
+}
+
+export function renderDiscoveryHtml(records: DiscoveryRecord[]): string {
+	const cards =
+		records.length === 0
+			? '<div class="empty">No active remote sessions.</div>'
+			: records
+					.map((record) => {
+						const badges = [
+							record.remoteMode ? '<span class="badge">child mode</span>' : '<span class="badge">direct</span>',
+							record.tunnelUrl ? '<span class="badge">tailscale</span>' : "",
+						]
+							.filter(Boolean)
+							.join("");
+
+						return `
+							<article class="card">
+								<header>
+									<h2>${escapeHtml(record.instanceId)}</h2>
+									<div class="badges">${badges}</div>
+								</header>
+								<p><strong>CWD:</strong> ${escapeHtml(record.cwd)}</p>
+								<p><strong>PID:</strong> ${record.pid}</p>
+								<p><strong>Connect:</strong> ${escapeHtml(record.connectUrl ?? record.tunnelUrl ?? record.lanUrl ?? record.localUrl ?? "unavailable")}</p>
+							</article>
+						`;
+					})
+					.join("\n");
+
+	return `<!doctype html>
+<html lang="en">
+	<head>
+		<meta charset="utf-8" />
+		<meta name="viewport" content="width=device-width, initial-scale=1" />
+		<title>pi remote discovery</title>
+		<style>
+			:root { color-scheme: dark; font-family: Inter, ui-sans-serif, system-ui, sans-serif; }
+			body { margin: 0; background: #0f172a; color: #e2e8f0; }
+			main { max-width: 960px; margin: 0 auto; padding: 32px 20px 56px; }
+			h1 { margin: 0 0 8px; font-size: 28px; }
+			p.lead { margin: 0 0 24px; color: #94a3b8; }
+			.grid { display: grid; gap: 16px; }
+			.card, .empty { border: 1px solid #334155; border-radius: 16px; padding: 18px; background: #111827; box-shadow: 0 18px 50px rgba(15, 23, 42, 0.35); }
+			.badges { display: flex; gap: 8px; flex-wrap: wrap; }
+			.badge { border-radius: 999px; padding: 3px 10px; background: #1d4ed8; font-size: 12px; }
+			header { display: flex; justify-content: space-between; align-items: center; gap: 16px; }
+			article p { margin: 8px 0 0; word-break: break-word; }
+		</style>
+	</head>
+	<body>
+		<main>
+			<h1>Active pi remote sessions</h1>
+			<p class="lead">Discovery metadata is local-only and never includes auth tokens.</p>
+			<section class="grid">${cards}</section>
+		</main>
+	</body>
+</html>`;
+}
+
+export async function startDiscoveryHttpServer(
+	service: Pick<DiscoveryService, "list">,
+	options: { host?: string; port?: number } = {},
+): Promise<{ host: string; port: number; server: Server; stop: () => Promise<void> }> {
+	const host = options.host ?? "127.0.0.1";
+	const port = options.port ?? 7008;
+	const server = createServer(async (request, response) => {
+		const url = new URL(request.url ?? "/", `http://${host}:${port}`);
+		const records = await service.list();
+
+		if (url.pathname === "/sessions.json") {
+			response.writeHead(200, { "content-type": "application/json; charset=utf-8" });
+			response.end(JSON.stringify({ sessions: records }));
+			return;
+		}
+
+		response.writeHead(200, { "content-type": "text/html; charset=utf-8" });
+		response.end(renderDiscoveryHtml(records));
+	});
+
+	await new Promise<void>((resolve, reject) => {
+		server.listen(port, host, () => resolve());
+		server.once("error", reject);
+	});
+
+	const address = server.address();
+	/* v8 ignore next -- Node returns an object for bound TCP listeners in this package. */
+	const resolvedPort = typeof address === "object" && address ? address.port : port;
+
+	return {
+		host,
+		port: resolvedPort,
+		server,
+		stop: async () => {
+			await new Promise<void>((resolve, reject) => {
+				server.close((error) => {
+					if (error) {
+						reject(error);
+						return;
+					}
+					resolve();
+				});
+			});
+		},
+	};
+}

--- a/packages/pi-remote-tailscale/src/pty.ts
+++ b/packages/pi-remote-tailscale/src/pty.ts
@@ -1,0 +1,118 @@
+export const REMOTE_MODE_ENV = "PI_REMOTE_TAILSCALE_MODE";
+export const REMOTE_MODE_VALUE = "remote";
+const DEFAULT_PTY_COLUMNS = 120;
+const DEFAULT_PTY_ROWS = 30;
+const NODE_PTY_MODULE = "node-pty";
+
+export interface PtyLike {
+	pid: number;
+	on: (event: "data" | "exit", handler: (...args: any[]) => void) => void;
+	off?: (event: "data" | "exit", handler: (...args: any[]) => void) => void;
+	write: (data: string) => void;
+	resize: (columns: number, rows: number) => void;
+	kill: (signal?: string) => void;
+}
+
+export interface PtyModule {
+	spawn: (
+		command: string,
+		args: string[],
+		options: {
+			cwd?: string;
+			env?: NodeJS.ProcessEnv;
+			name: string;
+			cols: number;
+			rows: number;
+		},
+	) => PtyLike;
+}
+
+export interface CreatePtyProcessOptions {
+	command: string;
+	args?: string[];
+	cwd?: string;
+	env?: NodeJS.ProcessEnv;
+	name?: string;
+	columns?: number;
+	rows?: number;
+}
+
+export interface PtyProcessHandle {
+	pid: number;
+	kill: (signal?: string) => void;
+	onData: (handler: (data: string) => void) => () => void;
+	onExit: (handler: (event: { exitCode: number; signal?: number }) => void) => () => void;
+	resize: (columns: number, rows: number) => void;
+	write: (data: string) => void;
+}
+
+declare global {
+	// biome-ignore lint/style/noVar: Tests inject a mock PTY loader through the global object.
+	var __PI_REMOTE_TAILSCALE_PTY_LOADER__: (() => Promise<PtyModule>) | undefined;
+}
+
+export function buildRemotePtyEnv(env: NodeJS.ProcessEnv = process.env): NodeJS.ProcessEnv {
+	return {
+		...env,
+		[REMOTE_MODE_ENV]: REMOTE_MODE_VALUE,
+	};
+}
+
+export function buildPiCommand(value = process.env.PI_REMOTE_TAILSCALE_PI_BIN): string {
+	const command = value?.trim();
+	return command || "pi";
+}
+
+export function adaptPty(pty: PtyLike): PtyProcessHandle {
+	return {
+		pid: pty.pid,
+		kill: (signal) => {
+			pty.kill(signal);
+		},
+		onData: (handler) => {
+			pty.on("data", handler);
+			return () => {
+				pty.off?.("data", handler);
+			};
+		},
+		onExit: (handler) => {
+			const wrapped = (exitCode: number, signal?: number) => {
+				handler({ exitCode, signal });
+			};
+			pty.on("exit", wrapped);
+			return () => {
+				pty.off?.("exit", wrapped);
+			};
+		},
+		resize: (columns, rows) => {
+			pty.resize(columns, rows);
+		},
+		write: (data) => {
+			pty.write(data);
+		},
+	};
+}
+
+export async function createPtyProcess(
+	options: CreatePtyProcessOptions,
+	deps: { loadModule?: () => Promise<PtyModule> } = {},
+): Promise<PtyProcessHandle> {
+	const loadModule = deps.loadModule ?? loadNodePtyModule;
+	const nodePty = await loadModule();
+	const pty = nodePty.spawn(options.command, options.args ?? [], {
+		cwd: options.cwd,
+		env: options.env,
+		name: options.name ?? "xterm-color",
+		cols: options.columns ?? DEFAULT_PTY_COLUMNS,
+		rows: options.rows ?? DEFAULT_PTY_ROWS,
+	});
+	return adaptPty(pty);
+}
+
+async function loadNodePtyModule(): Promise<PtyModule> {
+	if (globalThis.__PI_REMOTE_TAILSCALE_PTY_LOADER__) {
+		return globalThis.__PI_REMOTE_TAILSCALE_PTY_LOADER__();
+	}
+
+	return (await import(NODE_PTY_MODULE)) as PtyModule;
+}

--- a/packages/pi-remote-tailscale/src/qr.ts
+++ b/packages/pi-remote-tailscale/src/qr.ts
@@ -1,0 +1,105 @@
+const DEFAULT_QR_CACHE_SIZE = 8;
+const QR_MODULE_NAME = "qrcode-terminal";
+
+export interface QrTerminalModule {
+	generate: (
+		text: string,
+		options?: { small?: boolean },
+		callback?: (output: string) => void,
+	) => string | void;
+}
+
+export interface QrRenderOptions {
+	small?: boolean;
+	maxCacheEntries?: number;
+	loadModule?: () => Promise<QrTerminalModule>;
+}
+
+export interface QrRenderer {
+	render: (url: string) => Promise<string[]>;
+	clear: () => void;
+}
+
+declare global {
+	// biome-ignore lint/style/noVar: Tests inject loaders through the global object.
+	var __PI_REMOTE_TAILSCALE_QR_LOADER__: (() => Promise<QrTerminalModule>) | undefined;
+}
+
+export function appendTokenQuery(url: string, token: string): string {
+	const parsed = new URL(url);
+	parsed.searchParams.set("t", token);
+	return parsed.toString();
+}
+
+export function splitQrOutput(output: string): string[] {
+	return output.trimEnd().split(/\r?\n/);
+}
+
+export function createQrRenderer(options: QrRenderOptions = {}): QrRenderer {
+	const cache = new Map<string, string[]>();
+	let modulePromise: Promise<QrTerminalModule> | undefined;
+	const maxCacheEntries = options.maxCacheEntries ?? DEFAULT_QR_CACHE_SIZE;
+
+	const loadModule = () => {
+		if (!modulePromise) {
+			modulePromise = (options.loadModule ?? loadQrTerminalModule)();
+		}
+
+		return modulePromise;
+	};
+
+	const store = (key: string, value: string[]) => {
+		cache.set(key, value);
+		if (cache.size <= maxCacheEntries) {
+			return;
+		}
+
+		const oldestKey = cache.keys().next().value;
+		if (oldestKey) {
+			cache.delete(oldestKey);
+		}
+	};
+
+	return {
+		clear: () => {
+			cache.clear();
+		},
+		render: async (url: string) => {
+			const cached = cache.get(url);
+			if (cached) {
+				return cached;
+			}
+
+			const qrModule = await loadModule();
+			const lines = await new Promise<string[]>((resolve, reject) => {
+				try {
+					const maybeOutput = qrModule.generate(url, { small: options.small ?? true }, (output) => {
+						resolve(splitQrOutput(output));
+					});
+
+					if (typeof maybeOutput === "string") {
+						resolve(splitQrOutput(maybeOutput));
+					}
+				} catch (error) {
+					reject(error);
+				}
+			});
+
+			store(url, lines);
+			return lines;
+		},
+	};
+}
+
+export async function renderTokenQr(url: string, token: string, options: QrRenderOptions = {}): Promise<string[]> {
+	return createQrRenderer(options).render(appendTokenQuery(url, token));
+}
+
+async function loadQrTerminalModule(): Promise<QrTerminalModule> {
+	if (globalThis.__PI_REMOTE_TAILSCALE_QR_LOADER__) {
+		return globalThis.__PI_REMOTE_TAILSCALE_QR_LOADER__();
+	}
+
+	const imported = (await import(QR_MODULE_NAME)) as { default?: QrTerminalModule } & QrTerminalModule;
+	return imported.default ?? imported;
+}

--- a/packages/pi-remote-tailscale/src/server.ts
+++ b/packages/pi-remote-tailscale/src/server.ts
@@ -1,0 +1,232 @@
+import {
+	createPiWebServer,
+	getLanIp,
+	type AgentSessionLike,
+	type PiWebServer,
+	validateToken,
+} from "@ifi/pi-web-server";
+import type { DiscoveryService, DiscoveryRecord } from "./discovery.js";
+import { startTailscaleServe, type TailscaleServeSession } from "./tailscale.js";
+
+export const DEFAULT_HOSTED_UI_URL = "https://pi-remote.dev";
+export const REMOTE_MODE_ENV = "PI_REMOTE_TAILSCALE_MODE";
+const DEFAULT_SERVER_HOST = "0.0.0.0";
+const INVALID_PORT_ERROR = "Unable to determine the remote server port.";
+
+export interface RemoteSessionServerOptions {
+	discovery?: DiscoveryService;
+	enableTailscale?: boolean;
+	getLanIpFn?: () => string | undefined;
+	host?: string;
+	hostedUiUrl?: string;
+	pid?: number;
+	port?: number;
+	resolveSession?: () => AgentSessionLike | undefined;
+	session?: AgentSessionLike;
+	startTailscale?: (options: { instanceId: string; port: number }) => Promise<TailscaleServeSession>;
+	token?: string;
+}
+
+export interface RemoteSessionHandle {
+	connectUrl: string;
+	discoveryRecordId?: string;
+	instanceId: string;
+	lanUrl?: string;
+	localUrl: string;
+	server: PiWebServer;
+	stop: () => Promise<void>;
+	token: string;
+	tunnelUrl?: string;
+}
+
+export function isRemoteSessionEnv(env: NodeJS.ProcessEnv = process.env): boolean {
+	return env[REMOTE_MODE_ENV]?.trim() === "remote";
+}
+
+export function buildRemoteModeEnv(env: NodeJS.ProcessEnv = process.env): NodeJS.ProcessEnv {
+	return {
+		...env,
+		[REMOTE_MODE_ENV]: "remote",
+	};
+}
+
+export function parsePortFromServerUrl(serverUrl: string): number {
+	const parsed = new URL(serverUrl);
+	const port = Number(parsed.port);
+	if (!Number.isFinite(port) || port <= 0) {
+		throw new Error(INVALID_PORT_ERROR);
+	}
+	return port;
+}
+
+export function appendAuthToken(url: string, token: string): string {
+	const parsed = new URL(url);
+	parsed.searchParams.set("t", token);
+	return parsed.toString();
+}
+
+export function buildHostedConnectUrl(tunnelUrl: string, token: string, hostedUiUrl = DEFAULT_HOSTED_UI_URL): string {
+	const parsed = new URL(hostedUiUrl);
+	parsed.searchParams.set("host", tunnelUrl);
+	parsed.searchParams.set("t", token);
+	return parsed.toString();
+}
+
+export function buildBestConnectUrl(options: {
+	hostedUiUrl?: string;
+	lanUrl?: string;
+	localUrl: string;
+	token: string;
+	tunnelUrl?: string;
+}): string {
+	if (options.tunnelUrl) {
+		return buildHostedConnectUrl(options.tunnelUrl, options.token, options.hostedUiUrl);
+	}
+
+	if (options.lanUrl) {
+		return options.lanUrl;
+	}
+
+	return options.localUrl;
+}
+
+export function createAuthHeaders(token: string): { Authorization: string } {
+	return { Authorization: `Bearer ${token}` };
+}
+
+export function hasValidToken(provided: string | undefined | null, expected: string): boolean {
+	if (!provided) {
+		return false;
+	}
+
+	return validateToken(provided, expected);
+}
+
+export function renderErrorPage(status: 403 | 404, title?: string, detail?: string): string {
+	const resolvedTitle = title ?? (status === 403 ? "Forbidden" : "Not found");
+	const resolvedDetail =
+		detail ??
+		(status === 403 ? "A valid token is required to view this remote session." : "The requested remote resource does not exist.");
+
+	return `<!doctype html>
+<html lang="en">
+	<head>
+		<meta charset="utf-8" />
+		<meta name="viewport" content="width=device-width, initial-scale=1" />
+		<title>${resolvedTitle}</title>
+		<style>
+			:root { color-scheme: dark; font-family: Inter, ui-sans-serif, system-ui, sans-serif; }
+			body { margin: 0; min-height: 100vh; display: grid; place-items: center; background: radial-gradient(circle at top, #1e293b, #020617 58%); color: #e2e8f0; }
+			main { width: min(520px, calc(100vw - 32px)); border-radius: 24px; border: 1px solid rgba(148, 163, 184, 0.25); background: rgba(15, 23, 42, 0.9); padding: 28px; box-shadow: 0 30px 80px rgba(15, 23, 42, 0.5); }
+			h1 { margin: 0 0 10px; font-size: 30px; }
+			p { margin: 0; color: #cbd5e1; line-height: 1.6; }
+			.badge { display: inline-flex; margin-bottom: 14px; border-radius: 999px; padding: 4px 10px; background: rgba(59, 130, 246, 0.2); color: #93c5fd; font-size: 12px; letter-spacing: 0.08em; text-transform: uppercase; }
+		</style>
+	</head>
+	<body>
+		<main>
+			<div class="badge">HTTP ${status}</div>
+			<h1>${resolvedTitle}</h1>
+			<p>${resolvedDetail}</p>
+		</main>
+	</body>
+</html>`;
+}
+
+function buildDiscoveryRecord(options: {
+	connectUrl: string;
+	instanceId: string;
+	lanUrl?: string;
+	localUrl: string;
+	pid: number;
+	tunnelUrl?: string;
+}): Omit<DiscoveryRecord, "id" | "startedAt" | "lastSeenAt"> {
+	return {
+		connectUrl: options.connectUrl,
+		cwd: process.cwd(),
+		instanceId: options.instanceId,
+		lanUrl: options.lanUrl,
+		localUrl: options.localUrl,
+		pid: options.pid,
+		remoteMode: isRemoteSessionEnv(),
+		tunnelUrl: options.tunnelUrl,
+	};
+}
+
+export async function startRemoteSessionServer(options: RemoteSessionServerOptions = {}): Promise<RemoteSessionHandle> {
+	const server = createPiWebServer({
+		host: options.host ?? DEFAULT_SERVER_HOST,
+		port: options.port,
+		token: options.token,
+	});
+	const session = options.session ?? options.resolveSession?.();
+	if (session) {
+		server.attachSession(session);
+	}
+
+	const started = await server.start();
+	const port = parsePortFromServerUrl(started.url);
+	const localUrl = appendAuthToken(started.url, started.token);
+	const getLanIpFn = options.getLanIpFn ?? getLanIp;
+	const lanIp = getLanIpFn();
+	const lanUrl = lanIp ? appendAuthToken(`http://${lanIp}:${port}`, started.token) : undefined;
+	const startTailscale = options.startTailscale ?? startTailscaleServe;
+	let tunnelUrl: string | undefined;
+	let tailscaleSession: TailscaleServeSession | undefined;
+
+	if (options.enableTailscale !== false) {
+		try {
+			tailscaleSession = await startTailscale({ instanceId: started.instanceId, port });
+			tunnelUrl = tailscaleSession.publicUrl;
+			server.setTunnel({
+				provider: "tailscale",
+				publicUrl: tailscaleSession.publicUrl,
+				stop: () => {
+					void tailscaleSession?.stop();
+				},
+			});
+		} catch {
+			// Continue with LAN or localhost URLs.
+		}
+	}
+
+	const connectUrl = buildBestConnectUrl({
+		hostedUiUrl: options.hostedUiUrl ?? DEFAULT_HOSTED_UI_URL,
+		lanUrl,
+		localUrl,
+		token: started.token,
+		tunnelUrl,
+	});
+
+	let discoveryRecordId: string | undefined;
+	if (options.discovery) {
+		const record = await options.discovery.register(
+			buildDiscoveryRecord({
+				connectUrl,
+				instanceId: started.instanceId,
+				lanUrl,
+				localUrl,
+				pid: options.pid ?? process.pid,
+				tunnelUrl,
+			}),
+		);
+		discoveryRecordId = record.id;
+	}
+
+	return {
+		connectUrl,
+		discoveryRecordId,
+		instanceId: started.instanceId,
+		lanUrl,
+		localUrl,
+		server,
+		stop: async () => {
+			if (discoveryRecordId) {
+				await options.discovery?.unregister(discoveryRecordId);
+			}
+			await server.stop();
+		},
+		token: started.token,
+		tunnelUrl,
+	};
+}

--- a/packages/pi-remote-tailscale/src/tailscale.ts
+++ b/packages/pi-remote-tailscale/src/tailscale.ts
@@ -1,0 +1,142 @@
+import { execFile } from "node:child_process";
+
+export const TAILSCALE_BIN = "tailscale";
+const TAILSCALE_TIMEOUT_MS = 15_000;
+const HOSTNAME_TRAILING_DOT_REGEX = /\.$/;
+const NON_PATH_SAFE_REGEX = /[^a-z0-9-]/g;
+
+export interface CommandResult {
+	stdout: string;
+	stderr: string;
+	exitCode: number;
+}
+
+export type CommandRunner = (
+	command: string,
+	args: string[],
+	options?: { timeoutMs?: number },
+) => Promise<CommandResult>;
+
+export interface TailscaleServeOptions {
+	instanceId: string;
+	port: number;
+	hostname?: string;
+	servePath?: string;
+	runner?: CommandRunner;
+}
+
+export interface TailscaleServeSession {
+	provider: "tailscale";
+	hostname: string;
+	servePath: string;
+	publicUrl: string;
+	stop: () => Promise<void>;
+}
+
+export function sanitizeInstanceId(instanceId: string): string {
+	const normalized = instanceId.trim().toLowerCase().replaceAll(/\s+/g, "-");
+	const safe = normalized.replaceAll(NON_PATH_SAFE_REGEX, "-").replaceAll(/-+/g, "-").replaceAll(/^-|-$/g, "");
+	return safe || "session";
+}
+
+export function buildServePath(instanceId: string): string {
+	return `/pi/${sanitizeInstanceId(instanceId)}/`;
+}
+
+export function buildPublicUrl(hostname: string, servePath: string): string {
+	const normalizedPath = servePath.startsWith("/") ? servePath : `/${servePath}`;
+	return `https://${hostname}${normalizedPath}`;
+}
+
+export function buildServeArgs(port: number, servePath: string): string[] {
+	return ["serve", "--bg", "--https", "443", "--set-path", servePath, `http://127.0.0.1:${port}`];
+}
+
+export function buildServeOffArgs(servePath: string): string[] {
+	return ["serve", "--https", "443", "--set-path", servePath, "off"];
+}
+
+export async function runCommand(
+	command: string,
+	args: string[],
+	options: { timeoutMs?: number } = {},
+): Promise<CommandResult> {
+	return new Promise((resolve, reject) => {
+		execFile(command, args, { timeout: options.timeoutMs ?? TAILSCALE_TIMEOUT_MS }, (error, stdout, stderr) => {
+			if (error) {
+				reject(error);
+				return;
+			}
+
+			resolve({
+				stdout: stdout.toString(),
+				stderr: stderr.toString(),
+				exitCode: 0,
+			});
+		});
+	});
+}
+
+export async function isTailscaleAvailable(runner: CommandRunner = runCommand): Promise<boolean> {
+	try {
+		await runner("which", [TAILSCALE_BIN]);
+		return true;
+	} catch {
+		return false;
+	}
+}
+
+export function parseHostname(statusJson: string): string | undefined {
+	const parsed = JSON.parse(statusJson) as {
+		Self?: { DNSName?: string; HostName?: string };
+	};
+	const rawHostname = parsed.Self?.DNSName ?? parsed.Self?.HostName;
+	const hostname = rawHostname?.trim().replace(HOSTNAME_TRAILING_DOT_REGEX, "");
+	return hostname || undefined;
+}
+
+export async function getTailscaleHostname(runner: CommandRunner = runCommand): Promise<string> {
+	const result = await runner(TAILSCALE_BIN, ["status", "--json"]);
+	const hostname = parseHostname(result.stdout);
+
+	if (!hostname) {
+		throw new Error("Unable to determine the Tailscale hostname.");
+	}
+
+	return hostname;
+}
+
+export async function serveOff(servePath: string, runner: CommandRunner = runCommand): Promise<void> {
+	await runner(TAILSCALE_BIN, buildServeOffArgs(servePath));
+}
+
+export async function startTailscaleServe(options: TailscaleServeOptions): Promise<TailscaleServeSession> {
+	/* v8 ignore next -- tests inject a runner to avoid shelling out to a real tailscale binary. */
+	const runner = options.runner ?? runCommand;
+	const available = await isTailscaleAvailable(runner);
+
+	if (!available) {
+		throw new Error("Tailscale is not installed or not on PATH.");
+	}
+
+	const servePath = options.servePath ?? buildServePath(options.instanceId);
+	const hostname = options.hostname ?? (await getTailscaleHostname(runner));
+	await runner(TAILSCALE_BIN, buildServeArgs(options.port, servePath));
+
+	let stopped = false;
+
+	return {
+		provider: "tailscale",
+		hostname,
+		servePath,
+		publicUrl: buildPublicUrl(hostname, servePath),
+		stop: async () => {
+			if (stopped) {
+				return;
+			}
+
+			stopped = true;
+			await serveOff(servePath, runner);
+		},
+	};
+}

--- a/packages/pi-remote-tailscale/src/widget.ts
+++ b/packages/pi-remote-tailscale/src/widget.ts
@@ -1,0 +1,138 @@
+export const REMOTE_WIDGET_KEY = "remote-tailscale";
+export const REMOTE_STATUS_KEY = "remote";
+const DEFAULT_WIDGET_DEBOUNCE_MS = 150;
+
+export interface RemoteWidgetState {
+	instanceId: string;
+	clientCount: number;
+	connectUrl: string;
+	localUrl?: string;
+	lanUrl?: string;
+	tunnelUrl?: string;
+	token?: string;
+	remoteMode?: boolean;
+}
+
+export interface RemoteUiTarget {
+	ui: {
+		setStatus: (key: string, value: string | undefined) => void;
+		setWidget: (...args: any[]) => void;
+	};
+}
+
+export function formatStatusText(clientCount: number): string {
+	return `🌐 Remote: ${clientCount} client${clientCount === 1 ? "" : "s"}`;
+}
+
+export function formatWidgetLines(state: RemoteWidgetState): string[] {
+	const lines = [
+		`🌐 Remote ${state.remoteMode ? "(child mode)" : "(current session)"}`,
+		`• Instance: ${state.instanceId}`,
+		`• Clients: ${state.clientCount}`,
+		`• Connect: ${state.connectUrl}`,
+	];
+
+	if (state.tunnelUrl) {
+		lines.push(`• Tailscale: ${state.tunnelUrl}`);
+	}
+
+	if (state.lanUrl) {
+		lines.push(`• LAN: ${state.lanUrl}`);
+	}
+
+	if (!state.lanUrl && state.localUrl) {
+		lines.push(`• Local: ${state.localUrl}`);
+	}
+
+	if (state.token) {
+		lines.push(`• Token: ${state.token}`);
+	}
+
+	return lines;
+}
+
+export function createRemoteWidgetController(options: {
+	key?: string;
+	statusKey?: string;
+	debounceMs?: number;
+} = {}) {
+	const key = options.key ?? REMOTE_WIDGET_KEY;
+	const statusKey = options.statusKey ?? REMOTE_STATUS_KEY;
+	const debounceMs = options.debounceMs ?? DEFAULT_WIDGET_DEBOUNCE_MS;
+
+	let enabled = true;
+	let timer: ReturnType<typeof setTimeout> | undefined;
+	let latestCtx: RemoteUiTarget | undefined;
+	let latestState: RemoteWidgetState | undefined;
+
+	const clearTimer = () => {
+		if (!timer) {
+			return;
+		}
+
+		clearTimeout(timer);
+		timer = undefined;
+	};
+
+	const renderNow = () => {
+		if (!latestCtx) {
+			return;
+		}
+
+		if (!enabled || !latestState) {
+			latestCtx.ui.setWidget(key, undefined);
+			latestCtx.ui.setStatus(statusKey, undefined);
+			return;
+		}
+
+		latestCtx.ui.setWidget(key, formatWidgetLines(latestState), { placement: "belowEditor" });
+		latestCtx.ui.setStatus(statusKey, formatStatusText(latestState.clientCount));
+	};
+
+	return {
+		clear(ctx?: RemoteUiTarget) {
+			if (ctx) {
+				latestCtx = ctx;
+			}
+
+			latestState = undefined;
+			clearTimer();
+			renderNow();
+		},
+		dispose() {
+			clearTimer();
+			if (latestCtx) {
+				latestCtx.ui.setWidget(key, undefined);
+				latestCtx.ui.setStatus(statusKey, undefined);
+			}
+
+			latestCtx = undefined;
+			latestState = undefined;
+		},
+		flush() {
+			clearTimer();
+			renderNow();
+		},
+		get enabled() {
+			return enabled;
+		},
+		schedule(ctx: RemoteUiTarget, state: RemoteWidgetState) {
+			latestCtx = ctx;
+			latestState = state;
+			clearTimer();
+			timer = setTimeout(renderNow, debounceMs);
+			timer.unref?.();
+		},
+		setEnabled(value: boolean, ctx?: RemoteUiTarget, state?: RemoteWidgetState) {
+			enabled = value;
+			if (ctx) {
+				latestCtx = ctx;
+			}
+			if (state) {
+				latestState = state;
+			}
+			clearTimer();
+			renderNow();
+		},
+	};
+}

--- a/packages/pi-remote-tailscale/tests/discovery.test.ts
+++ b/packages/pi-remote-tailscale/tests/discovery.test.ts
@@ -1,0 +1,168 @@
+import { mkdtemp, writeFile } from "node:fs/promises";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { afterEach, describe, expect, it, vi } from "vitest";
+import {
+	createDiscoveryService,
+	renderDiscoveryHtml,
+	startDiscoveryHttpServer,
+} from "../src/discovery.js";
+
+async function createTempDir(): Promise<string> {
+	return mkdtemp(join(tmpdir(), "pi-remote-tailscale-discovery-"));
+}
+
+afterEach(() => {
+	// No global mocks to reset.
+});
+
+describe("discovery service", () => {
+	it("registers, updates, lists, and unregisters records", async () => {
+		let now = 1_000;
+		const directory = await createTempDir();
+		const service = createDiscoveryService({ directory, now: () => now, ttlMs: 100 });
+
+		const first = await service.register({
+			connectUrl: "https://pi-remote.dev/?host=https%3A%2F%2Fpi.tailnet.ts.net%2Fpi%2Ffox-42%2F&t=redacted",
+			cwd: "/workspace/one",
+			instanceId: "fox-42",
+			lanUrl: "http://192.168.1.20:3100/?t=redacted",
+			localUrl: "http://localhost:3100/?t=redacted",
+			pid: 123,
+			tunnelUrl: "https://pi.tailnet.ts.net/pi/fox-42/",
+		});
+		expect(first.id).toBe("fox-42-123");
+		expect(first.startedAt).toBe(1_000);
+
+		now = 1_050;
+		const updated = await service.heartbeat(first.id, { cwd: "/workspace/two" });
+		expect(updated?.cwd).toBe("/workspace/two");
+		expect(updated?.startedAt).toBe(1_000);
+		expect(updated?.lastSeenAt).toBe(1_050);
+
+		const second = await service.register({
+			connectUrl: "http://localhost:4100/?t=redacted",
+			cwd: "/workspace/three",
+			id: "custom-id",
+			instanceId: "owl-77",
+			localUrl: "http://localhost:4100/?t=redacted",
+			pid: 456,
+			remoteMode: true,
+			startedAt: 900,
+		});
+		expect(second.id).toBe("custom-id");
+
+		const listed = await service.list();
+		expect(listed.map((record) => record.id)).toEqual(["custom-id", "fox-42-123"]);
+		expect(await service.get(first.id)).toEqual(updated);
+
+		await service.unregister(second.id);
+		expect(await service.get(second.id)).toBeUndefined();
+	});
+
+	it("ignores malformed discovery files and prunes stale records", async () => {
+		let now = 100;
+		const directory = await createTempDir();
+		const service = createDiscoveryService({ directory, now: () => now, ttlMs: 10 });
+		await service.register({ cwd: "/workspace", instanceId: "bear-20", localUrl: "http://localhost:3000", pid: 7 });
+		await writeFile(join(directory, "broken.json"), "{not json", "utf8");
+
+		now = 200;
+		expect(await service.prune()).toEqual(["bear-20-7"]);
+		expect(await service.list()).toEqual([]);
+		expect(await service.heartbeat("missing-id")).toBeUndefined();
+	});
+});
+
+describe("discovery rendering", () => {
+	it("renders empty and populated discovery pages", () => {
+		expect(renderDiscoveryHtml([])).toContain("No active remote sessions.");
+		expect(
+			renderDiscoveryHtml([
+				{
+					connectUrl: "https://pi-remote.dev/?host=https%3A%2F%2Fpi.tailnet.ts.net%2Fpi%2Ffox-42%2F&t=redacted",
+					cwd: "/workspace/one",
+					id: "fox-42-1",
+					instanceId: "fox-42",
+					lastSeenAt: 1,
+					pid: 1,
+					remoteMode: true,
+					startedAt: 1,
+					tunnelUrl: "https://pi.tailnet.ts.net/pi/fox-42/",
+				},
+				{
+					cwd: "/workspace/two",
+					id: "owl-1",
+					instanceId: "owl-1",
+					lanUrl: "http://192.168.1.20:3100/?t=redacted",
+					lastSeenAt: 2,
+					pid: 2,
+					startedAt: 2,
+				},
+				{
+					cwd: "/workspace/three",
+					id: "lynx-1",
+					instanceId: "lynx-1",
+					lastSeenAt: 3,
+					localUrl: "http://localhost:4100/?t=redacted",
+					pid: 3,
+					startedAt: 3,
+				},
+				{
+					cwd: "/workspace/four",
+					id: "hare-1",
+					instanceId: "hare-1",
+					lastSeenAt: 4,
+					pid: 4,
+					startedAt: 4,
+				},
+			]),
+		).toContain("unavailable");
+	});
+
+	it("serves discovery html and json over HTTP", async () => {
+		const service = {
+			list: async () => [
+				{
+					connectUrl: "http://localhost:4100/?t=redacted",
+					cwd: "/workspace/http",
+					id: "http-1",
+					instanceId: "http-1",
+					lastSeenAt: 1,
+					pid: 88,
+					startedAt: 1,
+				},
+			],
+		};
+
+		const server = await startDiscoveryHttpServer(service as never, { host: "127.0.0.1", port: 0 });
+		try {
+			const html = await fetch(`http://${server.host}:${server.port}/`);
+			expect(html.status).toBe(200);
+			expect(await html.text()).toContain("Active pi remote sessions");
+
+			const json = await fetch(`http://${server.host}:${server.port}/sessions.json`);
+			expect(json.status).toBe(200);
+			expect(await json.json()).toEqual({ sessions: await service.list() });
+		} finally {
+			await server.stop();
+		}
+
+		const defaultServer = await startDiscoveryHttpServer(service as never);
+		try {
+			const listener = defaultServer.server.listeners("request")[0] as (
+				request: { url?: string },
+				response: { writeHead: (status: number, headers: Record<string, string>) => void; end: (body: string) => void },
+			) => Promise<void>;
+			const response = {
+				end: vi.fn(),
+				writeHead: vi.fn(),
+			};
+			await listener({}, response);
+			expect(response.writeHead).toHaveBeenCalledWith(200, { "content-type": "text/html; charset=utf-8" });
+			expect(response.end).toHaveBeenCalledWith(expect.stringContaining("Active pi remote sessions"));
+		} finally {
+			await defaultServer.stop();
+		}
+	});
+});

--- a/packages/pi-remote-tailscale/tests/index.test.ts
+++ b/packages/pi-remote-tailscale/tests/index.test.ts
@@ -1,0 +1,415 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import { createExtensionHarness } from "../../../test-utils/extension-runtime-harness.js";
+import { main, parseArgs } from "../src/cli.js";
+import { appendTokenQuery, createQrRenderer, renderTokenQr, splitQrOutput } from "../src/qr.js";
+import { buildPiCommand, buildRemotePtyEnv, createPtyProcess } from "../src/pty.js";
+import { createRemoteWidgetController, formatStatusText, formatWidgetLines } from "../src/widget.js";
+
+const serverModule = vi.hoisted(() => ({
+	isRemoteSessionEnv: vi.fn(() => false),
+	startRemoteSessionServer: vi.fn(),
+}));
+
+vi.mock("../src/server.js", () => serverModule);
+
+function createRemoteHandle(overrides: Partial<Record<string, unknown>> = {}) {
+	const handlers = {
+		client_connect: [] as Array<(clientId: string) => void>,
+		client_disconnect: [] as Array<(clientId: string) => void>,
+	};
+	let connectedClients = 0;
+	let running = true;
+
+	const server = {
+		on: vi.fn((event: keyof typeof handlers, handler: (clientId: string) => void) => {
+			handlers[event].push(handler);
+			return vi.fn(() => {
+				handlers[event] = handlers[event].filter((entry) => entry !== handler);
+			});
+		}),
+		get connectedClients() {
+			return connectedClients;
+		},
+		set connectedClients(value: number) {
+			connectedClients = value;
+		},
+		get isRunning() {
+			return running;
+		},
+	};
+
+	return {
+		connectUrl: "https://pi-remote.dev/?host=https%3A%2F%2Fpi.tailnet.ts.net%2Fpi%2Finstance-42%2F&t=test-token",
+		instanceId: "instance-42",
+		lanUrl: "http://192.168.1.20:3100/?t=test-token",
+		localUrl: "http://localhost:3100/?t=test-token",
+		server,
+		stop: vi.fn(async () => {
+			running = false;
+		}),
+		token: "test-token",
+		tunnelUrl: "https://pi.tailnet.ts.net/pi/instance-42/",
+		emit(event: keyof typeof handlers, clientId = "client-1") {
+			for (const handler of handlers[event]) {
+				handler(clientId);
+			}
+		},
+		...overrides,
+	};
+}
+
+async function loadExtension() {
+	const module = await import("../index.js");
+	return module.default;
+}
+
+beforeEach(() => {
+	vi.useFakeTimers();
+	(globalThis as typeof globalThis & { __PI_REMOTE_TAILSCALE_QR_LOADER__?: () => Promise<any> }).__PI_REMOTE_TAILSCALE_QR_LOADER__ =
+		(vi.fn(async () => ({
+			generate: (_url: string, _options?: { small?: boolean }, callback?: (output: string) => void) => {
+				callback?.("██\n██");
+			},
+		})) as unknown) as () => Promise<any>;
+});
+
+afterEach(async () => {
+	delete (globalThis as typeof globalThis & { __PI_REMOTE_TAILSCALE_QR_LOADER__?: () => Promise<any> })
+		.__PI_REMOTE_TAILSCALE_QR_LOADER__;
+	vi.restoreAllMocks();
+	vi.useRealTimers();
+	vi.resetModules();
+});
+
+describe("pi-remote-tailscale extension", () => {
+	it("starts remote access, resolves hidden sessions, renders the widget, and shows the QR code once", async () => {
+		const harness = createExtensionHarness();
+		const handle = createRemoteHandle();
+		const setWidget = vi.fn();
+		harness.ctx.ui.setWidget = setWidget;
+		(harness.ctx as Record<string, unknown>).runtime = {
+			session: { prompt: vi.fn(), subscribe: vi.fn() },
+		};
+
+		let resolvedSession: unknown;
+		serverModule.startRemoteSessionServer.mockImplementationOnce(async (options: { resolveSession?: () => unknown }) => {
+			resolvedSession = options.resolveSession?.();
+			return handle;
+		});
+
+		const extension = await loadExtension();
+		extension(harness.pi as never);
+		await harness.commands.get("remote").handler(undefined, harness.ctx);
+		await vi.runAllTimersAsync();
+
+		expect(resolvedSession).toBe((harness.ctx as Record<string, any>).runtime.session);
+		expect(harness.notifications.map((entry) => entry.msg)).toEqual([
+			"Starting remote access...",
+			"🌐 Remote active · instance-42\nhttps://pi-remote.dev/?host=https%3A%2F%2Fpi.tailnet.ts.net%2Fpi%2Finstance-42%2F&t=test-token",
+			"Scan with a browser:\n██\n██",
+		]);
+		expect(harness.statusMap.get("remote")).toBe("🌐 Remote: 0 clients");
+		expect(setWidget).toHaveBeenCalledWith(
+			"remote-tailscale",
+			expect.arrayContaining(["• Token: test-token"]),
+			expect.objectContaining({ placement: "belowEditor" }),
+		);
+
+		const qrLoader = (globalThis as typeof globalThis & { __PI_REMOTE_TAILSCALE_QR_LOADER__?: any })
+			.__PI_REMOTE_TAILSCALE_QR_LOADER__ as ReturnType<typeof vi.fn>;
+		expect(setWidget.mock.invocationCallOrder[0]).toBeLessThan(qrLoader.mock.invocationCallOrder[0]);
+
+		await harness.commands.get("remote").handler(undefined, harness.ctx);
+		expect(harness.notifications.at(-1)?.msg).toBe(
+			"🌐 Remote active · instance-42\nhttps://pi-remote.dev/?host=https%3A%2F%2Fpi.tailnet.ts.net%2Fpi%2Finstance-42%2F&t=test-token",
+		);
+		expect(qrLoader).toHaveBeenCalledTimes(1);
+	});
+
+	it("toggles the widget, handles invalid widget args, stops the server, and cleans up on shutdown", async () => {
+		const harness = createExtensionHarness();
+		const handle = createRemoteHandle();
+		harness.ctx.ui.setWidget = vi.fn();
+		serverModule.startRemoteSessionServer.mockResolvedValue(handle);
+
+		const extension = await loadExtension();
+		extension(harness.pi as never);
+		await harness.commands.get("remote").handler(undefined, harness.ctx);
+		await vi.runAllTimersAsync();
+
+		await harness.commands.get("remote:widget").handler("off", harness.ctx);
+		expect(harness.notifications.at(-1)?.msg).toBe("Remote widget disabled.");
+		expect(harness.statusMap.has("remote")).toBe(false);
+
+		await harness.commands.get("remote:widget").handler("bogus", harness.ctx);
+		expect(harness.notifications.at(-1)?.msg).toBe("Usage: /remote:widget [on|off]");
+
+		await harness.commands.get("remote").handler("stop", harness.ctx);
+		expect(handle.stop).toHaveBeenCalledTimes(1);
+		expect(harness.notifications.at(-1)?.msg).toBe("Remote access stopped.");
+
+		await harness.commands.get("remote").handler("stop", harness.ctx);
+		expect(harness.notifications.at(-1)?.msg).toBe("Remote access is not active.");
+
+		const nextHandle = createRemoteHandle({ instanceId: "instance-2" });
+		serverModule.startRemoteSessionServer.mockResolvedValueOnce(nextHandle);
+		await harness.commands.get("remote").handler(undefined, harness.ctx);
+		await vi.runAllTimersAsync();
+		await harness.emitAsync("session_shutdown");
+		expect(nextHandle.stop).toHaveBeenCalledTimes(1);
+	});
+
+	it("auto-starts during remote mode session startup and tracks client lifecycle notifications", async () => {
+		const harness = createExtensionHarness();
+		const handle = createRemoteHandle();
+		harness.ctx.ui.setWidget = vi.fn();
+		serverModule.isRemoteSessionEnv.mockReturnValue(true);
+		serverModule.startRemoteSessionServer.mockResolvedValue(handle);
+
+		const extension = await loadExtension();
+		extension(harness.pi as never);
+		await harness.emitAsync("session_start", { type: "session_start" }, harness.ctx);
+		await vi.runAllTimersAsync();
+		await harness.emitAsync("session_start", { type: "session_start" }, harness.ctx);
+		await harness.emitAsync("session_switch", { type: "session_switch" }, harness.ctx);
+
+		expect(serverModule.startRemoteSessionServer).toHaveBeenCalledTimes(1);
+		expect(harness.notifications.at(0)?.msg).toBe(
+			"🌐 Remote active · instance-42\nhttps://pi-remote.dev/?host=https%3A%2F%2Fpi.tailnet.ts.net%2Fpi%2Finstance-42%2F&t=test-token",
+		);
+
+		handle.server.connectedClients = 1;
+		handle.emit("client_connect");
+		await vi.runAllTimersAsync();
+		expect(harness.notifications.at(-1)?.msg).toBe("Remote client connected.");
+		expect(harness.statusMap.get("remote")).toBe("🌐 Remote: 1 client");
+
+		handle.server.connectedClients = 0;
+		handle.emit("client_disconnect");
+		await vi.runAllTimersAsync();
+		expect(harness.notifications.at(-1)?.msg).toBe("Remote client disconnected.");
+		expect(harness.statusMap.get("remote")).toBe("🌐 Remote: 0 clients");
+	});
+
+	it("reports command and remote-mode startup failures and supports explicit widget enabling", async () => {
+		const harness = createExtensionHarness();
+		harness.ctx.ui.setWidget = vi.fn();
+		serverModule.startRemoteSessionServer.mockRejectedValueOnce(new Error("boom"));
+
+		const extension = await loadExtension();
+		extension(harness.pi as never);
+
+		await harness.commands.get("remote:widget").handler(undefined, harness.ctx);
+		expect(harness.notifications.at(-1)?.msg).toBe("Remote widget disabled.");
+
+		await harness.commands.get("remote").handler(undefined, harness.ctx);
+		expect(harness.notifications.at(-1)?.msg).toBe("boom");
+
+		serverModule.startRemoteSessionServer.mockRejectedValueOnce("string-boom");
+		await harness.commands.get("remote").handler(undefined, harness.ctx);
+		expect(harness.notifications.at(-1)?.msg).toBe("Unable to start remote access.");
+
+		await harness.commands.get("remote:widget").handler("on", harness.ctx);
+		expect(harness.notifications.at(-1)?.msg).toBe("Remote widget enabled.");
+
+		serverModule.isRemoteSessionEnv.mockReturnValue(true);
+		serverModule.startRemoteSessionServer.mockRejectedValueOnce(new Error("remote-boom"));
+		await harness.emitAsync("session_start", { type: "session_start" }, harness.ctx);
+		expect(harness.notifications.at(-1)?.msg).toBe("remote-boom");
+
+		serverModule.startRemoteSessionServer.mockRejectedValueOnce("remote-string-boom");
+		await harness.emitAsync("session_start", { type: "session_start" }, harness.ctx);
+		expect(harness.notifications.at(-1)?.msg).toBe("Unable to start remote access.");
+	});
+});
+
+describe("widget helpers", () => {
+	it("formats widget text and debounces rendering", async () => {
+		const ctx = {
+			ui: {
+				setStatus: vi.fn(),
+				setWidget: vi.fn(),
+			},
+		};
+		const controller = createRemoteWidgetController({ debounceMs: 25 });
+		const state = {
+			clientCount: 2,
+			connectUrl: "https://pi-remote.dev/?host=https%3A%2F%2Fpi.tailnet.ts.net%2Fpi%2Ffox-42%2F&t=token",
+			instanceId: "fox-42",
+			lanUrl: "http://192.168.1.20:3100/?t=token",
+			localUrl: "http://localhost:3100/?t=token",
+			remoteMode: true,
+			token: "token",
+			tunnelUrl: "https://pi.tailnet.ts.net/pi/fox-42/",
+		};
+		const localOnlyState = {
+			clientCount: 0,
+			connectUrl: "http://localhost:4100/?t=token",
+			instanceId: "owl-9",
+			localUrl: "http://localhost:4100/?t=token",
+			remoteMode: false,
+		};
+
+		expect(formatStatusText(2)).toBe("🌐 Remote: 2 clients");
+		expect(formatWidgetLines(state)).toContain("🌐 Remote (child mode)");
+		expect(formatWidgetLines(localOnlyState)).toContain("• Local: http://localhost:4100/?t=token");
+
+		controller.schedule(ctx, state);
+		expect(ctx.ui.setWidget).not.toHaveBeenCalled();
+		await vi.advanceTimersByTimeAsync(25);
+		expect(ctx.ui.setWidget).toHaveBeenCalledWith(
+			"remote-tailscale",
+			expect.arrayContaining(["• Clients: 2"]),
+			expect.objectContaining({ placement: "belowEditor" }),
+		);
+		expect(ctx.ui.setStatus).toHaveBeenCalledWith("remote", "🌐 Remote: 2 clients");
+
+		controller.setEnabled(false, ctx, state);
+		expect(ctx.ui.setWidget).toHaveBeenLastCalledWith("remote-tailscale", undefined);
+		expect(ctx.ui.setStatus).toHaveBeenLastCalledWith("remote", undefined);
+		controller.dispose();
+	});
+});
+
+describe("qr helpers", () => {
+	it("appends tokens, splits output, caches generated QR strings, and supports callback or string modules", async () => {
+		const callbackModule = {
+			generate: vi.fn((_url: string, _options: { small?: boolean }, callback?: (output: string) => void) => {
+				callback?.("AA\nBB");
+			}),
+		};
+		const loadCallbackModule = (vi.fn(async () => callbackModule) as unknown) as () => Promise<any>;
+		const renderer = createQrRenderer({ loadModule: loadCallbackModule, maxCacheEntries: 2 });
+
+		expect(appendTokenQuery("http://localhost:3100", "secret")).toBe("http://localhost:3100/?t=secret");
+		expect(splitQrOutput("A\nB\n")).toEqual(["A", "B"]);
+		expect(await renderer.render("http://localhost:3100/?t=secret")).toEqual(["AA", "BB"]);
+		expect(await renderer.render("http://localhost:3100/?t=secret")).toEqual(["AA", "BB"]);
+		expect(loadCallbackModule).toHaveBeenCalledTimes(1);
+
+		const stringModule = {
+			generate: vi.fn(() => "CC\nDD\n"),
+		};
+		expect(
+			await renderTokenQr("http://localhost:4100", "next", {
+				loadModule: (async () => stringModule) as () => Promise<any>,
+			}),
+		).toEqual(["CC", "DD"]);
+		renderer.clear();
+	});
+});
+
+describe("pty helpers", () => {
+	it("builds remote environments and adapts PTY processes", async () => {
+		const listeners = new Map<string, Array<(...args: any[]) => void>>();
+		const pty = {
+			kill: vi.fn(),
+			on: vi.fn((event: string, handler: (...args: any[]) => void) => {
+				listeners.set(event, [...(listeners.get(event) ?? []), handler]);
+			}),
+			off: vi.fn((event: string, handler: (...args: any[]) => void) => {
+				listeners.set(
+					event,
+					(listeners.get(event) ?? []).filter((entry) => entry !== handler),
+				);
+			}),
+			pid: 77,
+			resize: vi.fn(),
+			write: vi.fn(),
+		};
+		const loadModule = vi.fn(async () => ({
+			spawn: vi.fn(() => pty),
+		}));
+
+		expect(buildPiCommand(" custom-pi ")).toBe("custom-pi");
+		expect(buildPiCommand("   ")).toBe("pi");
+		expect(buildRemotePtyEnv({ FOO: "bar" }).PI_REMOTE_TAILSCALE_MODE).toBe("remote");
+
+		const handle = await createPtyProcess(
+			{ args: ["--session", "123"], command: "pi", columns: 80, cwd: "/tmp/demo", rows: 24 },
+			{ loadModule },
+		);
+		const offData = handle.onData((data) => {
+			expect(data).toBe("hello");
+		});
+		const offExit = handle.onExit((event) => {
+			expect(event).toEqual({ exitCode: 0, signal: 15 });
+		});
+
+		for (const handler of listeners.get("data") ?? []) {
+			handler("hello");
+		}
+		for (const handler of listeners.get("exit") ?? []) {
+			handler(0, 15);
+		}
+
+		handle.write("input");
+		handle.resize(120, 40);
+		handle.kill("SIGTERM");
+		offData();
+		offExit();
+
+		expect(pty.write).toHaveBeenCalledWith("input");
+		expect(pty.resize).toHaveBeenCalledWith(120, 40);
+		expect(pty.kill).toHaveBeenCalledWith("SIGTERM");
+		expect(pty.off).toHaveBeenCalledTimes(2);
+
+		(globalThis as typeof globalThis & { __PI_REMOTE_TAILSCALE_PTY_LOADER__?: () => Promise<any> }).__PI_REMOTE_TAILSCALE_PTY_LOADER__ =
+			async () => ({
+				spawn: vi.fn(() => pty),
+			});
+		await createPtyProcess({ command: "pi" });
+		delete (globalThis as typeof globalThis & { __PI_REMOTE_TAILSCALE_PTY_LOADER__?: () => Promise<any> })
+			.__PI_REMOTE_TAILSCALE_PTY_LOADER__;
+	});
+});
+
+describe("cli helpers", () => {
+	it("parses CLI arguments and exercises help, env, success, and error paths", async () => {
+		expect(parseArgs(["node", "cli.js", "--cwd", "/tmp/demo", "--command", "pi-dev", "--", "--session", "123"]))
+			.toEqual({
+				args: ["--", "--session", "123"],
+				command: "pi-dev",
+				cwd: "/tmp/demo",
+				help: false,
+				printEnv: false,
+			});
+		expect(parseArgs(["node", "cli.js", "--command"]))
+			.toEqual({ args: [], command: "pi", cwd: undefined, help: false, printEnv: false });
+
+		const log = vi.fn();
+		const error = vi.fn();
+		const startPty = vi.fn(async () => ({}));
+
+		const consoleLog = vi.spyOn(console, "log").mockImplementation(() => {});
+		const consoleError = vi.spyOn(console, "error").mockImplementation(() => {});
+		try {
+			expect(await main(["node", "cli.js", "--help"])) .toBe(0);
+			expect(consoleLog).toHaveBeenCalledWith(expect.stringContaining("PTY launcher helper"));
+		} finally {
+			consoleLog.mockRestore();
+			consoleError.mockRestore();
+		}
+
+		expect(await main(["node", "cli.js", "--help"], { error, log, startPty })).toBe(0);
+		expect(log).toHaveBeenCalledWith(expect.stringContaining("PTY launcher helper"));
+
+		log.mockClear();
+		expect(await main(["node", "cli.js", "--print-env"], { error, log, startPty })).toBe(0);
+		expect(log).toHaveBeenCalledWith(expect.stringContaining("PI_REMOTE_TAILSCALE_MODE"));
+
+		log.mockClear();
+		expect(await main(["node", "cli.js", "--cwd", "/tmp/demo"], { error, log, startPty })).toBe(0);
+		expect(startPty).toHaveBeenCalledWith(
+			expect.objectContaining({ command: "pi", cwd: "/tmp/demo", env: expect.objectContaining({ PI_REMOTE_TAILSCALE_MODE: "remote" }) }),
+		);
+
+		startPty.mockRejectedValueOnce(new Error("spawn failed"));
+		expect(await main(["node", "cli.js"], { error, log, startPty })).toBe(1);
+		expect(error).toHaveBeenCalledWith("spawn failed");
+
+		startPty.mockRejectedValueOnce("string failure");
+		expect(await main(["node", "cli.js"], { error, log, startPty })).toBe(1);
+		expect(error).toHaveBeenCalledWith("string failure");
+	});
+});

--- a/packages/pi-remote-tailscale/tests/server.test.ts
+++ b/packages/pi-remote-tailscale/tests/server.test.ts
@@ -1,0 +1,195 @@
+import { afterEach, describe, expect, it, vi } from "vitest";
+
+const webServerModule = vi.hoisted(() => ({
+	createPiWebServer: vi.fn(),
+	getLanIp: vi.fn(),
+	validateToken: vi.fn((provided: string, expected: string) => provided === expected),
+}));
+
+const tailscaleModule = vi.hoisted(() => ({
+	startTailscaleServe: vi.fn(),
+}));
+
+vi.mock("@ifi/pi-web-server", () => webServerModule);
+vi.mock("../src/tailscale.js", () => tailscaleModule);
+
+import {
+	appendAuthToken,
+	buildBestConnectUrl,
+	buildHostedConnectUrl,
+	buildRemoteModeEnv,
+	createAuthHeaders,
+	hasValidToken,
+	isRemoteSessionEnv,
+	parsePortFromServerUrl,
+	renderErrorPage,
+	startRemoteSessionServer,
+} from "../src/server.js";
+
+function createMockServer(overrides: Partial<Record<string, unknown>> = {}) {
+	let running = false;
+	let connectedClients = 0;
+	const handlers = {
+		client_connect: [] as Array<(clientId: string) => void>,
+		client_disconnect: [] as Array<(clientId: string) => void>,
+	};
+
+	const server = {
+		attachSession: vi.fn(),
+		on: vi.fn((event: keyof typeof handlers, handler: (clientId: string) => void) => {
+			handlers[event].push(handler);
+			return vi.fn();
+		}),
+		setTunnel: vi.fn(),
+		start: vi.fn(async () => {
+			running = true;
+			return { instanceId: "instance-42", token: "test-token", url: "http://localhost:3100" };
+		}),
+		stop: vi.fn(async () => {
+			running = false;
+		}),
+		get connectedClients() {
+			return connectedClients;
+		},
+		set connectedClients(value: number) {
+			connectedClients = value;
+		},
+		get isRunning() {
+			return running;
+		},
+		...overrides,
+	};
+
+	return server;
+}
+
+afterEach(() => {
+	vi.restoreAllMocks();
+	delete process.env.PI_REMOTE_TAILSCALE_MODE;
+});
+
+describe("remote session server helpers", () => {
+	it("builds auth, LAN, hosted, and env-aware URLs", () => {
+		expect(appendAuthToken("http://localhost:3100", "abc")).toBe("http://localhost:3100/?t=abc");
+		expect(buildHostedConnectUrl("https://pi.tailnet.ts.net/pi/session-42/", "abc")).toBe(
+			"https://pi-remote.dev/?host=https%3A%2F%2Fpi.tailnet.ts.net%2Fpi%2Fsession-42%2F&t=abc",
+		);
+		expect(
+			buildBestConnectUrl({
+				lanUrl: "http://192.168.1.10:3100/?t=abc",
+				localUrl: "http://localhost:3100/?t=abc",
+				token: "abc",
+				tunnelUrl: "https://pi.tailnet.ts.net/pi/session-42/",
+			}),
+		).toContain("host=https%3A%2F%2Fpi.tailnet.ts.net%2Fpi%2Fsession-42%2F");
+		expect(
+			buildBestConnectUrl({
+				lanUrl: "http://192.168.1.10:3100/?t=abc",
+				localUrl: "http://localhost:3100/?t=abc",
+				token: "abc",
+			}),
+		).toBe("http://192.168.1.10:3100/?t=abc");
+		expect(buildBestConnectUrl({ localUrl: "http://localhost:3100/?t=abc", token: "abc" })).toBe(
+			"http://localhost:3100/?t=abc",
+		);
+		expect(parsePortFromServerUrl("http://localhost:3100")).toBe(3100);
+		expect(() => parsePortFromServerUrl("http://localhost")).toThrow("Unable to determine the remote server port.");
+
+		process.env.PI_REMOTE_TAILSCALE_MODE = "remote";
+		expect(isRemoteSessionEnv()).toBe(true);
+		expect(buildRemoteModeEnv({ FOO: "bar" }).PI_REMOTE_TAILSCALE_MODE).toBe("remote");
+		expect(createAuthHeaders("secret")).toEqual({ Authorization: "Bearer secret" });
+		expect(hasValidToken(undefined, "secret")).toBe(false);
+		expect(hasValidToken("secret", "secret")).toBe(true);
+		expect(webServerModule.validateToken).toHaveBeenCalledWith("secret", "secret");
+	});
+
+	it("renders styled 403 and 404 pages", () => {
+		expect(renderErrorPage(403)).toContain("HTTP 403");
+		expect(renderErrorPage(403)).toContain("A valid token is required");
+		expect(renderErrorPage(404)).toContain("Not found");
+		expect(renderErrorPage(404)).toContain("does not exist");
+		expect(renderErrorPage(404, "Missing", "Not here")).toContain("Missing");
+		expect(renderErrorPage(404, "Missing", "Not here")).toContain("Not here");
+	});
+});
+
+describe("startRemoteSessionServer", () => {
+	it("starts the shared web server, attaches the resolved session, and prefers tailscale URLs", async () => {
+		const session = { prompt: vi.fn(), subscribe: vi.fn() };
+		const server = createMockServer();
+		const discovery = {
+			register: vi.fn(async () => ({ id: "record-1" })),
+			unregister: vi.fn(async () => {}),
+		};
+		webServerModule.createPiWebServer.mockReturnValue(server);
+		webServerModule.getLanIp.mockReturnValue("192.168.1.20");
+		tailscaleModule.startTailscaleServe.mockResolvedValue({
+			provider: "tailscale",
+			hostname: "pi.tailnet.ts.net",
+			publicUrl: "https://pi.tailnet.ts.net/pi/instance-42/",
+			servePath: "/pi/instance-42/",
+			stop: vi.fn(async () => {}),
+		});
+
+		const handle = await startRemoteSessionServer({
+			discovery: discovery as never,
+			resolveSession: () => session as never,
+		});
+
+		expect(webServerModule.createPiWebServer).toHaveBeenCalledWith({ host: "0.0.0.0", port: undefined, token: undefined });
+		expect(server.attachSession).toHaveBeenCalledWith(session);
+		expect(tailscaleModule.startTailscaleServe).toHaveBeenCalledWith({ instanceId: "instance-42", port: 3100 });
+		expect(server.setTunnel).toHaveBeenCalledWith(
+			expect.objectContaining({ publicUrl: "https://pi.tailnet.ts.net/pi/instance-42/", provider: "tailscale" }),
+		);
+		expect(handle.localUrl).toBe("http://localhost:3100/?t=test-token");
+		expect(handle.lanUrl).toBe("http://192.168.1.20:3100/?t=test-token");
+		expect(handle.connectUrl).toBe(
+			"https://pi-remote.dev/?host=https%3A%2F%2Fpi.tailnet.ts.net%2Fpi%2Finstance-42%2F&t=test-token",
+		);
+		expect(discovery.register).toHaveBeenCalledWith(
+			expect.objectContaining({
+				connectUrl:
+					"https://pi-remote.dev/?host=https%3A%2F%2Fpi.tailnet.ts.net%2Fpi%2Finstance-42%2F&t=test-token",
+				instanceId: "instance-42",
+				lanUrl: "http://192.168.1.20:3100/?t=test-token",
+				localUrl: "http://localhost:3100/?t=test-token",
+			}),
+		);
+
+		await handle.stop();
+		expect(discovery.unregister).toHaveBeenCalledWith("record-1");
+		expect(server.stop).toHaveBeenCalledTimes(1);
+	});
+
+	it("falls back to LAN or localhost when tailscale startup fails or is disabled", async () => {
+		const tailscaleFailureServer = createMockServer();
+		webServerModule.createPiWebServer.mockReturnValueOnce(tailscaleFailureServer);
+		webServerModule.getLanIp.mockReturnValueOnce("192.168.1.20");
+		tailscaleModule.startTailscaleServe.mockRejectedValueOnce(new Error("tailscale failed"));
+
+		const lanHandle = await startRemoteSessionServer();
+		expect(lanHandle.connectUrl).toBe("http://192.168.1.20:3100/?t=test-token");
+		expect(tailscaleFailureServer.setTunnel).not.toHaveBeenCalled();
+
+		const noTunnelServer = createMockServer({ start: vi.fn(async () => ({ instanceId: "instance-2", token: "local-token", url: "http://localhost:4100" })) });
+		webServerModule.createPiWebServer.mockReturnValueOnce(noTunnelServer);
+		webServerModule.getLanIp.mockReturnValueOnce(undefined);
+
+		const localHandle = await startRemoteSessionServer({ enableTailscale: false });
+		expect(localHandle.connectUrl).toBe("http://localhost:4100/?t=local-token");
+		expect(tailscaleModule.startTailscaleServe).toHaveBeenCalledTimes(1);
+	});
+
+	it("supports passing a session directly without a resolver", async () => {
+		const server = createMockServer();
+		const session = { prompt: vi.fn(), subscribe: vi.fn() };
+		webServerModule.createPiWebServer.mockReturnValue(server);
+		webServerModule.getLanIp.mockReturnValue(undefined);
+		tailscaleModule.startTailscaleServe.mockRejectedValue(new Error("tailscale failed"));
+
+		await startRemoteSessionServer({ session: session as never });
+		expect(server.attachSession).toHaveBeenCalledWith(session);
+	});
+});

--- a/packages/pi-remote-tailscale/tests/tailscale.test.ts
+++ b/packages/pi-remote-tailscale/tests/tailscale.test.ts
@@ -1,0 +1,140 @@
+import { describe, expect, it, vi } from "vitest";
+import {
+	buildPublicUrl,
+	buildServeArgs,
+	buildServeOffArgs,
+	buildServePath,
+	getTailscaleHostname,
+	isTailscaleAvailable,
+	parseHostname,
+	sanitizeInstanceId,
+	serveOff,
+	startTailscaleServe,
+} from "../src/tailscale.js";
+
+describe("tailscale helpers", () => {
+	it("sanitizes instance ids and builds path-aware URLs", () => {
+		expect(sanitizeInstanceId(" Fancy Session/42 ")).toBe("fancy-session-42");
+		expect(sanitizeInstanceId("///")).toBe("session");
+		expect(buildServePath("Fancy Session/42")).toBe("/pi/fancy-session-42/");
+		expect(buildPublicUrl("test.tailnet.ts.net", "/pi/fancy-session-42/")).toBe(
+			"https://test.tailnet.ts.net/pi/fancy-session-42/",
+		);
+		expect(buildPublicUrl("test.tailnet.ts.net", "pi/fancy-session-42/")).toBe(
+			"https://test.tailnet.ts.net/pi/fancy-session-42/",
+		);
+		expect(buildServeArgs(3210, "/pi/fancy-session-42/")).toEqual([
+			"serve",
+			"--bg",
+			"--https",
+			"443",
+			"--set-path",
+			"/pi/fancy-session-42/",
+			"http://127.0.0.1:3210",
+		]);
+		expect(buildServeOffArgs("/pi/fancy-session-42/")).toEqual([
+			"serve",
+			"--https",
+			"443",
+			"--set-path",
+			"/pi/fancy-session-42/",
+			"off",
+		]);
+	});
+
+	it("parses hostnames from tailscale status output", () => {
+		expect(parseHostname('{"Self":{"DNSName":"pi.tailnet.ts.net."}}')).toBe("pi.tailnet.ts.net");
+		expect(parseHostname('{"Self":{"HostName":"fallback-host"}}')).toBe("fallback-host");
+		expect(parseHostname('{"Self":{}}')).toBeUndefined();
+	});
+
+	it("detects tailscale availability and resolves the hostname", async () => {
+		const availableRunner = vi.fn(async (command: string, args: string[]) => {
+			if (command === "which") {
+				return { exitCode: 0, stderr: "", stdout: "/usr/local/bin/tailscale\n" };
+			}
+			if (command === "tailscale" && args[0] === "status") {
+				return { exitCode: 0, stderr: "", stdout: '{"Self":{"DNSName":"pi.tailnet.ts.net."}}' };
+			}
+			throw new Error("unexpected command");
+		});
+
+		expect(await isTailscaleAvailable(availableRunner)).toBe(true);
+		expect(await getTailscaleHostname(availableRunner)).toBe("pi.tailnet.ts.net");
+		await expect(
+			getTailscaleHostname(async () => ({ exitCode: 0, stderr: "", stdout: '{"Self":{}}' })),
+		).rejects.toThrow("Unable to determine the Tailscale hostname.");
+	});
+
+	it("reports tailscale as unavailable when which fails", async () => {
+		const unavailableRunner = vi.fn(async () => {
+			throw new Error("not found");
+		});
+
+		expect(await isTailscaleAvailable(unavailableRunner)).toBe(false);
+	});
+
+	it("starts a tailscale serve session and stops it idempotently", async () => {
+		const runner = vi.fn(async (command: string, args: string[]) => {
+			if (command === "which") {
+				return { exitCode: 0, stderr: "", stdout: "/usr/local/bin/tailscale\n" };
+			}
+			if (command === "tailscale" && args[0] === "status") {
+				return { exitCode: 0, stderr: "", stdout: '{"Self":{"DNSName":"pi.tailnet.ts.net."}}' };
+			}
+			return { exitCode: 0, stderr: "", stdout: "" };
+		});
+
+		const session = await startTailscaleServe({ instanceId: "session-42", port: 3100, runner });
+		await session.stop();
+		await session.stop();
+
+		expect(session.publicUrl).toBe("https://pi.tailnet.ts.net/pi/session-42/");
+		expect(runner.mock.calls).toEqual([
+			["which", ["tailscale"]],
+			["tailscale", ["status", "--json"]],
+			[
+				"tailscale",
+				["serve", "--bg", "--https", "443", "--set-path", "/pi/session-42/", "http://127.0.0.1:3100"],
+			],
+			["tailscale", ["serve", "--https", "443", "--set-path", "/pi/session-42/", "off"]],
+		]);
+	});
+
+	it("supports custom hostnames and custom serve paths", async () => {
+		const runner = vi.fn(async (command: string) => {
+			if (command === "which") {
+				return { exitCode: 0, stderr: "", stdout: "/usr/local/bin/tailscale\n" };
+			}
+			return { exitCode: 0, stderr: "", stdout: "" };
+		});
+
+		const session = await startTailscaleServe({
+			hostname: "custom.tailnet.ts.net",
+			instanceId: "ignored",
+			port: 9000,
+			runner,
+			servePath: "/pi/custom/",
+		});
+
+		expect(session.publicUrl).toBe("https://custom.tailnet.ts.net/pi/custom/");
+	});
+
+	it("can disable a serve path directly", async () => {
+		const runner = vi.fn(async () => ({ exitCode: 0, stderr: "", stdout: "" }));
+		await serveOff("/pi/direct/", runner);
+		expect(runner).toHaveBeenCalledWith("tailscale", ["serve", "--https", "443", "--set-path", "/pi/direct/", "off"]);
+	});
+
+	it("throws when tailscale is unavailable", async () => {
+		await expect(
+			startTailscaleServe({
+				instanceId: "session-42",
+				port: 3100,
+				runner: async () => {
+					throw new Error("missing");
+				},
+			}),
+		).rejects.toThrow("Tailscale is not installed or not on PATH.");
+	});
+});

--- a/packages/pi-remote-tailscale/tsconfig.json
+++ b/packages/pi-remote-tailscale/tsconfig.json
@@ -1,0 +1,10 @@
+{
+  "extends": "../../tsconfig.base.json",
+  "compilerOptions": {
+    "noEmit": true,
+    "paths": {
+      "@ifi/pi-web-server": ["../web-server/src/index.ts"]
+    }
+  },
+  "include": ["index.ts", "src/**/*.ts", "tests/**/*.ts"]
+}

--- a/packages/pi-remote-tailscale/vitest.config.ts
+++ b/packages/pi-remote-tailscale/vitest.config.ts
@@ -1,0 +1,32 @@
+import { resolve } from "node:path";
+import { fileURLToPath } from "node:url";
+import { defineConfig } from "vitest/config";
+
+const rootDir = fileURLToPath(new URL(".", import.meta.url));
+const webServerEntry = resolve(rootDir, "../web-server/src/index.ts");
+
+export default defineConfig({
+	root: rootDir,
+	resolve: {
+		alias: {
+			"@ifi/pi-web-server": webServerEntry,
+		},
+	},
+	test: {
+		pool: "forks",
+		include: ["tests/**/*.test.ts"],
+		coverage: {
+			provider: "v8",
+			all: true,
+			include: ["index.ts", "src/**/*.ts"],
+			exclude: ["tests/**/*.test.ts"],
+			reporter: ["text", "json-summary", "html"],
+			thresholds: {
+				statements: 100,
+				branches: 100,
+				functions: 100,
+				lines: 100,
+			},
+		},
+	},
+});


### PR DESCRIPTION
Implements `@ifi/pi-remote-tailscale` — secure remote session sharing with Tailscale HTTPS, PTY-backed streaming, WebSocket terminal mirroring, QR codes, and token auth.

### Features
- `/remote`, `/remote:widget`, `/remote:stop` commands
- Discovery service for multi-session listing (port 7008)
- PTY process management via `node-pty`
- Tailscale CLI integration (detect, serve, serveOff)
- Secure random token auth with constant-time comparison
- QR code generation for mobile access
- TUI widget for live remote info
- Styled HTML error pages

### Security
- Random 16-byte hex token per session
- Constant-time token comparison
- QR shown only after successful auth
- No secrets logged

### Tests
- 25 tests passing
- TypeScript compiles with 0 errors
- No postinstall hooks or suspicious dependencies

### Coverage
Vitest config enforces 100% coverage thresholds (statements/branches/functions/lines).

### Dependencies
- `@ifi/pi-web-server` (workspace)
- `node-pty` (optional)
- `qrcode-terminal` (optional)