### PR TITLE
feat(pi-bash-live-view): PTY-backed live terminal viewing

### DIFF
--- a/.changeset/feat-pi-bash-live-view.md
+++ b/.changeset/feat-pi-bash-live-view.md
@@ -1,0 +1,5 @@
+---
+default: minor
+---
+
+Implement `@ifi/pi-bash-live-view` package for PTY-backed live terminal viewing of bash commands. Adds `usePTY` parameter to bash tool, live TUI widget with real-time output, and `/bash-pty` slash command.

--- a/.changeset/pi-bash-live-view.md
+++ b/.changeset/pi-bash-live-view.md
@@ -1,0 +1,5 @@
+---
+default: minor
+---
+
+Add the new `@ifi/pi-bash-live-view` package with PTY-backed bash execution, a live terminal widget, `/bash-pty`, and full test coverage.

--- a/packages/pi-bash-live-view/README.md
+++ b/packages/pi-bash-live-view/README.md
@@ -1,0 +1,60 @@
+# @ifi/pi-bash-live-view
+
+PTY-backed live bash rendering for pi.
+
+## Install
+
+```bash
+pi install npm:@ifi/pi-bash-live-view
+```
+
+## Why this exists
+
+The built-in `bash` tool is great for batch output, but it does not preserve a terminal screen while a command is actively running. This package adds an opt-in PTY mode so commands that depend on terminal behavior can stream into a live widget and still return a normal tool result when they finish.
+
+## What it provides
+
+- `bash` tool override with `usePTY?: boolean`
+- live terminal widget while PTY commands run
+- `@xterm/headless` terminal snapshots rendered back into ANSI lines
+- `node-pty` session management with timeout, abort, and cleanup handling
+- `/bash-pty <command>` slash command
+- `user_bash` support for `!` and `!!` commands
+- output truncation, exit summaries, and likely-error highlighting
+- spawn-helper permission checks for bundled `node-pty` binaries
+
+## Usage
+
+### Agent tool call
+
+```ts
+await bash({
+  command: "pnpm test --watch",
+  timeout: 30,
+  usePTY: true,
+});
+```
+
+`usePTY` defaults to `false`, so ordinary `bash` calls still use pi's original built-in tool behavior.
+
+### Slash command
+
+```text
+/bash-pty pnpm dev
+```
+
+### User bash
+
+```text
+!htop
+!!pnpm test --watch
+```
+
+## Notes
+
+- the live widget only appears for PTY-backed commands
+- elapsed time is shown as `MM:SS`
+- PTY output is still truncated to keep tool results compact
+- ANSI sanitization strips bell characters and limits CSI parameter payloads
+
+This package ships raw `.ts` sources for pi to load directly.

--- a/packages/pi-bash-live-view/index.ts
+++ b/packages/pi-bash-live-view/index.ts
@@ -1,0 +1,153 @@
+import type { ExtensionAPI, ExtensionContext } from "@mariozechner/pi-coding-agent";
+import { createBashTool } from "@mariozechner/pi-coding-agent";
+import { Type } from "@sinclair/typebox";
+import { executePtyCommand, toAgentToolResult, toUserBashResult } from "./src/pty-execute.js";
+import { PtySessionManager } from "./src/pty-session.js";
+
+export const BASH_PTY_COMMAND = "bash-pty";
+const BASH_PTY_MESSAGE_TYPE = "pi-bash-live-view:result";
+
+const BASH_TOOL_PARAMETERS = Type.Object({
+	command: Type.String({ description: "Bash command to execute" }),
+	timeout: Type.Optional(Type.Number({ description: "Optional timeout in seconds before the PTY command is terminated" })),
+	cwd: Type.Optional(Type.String({ description: "Optional working directory override for this command" })),
+	usePTY: Type.Optional(Type.Boolean({ description: "Run the command inside a pseudo-terminal with live terminal rendering" })),
+});
+
+function buildToolDescription(baseDescription: string): string {
+	return `${baseDescription} Set usePTY=true to stream the command through a pseudo-terminal with a live widget.`;
+}
+
+function resolveCwd(ctx: Pick<ExtensionContext, "cwd"> | undefined, fallbackCtx: Pick<ExtensionContext, "cwd"> | null, explicitCwd?: string): string {
+	return explicitCwd ?? ctx?.cwd ?? fallbackCtx?.cwd ?? process.cwd();
+}
+
+function toErrorToolResult(error: unknown) {
+	const message = error instanceof Error ? error.message : String(error);
+	return {
+		content: [{ type: "text" as const, text: `PTY execution failed: ${message}` }],
+		details: { pty: true, error: true },
+	};
+}
+
+export default function bashLiveViewExtension(pi: ExtensionAPI): void {
+	const bashTemplate = createBashTool(process.cwd()) as typeof createBashTool extends (...args: any[]) => infer T ? T & {
+		renderCall?: unknown;
+		renderResult?: unknown;
+		label?: string;
+		description: string;
+	} : never;
+	const sessionManager = new PtySessionManager();
+	let activeCtx: ExtensionContext | null = null;
+
+	const syncContext = (_event: unknown, ctx: ExtensionContext) => {
+		activeCtx = ctx;
+	};
+
+	pi.on("session_start", syncContext);
+	pi.on("session_switch", syncContext);
+	pi.on("session_tree", syncContext);
+	pi.on("session_fork", syncContext);
+	pi.on("before_agent_start", syncContext);
+	pi.on("session_shutdown", () => {
+		sessionManager.dispose();
+		activeCtx = null;
+	});
+
+	pi.registerTool({
+		name: "bash",
+		label: bashTemplate.label ?? "Bash",
+		description: buildToolDescription(bashTemplate.description),
+		parameters: BASH_TOOL_PARAMETERS,
+		renderCall: bashTemplate.renderCall as any,
+		renderResult: bashTemplate.renderResult as any,
+		async execute(toolCallId, params, signal, onUpdate, ctx) {
+			const commandCwd = resolveCwd(ctx, activeCtx, params.cwd);
+			if (!params.usePTY) {
+				const originalBash = createBashTool(commandCwd);
+				return originalBash.execute(toolCallId, { command: params.command, timeout: params.timeout } as never, signal, onUpdate);
+			}
+
+			try {
+				const result = await executePtyCommand({
+					command: params.command,
+					cwd: commandCwd,
+					timeout: params.timeout,
+					signal,
+					onUpdate,
+					ctx,
+					sessionManager,
+				});
+				return toAgentToolResult(result);
+			} catch (error) {
+				return toErrorToolResult(error);
+			}
+		},
+	});
+
+	pi.registerCommand(BASH_PTY_COMMAND, {
+		description: "Run a command inside a pseudo-terminal with live output rendering.",
+		handler: async (args, ctx) => {
+			activeCtx = ctx;
+			const command = args.trim();
+			if (!command) {
+				ctx.ui.notify(`/${BASH_PTY_COMMAND} requires a command.`, "warning");
+				return;
+			}
+
+			try {
+				const result = await executePtyCommand({
+					command,
+					cwd: resolveCwd(ctx, activeCtx),
+					ctx,
+					sessionManager,
+				});
+				pi.sendMessage({
+					customType: BASH_PTY_MESSAGE_TYPE,
+					content: result.text,
+					display: true,
+					details: {
+						pty: true,
+						sessionId: result.sessionId,
+						status: result.status,
+						exitCode: result.exitCode,
+					},
+				});
+			} catch (error) {
+				ctx.ui.notify(`PTY execution failed: ${error instanceof Error ? error.message : String(error)}`, "error");
+			}
+		},
+	});
+
+	pi.on("user_bash", async (event, ctx) => {
+		activeCtx = ctx;
+		try {
+			const result = await executePtyCommand({
+				command: event.command,
+				cwd: resolveCwd(ctx, activeCtx, event.cwd),
+				ctx,
+				sessionManager,
+			});
+			return {
+				result: toUserBashResult(result),
+			};
+		} catch (error) {
+			const message = error instanceof Error ? error.message : String(error);
+			return {
+				result: {
+					output: `PTY execution failed: ${message}`,
+					exitCode: 1,
+					cancelled: false,
+					truncated: false,
+				},
+			};
+		}
+	});
+}
+
+export const bashLiveViewInternals = {
+	buildToolDescription,
+	resolveCwd,
+	toErrorToolResult,
+	BASH_TOOL_PARAMETERS,
+};

--- a/packages/pi-bash-live-view/package.json
+++ b/packages/pi-bash-live-view/package.json
@@ -1,0 +1,53 @@
+{
+	"name": "@ifi/pi-bash-live-view",
+	"version": "0.4.4",
+	"description": "PTY-backed live bash rendering for pi with a real-time terminal widget and /bash-pty command.",
+	"type": "module",
+	"keywords": [
+		"pi-package",
+		"pi",
+		"pi-coding-agent",
+		"bash",
+		"pty",
+		"terminal",
+		"live-view"
+	],
+	"pi": {
+		"extensions": [
+			"./index.ts"
+		]
+	},
+	"files": [
+		"*.ts",
+		"src",
+		"README.md",
+		"!**/*.test.ts",
+		"!tests/**"
+	],
+	"scripts": {
+		"build": "pnpm run typecheck && pnpm run test:worktree",
+		"typecheck": "tsgo --project ./tsconfig.json --noEmit",
+		"test:worktree": "vitest run --config ./vitest.config.ts --coverage"
+	},
+	"dependencies": {
+		"@xterm/headless": "^5.5.0",
+		"node-pty": "^1.0.0"
+	},
+	"license": "MIT",
+	"repository": {
+		"type": "git",
+		"url": "git+https://github.com/ifiokjr/oh-pi.git",
+		"directory": "packages/pi-bash-live-view"
+	},
+	"homepage": "https://github.com/ifiokjr/oh-pi/tree/main/packages/pi-bash-live-view",
+	"bugs": {
+		"url": "https://github.com/ifiokjr/oh-pi/issues"
+	},
+	"peerDependencies": {
+		"@mariozechner/pi-agent-core": ">=0.56.1",
+		"@mariozechner/pi-ai": ">=0.56.1",
+		"@mariozechner/pi-coding-agent": ">=0.56.1",
+		"@mariozechner/pi-tui": ">=0.56.1",
+		"@sinclair/typebox": "*"
+	}
+}

--- a/packages/pi-bash-live-view/src/module-shims.d.ts
+++ b/packages/pi-bash-live-view/src/module-shims.d.ts
@@ -1,0 +1,39 @@
+declare module "node-pty" {
+	export interface IPty {
+		pid: number;
+		onData?: (listener: (data: string) => void) => { dispose?: () => void } | (() => void) | void;
+		onExit?: (listener: (event: { exitCode: number | null; signal?: number }) => void) => { dispose?: () => void } | (() => void) | void;
+		kill: () => void;
+		resize?: (columns: number, rows: number) => void;
+		write?: (data: string) => void;
+	}
+
+	export function spawn(
+		file: string,
+		args: string[],
+		options: {
+			cols: number;
+			rows: number;
+			cwd: string;
+			env: Record<string, string>;
+			name: string;
+		},
+	): IPty;
+}
+
+declare module "@xterm/headless" {
+	export class Terminal {
+		constructor(options?: Record<string, unknown>);
+		buffer?: {
+			active?: {
+				baseY?: number;
+				cursorY?: number;
+				length?: number;
+				getLine?: (index: number) => unknown;
+			};
+		};
+		write(data: string, callback?: () => void): void;
+		resize(columns: number, rows: number): void;
+		dispose(): void;
+	}
+}

--- a/packages/pi-bash-live-view/src/pty-execute.ts
+++ b/packages/pi-bash-live-view/src/pty-execute.ts
@@ -1,0 +1,258 @@
+import type { AgentToolResult, AgentToolUpdateCallback } from "@mariozechner/pi-coding-agent";
+import { appendExitSummary, highlightErrorOutput, tailText, truncateOutput, type OutputTruncation } from "./truncate.js";
+import { PtySessionManager, type ManagedPtySession } from "./pty-session.js";
+import { createTerminalEmulator, type TerminalEmulator } from "./terminal-emulator.js";
+import { PtyLiveWidgetController, type WidgetContextLike, type WidgetStatus } from "./widget.js";
+
+const STREAM_UPDATE_DEBOUNCE_MS = 120;
+const DEFAULT_PREVIEW_LINES = 40;
+const DEFAULT_TERMINAL_COLUMNS = 120;
+const DEFAULT_TERMINAL_ROWS = 32;
+
+export interface PtyExecutionResult {
+	command: string;
+	cwd: string;
+	sessionId: string;
+	status: WidgetStatus;
+	exitCode: number | null;
+	cancelled: boolean;
+	timedOut: boolean;
+	output: string;
+	text: string;
+	truncated: boolean;
+	truncation: OutputTruncation;
+	durationMs: number;
+}
+
+export interface ExecutePtyCommandOptions {
+	command: string;
+	cwd: string;
+	timeout?: number;
+	signal?: AbortSignal;
+	onUpdate?: AgentToolUpdateCallback;
+	ctx?: WidgetContextLike;
+	sessionManager?: PtySessionManager;
+	createEmulator?: () => Promise<TerminalEmulator>;
+	createWidget?: (ctx: WidgetContextLike, sessionId: string) => PtyLiveWidgetController;
+	now?: () => number;
+}
+
+function toExecutionStatus(exitCode: number | null, cancelled: boolean, timedOut: boolean): WidgetStatus {
+	if (timedOut) {
+		return "timed_out";
+	}
+
+	if (cancelled) {
+		return "cancelled";
+	}
+
+	return exitCode === 0 ? "completed" : "failed";
+}
+
+function buildPreviewText(output: string): string {
+	return tailText(output, DEFAULT_PREVIEW_LINES) || "(waiting for output)";
+}
+
+function flushQueuedChunks(queue: string[]): string {
+	if (queue.length === 0) {
+		return "";
+	}
+
+	const chunk = queue.join("");
+	queue.length = 0;
+	return chunk;
+}
+
+export function toAgentToolResult(result: PtyExecutionResult): AgentToolResult<Record<string, unknown>> {
+	return {
+		content: [{ type: "text", text: result.text }],
+		details: {
+			pty: true,
+			sessionId: result.sessionId,
+			status: result.status,
+			exitCode: result.exitCode,
+			cancelled: result.cancelled,
+			timedOut: result.timedOut,
+			durationMs: result.durationMs,
+			truncation: result.truncation,
+		},
+	};
+}
+
+export function toUserBashResult(result: PtyExecutionResult): {
+	output: string;
+	exitCode: number;
+	cancelled: boolean;
+	truncated: boolean;
+} {
+	return {
+		output: result.text,
+		exitCode: result.exitCode ?? (result.status === "completed" ? 0 : 1),
+		cancelled: result.cancelled,
+		truncated: result.truncated,
+	};
+}
+
+export async function executePtyCommand(options: ExecutePtyCommandOptions): Promise<PtyExecutionResult> {
+	const now = options.now ?? Date.now;
+	const startedAt = now();
+	const ownsSessionManager = !options.sessionManager;
+	const sessionManager = options.sessionManager ?? new PtySessionManager({ now });
+	const createEmulator = options.createEmulator ?? (() => createTerminalEmulator({ columns: DEFAULT_TERMINAL_COLUMNS, rows: DEFAULT_TERMINAL_ROWS }));
+	const createWidget =
+		options.createWidget ??
+		((ctx: WidgetContextLike, sessionId: string) =>
+			new PtyLiveWidgetController(ctx, {
+				key: `pi-bash-live-view:${sessionId}`,
+				maxLines: 12,
+				placement: "belowEditor",
+			}));
+
+	let session: ManagedPtySession | null = null;
+	let emulator: TerminalEmulator | null = null;
+	let widget: PtyLiveWidgetController | null = null;
+	let cancelled = false;
+	let timedOut = false;
+	let flushTimer: ReturnType<typeof setTimeout> | null = null;
+	const queuedChunks: string[] = [];
+
+	const cleanup = () => {
+		if (flushTimer) {
+			clearTimeout(flushTimer);
+			flushTimer = null;
+		}
+		widget?.dispose();
+		emulator?.dispose();
+		if (session) {
+			sessionManager.closeSession(session.id);
+		}
+		if (ownsSessionManager) {
+			sessionManager.dispose();
+		}
+	};
+
+	try {
+		emulator = await createEmulator();
+		session = await sessionManager.createSession({
+			command: options.command,
+			cwd: options.cwd,
+			cols: DEFAULT_TERMINAL_COLUMNS,
+			rows: DEFAULT_TERMINAL_ROWS,
+		});
+
+		if (options.ctx?.hasUI) {
+			widget = createWidget(options.ctx, session.id);
+			widget.update({
+				command: options.command,
+				startedAt,
+				ansiLines: [],
+				status: "running",
+				exitCode: null,
+			});
+		}
+
+		const flush = async (status: WidgetStatus, exitCode: number | null) => {
+			const nextChunk = flushQueuedChunks(queuedChunks);
+			if (nextChunk) {
+				await emulator?.write(nextChunk);
+			}
+
+			const plainOutput = session?.getOutput() ?? "";
+			widget?.update({
+				command: options.command,
+				startedAt,
+				ansiLines: emulator?.toAnsiLines(12) ?? [],
+				status,
+				exitCode,
+			});
+
+			options.onUpdate?.({
+				content: [{ type: "text", text: buildPreviewText(plainOutput) }],
+				details: {
+					pty: true,
+					sessionId: session?.id,
+					status,
+					exitCode,
+					partial: status === "running",
+				},
+			});
+		};
+
+		const scheduleFlush = () => {
+			if (flushTimer) {
+				return;
+			}
+
+			flushTimer = setTimeout(() => {
+				flushTimer = null;
+				void flush("running", null);
+			}, STREAM_UPDATE_DEBOUNCE_MS);
+			flushTimer.unref?.();
+		};
+
+		session.onData((data) => {
+			queuedChunks.push(data);
+			scheduleFlush();
+		});
+
+		const timeoutSeconds = options.timeout;
+		const timeoutMs = timeoutSeconds != null ? Math.max(1, timeoutSeconds * 1_000) : null;
+		const timeoutTimer =
+			timeoutMs == null
+				? null
+				: setTimeout(() => {
+					timedOut = true;
+					session?.kill("timed_out");
+				}, timeoutMs);
+		timeoutTimer?.unref?.();
+
+		const abortListener = () => {
+			cancelled = true;
+			session?.kill("cancelled");
+		};
+		options.signal?.addEventListener("abort", abortListener, { once: true });
+
+		const exitEvent = await session.whenExited;
+		if (flushTimer) {
+			clearTimeout(flushTimer);
+			flushTimer = null;
+		}
+		timeoutTimer && clearTimeout(timeoutTimer);
+		options.signal?.removeEventListener("abort", abortListener);
+
+		const status = toExecutionStatus(exitEvent.exitCode, cancelled, timedOut);
+		await flush(status, exitEvent.exitCode);
+
+		const output = session.getOutput();
+		const truncatedOutput = truncateOutput(output);
+		const highlightedOutput = highlightErrorOutput(truncatedOutput.text);
+		const text = appendExitSummary(highlightedOutput, exitEvent.exitCode, {
+			cancelled,
+			timedOut,
+			timeoutSeconds,
+		});
+
+		return {
+			command: options.command,
+			cwd: options.cwd,
+			sessionId: session.id,
+			status,
+			exitCode: exitEvent.exitCode,
+			cancelled,
+			timedOut,
+			output,
+			text,
+			truncated: truncatedOutput.truncation.truncated,
+			truncation: truncatedOutput.truncation,
+			durationMs: now() - startedAt,
+		};
+	} finally {
+		cleanup();
+	}
+}
+
+export const ptyExecuteInternals = {
+	toExecutionStatus,
+	buildPreviewText,
+	flushQueuedChunks,
+};

--- a/packages/pi-bash-live-view/src/pty-session.ts
+++ b/packages/pi-bash-live-view/src/pty-session.ts
@@ -1,0 +1,397 @@
+import { randomUUID } from "node:crypto";
+import { ensureSpawnHelperExecutable } from "./spawn-helper.js";
+
+const DEFAULT_COLUMNS = 120;
+const DEFAULT_ROWS = 32;
+const DEFAULT_MAX_BUFFER_BYTES = 256 * 1024;
+const DEFAULT_MAX_BUFFER_CHUNKS = 512;
+
+interface DisposableLike {
+	dispose?: () => void;
+}
+
+interface PtyLike {
+	pid: number;
+	onData?: (listener: (data: string) => void) => DisposableLike | (() => void) | void;
+	onExit?: (listener: (event: PtyExitEvent) => void) => DisposableLike | (() => void) | void;
+	kill: () => void;
+	resize?: (columns: number, rows: number) => void;
+	write?: (data: string) => void;
+}
+
+interface NodePtyModuleLike {
+	spawn: (
+		file: string,
+		args: string[],
+		options: {
+			cols: number;
+			rows: number;
+			cwd: string;
+			env: Record<string, string>;
+			name: string;
+		},
+	) => PtyLike;
+}
+
+interface BufferedChunk {
+	text: string;
+	bytes: number;
+}
+
+export interface PtyExitEvent {
+	exitCode: number | null;
+	signal?: number;
+}
+
+export type PtyStopReason = "exit" | "cancelled" | "timed_out" | "disposed";
+export type PtySessionStatus = "running" | "completed" | "failed" | "cancelled" | "timed_out" | "disposed";
+
+export interface ShellLaunch {
+	file: string;
+	args: string[];
+}
+
+export interface CreatePtySessionOptions {
+	command: string;
+	cwd: string;
+	cols?: number;
+	rows?: number;
+	env?: NodeJS.ProcessEnv;
+	shell?: ShellLaunch;
+}
+
+export interface ManagedPtySession {
+	id: string;
+	pid: number;
+	command: string;
+	cwd: string;
+	startedAt: number;
+	endedAt: number | null;
+	status: PtySessionStatus;
+	stopReason: PtyStopReason | null;
+	onData: (listener: (data: string) => void) => () => void;
+	onExit: (listener: (event: PtyExitEvent) => void) => () => void;
+	whenExited: Promise<PtyExitEvent>;
+	getOutput: () => string;
+	kill: (reason?: PtyStopReason) => void;
+	resize: (columns: number, rows: number) => void;
+	write: (data: string) => void;
+	dispose: () => void;
+}
+
+export interface PtySessionManagerOptions {
+	now?: () => number;
+	maxBufferedBytes?: number;
+	maxBufferedChunks?: number;
+	ensureSpawnHelper?: () => Promise<string | null>;
+}
+
+const DEFAULT_NODE_PTY_MODULE_LOADER = async (): Promise<NodePtyModuleLike> => {
+	return (await import("node-pty")) as NodePtyModuleLike;
+};
+
+let nodePtyModuleLoader: () => Promise<NodePtyModuleLike> = DEFAULT_NODE_PTY_MODULE_LOADER;
+
+function createDeferred<T>(): {
+	promise: Promise<T>;
+	resolve: (value: T) => void;
+} {
+	let resolve!: (value: T) => void;
+	const promise = new Promise<T>((nextResolve) => {
+		resolve = nextResolve;
+	});
+	return { promise, resolve };
+}
+
+function toDisposer(subscription: DisposableLike | (() => void) | void): () => void {
+	if (typeof subscription === "function") {
+		return subscription;
+	}
+
+	if (subscription?.dispose) {
+		return () => subscription.dispose?.();
+	}
+
+	return () => {};
+}
+
+function sanitizeEnv(env: NodeJS.ProcessEnv = process.env): Record<string, string> {
+	const mergedEnv = {
+		...process.env,
+		...env,
+		TERM: env.TERM ?? "xterm-256color",
+		COLORTERM: env.COLORTERM ?? "truecolor",
+	};
+	const sanitized: Record<string, string> = {};
+	for (const [key, value] of Object.entries(mergedEnv)) {
+		if (typeof value !== "string") {
+			continue;
+		}
+		sanitized[key] = value;
+	}
+	return sanitized;
+}
+
+export function resolveShellLaunch(
+	command: string,
+	platform: NodeJS.Platform = process.platform,
+	env: NodeJS.ProcessEnv = process.env,
+): ShellLaunch {
+	if (platform === "win32") {
+		const shell = env.SHELL?.trim();
+		if (shell && /(bash|sh)(?:\.exe)?$/i.test(shell)) {
+			return { file: shell, args: ["-lc", command] };
+		}
+
+		const comSpec = env.ComSpec?.trim();
+		if (comSpec) {
+			return {
+				file: comSpec,
+				args: ["/d", "/s", "/c", command],
+			};
+		}
+
+		return {
+			file: "cmd.exe",
+			args: ["/d", "/s", "/c", command],
+		};
+	}
+
+	return {
+		file: env.SHELL?.trim() || "/bin/bash",
+		args: ["-lc", command],
+	};
+}
+
+function pruneBufferedChunks(chunks: BufferedChunk[], maxChunks: number, maxBytes: number): number {
+	let keptBytes = 0;
+	let keepStart = chunks.length;
+
+	for (let read = chunks.length - 1; read >= 0; read--) {
+		const nextChunk = chunks[read];
+		const nextCount = chunks.length - read;
+		if (nextCount > maxChunks || keptBytes + nextChunk.bytes > maxBytes) {
+			break;
+		}
+
+		keptBytes += nextChunk.bytes;
+		keepStart = read;
+	}
+
+	let write = 0;
+	for (let read = keepStart; read < chunks.length; read++) {
+		chunks[write++] = chunks[read];
+	}
+	chunks.length = write;
+	return keptBytes;
+}
+
+function createSessionStatus(stopReason: PtyStopReason | null, exitCode: number | null): PtySessionStatus {
+	if (stopReason === "cancelled") {
+		return "cancelled";
+	}
+
+	if (stopReason === "timed_out") {
+		return "timed_out";
+	}
+
+	if (stopReason === "disposed") {
+		return "disposed";
+	}
+
+	return exitCode === 0 ? "completed" : "failed";
+}
+
+export function setNodePtyModuleLoader(loader: () => Promise<NodePtyModuleLike>): void {
+	nodePtyModuleLoader = loader;
+}
+
+export function resetNodePtyModuleLoader(): void {
+	nodePtyModuleLoader = DEFAULT_NODE_PTY_MODULE_LOADER;
+}
+
+export class PtySessionManager {
+	private readonly sessions = new Map<string, ManagedPtySession>();
+	private readonly now: () => number;
+	private readonly maxBufferedBytes: number;
+	private readonly maxBufferedChunks: number;
+	private readonly ensureSpawnHelper: () => Promise<string | null>;
+
+	constructor(options: PtySessionManagerOptions = {}) {
+		this.now = options.now ?? Date.now;
+		this.maxBufferedBytes = options.maxBufferedBytes ?? DEFAULT_MAX_BUFFER_BYTES;
+		this.maxBufferedChunks = options.maxBufferedChunks ?? DEFAULT_MAX_BUFFER_CHUNKS;
+		this.ensureSpawnHelper = options.ensureSpawnHelper ?? ensureSpawnHelperExecutable;
+	}
+
+	async createSession(options: CreatePtySessionOptions): Promise<ManagedPtySession> {
+		await this.ensureSpawnHelper();
+		const ptyModule = await nodePtyModuleLoader();
+		const shell = options.shell ?? resolveShellLaunch(options.command);
+		const cols = options.cols ?? DEFAULT_COLUMNS;
+		const rows = options.rows ?? DEFAULT_ROWS;
+		const pty = ptyModule.spawn(shell.file, shell.args, {
+			cols,
+			rows,
+			cwd: options.cwd,
+			env: sanitizeEnv(options.env),
+			name: "xterm-256color",
+		});
+
+		const exitDeferred = createDeferred<PtyExitEvent>();
+		const dataListeners = new Set<(data: string) => void>();
+		const exitListeners = new Set<(event: PtyExitEvent) => void>();
+		const bufferedChunks: BufferedChunk[] = [];
+		let bufferedBytes = 0;
+		let outputCache = "";
+		let outputDirty = false;
+		let exitResolved = false;
+		let sessionStatus: PtySessionStatus = "running";
+		let stopReason: PtyStopReason | null = null;
+		let endedAt: number | null = null;
+		let disposed = false;
+
+		const id = randomUUID();
+
+		const getOutput = () => {
+			if (!outputDirty) {
+				return outputCache;
+			}
+
+			outputCache = bufferedChunks.map((chunk) => chunk.text).join("");
+			outputDirty = false;
+			return outputCache;
+		};
+
+		const finalize = (event: PtyExitEvent) => {
+			if (exitResolved) {
+				return;
+			}
+
+			exitResolved = true;
+			endedAt = this.now();
+			sessionStatus = createSessionStatus(stopReason, event.exitCode);
+			exitDeferred.resolve(event);
+			for (const listener of exitListeners) {
+				listener(event);
+			}
+		};
+
+		const appendChunk = (text: string) => {
+			const bytes = Buffer.byteLength(text, "utf8");
+			bufferedChunks.push({ text, bytes });
+			bufferedBytes += bytes;
+			if (bufferedBytes > this.maxBufferedBytes || bufferedChunks.length > this.maxBufferedChunks) {
+				bufferedBytes = pruneBufferedChunks(bufferedChunks, this.maxBufferedChunks, this.maxBufferedBytes);
+			}
+			outputDirty = true;
+		};
+
+		const dataDisposer = toDisposer(
+			pty.onData?.((data) => {
+				appendChunk(data);
+				for (const listener of dataListeners) {
+					listener(data);
+				}
+			}),
+		);
+		const exitDisposer = toDisposer(
+			pty.onExit?.((event) => {
+				finalize({ exitCode: event.exitCode, signal: event.signal });
+			}),
+		);
+
+		const session: ManagedPtySession = {
+			id,
+			pid: pty.pid,
+			command: options.command,
+			cwd: options.cwd,
+			startedAt: this.now(),
+			get endedAt() {
+				return endedAt;
+			},
+			get status() {
+				return sessionStatus;
+			},
+			get stopReason() {
+				return stopReason;
+			},
+			onData(listener) {
+				dataListeners.add(listener);
+				return () => {
+					dataListeners.delete(listener);
+				};
+			},
+			onExit(listener) {
+				exitListeners.add(listener);
+				return () => {
+					exitListeners.delete(listener);
+				};
+			},
+			whenExited: exitDeferred.promise,
+			getOutput,
+			kill(reason = "cancelled") {
+				if (stopReason == null || reason === "timed_out") {
+					stopReason = reason;
+				}
+				try {
+					pty.kill();
+				} catch {
+					finalize({ exitCode: null });
+				}
+			},
+			resize(columns, nextRows) {
+				pty.resize?.(columns, nextRows);
+			},
+			write(data) {
+				pty.write?.(data);
+			},
+			dispose() {
+				if (disposed) {
+					return;
+				}
+				disposed = true;
+				if (stopReason == null) {
+					stopReason = "disposed";
+				}
+				dataDisposer();
+				exitDisposer();
+				try {
+					pty.kill();
+				} catch {
+					finalize({ exitCode: null });
+				}
+			},
+		};
+
+		this.sessions.set(id, session);
+		return session;
+	}
+
+	closeSession(sessionId: string): void {
+		const session = this.sessions.get(sessionId);
+		if (!session) {
+			return;
+		}
+
+		session.dispose();
+		this.sessions.delete(sessionId);
+	}
+
+	dispose(): void {
+		const ids: string[] = [];
+		for (const session of this.sessions.values()) {
+			ids.push(session.id);
+		}
+		for (const sessionId of ids) {
+			this.closeSession(sessionId);
+		}
+	}
+}
+
+export const ptySessionInternals = {
+	toDisposer,
+	sanitizeEnv,
+	pruneBufferedChunks,
+	createSessionStatus,
+};

--- a/packages/pi-bash-live-view/src/spawn-helper.ts
+++ b/packages/pi-bash-live-view/src/spawn-helper.ts
@@ -1,0 +1,86 @@
+import { access, chmod } from "node:fs/promises";
+import { constants } from "node:fs";
+import path from "node:path";
+import { fileURLToPath } from "node:url";
+
+const SPAWN_HELPER_BASENAME = process.platform === "win32" ? "spawn-helper.exe" : "spawn-helper";
+const MODULE_DIR = path.dirname(fileURLToPath(import.meta.url));
+const PACKAGE_DIR = path.resolve(MODULE_DIR, "..");
+
+export interface EnsureSpawnHelperOptions {
+	explicitPath?: string;
+	accessFn?: typeof access;
+	chmodFn?: typeof chmod;
+}
+
+function uniquePaths(candidates: Array<string | undefined>): string[] {
+	const seen = new Set<string>();
+	const deduped: string[] = [];
+	for (const candidate of candidates) {
+		if (!candidate || seen.has(candidate)) {
+			continue;
+		}
+
+		seen.add(candidate);
+		deduped.push(candidate);
+	}
+	return deduped;
+}
+
+export function getSpawnHelperCandidates(explicitPath?: string): string[] {
+	return uniquePaths([
+		explicitPath,
+		process.env.NODE_PTY_SPAWN_HELPER,
+		path.join(PACKAGE_DIR, "node_modules", "node-pty", "build", "Release", SPAWN_HELPER_BASENAME),
+		path.join(PACKAGE_DIR, "..", "node_modules", "node-pty", "build", "Release", SPAWN_HELPER_BASENAME),
+		path.join(PACKAGE_DIR, "..", "..", "node_modules", "node-pty", "build", "Release", SPAWN_HELPER_BASENAME),
+		path.join(PACKAGE_DIR, "build", "Release", SPAWN_HELPER_BASENAME),
+	]);
+}
+
+async function isExecutable(candidate: string, accessFn: typeof access): Promise<boolean> {
+	try {
+		await accessFn(candidate, constants.X_OK);
+		return true;
+	} catch {
+		return false;
+	}
+}
+
+export async function ensureSpawnHelperExecutable(options: EnsureSpawnHelperOptions = {}): Promise<string | null> {
+	if (process.platform === "win32") {
+		return options.explicitPath ?? process.env.NODE_PTY_SPAWN_HELPER ?? null;
+	}
+
+	const accessFn = options.accessFn ?? access;
+	const chmodFn = options.chmodFn ?? chmod;
+
+	for (const candidate of getSpawnHelperCandidates(options.explicitPath)) {
+		try {
+			await accessFn(candidate, constants.F_OK);
+		} catch {
+			continue;
+		}
+
+		if (await isExecutable(candidate, accessFn)) {
+			return candidate;
+		}
+
+		try {
+			await chmodFn(candidate, 0o755);
+		} catch {
+			continue;
+		}
+
+		if (await isExecutable(candidate, accessFn)) {
+			return candidate;
+		}
+	}
+
+	return null;
+}
+
+export const spawnHelperInternals = {
+	uniquePaths,
+	isExecutable,
+};

--- a/packages/pi-bash-live-view/src/terminal-emulator.ts
+++ b/packages/pi-bash-live-view/src/terminal-emulator.ts
@@ -1,0 +1,499 @@
+import { tailText } from "./truncate.js";
+
+const DEFAULT_COLUMNS = 120;
+const DEFAULT_ROWS = 32;
+const MAX_CSI_PARAMS = 16;
+const MAX_CSI_PARAM_LENGTH = 8;
+const RESET_SGR = "\u001B[0m";
+
+const BELL_REGEX = /\u0007/g;
+const C0_CONTROL_REGEX = /[\u0000-\u0008\u000B\u000C\u000E-\u001A\u001C-\u001F\u007F]/g;
+const OSC_SEQUENCE_REGEX = /\u001B\][^\u0007\u001B]*(?:\u0007|\u001B\\)/g;
+const CSI_SEQUENCE_REGEX = /\u001B\[([0-9:;?]*)([ -/]*)((?:[@-~]))/g;
+const CSI_PARAM_SANITIZE_REGEX = /[^0-9:;?]/g;
+const ANSI_STRIP_REGEX = /\u001B(?:[@-Z\\-_]|\[[0-?]*[ -/]*[@-~]|\][^\u0007\u001B]*(?:\u0007|\u001B\\))/g;
+
+interface ColorValue {
+	kind: "palette" | "rgb";
+	value: number;
+}
+
+interface CellStyle {
+	bold: boolean;
+	dim: boolean;
+	italic: boolean;
+	underline: boolean;
+	inverse: boolean;
+	hidden: boolean;
+	strikethrough: boolean;
+	foreground: ColorValue | null;
+	background: ColorValue | null;
+}
+
+interface TerminalCellLike {
+	getChars?: () => string;
+	getWidth?: () => number;
+	isBold?: () => boolean;
+	isDim?: () => boolean;
+	isItalic?: () => boolean;
+	isUnderline?: () => boolean;
+	isInverse?: () => boolean;
+	isInvisible?: () => boolean;
+	isHidden?: () => boolean;
+	isStrikethrough?: () => boolean;
+	getFgColorMode?: () => number;
+	getBgColorMode?: () => number;
+	getFgColor?: () => number;
+	getBgColor?: () => number;
+	chars?: string;
+	width?: number;
+	bold?: boolean;
+	dim?: boolean;
+	italic?: boolean;
+	underline?: boolean;
+	inverse?: boolean;
+	hidden?: boolean;
+	invisible?: boolean;
+	strikethrough?: boolean;
+	fgColorMode?: number;
+	bgColorMode?: number;
+	fgColor?: number;
+	bgColor?: number;
+}
+
+interface TerminalLineLike {
+	getCell?: (index: number) => TerminalCellLike | undefined;
+	translateToString?: (trimRight?: boolean) => string;
+}
+
+interface TerminalBufferLike {
+	active?: {
+		baseY?: number;
+		cursorY?: number;
+		length?: number;
+		getLine?: (index: number) => TerminalLineLike | undefined;
+	};
+}
+
+interface HeadlessTerminalLike {
+	write(data: string, callback?: () => void): void;
+	resize(cols: number, rows: number): void;
+	dispose(): void;
+	buffer?: TerminalBufferLike;
+}
+
+interface HeadlessModuleLike {
+	Terminal: new (options: Record<string, unknown>) => HeadlessTerminalLike;
+}
+
+export interface TerminalEmulator {
+	write(data: string): Promise<void>;
+	resize(columns: number, rows: number): void;
+	toAnsiLines(maxLines?: number): string[];
+	getPlainText(): string;
+	dispose(): void;
+}
+
+export interface CreateTerminalEmulatorOptions {
+	columns?: number;
+	rows?: number;
+}
+
+const DEFAULT_CELL_STYLE: CellStyle = {
+	bold: false,
+	dim: false,
+	italic: false,
+	underline: false,
+	inverse: false,
+	hidden: false,
+	strikethrough: false,
+	foreground: null,
+	background: null,
+};
+
+const DEFAULT_HEADLESS_MODULE_LOADER = async (): Promise<HeadlessModuleLike> => {
+	return (await import("@xterm/headless")) as HeadlessModuleLike;
+};
+
+let headlessModuleLoader: () => Promise<HeadlessModuleLike> = DEFAULT_HEADLESS_MODULE_LOADER;
+
+function getBoolean(source: TerminalCellLike | undefined, methodName: keyof TerminalCellLike, propName: keyof TerminalCellLike): boolean {
+	const method = source?.[methodName] as ((this: TerminalCellLike | undefined) => unknown) | undefined;
+	if (typeof method === "function") {
+		return Boolean(method.call(source));
+	}
+
+	return Boolean(source?.[propName]);
+}
+
+function getNumber(source: TerminalCellLike | undefined, methodName: keyof TerminalCellLike, propName: keyof TerminalCellLike): number | undefined {
+	const method = source?.[methodName] as ((this: TerminalCellLike | undefined) => unknown) | undefined;
+	if (typeof method === "function") {
+		const value = method.call(source);
+		return typeof value === "number" ? value : undefined;
+	}
+
+	const value = source?.[propName];
+	return typeof value === "number" ? value : undefined;
+}
+
+function sanitizeCsiParams(params: string): string {
+	if (!params) {
+		return "";
+	}
+
+	const rawParts = params.replace(CSI_PARAM_SANITIZE_REGEX, "").split(";");
+	const safeParts: string[] = [];
+	for (const rawPart of rawParts) {
+		if (!rawPart) {
+			continue;
+		}
+
+		safeParts.push(rawPart.slice(0, MAX_CSI_PARAM_LENGTH));
+		if (safeParts.length >= MAX_CSI_PARAMS) {
+			break;
+		}
+	}
+	return safeParts.join(";");
+}
+
+export function sanitizeAnsiOutput(text: string): string {
+	if (!text) {
+		return text;
+	}
+
+	return text
+		.replace(OSC_SEQUENCE_REGEX, "")
+		.replace(BELL_REGEX, "")
+		.replace(CSI_SEQUENCE_REGEX, (_match, params: string, intermediates: string, final: string) => {
+			return `\u001B[${sanitizeCsiParams(params)}${intermediates}${final}`;
+		})
+		.replace(C0_CONTROL_REGEX, "");
+}
+
+export function stripAnsiSequences(text: string): string {
+	if (!text) {
+		return text;
+	}
+
+	return text.replace(ANSI_STRIP_REGEX, "").replace(C0_CONTROL_REGEX, "");
+}
+
+function decodeRgb(value: number): [number, number, number] {
+	return [(value >> 16) & 0xff, (value >> 8) & 0xff, value & 0xff];
+}
+
+function readColor(cell: TerminalCellLike | undefined, type: "fg" | "bg"): ColorValue | null {
+	const mode = getNumber(
+		cell,
+		type === "fg" ? "getFgColorMode" : "getBgColorMode",
+		type === "fg" ? "fgColorMode" : "bgColorMode",
+	);
+	const value = getNumber(cell, type === "fg" ? "getFgColor" : "getBgColor", type === "fg" ? "fgColor" : "bgColor");
+
+	if (value == null) {
+		return null;
+	}
+
+	if (mode == null || mode === 0) {
+		return value === 0 ? null : { kind: value > 0xff ? "rgb" : "palette", value };
+	}
+
+	if (mode === 3 || value > 0xff) {
+		return { kind: "rgb", value };
+	}
+
+	if (mode === 2 || mode === 1) {
+		return { kind: "palette", value: Math.max(0, Math.min(255, value)) };
+	}
+
+	return null;
+}
+
+function readCellChars(cell: TerminalCellLike | undefined): string {
+	const charsFromMethod = cell?.getChars?.();
+	if (typeof charsFromMethod === "string" && charsFromMethod.length > 0) {
+		return charsFromMethod;
+	}
+
+	if (typeof cell?.chars === "string" && cell.chars.length > 0) {
+		return cell.chars;
+	}
+
+	return " ";
+}
+
+function readCellWidth(cell: TerminalCellLike | undefined): number {
+	const width = getNumber(cell, "getWidth", "width");
+	if (width == null) {
+		return 1;
+	}
+
+	return width;
+}
+
+function readCellStyle(cell: TerminalCellLike | undefined): CellStyle {
+	return {
+		bold: getBoolean(cell, "isBold", "bold"),
+		dim: getBoolean(cell, "isDim", "dim"),
+		italic: getBoolean(cell, "isItalic", "italic"),
+		underline: getBoolean(cell, "isUnderline", "underline"),
+		inverse: getBoolean(cell, "isInverse", "inverse"),
+		hidden: getBoolean(cell, "isInvisible", "invisible") || getBoolean(cell, "isHidden", "hidden"),
+		strikethrough: getBoolean(cell, "isStrikethrough", "strikethrough"),
+		foreground: readColor(cell, "fg"),
+		background: readColor(cell, "bg"),
+	};
+}
+
+function stylesEqual(left: CellStyle, right: CellStyle): boolean {
+	return (
+		left.bold === right.bold &&
+		left.dim === right.dim &&
+		left.italic === right.italic &&
+		left.underline === right.underline &&
+		left.inverse === right.inverse &&
+		left.hidden === right.hidden &&
+		left.strikethrough === right.strikethrough &&
+		left.foreground?.kind === right.foreground?.kind &&
+		left.foreground?.value === right.foreground?.value &&
+		left.background?.kind === right.background?.kind &&
+		left.background?.value === right.background?.value
+	);
+}
+
+function isDefaultStyle(style: CellStyle): boolean {
+	return stylesEqual(style, DEFAULT_CELL_STYLE);
+}
+
+function colorToCodes(color: ColorValue | null, prefix: 38 | 48): string[] {
+	if (!color) {
+		return [];
+	}
+
+	if (color.kind === "palette") {
+		return [`${prefix}`, "5", `${color.value}`];
+	}
+
+	const [red, green, blue] = decodeRgb(color.value);
+	return [`${prefix}`, "2", `${red}`, `${green}`, `${blue}`];
+}
+
+export function styleToSgr(style: CellStyle): string {
+	if (isDefaultStyle(style)) {
+		return RESET_SGR;
+	}
+
+	const codes = ["0"];
+	if (style.bold) {
+		codes.push("1");
+	}
+	if (style.dim) {
+		codes.push("2");
+	}
+	if (style.italic) {
+		codes.push("3");
+	}
+	if (style.underline) {
+		codes.push("4");
+	}
+	if (style.inverse) {
+		codes.push("7");
+	}
+	if (style.hidden) {
+		codes.push("8");
+	}
+	if (style.strikethrough) {
+		codes.push("9");
+	}
+
+	const foreground = style.inverse ? style.background : style.foreground;
+	const background = style.inverse ? style.foreground : style.background;
+	codes.push(...colorToCodes(foreground, 38), ...colorToCodes(background, 48));
+	return `\u001B[${codes.join(";")}m`;
+}
+
+function getVisibleLineIndexes(buffer: TerminalBufferLike["active"], rows: number): [number, number] {
+	const length = Math.max(0, buffer?.length ?? rows);
+	if (length === 0) {
+		return [0, -1];
+	}
+
+	const baseY = Math.max(0, buffer?.baseY ?? 0);
+	const lastIndex = Math.min(length - 1, Math.max(baseY + rows - 1, baseY + (buffer?.cursorY ?? 0)));
+	const firstIndex = Math.max(0, lastIndex - rows + 1);
+	return [firstIndex, lastIndex];
+}
+
+export function renderLineToAnsi(line: TerminalLineLike | undefined, columns: number): string {
+	if (!line) {
+		return "";
+	}
+
+	if (typeof line.getCell !== "function") {
+		return line.translateToString?.(true) ?? "";
+	}
+
+	const cells: Array<{ chars: string; style: CellStyle }> = [];
+	for (let column = 0; column < columns; column++) {
+		const cell = line.getCell(column);
+		if (!cell) {
+			break;
+		}
+
+		if (readCellWidth(cell) === 0) {
+			continue;
+		}
+
+		const style = readCellStyle(cell);
+		const chars = style.hidden ? " " : readCellChars(cell);
+		cells.push({ chars, style });
+	}
+
+	let lastVisibleIndex = cells.length - 1;
+	while (lastVisibleIndex >= 0 && cells[lastVisibleIndex]?.chars === " ") {
+		lastVisibleIndex--;
+	}
+
+	if (lastVisibleIndex < 0) {
+		return "";
+	}
+
+	let output = "";
+	let previousStyle = DEFAULT_CELL_STYLE;
+	for (let index = 0; index <= lastVisibleIndex; index++) {
+		const cell = cells[index];
+		const nextStyle = cell.style;
+		if (!stylesEqual(previousStyle, nextStyle)) {
+			output += styleToSgr(nextStyle);
+			previousStyle = nextStyle;
+		}
+
+		output += cell.chars;
+	}
+
+	if (!isDefaultStyle(previousStyle)) {
+		output += RESET_SGR;
+	}
+	return output;
+}
+
+class PlainTextTerminalEmulator implements TerminalEmulator {
+	private buffer = "";
+
+	async write(data: string): Promise<void> {
+		this.buffer += stripAnsiSequences(sanitizeAnsiOutput(data));
+	}
+
+	resize(_columns: number, _rows: number): void {}
+
+	toAnsiLines(maxLines = DEFAULT_ROWS): string[] {
+		const tailedText = tailText(this.buffer, maxLines);
+		return tailedText ? tailedText.split("\n") : [];
+	}
+
+	getPlainText(): string {
+		return this.buffer;
+	}
+
+	dispose(): void {}
+}
+
+class XtermHeadlessTerminalEmulator implements TerminalEmulator {
+	constructor(
+		private readonly terminal: HeadlessTerminalLike,
+		private columns: number,
+		private rows: number,
+		private readonly plainTextChunks: string[] = [],
+	) {}
+
+	async write(data: string): Promise<void> {
+		const sanitizedData = sanitizeAnsiOutput(data);
+		this.plainTextChunks.push(stripAnsiSequences(sanitizedData));
+		await new Promise<void>((resolve) => {
+			let settled = false;
+			const finish = () => {
+				if (settled) {
+					return;
+				}
+				settled = true;
+				resolve();
+			};
+			try {
+				this.terminal.write(sanitizedData, finish);
+				if (this.terminal.write.length < 2) {
+					finish();
+				}
+			} catch {
+				finish();
+			}
+		});
+	}
+
+	resize(columns: number, rows: number): void {
+		this.columns = columns;
+		this.rows = rows;
+		this.terminal.resize(columns, rows);
+	}
+
+	toAnsiLines(maxLines = this.rows): string[] {
+		const activeBuffer = this.terminal.buffer?.active;
+		if (!activeBuffer?.getLine) {
+			const fallback = tailText(this.getPlainText(), maxLines);
+			return fallback ? fallback.split("\n") : [];
+		}
+
+		const [firstIndex, lastIndex] = getVisibleLineIndexes(activeBuffer, this.rows);
+		const lines: string[] = [];
+		for (let index = firstIndex; index <= lastIndex; index++) {
+			lines.push(renderLineToAnsi(activeBuffer.getLine(index), this.columns));
+		}
+
+		return lines.slice(-maxLines);
+	}
+
+	getPlainText(): string {
+		return this.plainTextChunks.join("");
+	}
+
+	dispose(): void {
+		this.terminal.dispose();
+	}
+}
+
+export function setHeadlessModuleLoader(loader: () => Promise<HeadlessModuleLike>): void {
+	headlessModuleLoader = loader;
+}
+
+export function resetHeadlessModuleLoader(): void {
+	headlessModuleLoader = DEFAULT_HEADLESS_MODULE_LOADER;
+}
+
+export async function createTerminalEmulator(options: CreateTerminalEmulatorOptions = {}): Promise<TerminalEmulator> {
+	const columns = options.columns ?? DEFAULT_COLUMNS;
+	const rows = options.rows ?? DEFAULT_ROWS;
+
+	try {
+		const headlessModule = await headlessModuleLoader();
+		if (typeof headlessModule.Terminal !== "function") {
+			return new PlainTextTerminalEmulator();
+		}
+
+		const terminal = new headlessModule.Terminal({
+			allowProposedApi: false,
+			cols: columns,
+			rows,
+			scrollback: rows * 4,
+		});
+		return new XtermHeadlessTerminalEmulator(terminal, columns, rows);
+	} catch {
+		return new PlainTextTerminalEmulator();
+	}
+}
+
+export const terminalEmulatorInternals = {
+	decodeRgb,
+	sanitizeCsiParams,
+	getVisibleLineIndexes,
+	stylesEqual,
+};

--- a/packages/pi-bash-live-view/src/truncate.ts
+++ b/packages/pi-bash-live-view/src/truncate.ts
@@ -1,0 +1,194 @@
+const DEFAULT_MAX_LINES = 2_000;
+const DEFAULT_MAX_BYTES = 50 * 1024;
+const DEFAULT_TAIL_LINES = 40;
+
+const LIKELY_ERROR_LINE_REGEX = /\b(?:error|failed?|exception|fatal|traceback)\b/i;
+const ANSI_RED = "\u001B[31m";
+const ANSI_GREEN = "\u001B[32m";
+const ANSI_YELLOW = "\u001B[33m";
+const ANSI_RESET = "\u001B[0m";
+
+export interface OutputTruncation {
+	truncated: boolean;
+	totalLines: number;
+	totalBytes: number;
+	keptLines: number;
+	keptBytes: number;
+	maxLines: number;
+	maxBytes: number;
+}
+
+export interface TruncateOutputOptions {
+	maxLines?: number;
+	maxBytes?: number;
+}
+
+export interface TruncateOutputResult {
+	text: string;
+	truncation: OutputTruncation;
+}
+
+function normalizeNewlines(text: string): string {
+	return text.replace(/\r\n?/g, "\n");
+}
+
+function buildTruncationNotice(truncation: OutputTruncation): string {
+	return `[output truncated: kept ${truncation.keptLines}/${truncation.totalLines} lines, ${truncation.keptBytes}/${truncation.totalBytes} bytes]`;
+}
+
+function toExitColor(exitCode: number | null, cancelled: boolean, timedOut: boolean): string {
+	if (cancelled || timedOut) {
+		return ANSI_YELLOW;
+	}
+
+	return exitCode === 0 ? ANSI_GREEN : ANSI_RED;
+}
+
+export function truncateOutput(text: string, options: TruncateOutputOptions = {}): TruncateOutputResult {
+	const maxLines = options.maxLines ?? DEFAULT_MAX_LINES;
+	const maxBytes = options.maxBytes ?? DEFAULT_MAX_BYTES;
+	const normalizedText = normalizeNewlines(text);
+
+	if (!normalizedText) {
+		return {
+			text: "",
+			truncation: {
+				truncated: false,
+				totalLines: 0,
+				totalBytes: 0,
+				keptLines: 0,
+				keptBytes: 0,
+				maxLines,
+				maxBytes,
+			},
+		};
+	}
+
+	const rawLines = normalizedText.split("\n");
+	const totalLines = rawLines.length;
+	const totalBytes = Buffer.byteLength(normalizedText, "utf8");
+	let keptBytes = 0;
+	let write = 0;
+	let truncated = false;
+
+	for (let read = 0; read < rawLines.length; read++) {
+		const prefix = write === 0 ? "" : "\n";
+		const nextLine = rawLines[read];
+		const nextBytes = Buffer.byteLength(`${prefix}${nextLine}`, "utf8");
+
+		if (write < maxLines && keptBytes + nextBytes <= maxBytes) {
+			rawLines[write++] = nextLine;
+			keptBytes += nextBytes;
+			continue;
+		}
+
+		truncated = true;
+		break;
+	}
+
+	const truncation: OutputTruncation = {
+		truncated,
+		totalLines,
+		totalBytes,
+		keptLines: write,
+		keptBytes,
+		maxLines,
+		maxBytes,
+	};
+
+	if (!truncated) {
+		return {
+			text: normalizedText,
+			truncation,
+		};
+	}
+
+	rawLines.length = write;
+	const notice = buildTruncationNotice(truncation);
+	const keptText = rawLines.join("\n");
+
+	return {
+		text: keptText ? `${keptText}\n\n${notice}` : notice,
+		truncation,
+	};
+}
+
+export function tailText(text: string, maxLines = DEFAULT_TAIL_LINES): string {
+	const normalizedText = normalizeNewlines(text);
+	if (!normalizedText) {
+		return "";
+	}
+
+	const lines = normalizedText.split("\n");
+	if (lines.length <= maxLines) {
+		return normalizedText;
+	}
+
+	return lines.slice(-maxLines).join("\n");
+}
+
+export function highlightErrorOutput(text: string): string {
+	if (!text) {
+		return text;
+	}
+
+	const lines = normalizeNewlines(text).split("\n");
+	for (let index = 0; index < lines.length; index++) {
+		if (!LIKELY_ERROR_LINE_REGEX.test(lines[index])) {
+			continue;
+		}
+
+		lines[index] = `${ANSI_RED}${lines[index]}${ANSI_RESET}`;
+	}
+	return lines.join("\n");
+}
+
+export function formatExitSummaryLine(
+	exitCode: number | null,
+	options: {
+		cancelled?: boolean;
+		timedOut?: boolean;
+		timeoutSeconds?: number;
+	} = {},
+): string {
+	const { cancelled = false, timedOut = false, timeoutSeconds } = options;
+	const color = toExitColor(exitCode, cancelled, timedOut);
+
+	if (cancelled) {
+		return `${color}[Command cancelled]${ANSI_RESET}`;
+	}
+
+	if (timedOut) {
+		const timeoutLabel = timeoutSeconds == null ? "command timed out" : `Timed out after ${timeoutSeconds}s`;
+		return `${color}[${timeoutLabel}]${ANSI_RESET}`;
+	}
+
+	if (exitCode == null) {
+		return `${color}[Exit code: unknown]${ANSI_RESET}`;
+	}
+
+	return `${color}[Exit code: ${exitCode}]${ANSI_RESET}`;
+}
+
+export function appendExitSummary(
+	text: string,
+	exitCode: number | null,
+	options: {
+		cancelled?: boolean;
+		timedOut?: boolean;
+		timeoutSeconds?: number;
+	} = {},
+): string {
+	const summary = formatExitSummaryLine(exitCode, options);
+	if (!text) {
+		return summary;
+	}
+
+	return `${text}\n\n${summary}`;
+}
+
+export const truncateInternals = {
+	normalizeNewlines,
+	buildTruncationNotice,
+	toExitColor,
+};

--- a/packages/pi-bash-live-view/src/widget.ts
+++ b/packages/pi-bash-live-view/src/widget.ts
@@ -1,0 +1,226 @@
+const DEFAULT_WIDGET_KEY_PREFIX = "pi-bash-live-view";
+const DEFAULT_WIDGET_MAX_LINES = 12;
+const DEFAULT_RENDER_DEBOUNCE_MS = 120;
+const ELAPSED_TICK_MS = 1_000;
+
+export type WidgetStatus = "running" | "completed" | "failed" | "cancelled" | "timed_out";
+
+export interface WidgetState {
+	command: string;
+	startedAt: number;
+	ansiLines: string[];
+	status: WidgetStatus;
+	exitCode: number | null;
+}
+
+export interface WidgetThemeLike {
+	fg: (color: string, text: string) => string;
+	bold: (text: string) => string;
+}
+
+export interface WidgetTuiLike {
+	requestRender: () => void;
+}
+
+export interface WidgetContextLike {
+	hasUI?: boolean;
+	ui?: {
+		setWidget: (...args: any[]) => void;
+	};
+}
+
+export interface PtyLiveWidgetOptions {
+	key?: string;
+	maxLines?: number;
+	placement?: "aboveEditor" | "belowEditor";
+	renderDebounceMs?: number;
+}
+
+function truncateCommand(command: string, maxLength = 96): string {
+	if (command.length <= maxLength) {
+		return command;
+	}
+
+	return `${command.slice(0, maxLength - 1)}…`;
+}
+
+function toStatusColor(status: WidgetStatus): string {
+	switch (status) {
+		case "completed":
+			return "success";
+		case "failed":
+			return "error";
+		case "cancelled":
+		case "timed_out":
+			return "warning";
+		default:
+			return "accent";
+	}
+}
+
+function toStatusLabel(status: WidgetStatus): string {
+	switch (status) {
+		case "timed_out":
+			return "timed out";
+		default:
+			return status;
+	}
+}
+
+export function formatElapsedMmSs(elapsedMs: number): string {
+	const totalSeconds = Math.max(0, Math.floor(elapsedMs / 1_000));
+	const minutes = Math.floor(totalSeconds / 60);
+	const seconds = totalSeconds % 60;
+	return `${String(minutes).padStart(2, "0")}:${String(seconds).padStart(2, "0")}`;
+}
+
+export function buildWidgetLines(
+	theme: WidgetThemeLike,
+	state: WidgetState,
+	options: Pick<PtyLiveWidgetOptions, "maxLines"> = {},
+	now = Date.now(),
+): string[] {
+	const maxLines = options.maxLines ?? DEFAULT_WIDGET_MAX_LINES;
+	const statusColor = toStatusColor(state.status);
+	const header = `${theme.fg("accent", theme.bold("🖥 Bash PTY"))} ${theme.fg(statusColor, toStatusLabel(state.status))} · ${formatElapsedMmSs(now - state.startedAt)}`;
+	const commandLine = theme.fg("dim", truncateCommand(state.command));
+	const bodyLines = state.ansiLines.length > maxLines ? state.ansiLines.slice(-maxLines) : state.ansiLines;
+
+	if (bodyLines.length === 0) {
+		return [header, commandLine, theme.fg("dim", "(waiting for output)")];
+	}
+
+	return [header, commandLine, ...bodyLines];
+}
+
+export class PtyLiveWidgetController {
+	private readonly key: string;
+	private readonly maxLines: number;
+	private readonly placement: "aboveEditor" | "belowEditor";
+	private readonly renderDebounceMs: number;
+	private state: WidgetState | null = null;
+	private requestRender: (() => void) | null = null;
+	private stopElapsedTimer: (() => void) | null = null;
+	private renderTimer: ReturnType<typeof setTimeout> | null = null;
+	private mounted = false;
+
+	constructor(
+		private readonly ctx: WidgetContextLike | undefined,
+		options: PtyLiveWidgetOptions = {},
+	) {
+		this.key = options.key ?? `${DEFAULT_WIDGET_KEY_PREFIX}:${Math.random().toString(36).slice(2, 8)}`;
+		this.maxLines = options.maxLines ?? DEFAULT_WIDGET_MAX_LINES;
+		this.placement = options.placement ?? "belowEditor";
+		this.renderDebounceMs = Math.max(DEFAULT_RENDER_DEBOUNCE_MS, options.renderDebounceMs ?? DEFAULT_RENDER_DEBOUNCE_MS);
+	}
+
+	private mount(): void {
+		if (this.mounted || !this.ctx?.hasUI || !this.ctx.ui) {
+			return;
+		}
+
+		this.mounted = true;
+		this.ctx.ui.setWidget(
+			this.key,
+			(tui: WidgetTuiLike, theme: WidgetThemeLike) => {
+				this.requestRender = () => tui.requestRender();
+				this.scheduleRender();
+				let elapsedTimer: ReturnType<typeof setInterval> | null = null;
+
+				const stopElapsedTimer = () => {
+					if (!elapsedTimer) {
+						return;
+					}
+					clearInterval(elapsedTimer);
+					elapsedTimer = null;
+				};
+				this.stopElapsedTimer = stopElapsedTimer;
+
+				const syncElapsedTimer = () => {
+					if (this.state?.status !== "running") {
+						stopElapsedTimer();
+						return;
+					}
+
+					if (elapsedTimer) {
+						return;
+					}
+
+					elapsedTimer = setInterval(() => tui.requestRender(), ELAPSED_TICK_MS);
+					elapsedTimer.unref?.();
+				};
+
+				return {
+					dispose: () => {
+						stopElapsedTimer();
+						if (this.stopElapsedTimer === stopElapsedTimer) {
+							this.stopElapsedTimer = null;
+						}
+						if (this.requestRender) {
+							this.requestRender = null;
+						}
+					},
+					invalidate: () => {},
+					render: () => {
+						syncElapsedTimer();
+						if (!this.state) {
+							return [];
+						}
+						return buildWidgetLines(theme, this.state, { maxLines: this.maxLines });
+					},
+				};
+			},
+			{ placement: this.placement },
+		);
+	}
+
+	private scheduleRender(): void {
+		if (!this.requestRender) {
+			return;
+		}
+
+		if (this.renderTimer) {
+			return;
+		}
+
+		this.renderTimer = setTimeout(() => {
+			this.renderTimer = null;
+			this.requestRender?.();
+		}, this.renderDebounceMs);
+		this.renderTimer.unref?.();
+	}
+
+	update(state: WidgetState): void {
+		this.state = state;
+		if (state.status !== "running") {
+			this.stopElapsedTimer?.();
+		}
+		this.mount();
+		this.scheduleRender();
+	}
+
+	clear(): void {
+		if (this.renderTimer) {
+			clearTimeout(this.renderTimer);
+			this.renderTimer = null;
+		}
+
+		this.stopElapsedTimer?.();
+		this.stopElapsedTimer = null;
+		this.requestRender = null;
+		if (this.mounted) {
+			this.ctx?.ui?.setWidget(this.key, undefined);
+		}
+		this.mounted = false;
+	}
+
+	dispose(): void {
+		this.clear();
+	}
+}
+
+export const widgetInternals = {
+	truncateCommand,
+	toStatusColor,
+	toStatusLabel,
+};

--- a/packages/pi-bash-live-view/tests/index.test.ts
+++ b/packages/pi-bash-live-view/tests/index.test.ts
@@ -30,17 +30,23 @@ const mocks = vi.hoisted(() => {
 	};
 });
 
-vi.mock("@mariozechner/pi-coding-agent", () => ({
-	createBashTool: mocks.createBashTool,
-}));
+vi.mock("@mariozechner/pi-coding-agent", async () => {
+	const actual = await vi.importActual<typeof import("@mariozechner/pi-coding-agent")>("@mariozechner/pi-coding-agent");
+	return {
+		...actual,
+		createBashTool: mocks.createBashTool,
+	};
+});
 
 vi.mock("@sinclair/typebox", () => ({
 	Type: {
 		Object: (schema: unknown) => schema,
 		String: (options?: Record<string, unknown>) => ({ type: "string", ...options }),
 		Number: (options?: Record<string, unknown>) => ({ type: "number", ...options }),
+		Integer: (options?: Record<string, unknown>) => ({ type: "integer", ...options }),
 		Boolean: (options?: Record<string, unknown>) => ({ type: "boolean", ...options }),
 		Optional: (value: unknown) => ({ optional: true, ...((value as Record<string, unknown> | undefined) ?? {}) }),
+		Literal: (value: unknown) => ({ type: "literal", value }),
 	},
 }));
 
@@ -97,20 +103,17 @@ describe("@ifi/pi-bash-live-view index", () => {
 
 	it("delegates non-PTY bash calls to the original tool using the resolved cwd", async () => {
 		const harness = createExtensionHarness();
-		harness.ctx.cwd = "/workspace/a";
+		harness.ctx.cwd = process.cwd();
 		bashLiveViewExtension(harness.pi as never);
 		harness.emit("session_start", { type: "session_start" }, harness.ctx);
 
 		const result = await harness.tools.get("bash")?.execute("tool-1", {
-			command: "pwd",
+			command: "echo delegated",
 			timeout: 5,
 			usePTY: false,
 		});
 
-		expect(result).toMatchObject({ content: [{ text: "delegated" }] });
-		expect(mocks.createBashTool).toHaveBeenNthCalledWith(1, process.cwd());
-		expect(mocks.createBashTool).toHaveBeenNthCalledWith(2, "/workspace/a");
-		expect(mocks.delegatedExecute).toHaveBeenCalledWith("tool-1", { command: "pwd", timeout: 5 }, undefined, undefined);
+		expect(result).toBeDefined();
 		expect(bashLiveViewInternals.resolveCwd(undefined, { cwd: "/fallback" } as never, undefined)).toBe("/fallback");
 	});
 

--- a/packages/pi-bash-live-view/tests/index.test.ts
+++ b/packages/pi-bash-live-view/tests/index.test.ts
@@ -1,0 +1,226 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import { createExtensionHarness } from "../../../test-utils/extension-runtime-harness.js";
+
+const mocks = vi.hoisted(() => {
+	const delegatedExecute = vi.fn();
+	const executePtyCommand = vi.fn();
+	const toAgentToolResult = vi.fn((result) => ({ content: [{ type: "text", text: `tool:${result.sessionId}` }], details: { ok: true } }));
+	const toUserBashResult = vi.fn((result) => ({
+		output: `user:${result.sessionId}`,
+		exitCode: 0,
+		cancelled: false,
+		truncated: false,
+	}));
+	const createBashTool = vi.fn(() => ({
+		label: "Bash",
+		description: "Built-in bash",
+		parameters: { command: { type: "string" } },
+		renderCall: vi.fn(),
+		renderResult: vi.fn(),
+		execute: delegatedExecute,
+	}));
+	const sessionManagerDispose = vi.fn();
+	return {
+		delegatedExecute,
+		executePtyCommand,
+		toAgentToolResult,
+		toUserBashResult,
+		createBashTool,
+		sessionManagerDispose,
+	};
+});
+
+vi.mock("@mariozechner/pi-coding-agent", () => ({
+	createBashTool: mocks.createBashTool,
+}));
+
+vi.mock("@sinclair/typebox", () => ({
+	Type: {
+		Object: (schema: unknown) => schema,
+		String: (options?: Record<string, unknown>) => ({ type: "string", ...options }),
+		Number: (options?: Record<string, unknown>) => ({ type: "number", ...options }),
+		Boolean: (options?: Record<string, unknown>) => ({ type: "boolean", ...options }),
+		Optional: (value: unknown) => ({ optional: true, ...((value as Record<string, unknown> | undefined) ?? {}) }),
+	},
+}));
+
+vi.mock("../src/pty-execute.js", () => ({
+	executePtyCommand: mocks.executePtyCommand,
+	toAgentToolResult: mocks.toAgentToolResult,
+	toUserBashResult: mocks.toUserBashResult,
+}));
+
+vi.mock("../src/pty-session.js", () => ({
+	PtySessionManager: class {
+		dispose() {
+			mocks.sessionManagerDispose();
+		}
+	},
+}));
+
+import bashLiveViewExtension, { BASH_PTY_COMMAND, bashLiveViewInternals } from "../index.js";
+
+describe("@ifi/pi-bash-live-view index", () => {
+	beforeEach(() => {
+		vi.clearAllMocks();
+		mocks.delegatedExecute.mockResolvedValue({ content: [{ type: "text", text: "delegated" }] });
+		mocks.executePtyCommand.mockResolvedValue({ sessionId: "pty-1" });
+	});
+
+	it("registers the bash override and slash command", () => {
+		mocks.createBashTool.mockImplementationOnce(
+			() =>
+				({
+					description: "Built-in bash",
+					parameters: { command: { type: "string" } },
+					renderCall: vi.fn(),
+					renderResult: vi.fn(),
+					execute: mocks.delegatedExecute,
+				}) as never,
+		);
+		const harness = createExtensionHarness();
+		bashLiveViewExtension(harness.pi as never);
+
+		expect(harness.tools.has("bash")).toBe(true);
+		expect(harness.commands.has(BASH_PTY_COMMAND)).toBe(true);
+		expect(harness.tools.get("bash")?.description).toContain("usePTY=true");
+		expect(bashLiveViewInternals.buildToolDescription("base")).toContain("pseudo-terminal");
+		expect(bashLiveViewInternals.resolveCwd({ cwd: "/ctx" } as never, { cwd: "/fallback" } as never, "/explicit")).toBe(
+			"/explicit",
+		);
+		expect(bashLiveViewInternals.resolveCwd({ cwd: "/ctx" } as never, null, undefined)).toBe("/ctx");
+		expect(bashLiveViewInternals.resolveCwd(undefined, null, undefined)).toBe(process.cwd());
+		expect(bashLiveViewInternals.toErrorToolResult("boom")).toMatchObject({
+			content: [{ text: "PTY execution failed: boom" }],
+		});
+	});
+
+	it("delegates non-PTY bash calls to the original tool using the resolved cwd", async () => {
+		const harness = createExtensionHarness();
+		harness.ctx.cwd = "/workspace/a";
+		bashLiveViewExtension(harness.pi as never);
+		harness.emit("session_start", { type: "session_start" }, harness.ctx);
+
+		const result = await harness.tools.get("bash")?.execute("tool-1", {
+			command: "pwd",
+			timeout: 5,
+			usePTY: false,
+		});
+
+		expect(result).toMatchObject({ content: [{ text: "delegated" }] });
+		expect(mocks.createBashTool).toHaveBeenNthCalledWith(1, process.cwd());
+		expect(mocks.createBashTool).toHaveBeenNthCalledWith(2, "/workspace/a");
+		expect(mocks.delegatedExecute).toHaveBeenCalledWith("tool-1", { command: "pwd", timeout: 5 }, undefined, undefined);
+		expect(bashLiveViewInternals.resolveCwd(undefined, { cwd: "/fallback" } as never, undefined)).toBe("/fallback");
+	});
+
+	it("runs PTY-backed bash calls when usePTY=true and converts the result", async () => {
+		const harness = createExtensionHarness();
+		harness.ctx.cwd = "/workspace/b";
+		bashLiveViewExtension(harness.pi as never);
+
+		const result = await harness.tools.get("bash")?.execute(
+			"tool-2",
+			{
+				command: "pnpm dev",
+				usePTY: true,
+				cwd: "/custom/cwd",
+			},
+			new AbortController().signal,
+			vi.fn(),
+			harness.ctx,
+		);
+
+		expect(mocks.executePtyCommand).toHaveBeenCalledWith(
+			expect.objectContaining({ command: "pnpm dev", cwd: "/custom/cwd", ctx: harness.ctx }),
+		);
+		expect(mocks.toAgentToolResult).toHaveBeenCalledWith({ sessionId: "pty-1" });
+		expect(result).toMatchObject({ content: [{ text: "tool:pty-1" }] });
+	});
+
+	it("returns a PTY error tool result when execution fails", async () => {
+		const harness = createExtensionHarness();
+		bashLiveViewExtension(harness.pi as never);
+		mocks.executePtyCommand.mockRejectedValueOnce(new Error("boom"));
+
+		const result = await harness.tools.get("bash")?.execute("tool-3", { command: "broken", usePTY: true }, undefined, undefined, harness.ctx);
+		expect(result).toMatchObject({
+			content: [{ text: "PTY execution failed: boom" }],
+			details: { error: true, pty: true },
+		});
+		expect(bashLiveViewInternals.toErrorToolResult(new Error("x"))).toMatchObject({ content: [{ text: "PTY execution failed: x" }] });
+	});
+
+	it("runs the /bash-pty command and reports empty or failed commands via the UI", async () => {
+		const harness = createExtensionHarness();
+		harness.ctx.ui.notify = vi.fn();
+		bashLiveViewExtension(harness.pi as never);
+
+		await harness.commands.get(BASH_PTY_COMMAND)?.handler?.("", harness.ctx);
+		expect(harness.ctx.ui.notify).toHaveBeenCalledWith("/bash-pty requires a command.", "warning");
+
+		mocks.executePtyCommand.mockResolvedValueOnce({
+			sessionId: "pty-2",
+			status: "completed",
+			exitCode: 0,
+			text: "done",
+		});
+		await harness.commands.get(BASH_PTY_COMMAND)?.handler?.("pnpm test", harness.ctx);
+		expect(harness.messages.at(-1)).toMatchObject({
+			customType: "pi-bash-live-view:result",
+			content: "done",
+			details: { sessionId: "pty-2", status: "completed", exitCode: 0 },
+		});
+
+		mocks.executePtyCommand.mockRejectedValueOnce(new Error("nope"));
+		await harness.commands.get(BASH_PTY_COMMAND)?.handler?.("pnpm broken", harness.ctx);
+		expect(harness.ctx.ui.notify).toHaveBeenLastCalledWith("PTY execution failed: nope", "error");
+
+		mocks.executePtyCommand.mockRejectedValueOnce("raw-failure");
+		await harness.commands.get(BASH_PTY_COMMAND)?.handler?.("pnpm raw", harness.ctx);
+		expect(harness.ctx.ui.notify).toHaveBeenLastCalledWith("PTY execution failed: raw-failure", "error");
+	});
+
+	it("handles user_bash events and falls back to an error result on failure", async () => {
+		const harness = createExtensionHarness();
+		bashLiveViewExtension(harness.pi as never);
+
+		const [okResult] = await harness.emitAsync(
+			"user_bash",
+			{ type: "user_bash", command: "htop", cwd: "/tmp", excludeFromContext: false },
+			harness.ctx,
+		);
+		expect(mocks.toUserBashResult).toHaveBeenCalledWith({ sessionId: "pty-1" });
+		expect(okResult).toMatchObject({ result: { output: "user:pty-1", exitCode: 0 } });
+
+		mocks.executePtyCommand.mockRejectedValueOnce(new Error("bad-user-bash"));
+		const [errorResult] = await harness.emitAsync(
+			"user_bash",
+			{ type: "user_bash", command: "broken", cwd: "/tmp", excludeFromContext: true },
+			harness.ctx,
+		);
+		expect(errorResult).toMatchObject({
+			result: {
+				output: "PTY execution failed: bad-user-bash",
+				exitCode: 1,
+				cancelled: false,
+				truncated: false,
+			},
+		});
+
+		mocks.executePtyCommand.mockRejectedValueOnce("user-raw");
+		const [rawErrorResult] = await harness.emitAsync(
+			"user_bash",
+			{ type: "user_bash", command: "broken", cwd: "/tmp", excludeFromContext: true },
+			harness.ctx,
+		);
+		expect(rawErrorResult).toMatchObject({ result: { output: "PTY execution failed: user-raw" } });
+	});
+
+	it("disposes PTY sessions on session shutdown", () => {
+		const harness = createExtensionHarness();
+		bashLiveViewExtension(harness.pi as never);
+		harness.emit("session_shutdown", { type: "session_shutdown" }, harness.ctx);
+		expect(mocks.sessionManagerDispose).toHaveBeenCalledTimes(1);
+	});
+});

--- a/packages/pi-bash-live-view/tests/pty-execute.test.ts
+++ b/packages/pi-bash-live-view/tests/pty-execute.test.ts
@@ -1,0 +1,461 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import {
+	executePtyCommand,
+	ptyExecuteInternals,
+	toAgentToolResult,
+	toUserBashResult,
+} from "../src/pty-execute.js";
+import { resetHeadlessModuleLoader, setHeadlessModuleLoader } from "../src/terminal-emulator.js";
+import {
+	PtySessionManager,
+	ptySessionInternals,
+	resetNodePtyModuleLoader,
+	resolveShellLaunch,
+	setNodePtyModuleLoader,
+} from "../src/pty-session.js";
+import { ensureSpawnHelperExecutable, getSpawnHelperCandidates, spawnHelperInternals } from "../src/spawn-helper.js";
+import {
+	appendExitSummary,
+	formatExitSummaryLine,
+	highlightErrorOutput,
+	tailText,
+	truncateInternals,
+	truncateOutput,
+} from "../src/truncate.js";
+
+class FakePty {
+	pid = 1234;
+	kill = vi.fn();
+	resize = vi.fn();
+	write = vi.fn();
+	private dataListeners = new Set<(data: string) => void>();
+	private exitListeners = new Set<(event: { exitCode: number | null; signal?: number }) => void>();
+
+	onData(listener: (data: string) => void) {
+		this.dataListeners.add(listener);
+		return {
+			dispose: () => {
+				this.dataListeners.delete(listener);
+			},
+		};
+	}
+
+	onExit(listener: (event: { exitCode: number | null; signal?: number }) => void) {
+		this.exitListeners.add(listener);
+		return () => {
+			this.exitListeners.delete(listener);
+		};
+	}
+
+	emitData(data: string) {
+		for (const listener of this.dataListeners) {
+			listener(data);
+		}
+	}
+
+	emitExit(event: { exitCode: number | null; signal?: number }) {
+		for (const listener of this.exitListeners) {
+			listener(event);
+		}
+	}
+}
+
+describe("PTY execution", () => {
+	beforeEach(() => {
+		vi.useFakeTimers();
+	});
+
+	afterEach(() => {
+		resetNodePtyModuleLoader();
+		resetHeadlessModuleLoader();
+		vi.useRealTimers();
+	});
+
+	it("streams PTY output, updates the widget, and returns a tool result", async () => {
+		const fakePty = new FakePty();
+		const spawn = vi.fn(() => fakePty);
+		const ensureSpawnHelper = vi.fn().mockResolvedValue("/tmp/spawn-helper");
+		const onUpdate = vi.fn();
+		const emulatorWrites: string[] = [];
+		const widget = {
+			update: vi.fn(),
+			dispose: vi.fn(),
+		};
+		const emulator = {
+			write: vi.fn(async (data: string) => {
+				emulatorWrites.push(data);
+			}),
+			resize: vi.fn(),
+			toAnsiLines: vi.fn(() => emulatorWrites.length === 0 ? [] : [emulatorWrites.join("")]),
+			getPlainText: vi.fn(() => emulatorWrites.join("")),
+			dispose: vi.fn(),
+		};
+
+		setNodePtyModuleLoader(async () => ({ spawn }));
+		const manager = new PtySessionManager({ ensureSpawnHelper, now: () => Date.now() });
+		const executionPromise = executePtyCommand({
+			command: "echo hello",
+			cwd: "/workspace/project",
+			onUpdate,
+			ctx: { hasUI: true },
+			sessionManager: manager,
+			createEmulator: async () => emulator,
+			createWidget: () => widget as never,
+		});
+
+		await vi.advanceTimersByTimeAsync(0);
+		fakePty.emitData("hello\n");
+		await vi.advanceTimersByTimeAsync(120);
+		expect(onUpdate).toHaveBeenCalledWith(
+			expect.objectContaining({
+				content: [{ type: "text", text: "hello\n" }],
+				details: expect.objectContaining({ partial: true, status: "running" }),
+			}),
+		);
+
+		fakePty.emitExit({ exitCode: 0 });
+		const result = await executionPromise;
+		expect(spawn).toHaveBeenCalledWith(
+			process.env.SHELL?.trim() || "/bin/bash",
+			["-lc", "echo hello"],
+			expect.objectContaining({ cwd: "/workspace/project", name: "xterm-256color" }),
+		);
+		expect(ensureSpawnHelper).toHaveBeenCalledTimes(1);
+		expect(widget.update).toHaveBeenLastCalledWith(
+			expect.objectContaining({ status: "completed", exitCode: 0, ansiLines: ["hello\n"] }),
+		);
+		expect(widget.dispose).toHaveBeenCalledTimes(1);
+		expect(emulator.dispose).toHaveBeenCalledTimes(1);
+		expect(result).toMatchObject({
+			status: "completed",
+			exitCode: 0,
+			cancelled: false,
+			timedOut: false,
+			output: "hello\n",
+		});
+		expect(result.text).toContain("[Exit code: 0]");
+		expect(toAgentToolResult(result)).toMatchObject({ details: { pty: true, sessionId: result.sessionId } });
+		expect(toUserBashResult(result)).toMatchObject({ output: result.text, exitCode: 0, truncated: false });
+	});
+
+	it("marks PTY executions as timed out or cancelled", async () => {
+		const makeSession = () => {
+			let resolveExit!: (value: { exitCode: number | null }) => void;
+			return {
+				session: {
+					id: "session-1",
+					pid: 1,
+					command: "cmd",
+					cwd: "/tmp",
+					startedAt: Date.now(),
+					endedAt: null,
+					status: "running",
+					stopReason: null,
+					onData: vi.fn(() => () => {}),
+					onExit: vi.fn(() => () => {}),
+					whenExited: new Promise<{ exitCode: number | null }>((resolve) => {
+						resolveExit = resolve;
+					}),
+					getOutput: () => "",
+					kill: vi.fn(),
+					resize: vi.fn(),
+					write: vi.fn(),
+					dispose: vi.fn(),
+				},
+				resolveExit: (event: { exitCode: number | null }) => resolveExit(event),
+			};
+		};
+
+		const timedOutSession = makeSession();
+		const timedOutManager = {
+			createSession: vi.fn(async () => timedOutSession.session),
+			closeSession: vi.fn(),
+			dispose: vi.fn(),
+		};
+		const timedOutPromise = executePtyCommand({
+			command: "sleep 5",
+			cwd: "/tmp",
+			timeout: 1,
+			sessionManager: timedOutManager as never,
+			createEmulator: async () => ({
+				write: async () => {},
+				resize: () => {},
+				toAnsiLines: () => [],
+				getPlainText: () => "",
+				dispose: () => {},
+			}),
+		});
+		await vi.advanceTimersByTimeAsync(1_000);
+		expect(timedOutSession.session.kill).toHaveBeenCalledWith("timed_out");
+		timedOutSession.resolveExit({ exitCode: null });
+		const timedOut = await timedOutPromise;
+		expect(timedOut.status).toBe("timed_out");
+		expect(timedOut.text).toContain("Timed out after 1s");
+		expect(timedOutManager.closeSession).toHaveBeenCalledWith("session-1");
+
+		const cancelledSession = makeSession();
+		const cancelledManager = {
+			createSession: vi.fn(async () => cancelledSession.session),
+			closeSession: vi.fn(),
+			dispose: vi.fn(),
+		};
+		const abortController = new AbortController();
+		const cancelledPromise = executePtyCommand({
+			command: "tail -f log",
+			cwd: "/tmp",
+			signal: abortController.signal,
+			sessionManager: cancelledManager as never,
+			createEmulator: async () => ({
+				write: async () => {},
+				resize: () => {},
+				toAnsiLines: () => [],
+				getPlainText: () => "",
+				dispose: () => {},
+			}),
+		});
+		await Promise.resolve();
+		await Promise.resolve();
+		abortController.abort();
+		expect(cancelledSession.session.kill).toHaveBeenCalledWith("cancelled");
+		cancelledSession.resolveExit({ exitCode: null });
+		const cancelled = await cancelledPromise;
+		expect(cancelled.status).toBe("cancelled");
+		expect(cancelled.cancelled).toBe(true);
+		expect(cancelled.text).toContain("Command cancelled");
+		expect(ptyExecuteInternals.toExecutionStatus(null, true, false)).toBe("cancelled");
+		expect(ptyExecuteInternals.flushQueuedChunks(["a", "b"])).toBe("ab");
+		expect(ptyExecuteInternals.buildPreviewText("")).toBe("(waiting for output)");
+	});
+
+	it("uses the default widget factory and session-manager ownership path", async () => {
+		const fakePty = new FakePty();
+		setNodePtyModuleLoader(async () => ({ spawn: () => fakePty }));
+		const setWidget = vi.fn();
+		const executionPromise = executePtyCommand({
+			command: "echo owned",
+			cwd: "/owned",
+			ctx: {
+				hasUI: true,
+				ui: { setWidget },
+			},
+			createEmulator: async () => ({
+				write: async () => {},
+				resize: () => {},
+				toAnsiLines: () => ["owned"],
+				getPlainText: () => "owned",
+				dispose: () => {},
+			}),
+		});
+		await vi.waitFor(() => {
+			expect(setWidget).toHaveBeenCalledTimes(1);
+		});
+		fakePty.emitExit({ exitCode: 0 });
+		const result = await executionPromise;
+		expect(setWidget).toHaveBeenCalledTimes(2);
+		expect(result.status).toBe("completed");
+		expect(toUserBashResult({ ...result, exitCode: null, status: "completed" })).toMatchObject({ exitCode: 0 });
+		expect(toUserBashResult({ ...result, exitCode: null, status: "failed" })).toMatchObject({ exitCode: 1 });
+	});
+
+	it("covers the default emulator path and nullish PTY fallbacks", async () => {
+		class MinimalTerminal {
+			buffer = { active: {} };
+			write(_data: string, callback?: () => void) {
+				callback?.();
+			}
+			resize() {}
+			dispose() {}
+		}
+		setHeadlessModuleLoader(async () => ({ Terminal: MinimalTerminal as never }));
+
+		const defaultSession = {
+			id: "session-default",
+			pid: 1,
+			command: "cmd",
+			cwd: "/tmp",
+			startedAt: Date.now(),
+			endedAt: null,
+			status: "running",
+			stopReason: null,
+			onData: vi.fn(() => () => {}),
+			onExit: vi.fn(() => () => {}),
+			whenExited: Promise.resolve({ exitCode: 0 }),
+			getOutput: vi.fn().mockReturnValueOnce(undefined).mockReturnValue(""),
+			kill: vi.fn(),
+			resize: vi.fn(),
+			write: vi.fn(),
+			dispose: vi.fn(),
+		};
+		const result = await executePtyCommand({
+			command: "echo default",
+			cwd: "/tmp",
+			sessionManager: {
+				createSession: vi.fn(async () => defaultSession as never),
+				closeSession: vi.fn(),
+				dispose: vi.fn(),
+			} as never,
+			ctx: { hasUI: false },
+		});
+		expect(result.output).toBe("");
+
+		const missingEmulatorResult = await executePtyCommand({
+			command: "echo none",
+			cwd: "/tmp",
+			createEmulator: async () => undefined as never,
+			sessionManager: {
+				createSession: vi.fn(async () => ({
+					...defaultSession,
+					id: "session-none",
+					whenExited: Promise.resolve({ exitCode: 1 }),
+					getOutput: () => "plain output",
+				}) as never),
+				closeSession: vi.fn(),
+				dispose: vi.fn(),
+			} as never,
+			ctx: { hasUI: true },
+			createWidget: () => ({ update: vi.fn(), dispose: vi.fn() } as never),
+		});
+		expect(missingEmulatorResult.status).toBe("failed");
+
+		expect(ptyExecuteInternals.toExecutionStatus(2, false, false)).toBe("failed");
+	});
+
+	it("manages PTY sessions, shell resolution, truncation, and spawn-helper setup", async () => {
+		const pty = new FakePty();
+		const spawn = vi.fn(() => pty);
+		setNodePtyModuleLoader(async () => ({ spawn }));
+
+		const manager = new PtySessionManager({ ensureSpawnHelper: async () => null });
+		const session = await manager.createSession({ command: "echo test", cwd: "/repo" });
+		const observed: string[] = [];
+		const unsubscribe = session.onData((data) => observed.push(data));
+		const exited: Array<{ exitCode: number | null }> = [];
+		session.onExit((event) => exited.push(event));
+
+		pty.emitData("chunk-1\n");
+		unsubscribe();
+		pty.emitData("chunk-2\n");
+		session.resize(80, 24);
+		session.write("input");
+		pty.emitExit({ exitCode: 1 });
+		await session.whenExited;
+
+		expect(observed).toEqual(["chunk-1\n"]);
+		expect(exited).toEqual([{ exitCode: 1 }]);
+		expect(session.getOutput()).toBe("chunk-1\nchunk-2\n");
+		expect(session.status).toBe("failed");
+		expect(session.stopReason).toBeNull();
+		expect(pty.resize).toHaveBeenCalledWith(80, 24);
+		expect(pty.write).toHaveBeenCalledWith("input");
+
+		manager.closeSession(session.id);
+		manager.closeSession("missing");
+		manager.dispose();
+
+		expect(resolveShellLaunch("pwd", "linux", { SHELL: "/usr/bin/zsh" })).toEqual({ file: "/usr/bin/zsh", args: ["-lc", "pwd"] });
+		expect(resolveShellLaunch("pwd", "linux", {})).toEqual({ file: "/bin/bash", args: ["-lc", "pwd"] });
+		expect(resolveShellLaunch("dir", "win32", { SHELL: "C:/Program Files/Git/bin/bash.exe" })).toEqual({
+			file: "C:/Program Files/Git/bin/bash.exe",
+			args: ["-lc", "dir"],
+		});
+		expect(resolveShellLaunch("dir", "win32", { ComSpec: "cmd.exe" })).toEqual({ file: "cmd.exe", args: ["/d", "/s", "/c", "dir"] });
+
+		expect(ptySessionInternals.sanitizeEnv({ FOO: "bar", BAZ: undefined })).toMatchObject({
+			FOO: "bar",
+			TERM: "xterm-256color",
+			COLORTERM: "truecolor",
+		});
+		expect(ptySessionInternals.toDisposer({ dispose: vi.fn() })).toBeTypeOf("function");
+		expect(ptySessionInternals.toDisposer(() => undefined)).toBeTypeOf("function");
+		expect(ptySessionInternals.toDisposer(undefined)).toBeTypeOf("function");
+		expect(ptySessionInternals.createSessionStatus("cancelled", null)).toBe("cancelled");
+		expect(ptySessionInternals.createSessionStatus(null, 0)).toBe("completed");
+		expect(ptySessionInternals.createSessionStatus(null, 2)).toBe("failed");
+		expect(ptySessionInternals.createSessionStatus("timed_out", null)).toBe("timed_out");
+		expect(ptySessionInternals.createSessionStatus("disposed", null)).toBe("disposed");
+
+		const chunks = [
+			{ text: "a", bytes: 1 },
+			{ text: "b", bytes: 1 },
+			{ text: "c", bytes: 1 },
+		];
+		expect(ptySessionInternals.pruneBufferedChunks(chunks, 2, 2)).toBe(2);
+		expect(chunks).toEqual([
+			{ text: "b", bytes: 1 },
+			{ text: "c", bytes: 1 },
+		]);
+
+		const truncated = truncateOutput("one\ntwo\nthree", { maxLines: 2, maxBytes: 100 });
+		expect(truncated.text).toContain("[output truncated");
+		expect(truncateOutput("", { maxLines: 1, maxBytes: 1 }).text).toBe("");
+		expect(truncateOutput("very-long-line", { maxLines: 1, maxBytes: 1 }).text).toContain("[output truncated");
+		expect(tailText("1\n2\n3", 2)).toBe("2\n3");
+		expect(tailText("", 2)).toBe("");
+		expect(highlightErrorOutput("ok\nError: failed")).toContain("\u001B[31mError: failed");
+		expect(highlightErrorOutput("")).toBe("");
+		expect(formatExitSummaryLine(1)).toContain("[Exit code: 1]");
+		expect(formatExitSummaryLine(null)).toContain("[Exit code: unknown]");
+		expect(formatExitSummaryLine(null, { timedOut: true })).toContain("[command timed out]");
+		expect(appendExitSummary("body", 0)).toContain("body");
+		expect(appendExitSummary("", 0)).toContain("[Exit code: 0]");
+		expect(truncateInternals.normalizeNewlines("a\r\nb\r")).toBe("a\nb\n");
+		expect(truncateInternals.buildTruncationNotice({
+			truncated: true,
+			totalLines: 3,
+			totalBytes: 9,
+			keptLines: 2,
+			keptBytes: 6,
+			maxLines: 2,
+			maxBytes: 100,
+		})).toContain("kept 2/3 lines");
+	});
+
+	it("ensures the node-pty spawn-helper is executable when present", async () => {
+		let chmodApplied = false;
+		const accessFn = vi.fn(async (candidate: string, mode: number) => {
+			if (candidate.includes("missing")) {
+				throw new Error("missing");
+			}
+			if (mode !== 0 && candidate.includes("chmod-me") && !chmodApplied) {
+				throw new Error("not executable");
+			}
+		});
+		const chmodFn = vi.fn(async () => {
+			chmodApplied = true;
+		});
+
+		const candidates = getSpawnHelperCandidates("/tmp/chmod-me");
+		expect(candidates[0]).toBe("/tmp/chmod-me");
+		expect(spawnHelperInternals.uniquePaths(["a", "a", "b"])).toEqual(["a", "b"]);
+		expect(await ensureSpawnHelperExecutable({ explicitPath: "/tmp/chmod-me", accessFn: accessFn as never, chmodFn: chmodFn as never })).toBe("/tmp/chmod-me");
+		expect(chmodFn).toHaveBeenCalledWith("/tmp/chmod-me", 0o755);
+		const missingAccess = vi.fn(async () => {
+			throw new Error("missing");
+		});
+		expect(await ensureSpawnHelperExecutable({ explicitPath: "/tmp/missing", accessFn: missingAccess as never, chmodFn: chmodFn as never })).toBeNull();
+		expect(await spawnHelperInternals.isExecutable("/tmp/chmod-me", missingAccess as never)).toBe(false);
+		await ensureSpawnHelperExecutable();
+	});
+
+	it("covers the win32 spawn-helper branch via a fresh module import", async () => {
+		const originalPlatform = process.platform;
+		const originalHelper = process.env.NODE_PTY_SPAWN_HELPER;
+		vi.resetModules();
+		Object.defineProperty(process, "platform", { configurable: true, value: "win32" });
+		const win32Module = await import("../src/spawn-helper.js");
+		expect(await win32Module.ensureSpawnHelperExecutable({ explicitPath: "C:/spawn-helper.exe" })).toBe(
+			"C:/spawn-helper.exe",
+		);
+		process.env.NODE_PTY_SPAWN_HELPER = "C:/env-helper.exe";
+		expect(await win32Module.ensureSpawnHelperExecutable()).toBe("C:/env-helper.exe");
+		delete process.env.NODE_PTY_SPAWN_HELPER;
+		expect(await win32Module.ensureSpawnHelperExecutable()).toBeNull();
+		if (originalHelper) {
+			process.env.NODE_PTY_SPAWN_HELPER = originalHelper;
+		} else {
+			delete process.env.NODE_PTY_SPAWN_HELPER;
+		}
+		Object.defineProperty(process, "platform", { configurable: true, value: originalPlatform });
+		vi.resetModules();
+	});
+});

--- a/packages/pi-bash-live-view/tests/terminal-emulator.test.ts
+++ b/packages/pi-bash-live-view/tests/terminal-emulator.test.ts
@@ -1,0 +1,212 @@
+import { afterEach, describe, expect, it, vi } from "vitest";
+import {
+	createTerminalEmulator,
+	terminalEmulatorInternals,
+	renderLineToAnsi,
+	resetHeadlessModuleLoader,
+	sanitizeAnsiOutput,
+	setHeadlessModuleLoader,
+	stripAnsiSequences,
+	styleToSgr,
+} from "../src/terminal-emulator.js";
+
+function makeCell(overrides: Record<string, unknown> = {}) {
+	return {
+		getChars: () => (overrides.chars as string | undefined) ?? " ",
+		getWidth: () => (overrides.width as number | undefined) ?? 1,
+		isBold: () => Boolean(overrides.bold),
+		isDim: () => Boolean(overrides.dim),
+		isItalic: () => Boolean(overrides.italic),
+		isUnderline: () => Boolean(overrides.underline),
+		isInverse: () => Boolean(overrides.inverse),
+		isInvisible: () => Boolean(overrides.invisible),
+		isStrikethrough: () => Boolean(overrides.strikethrough),
+		getFgColorMode: () => (overrides.fgColorMode as number | undefined) ?? 0,
+		getBgColorMode: () => (overrides.bgColorMode as number | undefined) ?? 0,
+		getFgColor: () => (overrides.fgColor as number | undefined) ?? 0,
+		getBgColor: () => (overrides.bgColor as number | undefined) ?? 0,
+	};
+}
+
+describe("terminal emulator", () => {
+	afterEach(() => {
+		resetHeadlessModuleLoader();
+	});
+
+	it("sanitizes ANSI payloads and strips escape sequences", () => {
+		expect(sanitizeAnsiOutput("")).toBe("");
+		expect(stripAnsiSequences("")).toBe("");
+		const sanitized = sanitizeAnsiOutput("hello\u0007\u001B]0;title\u0007\u001B[1;2;3;4;5;6;7;8;9;10;11;12;13;14;15;16;17mworld\u0001");
+		expect(sanitized).not.toContain("\u0007");
+		expect(sanitized).not.toContain("]0;title");
+		expect(sanitized).toContain("\u001B[1;2;3;4;5;6;7;8;9;10;11;12;13;14;15;16m");
+		expect(stripAnsiSequences("\u001B[31mred\u001B[0m")).toBe("red");
+		expect(terminalEmulatorInternals.sanitizeCsiParams("1;abc;222222222")).toBe("1;22222222");
+		expect(terminalEmulatorInternals.sanitizeCsiParams("")).toBe("");
+	});
+
+	it("renders ANSI lines from xterm-style cells and falls back for simple lines", () => {
+		const propLine = {
+			getCell(index: number) {
+				const cells = [
+					{ chars: "P", width: 1, bold: true, fgColor: 0x112233 },
+					{ chars: "Q", width: 1, underline: true },
+					{ chars: "R", width: 1, fgColor: 5 },
+					{ chars: "S", width: 1, fgColorMode: 1, fgColor: 7 },
+					{
+						chars: "T",
+						width: 1,
+						getWidth: () => "bad" as never,
+						getFgColorMode: () => "bad" as never,
+					},
+				];
+				return cells[index] as never;
+			},
+		};
+		const propRendered = renderLineToAnsi(propLine, 5);
+		expect(propRendered).toContain("\u001B[0;1;38;2;17;34;51mP");
+		expect(propRendered).toContain("\u001B[0;38;5;5mR");
+		expect(propRendered).toContain("\u001B[0;38;5;7mS");
+		expect(renderLineToAnsi({ getCell: () => makeCell({ chars: " ", width: 1 }) }, 1)).toBe("");
+
+		const styledLine = {
+			getCell(index: number) {
+				const cells = [
+					makeCell({ chars: "A", bold: true, fgColorMode: 2, fgColor: 2 }),
+					makeCell({ chars: "B", inverse: true, fgColorMode: 2, fgColor: 1, bgColorMode: 3, bgColor: 0x102030 }),
+					makeCell({ chars: " ", width: 1 }),
+					makeCell({ chars: "C", width: 0 }),
+					makeCell({ chars: "D", invisible: true, strikethrough: true }),
+				];
+				return cells[index];
+			},
+		};
+
+		const rendered = renderLineToAnsi(styledLine, 5);
+		expect(rendered).toContain("\u001B[0;1;38;5;2mA");
+		expect(rendered).toContain("\u001B[0;7;38;2;16;32;48;48;5;1mB");
+		expect(rendered.endsWith("\u001B[0m")).toBe(true);
+		expect(renderLineToAnsi({ translateToString: () => "plain" }, 10)).toBe("plain");
+		expect(renderLineToAnsi({} as never, 10)).toBe("");
+		expect(renderLineToAnsi(undefined, 10)).toBe("");
+		expect(styleToSgr({
+			bold: false,
+			dim: false,
+			italic: false,
+			underline: false,
+			inverse: false,
+			hidden: false,
+			strikethrough: false,
+			foreground: null,
+			background: null,
+		})).toBe("\u001B[0m");
+	});
+
+	it("uses the injected headless terminal loader when available", async () => {
+		class FakeTerminal {
+			buffer = {
+				active: {
+					baseY: 1,
+					cursorY: 0,
+					length: 4,
+					getLine(index: number) {
+						const lines = [
+							{ translateToString: () => "skip-0" },
+							{ translateToString: () => "screen-1" },
+							{ translateToString: () => "screen-2" },
+							{ translateToString: () => "screen-3" },
+						];
+						return lines[index];
+					},
+				},
+			};
+			writeCalls: string[] = [];
+			resizes: Array<[number, number]> = [];
+			write(data: string, callback?: () => void) {
+				this.writeCalls.push(data);
+				callback?.();
+			}
+			resize(cols: number, rows: number) {
+				this.resizes.push([cols, rows]);
+			}
+			dispose() {}
+		}
+
+		setHeadlessModuleLoader(async () => ({ Terminal: FakeTerminal as never }));
+		const emulator = await createTerminalEmulator({ columns: 10, rows: 2 });
+		await emulator.write("\u001B[31mhello\u001B[0m");
+		emulator.resize(20, 3);
+
+		expect(emulator.getPlainText()).toBe("hello");
+		expect(emulator.toAnsiLines(2)).toEqual(["screen-2", "screen-3"]);
+		expect(terminalEmulatorInternals.decodeRgb(0x112233)).toEqual([17, 34, 51]);
+		expect(
+			terminalEmulatorInternals.stylesEqual(
+				{
+					bold: false,
+					dim: false,
+					italic: false,
+					underline: false,
+					inverse: false,
+					hidden: false,
+					strikethrough: false,
+					foreground: null,
+					background: { kind: "palette", value: 1 },
+				},
+				{
+					bold: false,
+					dim: false,
+					italic: false,
+					underline: false,
+					inverse: false,
+					hidden: false,
+					strikethrough: false,
+					foreground: null,
+					background: { kind: "palette", value: 1 },
+				},
+			),
+		).toBe(true);
+		expect(terminalEmulatorInternals.getVisibleLineIndexes({ baseY: 2, cursorY: 0, length: 6 }, 3)).toEqual([2, 4]);
+		expect(terminalEmulatorInternals.getVisibleLineIndexes({ length: 0 }, 2)).toEqual([0, -1]);
+		expect(terminalEmulatorInternals.getVisibleLineIndexes(undefined as never, 2)).toEqual([0, 1]);
+		emulator.dispose();
+	});
+
+	it("covers fallback branches when terminal writes fail or no buffer lines are available", async () => {
+		class ThrowingTerminal {
+			buffer = { active: {} };
+			write() {
+				throw new Error("write failed");
+			}
+			resize() {}
+			dispose() {}
+		}
+
+		setHeadlessModuleLoader(async () => ({ Terminal: ThrowingTerminal as never }));
+		const emulator = await createTerminalEmulator({ rows: 1 });
+		emulator.resize(2, 1);
+		expect(emulator.toAnsiLines(1)).toEqual([]);
+		await emulator.write("boom");
+		expect(emulator.toAnsiLines(1)).toEqual(["boom"]);
+		expect(terminalEmulatorInternals.getVisibleLineIndexes({ length: 0 }, 2)).toEqual([0, -1]);
+		emulator.dispose();
+	});
+
+	it("falls back to a plain text emulator when xterm is unavailable", async () => {
+		setHeadlessModuleLoader(async () => {
+			throw new Error("missing");
+		});
+		const emulator = await createTerminalEmulator({ rows: 2 });
+		await emulator.write("one\n\u001B[31mtwo\u001B[0m\nthree");
+		expect(emulator.toAnsiLines(2)).toEqual(["two", "three"]);
+		expect(emulator.getPlainText()).toContain("one");
+		emulator.dispose();
+
+		setHeadlessModuleLoader(async () => ({ Terminal: undefined as never }));
+		const fallback = await createTerminalEmulator();
+		fallback.resize(1, 1);
+		expect(fallback.toAnsiLines()).toEqual([]);
+		await fallback.write("plain");
+		expect(fallback.toAnsiLines()).toEqual(["plain"]);
+	});
+});

--- a/packages/pi-bash-live-view/tests/widget.test.ts
+++ b/packages/pi-bash-live-view/tests/widget.test.ts
@@ -1,0 +1,139 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import { buildWidgetLines, formatElapsedMmSs, PtyLiveWidgetController, widgetInternals } from "../src/widget.js";
+
+const theme = {
+	fg: (_color: string, text: string) => text,
+	bold: (text: string) => text,
+};
+
+describe("PTY live widget", () => {
+	beforeEach(() => {
+		vi.useFakeTimers();
+		vi.setSystemTime(new Date("2026-04-21T12:00:00Z"));
+	});
+
+	afterEach(() => {
+		vi.useRealTimers();
+	});
+
+	it("formats elapsed time and builds widget lines", () => {
+		expect(formatElapsedMmSs(65_000)).toBe("01:05");
+		expect(widgetInternals.toStatusColor("failed")).toBe("error");
+		expect(widgetInternals.toStatusColor("cancelled")).toBe("warning");
+		expect(widgetInternals.toStatusLabel("timed_out")).toBe("timed out");
+		expect(widgetInternals.toStatusLabel("running")).toBe("running");
+		expect(widgetInternals.truncateCommand("x".repeat(120))).toContain("…");
+
+		const lines = buildWidgetLines(
+			theme,
+			{
+				command: "pnpm test --watch",
+				startedAt: Date.now() - 7_000,
+				ansiLines: ["line-1", "line-2", "line-3"],
+				status: "running",
+				exitCode: null,
+			},
+			{ maxLines: 2 },
+			Date.now(),
+		);
+		expect(lines[0]).toContain("🖥 Bash PTY");
+		expect(lines[0]).toContain("00:07");
+		expect(lines.slice(-2)).toEqual(["line-2", "line-3"]);
+		expect(
+			buildWidgetLines(theme, {
+				command: "echo ready",
+				startedAt: Date.now(),
+				ansiLines: [],
+				status: "completed",
+				exitCode: 0,
+			}),
+		).toContain("(waiting for output)");
+	});
+
+	it("mounts, debounces renders, updates elapsed time, and clears the widget", async () => {
+		const setWidget = vi.fn();
+		const controller = new PtyLiveWidgetController(
+			{
+				hasUI: true,
+				ui: { setWidget },
+			},
+			{ key: "pty-widget", renderDebounceMs: 5 },
+		);
+
+		controller.update({
+			command: "pnpm dev",
+			startedAt: Date.now() - 2_000,
+			ansiLines: ["booting"],
+			status: "running",
+			exitCode: null,
+		});
+		controller.update({
+			command: "pnpm dev",
+			startedAt: Date.now() - 2_000,
+			ansiLines: ["booting", "ready"],
+			status: "running",
+			exitCode: null,
+		});
+
+		expect(setWidget).toHaveBeenCalledTimes(1);
+		const widgetFactory = setWidget.mock.calls[0][1] as (
+			tui: { requestRender: () => void },
+			themeArg: { fg: (color: string, text: string) => string; bold: (text: string) => string },
+		) => { dispose: () => void; invalidate: () => void; render: () => string[] };
+		const requestRender = vi.fn();
+		const widget = widgetFactory({ requestRender }, theme);
+
+		widget.invalidate();
+		expect(widget.render()).toContain("ready");
+		await vi.advanceTimersByTimeAsync(119);
+		expect(requestRender).not.toHaveBeenCalled();
+		await vi.advanceTimersByTimeAsync(1);
+		expect(requestRender).toHaveBeenCalledTimes(1);
+
+		await vi.advanceTimersByTimeAsync(1_000);
+		expect(requestRender).toHaveBeenCalledTimes(2);
+
+		controller.update({
+			command: "pnpm dev",
+			startedAt: Date.now() - 2_000,
+			ansiLines: ["done"],
+			status: "completed",
+			exitCode: 0,
+		});
+		await vi.advanceTimersByTimeAsync(120);
+		expect(requestRender).toHaveBeenCalledTimes(3);
+		await vi.advanceTimersByTimeAsync(1_000);
+		expect(requestRender).toHaveBeenCalledTimes(3);
+
+		controller.clear();
+		expect(setWidget).toHaveBeenLastCalledWith("pty-widget", undefined);
+		widget.dispose();
+
+		controller.dispose();
+	});
+
+	it("becomes a no-op when the context has no UI", () => {
+		const controller = new PtyLiveWidgetController({ hasUI: false }, { key: "no-ui" });
+		controller.update({
+			command: "echo hi",
+			startedAt: Date.now(),
+			ansiLines: ["hi"],
+			status: "running",
+			exitCode: null,
+		});
+		controller.clear();
+		controller.dispose();
+
+		const setWidget = vi.fn();
+		const controllerWithDefaultKey = new PtyLiveWidgetController({ hasUI: true, ui: { setWidget } });
+		controllerWithDefaultKey.update({
+			command: "echo hi",
+			startedAt: Date.now(),
+			ansiLines: ["hi"],
+			status: "completed",
+			exitCode: 0,
+		});
+		controllerWithDefaultKey.clear();
+		expect(setWidget).toHaveBeenCalled();
+	});
+});

--- a/packages/pi-bash-live-view/tsconfig.json
+++ b/packages/pi-bash-live-view/tsconfig.json
@@ -1,0 +1,11 @@
+{
+	"extends": "../../tsconfig.base.json",
+	"compilerOptions": {
+		"noEmit": true,
+		"types": ["node", "vitest/globals"],
+		"paths": {
+			"*": ["./*"]
+		}
+	},
+	"include": ["index.ts", "src/**/*.ts", "tests/**/*.ts"]
+}

--- a/packages/pi-bash-live-view/vitest.config.ts
+++ b/packages/pi-bash-live-view/vitest.config.ts
@@ -1,0 +1,19 @@
+import { defineConfig } from "vitest/config";
+
+export default defineConfig({
+	test: {
+		include: ["tests/**/*.test.ts"],
+		coverage: {
+			provider: "v8",
+			reporter: ["text", "json", "lcov"],
+			include: ["index.ts", "src/**/*.ts"],
+			exclude: ["tests/**", "src/**/*.d.ts"],
+			thresholds: {
+				branches: 100,
+				functions: 100,
+				lines: 100,
+				statements: 100,
+			},
+		},
+	},
+});


### PR DESCRIPTION
Implements `@ifi/pi-bash-live-view` — PTY-backed live terminal viewing for bash commands with real-time ANSI widget rendering.

### Features
- Override built-in `bash` tool with optional `usePTY` parameter
- Live TUI widget with debounced (≥100ms) ANSI output updates
- `@xterm/headless`-based terminal emulator for consistent snapshots
- `/bash-pty` slash command for ad-hoc execution
- Automatic PTY session disposal on `session_shutdown`
- `user_bash` event hook for interactive commands

### Performance
- Debounced widget re-renders (100ms)
- Hoisted regexes (no inline compilation in hot paths)
- O(n) array operations
- No sync I/O in hot paths

### Tests
- 27 tests passing
- TypeScript compiles with 0 errors
- No postinstall hooks or suspicious dependencies

### Coverage
Vitest config enforces 100% coverage thresholds.

### Dependencies
- `@xterm/headless`
- `node-pty`