### PR TITLE
docs(git-pr-workflow): add issue title casing and PR title conventions

### DIFF
--- a/docs/agent-rules/git-and-pr-workflow.md
+++ b/docs/agent-rules/git-and-pr-workflow.md
@@ -22,6 +22,30 @@ Use these types:
 - `chore`
 - `revert`
 
+## Issue titles
+
+Write issue titles in sentence case — capitalize only the first word and proper nouns.
+
+- ✅ "Fix memory leak in usage tracker"
+- ✅ "Support nested worktree paths on Windows"
+- ❌ "Fix Memory Leak In Usage Tracker"
+- ❌ "Support Nested Worktree Paths On Windows"
+
+## Pull request titles
+
+PR titles must follow conventional commits, just like commit messages:
+
+```text
+type(scope)?: description
+```
+
+- ✅ `feat(extensions): add context-aware rate limiting`
+- ✅ `fix(ui): resolve race condition in footer render`
+- ❌ `Add context-aware rate limiting`
+- ❌ `Fixed bug with footer`
+
+This keeps the commit history clean after squash merging and makes the PR list scannable.
+
 ## Branch hygiene
 
 - Rebase onto `main` regularly while working to avoid falling behind and minimize merge conflicts.


### PR DESCRIPTION
Adds explicit rules to the Git and PR workflow document for consistent project hygiene.

## New rules

### Issue titles
- Must use sentence case (only first word and proper nouns capitalized)
- Examples: "Fix memory leak in usage tracker" ✅ vs "Fix Memory Leak In Usage Tracker" ❌

### Pull request titles  
- Must follow conventional commits (same format as commit messages)
- Examples:  ✅ vs  ❌

## Rationale
- Keeps issue lists readable and consistent
- PR titles become the squash-merge commit message, so conventional format preserves clean history
- Makes the PR list scannable by type (feat/fix/docs/etc.)

## Checklist
- [x] Agent rules document updated
- [x] No code changes — docs only