### PR TITLE
fix: scheduler dispatch not triggering agent turns reliably

### DIFF
--- a/.changeset/fix-scheduler-dispatch-followup.md
+++ b/.changeset/fix-scheduler-dispatch-followup.md
@@ -1,0 +1,5 @@
+---
+default: patch
+---
+
+Fix scheduled task dispatching to use `deliverAs: "followUp"` alongside `triggerTurn: true`. This ensures scheduled prompts are properly injected into the agent's message stream and trigger a real LLM turn, matching the behavior of the previous `sendUserMessage` approach.

--- a/packages/extensions/extensions/scheduler.ts
+++ b/packages/extensions/extensions/scheduler.ts
@@ -1243,7 +1243,7 @@ export class SchedulerRuntime {
 					display: true,
 					details: { taskId: task.id, taskMode: this.taskMode(task), runCount: task.runCount + 1 },
 				},
-				{ triggerTurn: true },
+				{ triggerTurn: true, deliverAs: "followUp" },
 			);
 			this.recordDispatch(now);
 		} catch {


### PR DESCRIPTION
## Problem

Scheduled tasks were dispatching but not reliably triggering LLM agent turns. In PR #233, the scheduler switched from `sendUserMessage` to `sendMessage` with `triggerTurn: true`.

However, without `deliverAs: "followUp"`, the dispatched prompt may not properly inject into the LLM message stream as a user message in all runtime states.

## Fix

Add `deliverAs: "followUp"` to the `sendMessage` options. This aligns with:
- `background-tasks` — uses `{ triggerTurn: true, deliverAs: "followUp" }`
- `ant-colony` — uses `{ triggerTurn: true, deliverAs: "followUp" }`

## Verification

- All 267 scheduler tests pass
- All 528 extension tests pass
- Single-line change in `packages/extensions/extensions/scheduler.ts`

**Fixes:** Schedule command usage regression introduced in #233