### PR TITLE
fix: stop scheduler idle heartbeat and cache compact-header catalog

### DIFF
--- a/.changeset/fix-bg-task-auto-background.md
+++ b/.changeset/fix-bg-task-auto-background.md
@@ -1,0 +1,13 @@
+---
+default: patch
+---
+
+Remove auto-backgrounding from the `bash` tool override in `@ifi/pi-background-tasks`.
+
+The extension no longer intercepts ordinary `bash` calls to promote them into
+background tasks after a timeout. Instead, the `bash` tool passes through to
+pi's built-in execution flow so output stays visible in the foreground.
+
+Background task management remains available through `bg_task`, `bg_status`,
+`/bg`, and `Ctrl+Shift+B` for commands that should explicitly run in the
+background (e.g. dev servers, file watchers, log tails).

--- a/.changeset/fix-scheduler-idle-churn-and-header-render-cache.md
+++ b/.changeset/fix-scheduler-idle-churn-and-header-render-cache.md
@@ -1,0 +1,11 @@
+---
+default: patch
+---
+
+Fix two sources of typing lag in long-running pi sessions:
+
+1. **Scheduler idle heartbeat**: The scheduler previously started a 1-second heartbeat interval on every `session_start`, even when no tasks were scheduled. Over time this added unnecessary event-loop wake-ups and disk I/O. It now lazily starts the heartbeat only when the first task is added, and stops it when the last task is removed.
+
+2. **Compact-header per-render catalog scan**: The compact header rebuilt the full prompt/skill command list on every render (which fires on every keystroke). The catalog is now computed once at header mount and reused across renders.
+
+This also tightens the runtime-churn benchmark so the isolated scheduler scenario must show exactly zero widget, footer, status, and notification churn when no tasks exist.

--- a/README.md
+++ b/README.md
@@ -382,19 +382,19 @@ agent or inject a generated summary instead.
 
 ### ⏳ Background Process (`bg-process`) — **default: off**
 
-Automatically backgrounds long-running commands (dev servers, builds, test suites). When a command
-exceeds a 10-second timeout, it's moved to the background and the agent gets the PID + log file
-path.
+Manages explicit background tasks for long-lived commands like dev servers, PR watchers, and log
+followers. Ordinary `bash` commands stay in the foreground so their output remains visible in the
+current pi session.
 
-**How it works:** Overrides the built-in `bash` tool. Spawns commands with a timer — if they're
-still running after 10s, detaches them and writes output to `/tmp/oh-pi-bg-*.log`. Provides a
-`bg_status` tool for listing, viewing logs, and stopping background processes.
+**How it works:** Use `bg_task` or `/bg` when you want a command to keep running after the tool
+returns. Background tasks write output to `/tmp/oh-pi-bg-*.log`, can wake pi up on new output, and
+can be inspected or stopped later with `bg_status`, `bg_task`, or the `/bg` dashboard.
 
 ```
-Agent: bash npm run dev
-→ Command still running after 10s, moved to background.
-  PID: 12345 | Log: /tmp/oh-pi-bg-1709654321.log
-  ⏳ You will be notified automatically when it finishes.
+Agent: bg_task spawn "npm run dev"
+→ Started bg-1 (pid 12345) in the background.
+  Log: /tmp/oh-pi-bg-bg-1-1709654321.log
+  ⏳ Pi can notify you when new output arrives or when the task exits.
 ```
 
 **Commands:** `bg_status list` | `bg_status log --pid 12345` | `bg_status stop --pid 12345`

--- a/benchmarks/live-runtime-behavior.ts
+++ b/benchmarks/live-runtime-behavior.ts
@@ -1,5 +1,6 @@
 #!/usr/bin/env node
 import { performance } from "node:perf_hooks";
+import { buildCommandCatalog } from "../packages/extensions/extensions/compact-header.ts";
 
 function time(label, fn, iterations) {
 	const start = performance.now();
@@ -13,6 +14,21 @@ function time(label, fn, iterations) {
 		totalMs,
 		avgMs: totalMs / iterations,
 	};
+}
+
+function makeCommands(count) {
+	const commands = [];
+	for (let index = 0; index < count; index++) {
+		commands.push({
+			name: `command-${index}`,
+			source: index % 6 === 0 ? "prompt" : index % 5 === 0 ? "skill" : "command",
+		});
+	}
+	return commands;
+}
+
+function renderHeaderFromCatalog(catalog) {
+	return `${catalog.prompts}\n${catalog.skills}`;
 }
 
 function makeJobs(count) {
@@ -63,7 +79,18 @@ function makeSamples(count) {
 
 const iterations = 500;
 
-console.log("Subagent widget scaling with and without the display cap (MAX_WIDGET_JOBS=4)\n");
+console.log("Compact-header command catalog rebuild vs cached render data\n");
+console.log("commands\trebuild avg\tcached avg\tspeedup");
+for (const size of [10, 100, 1_000, 10_000]) {
+	const commands = makeCommands(size);
+	const catalog = buildCommandCatalog(commands);
+	const rebuild = time("rebuild", () => buildCommandCatalog(commands), iterations);
+	const cached = time("cached", () => renderHeaderFromCatalog(catalog), iterations);
+	const speedup = cached.totalMs > 0 ? rebuild.totalMs / cached.totalMs : Number.POSITIVE_INFINITY;
+	console.log(`${size}\t${rebuild.avgMs.toFixed(4)}ms\t${cached.avgMs.toFixed(4)}ms\t${speedup.toFixed(1)}x`);
+}
+
+console.log("\nSubagent widget scaling with and without the display cap (MAX_WIDGET_JOBS=4)\n");
 console.log("jobs\tuncapped avg\tcapped avg\tspeedup");
 for (const size of [1, 4, 16, 64]) {
 	const jobs = makeJobs(size);

--- a/benchmarks/runtime/runtime-bench.test.ts
+++ b/benchmarks/runtime/runtime-bench.test.ts
@@ -11,6 +11,15 @@ describe("runtime churn benchmark suite", () => {
 			const suite = await createRuntimeBenchmarkSuite();
 			try {
 				expect(suite.report.results.length).toBeGreaterThan(0);
+
+				const schedulerIdle = suite.report.results.find((result) => result.id === "extension-runtime-idle-scheduler");
+				expect(schedulerIdle).toBeDefined();
+				expect(schedulerIdle).toMatchObject({
+					widgetRenderRequests: 0,
+					footerRenderRequests: 0,
+					statusUpdates: 0,
+					notifications: 0,
+				});
 			} finally {
 				await suite.cleanup();
 				vi.useRealTimers();

--- a/docs/feature-catalog.md
+++ b/docs/feature-catalog.md
@@ -168,7 +168,7 @@ This package is where most of the day-to-day ergonomics live.
 | `auto-update` | startup notification | Checks npm asynchronously and tells you when a newer oh-pi release is available |
 | `external-editor` | `/external-editor`, `Ctrl+Shift+E` | Opens the current draft in `$VISUAL` or `$EDITOR`, then syncs the saved text back into pi |
 | `worktree` | `/worktree`, `/worktree list`, `/worktree create`, `/worktree cleanup` | Gives oh-pi first-class git worktree awareness and managed pi-owned worktrees under shared storage |
-| `bg-process` | `bash` override, `bg_status` tool | Automatically detaches long-running commands after a timeout and lets the agent inspect/stop them later |
+| `bg-process` | `bg_task`, `bg_status`, `/bg`, `Ctrl+Shift+B` | Explicitly manages long-lived background tasks like watchers, servers, and log tails without auto-detaching ordinary bash commands |
 | `scheduler` | `/remind`, `/loop`, `/schedule*`, `schedule_prompt` tool | Schedules one-time reminders and recurring follow-ups for builds, CI, deploys, PRs, and long-running checks |
 | `usage-tracker` | widget, `/usage`, `/usage-toggle`, `/usage-refresh`, `Ctrl+U`, `usage_report` | Tracks provider quotas, rolling cost history, and per-model/session usage |
 | `btw` / `qq` | `/btw*`, `/qq*` | Runs side conversations in a widget above the editor, then injects the full thread or a summary back into the main agent |
@@ -219,7 +219,7 @@ It includes:
 
 ## `@ifi/pi-background-tasks`: reactive background shell tasks
 
-This package promotes long-running shell commands from an implementation detail into a first-class pi workflow.
+This package turns explicit long-lived shell tasks into a first-class pi workflow while leaving ordinary `bash` commands in the foreground.
 
 ### Primary surfaces
 
@@ -565,7 +565,7 @@ The AGENTS template pack currently ships 5 templates.
 ## Which feature should I reach for?
 
 - **Safer day-to-day pi sessions** → `@ifi/oh-pi-extensions`
-- **Long-running shell commands, watches, and log tails** → `@ifi/pi-background-tasks`
+- **Long-lived watchers, servers, and log tails** → `@ifi/pi-background-tasks`
 - **Timing and completion visibility** → `@ifi/pi-diagnostics`
 - **Large parallel work** → `@ifi/oh-pi-ant-colony`
 - **Named specialists and reusable pipelines** → `@ifi/pi-extension-subagents`

--- a/packages/background-tasks/README.md
+++ b/packages/background-tasks/README.md
@@ -16,9 +16,9 @@ npx @ifi/oh-pi
 
 ## What it provides
 
-This package turns background shell commands into a first-class pi workflow:
+This package turns explicit background shell commands into a first-class pi workflow:
 
-- `bash` override — long-running shell commands auto-promote into tracked background tasks after 10s
+- ordinary `bash` commands stay in the foreground and use pi's built-in execution flow
 - `bg_status` — compatibility tool for listing, tailing, and stopping tracked background tasks by PID
 - `bg_task` — richer LLM-callable tool for spawning, listing, tailing, stopping, and clearing tasks by id or PID
 - `/bg` — slash command for launching and managing background tasks manually
@@ -37,7 +37,7 @@ This package turns background shell commands into a first-class pi workflow:
 /bg stop bg-1
 ```
 
-The `bg_task` tool also lets the agent start tasks itself and optionally gate wakeups with a
+The `bg_task` tool lets the agent start tasks explicitly and optionally gate wakeups with a
 substring or `/regex/flags` pattern.
 
 The dashboard supports:
@@ -52,6 +52,7 @@ The dashboard supports:
 
 - tasks are tracked for the current pi runtime and cleaned up on session shutdown
 - every task writes output to a log file so you can inspect recent activity even after the command returns
+- use `bg_task` or `/bg` for servers, watchers, PR checks, and other commands you want to keep running after the tool returns
 - `reactToOutput` defaults to `true`, so long-lived watchers like `gh ... --watch` can wake the agent when new output arrives
 
 This package ships raw `.ts` sources for pi to load directly.

--- a/packages/background-tasks/index.ts
+++ b/packages/background-tasks/index.ts
@@ -3,6 +3,7 @@
 import { spawn } from "node:child_process";
 import { appendFileSync, existsSync, readFileSync, writeFileSync } from "node:fs";
 import {
+	createBashTool,
 	type ExtensionAPI,
 	type ExtensionCommandContext,
 	type ExtensionContext,
@@ -65,8 +66,6 @@ type SpawnTaskOptions = {
 };
 
 type ThemeLike = Theme;
-
-const BG_TIMEOUT_MS = 10_000;
 
 function taskSnapshot(task: ManagedTask): BackgroundTaskSnapshot {
 	return {
@@ -905,100 +904,35 @@ export default function backgroundTasksExtension(pi: ExtensionAPI): void {
 		clearWidget();
 	});
 
+	const bashTemplate = createBashTool(process.cwd()) as ReturnType<typeof createBashTool> & {
+		label?: string;
+		description: string;
+		renderCall?: unknown;
+		renderResult?: unknown;
+	};
+
 	pi.registerTool({
 		name: "bash",
-		label: "Bash",
-		description: `Execute a bash command. Output is truncated to 2000 lines or 50KB. If a command runs longer than ${BG_TIMEOUT_MS / 1000}s, it is automatically moved into the background task runtime and you get the task id, PID, and log file. Background tasks expire after 10 minutes by default. Use bg_status or bg_task to inspect it later.`,
+		label: bashTemplate.label ?? "Bash",
+		description: `${bashTemplate.description} Use bg_task or /bg only for long-lived watchers, servers, and other commands that should keep running after the tool returns.`,
 		parameters: Type.Object({
 			command: Type.String({ description: "Bash command to execute" }),
-			timeout: Type.Optional(Type.Number({ description: "Timeout in seconds before auto-backgrounding" })),
+			timeout: Type.Optional(Type.Number({ description: "Optional timeout in seconds before the command is terminated" })),
 		}),
-		async execute(_toolCallId, params, signal, _onUpdate, _ctx): Promise<any> {
-			const command = params.command.trim();
-			const cwd = activeCtx?.cwd || process.cwd();
-			const timeoutMs = params.timeout ? Math.max(1, params.timeout * 1_000) : BG_TIMEOUT_MS;
-			const { shell, args } = getShellConfig();
+		renderCall: bashTemplate.renderCall as any,
+		renderResult: bashTemplate.renderResult as any,
+		async execute(toolCallId, params, signal, onUpdate, ctx): Promise<any> {
+			const cwd = ctx?.cwd ?? activeCtx?.cwd ?? process.cwd();
+			const bashTool = createBashTool(cwd);
 
-			return await new Promise<any>((resolve) => {
-				let settled = false;
-				let stdout = "";
-				let stderr = "";
-				const child = spawn(shell, [...args, command], {
-					cwd,
-					env: createBgProcessShellEnv(),
-					stdio: ["ignore", "pipe", "pipe"],
-				});
-
-				const finish = (result: { text: string; isError?: boolean; details?: Record<string, unknown> }) => {
-					if (settled) {
-						return;
-					}
-					settled = true;
-					clearTimeout(timer);
-					resolve(makeToolResult(result.text, { details: result.details, isError: result.isError }));
-				};
-
-				child.stdout?.on("data", (chunk: Buffer) => {
-					stdout += chunk.toString();
-				});
-				child.stderr?.on("data", (chunk: Buffer) => {
-					stderr += chunk.toString();
-				});
-
-				const timer = setTimeout(() => {
-					const task = spawnTask({
-						command,
-						cwd,
-						child,
-						initialOutput: stdout + stderr,
-						initialLastAlertLength: (stdout + stderr).length,
-					});
-					const preview = tailText((stdout + stderr).trim(), 500) || "(no output yet)";
-					finish({
-						text: `Command still running after ${timeoutMs / 1000}s, moved to the background.\nTask: ${task.id}\nPID: ${task.pid}\nLog: ${task.logFile}\nExpiry: ${task.expiresAt != null ? formatRelativeTime(task.expiresAt) : "none"}\n\nOutput so far:\n${preview}\n\nPi will watch for new output and notify you when the task exits.`,
-						details: { task: taskSnapshot(task) },
-					});
-				}, timeoutMs);
-				timer.unref?.();
-
-				child.on("close", (code) => {
-					if (settled) {
-						return;
-					}
-					const output = (stdout + stderr).trim();
-					const exitInfo = code === 0 ? "" : `\n[Exit code: ${code}]`;
-					finish({ text: output + exitInfo });
-				});
-
-				child.on("error", (error) => {
-					finish({ text: `Error: ${error.message}`, isError: true });
-				});
-
-				if (signal) {
-					signal.addEventListener(
-						"abort",
-						() => {
-							if (settled) {
-								return;
-							}
-							try {
-								child.kill();
-							} catch {
-								// Ignore abort races for already-exited commands.
-							}
-							finish({ text: "Command cancelled." });
-						},
-						{ once: true },
-					);
-				}
-			});
+			return await bashTool.execute(toolCallId, { command: params.command, timeout: params.timeout } as never, signal, onUpdate);
 		},
 	});
 
 	pi.registerTool({
 		name: "bg_status",
 		label: "Background Process Status",
-		description: "Check status, view output, or stop background tasks that were auto-backgrounded or spawned explicitly.",
+		description: "Check status, view output, or stop background tasks that were spawned explicitly.",
 		parameters: Type.Object({
 			action: StringEnum(["list", "log", "stop"] as const, {
 				description: "list=show tasks, log=view task output, stop=terminate a task",

--- a/packages/background-tasks/tests/background-tasks.test.ts
+++ b/packages/background-tasks/tests/background-tasks.test.ts
@@ -2,7 +2,8 @@ import { EventEmitter } from "node:events";
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 import { createExtensionHarness } from "../../../test-utils/extension-runtime-harness.js";
 
-const { getShellConfigMock, spawnMock } = vi.hoisted(() => ({
+const { createBashToolMock, getShellConfigMock, spawnMock } = vi.hoisted(() => ({
+	createBashToolMock: vi.fn(),
 	getShellConfigMock: vi.fn(() => ({ shell: "/bin/bash", args: ["-lc"] })),
 	spawnMock: vi.fn(),
 }));
@@ -15,6 +16,7 @@ vi.mock("@mariozechner/pi-coding-agent", async () => {
 	const actual = await vi.importActual<typeof import("@mariozechner/pi-coding-agent")>("@mariozechner/pi-coding-agent");
 	return {
 		...actual,
+		createBashTool: createBashToolMock,
 		getAgentDir: () => "/mock-home/.pi/agent",
 		getShellConfig: getShellConfigMock,
 	};
@@ -57,11 +59,47 @@ function createMockChild() {
 describe("background tasks extension", () => {
 	beforeEach(() => {
 		vi.useFakeTimers();
+		createBashToolMock.mockImplementation(() => ({
+			label: "Bash",
+			description: "Built-in bash tool.",
+			renderCall: undefined,
+			renderResult: undefined,
+			execute: vi.fn(async () => ({ content: [{ type: "text", text: "" }] })),
+		}));
 	});
 
 	afterEach(() => {
 		vi.clearAllMocks();
 		vi.useRealTimers();
+	});
+
+	it("keeps ordinary bash commands in the foreground via pi's built-in bash tool", async () => {
+		const executeMock = vi.fn(async () => ({ content: [{ type: "text", text: "foreground output" }] }));
+		createBashToolMock.mockImplementation((cwd: string) => ({
+			label: "Bash",
+			description: "Built-in bash tool.",
+			renderCall: undefined,
+			renderResult: undefined,
+			execute: executeMock,
+			cwd,
+		}));
+
+		const harness = createExtensionHarness();
+		backgroundTasksExtension(harness.pi as never);
+		const tool = harness.tools.get("bash");
+
+		const result = await tool.execute("tool-1", { command: "pnpm test", timeout: 30 }, undefined, undefined, harness.ctx);
+
+		expect(createBashToolMock).toHaveBeenNthCalledWith(1, process.cwd());
+		expect(createBashToolMock).toHaveBeenNthCalledWith(2, harness.ctx.cwd);
+		expect(executeMock).toHaveBeenCalledWith(
+			"tool-1",
+			{ command: "pnpm test", timeout: 30 },
+			undefined,
+			undefined,
+		);
+		expect(spawnMock).not.toHaveBeenCalled();
+		expect(result.content[0].text).toBe("foreground output");
 	});
 
 	it("spawns tasks, tails logs, reacts to output, and reports completion", async () => {

--- a/packages/docs/src/content/feature-catalog.mdx
+++ b/packages/docs/src/content/feature-catalog.mdx
@@ -162,7 +162,7 @@ This package is where most of the day-to-day ergonomics live.
 | `auto-update` | startup notification | Checks npm asynchronously and tells you when a newer oh-pi release is available |
 | `external-editor` | `/external-editor`, `Ctrl+Shift+E` | Opens the current draft in `$VISUAL` or `$EDITOR`, then syncs the saved text back into pi |
 | `worktree` | `/worktree`, `/worktree list`, `/worktree create`, `/worktree cleanup` | Gives oh-pi first-class git worktree awareness and managed pi-owned worktrees under shared storage |
-| `bg-process` | `bash` override, `bg_status` tool | Automatically detaches long-running commands after a timeout and lets the agent inspect/stop them later |
+| `bg-process` | `bg_task`, `bg_status`, `/bg`, `Ctrl+Shift+B` | Explicitly manages long-lived background tasks like watchers, servers, and log tails without auto-detaching ordinary bash commands |
 | `scheduler` | `/remind`, `/loop`, `/schedule*`, `schedule_prompt` tool | Schedules one-time reminders and recurring follow-ups for builds, CI, deploys, PRs, and long-running checks |
 | `usage-tracker` | widget, `/usage`, `/usage-toggle`, `/usage-refresh`, `Ctrl+U`, `usage_report` | Tracks provider quotas, rolling cost history, and per-model/session usage |
 | `btw` / `qq` | `/btw*`, `/qq*` | Runs side conversations in a widget above the editor, then injects the full thread or a summary back into the main agent |
@@ -213,7 +213,7 @@ It includes:
 
 ## `@ifi/pi-background-tasks`: reactive background shell tasks
 
-This package promotes long-running shell commands from an implementation detail into a first-class pi workflow.
+This package turns explicit long-lived shell tasks into a first-class pi workflow while leaving ordinary `bash` commands in the foreground.
 
 ### Primary surfaces
 
@@ -559,7 +559,7 @@ The AGENTS template pack currently ships 5 templates.
 ## Which feature should I reach for?
 
 - **Safer day-to-day pi sessions** → `@ifi/oh-pi-extensions`
-- **Long-running shell commands, watches, and log tails** → `@ifi/pi-background-tasks`
+- **Long-lived watchers, servers, and log tails** → `@ifi/pi-background-tasks`
 - **Timing and completion visibility** → `@ifi/pi-diagnostics`
 - **Large parallel work** → `@ifi/oh-pi-ant-colony`
 - **Named specialists and reusable pipelines** → `@ifi/pi-extension-subagents`

--- a/packages/extensions/extensions/bg-process.test.ts
+++ b/packages/extensions/extensions/bg-process.test.ts
@@ -2,7 +2,14 @@ import { EventEmitter } from "node:events";
 import { delimiter, join } from "node:path";
 import { afterEach, describe, expect, it, vi } from "vitest";
 
-const { getShellConfigMock, spawnMock } = vi.hoisted(() => ({
+const { createBashToolMock, getShellConfigMock, spawnMock } = vi.hoisted(() => ({
+	createBashToolMock: vi.fn(() => ({
+		label: "Bash",
+		description: "Built-in bash tool.",
+		renderCall: undefined,
+		renderResult: undefined,
+		execute: vi.fn(),
+	})),
 	getShellConfigMock: vi.fn(() => ({ shell: "C:/Program Files/Git/bin/bash.exe", args: ["-c"] })),
 	spawnMock: vi.fn(),
 }));
@@ -12,6 +19,7 @@ vi.mock("node:child_process", () => ({
 }));
 
 vi.mock("@mariozechner/pi-coding-agent", () => ({
+	createBashTool: createBashToolMock,
 	getAgentDir: () => "/mock-home/.pi/agent",
 	getShellConfig: getShellConfigMock,
 }));
@@ -85,19 +93,15 @@ describe("bg-process", () => {
 		expect(getBgProcessLogFilePath(123, "C:/Temp")).toBe(join("C:/Temp", "oh-pi-bg-123.log"));
 	});
 
-	it("uses pi shell resolution instead of spawning a bare bash command", async () => {
+	it("uses pi shell resolution for explicit background tasks", async () => {
 		const child = createMockChild();
 		spawnMock.mockReturnValueOnce(child);
 
 		const pi = createMockPi();
 		bgProcessExtension(pi as never);
-		const tool = pi.tools.get("bash");
+		const tool = pi.tools.get("bg_task");
 
-		const resultPromise = tool.execute("tool-1", { command: "echo hello" });
-		child.stdout.emit("data", Buffer.from("hello\n"));
-		child.emit("close", 0);
-
-		const result = await resultPromise;
+		const result = await tool.execute("tool-1", { action: "spawn", command: "echo hello" });
 
 		expect(getShellConfigMock).toHaveBeenCalledOnce();
 		expect(spawnMock).toHaveBeenCalledWith(
@@ -111,6 +115,6 @@ describe("bg-process", () => {
 				}),
 			}),
 		);
-		expect(result.content[0].text).toBe("hello");
+		expect(result.content[0].text).toContain("Started bg-1");
 	});
 });

--- a/packages/extensions/extensions/compact-header.test.ts
+++ b/packages/extensions/extensions/compact-header.test.ts
@@ -22,7 +22,22 @@ vi.mock("@mariozechner/pi-coding-agent", async () => {
 	};
 });
 
-import compactHeaderExtension from "./compact-header.js";
+import compactHeaderExtension, { buildCommandCatalog } from "./compact-header.js";
+
+describe("buildCommandCatalog", () => {
+	it("groups prompts and skills once into cached display strings", () => {
+		expect(
+			buildCommandCatalog([
+				{ name: "optimize", source: "prompt" },
+				{ name: "git-workflow", source: "skill" },
+				{ name: "usage", source: "command" },
+			]),
+		).toEqual({
+			prompts: "/optimize",
+			skills: "git-workflow",
+		});
+	});
+});
 
 describe("compact-header plain-icons bootstrap", () => {
 	beforeEach(() => {
@@ -77,5 +92,33 @@ describe("compact-header plain-icons bootstrap", () => {
 		compactHeaderExtension(harness.pi as never);
 		expect(process.env.OH_PI_PLAIN_ICONS).toBe("1");
 		expect(readFileSyncMock).not.toHaveBeenCalled();
+	});
+
+	it("caches the command catalog at header mount instead of rescanning on every render", () => {
+		const harness = createExtensionHarness();
+		const setHeader = vi.fn();
+		(harness.ctx.ui as { setHeader: typeof setHeader }).setHeader = setHeader;
+		harness.pi.getCommands = vi.fn(() => [
+			{ name: "optimize", source: "prompt" },
+			{ name: "review", source: "prompt" },
+			{ name: "git-workflow", source: "skill" },
+		]) as never;
+
+		compactHeaderExtension(harness.pi as never);
+		harness.emit("session_start", { type: "session_start" }, harness.ctx);
+
+		const headerFactory = setHeader.mock.calls[0]?.[0] as
+			| ((
+					tui: { requestRender: () => void },
+					theme: { fg: (color: string, text: string) => string },
+			  ) => { render: (width: number) => string[]; dispose?: () => void })
+			| undefined;
+		expect(headerFactory).toBeTypeOf("function");
+
+		const component = headerFactory?.({ requestRender() {} }, { fg: (_color: string, text: string) => text });
+		component?.render(120);
+		component?.render(120);
+
+		expect(harness.pi.getCommands).toHaveBeenCalledTimes(1);
 	});
 });

--- a/packages/extensions/extensions/compact-header.ts
+++ b/packages/extensions/extensions/compact-header.ts
@@ -30,6 +30,29 @@ function loadPlainIconsSetting(): boolean {
 	return false;
 }
 
+export function buildCommandCatalog(commands: ReadonlyArray<{ name: string; source?: string }>): {
+	prompts: string;
+	skills: string;
+} {
+	const promptNames: string[] = [];
+	const skillNames: string[] = [];
+
+	for (const command of commands) {
+		if (command.source === "prompt") {
+			promptNames.push(`/${command.name}`);
+			continue;
+		}
+		if (command.source === "skill") {
+			skillNames.push(command.name);
+		}
+	}
+
+	return {
+		prompts: promptNames.join("  "),
+		skills: skillNames.join("  "),
+	};
+}
+
 export default function (pi: ExtensionAPI) {
 	let plainIconsSyncTimer: ReturnType<typeof setTimeout> | undefined;
 	const cancelPlainIconsSync = () => {
@@ -73,6 +96,7 @@ export default function (pi: ExtensionAPI) {
 
 		ctx.ui.setHeader((tui, theme) => {
 			const unsubSafeMode = subscribeSafeMode(() => tui.requestRender());
+			const commandCatalog = buildCommandCatalog(pi.getCommands());
 			return {
 				dispose() {
 					unsubSafeMode();
@@ -84,16 +108,8 @@ export default function (pi: ExtensionAPI) {
 					const d = (s: string) => theme.fg("dim", s);
 					const a = (s: string) => theme.fg("accent", s);
 
-					const cmds = pi.getCommands();
-					const prompts = cmds
-						.filter((c) => c.source === "prompt")
-						.map((c) => `/${c.name}`)
-						.join("  ");
-					const skills = cmds
-						.filter((c) => c.source === "skill")
-						.map((c) => c.name)
-						.join("  ");
 					const model = ctx.model ? `${ctx.model.id}` : "no model";
+					const { prompts, skills } = commandCatalog;
 					const thinking = pi.getThinkingLevel();
 					const provider = ctx.model?.provider ?? "";
 

--- a/packages/extensions/extensions/scheduler.test.ts
+++ b/packages/extensions/extensions/scheduler.test.ts
@@ -1211,10 +1211,40 @@ describe("SchedulerRuntime", () => {
 	});
 
 	describe("scheduler lifecycle", () => {
-		it("startScheduler is idempotent", () => {
+		it("does not start the heartbeat while no tasks exist", () => {
+			const setIntervalSpy = vi.spyOn(globalThis, "setInterval");
+
 			runtime.startScheduler();
-			runtime.startScheduler(); // Should not create second timer
+
+			expect(setIntervalSpy).not.toHaveBeenCalled();
+		});
+
+		it("startScheduler is idempotent once tasks exist", () => {
+			const setIntervalSpy = vi.spyOn(globalThis, "setInterval");
+
+			runtime.addOneShotTask("check ci", ONE_MINUTE);
+			runtime.startScheduler();
+			runtime.startScheduler();
+
+			expect(setIntervalSpy).toHaveBeenCalledTimes(1);
 			runtime.stopScheduler();
+		});
+
+		it("starts the heartbeat when the first task is added", () => {
+			const setIntervalSpy = vi.spyOn(globalThis, "setInterval");
+
+			runtime.addOneShotTask("check ci", ONE_MINUTE);
+
+			expect(setIntervalSpy).toHaveBeenCalledTimes(1);
+			runtime.stopScheduler();
+		});
+
+		it("stops the heartbeat after the last task is removed", () => {
+			const clearIntervalSpy = vi.spyOn(globalThis, "clearInterval");
+			const task = runtime.addOneShotTask("check ci", ONE_MINUTE);
+
+			expect(runtime.deleteTask(task.id)).toBe(true);
+			expect(clearIntervalSpy).toHaveBeenCalledTimes(1);
 		});
 
 		it("stopScheduler is safe when not started", () => {

--- a/packages/extensions/extensions/scheduler.test.ts
+++ b/packages/extensions/extensions/scheduler.test.ts
@@ -1007,8 +1007,9 @@ describe("SchedulerRuntime", () => {
 			const task = runtime.addRecurringIntervalTask("check", 5 * ONE_MINUTE);
 			expect(runtime.taskCount).toBe(1);
 
-			// Advance past the default recurring expiry window.
-			vi.advanceTimersByTime(DEFAULT_RECURRING_EXPIRY_MS + 1000);
+			// Advance past the default recurring expiry window without triggering
+			// the 1 s heartbeat interval 86 k times.
+			vi.setSystemTime(Date.now() + DEFAULT_RECURRING_EXPIRY_MS + 1000);
 			await runtime.tickScheduler();
 
 			expect(runtime.taskCount).toBe(0);

--- a/packages/extensions/extensions/scheduler.ts
+++ b/packages/extensions/extensions/scheduler.ts
@@ -297,6 +297,9 @@ export class SchedulerRuntime {
 			}
 			this.persistTasks();
 			this.updateStatus();
+			if (this.tasks.size === 0) {
+				this.stopScheduler();
+			}
 		}
 		return removed;
 	}
@@ -307,6 +310,9 @@ export class SchedulerRuntime {
 		this.awaitingTaskId = null;
 		this.persistTasks();
 		this.updateStatus();
+		if (count > 0) {
+			this.stopScheduler();
+		}
 		return count;
 	}
 
@@ -492,6 +498,7 @@ export class SchedulerRuntime {
 		this.tasks.set(id, task);
 		this.persistTasks();
 		this.updateStatus();
+		this.startScheduler();
 		return task;
 	}
 
@@ -537,6 +544,7 @@ export class SchedulerRuntime {
 		this.tasks.set(id, task);
 		this.persistTasks();
 		this.updateStatus();
+		this.startScheduler();
 		return task;
 	}
 
@@ -569,11 +577,12 @@ export class SchedulerRuntime {
 		this.tasks.set(id, task);
 		this.persistTasks();
 		this.updateStatus();
+		this.startScheduler();
 		return task;
 	}
 
 	startScheduler() {
-		if (this.schedulerTimer) {
+		if (this.schedulerTimer || this.tasks.size === 0) {
 			return;
 		}
 		const intervalMs = this.safeModeEnabled ? SCHEDULER_SAFE_MODE_HEARTBEAT_MS : SCHEDULER_LEASE_HEARTBEAT_MS;
@@ -667,6 +676,9 @@ export class SchedulerRuntime {
 
 		if (this.tasks.size === 0) {
 			this.setStatus("pi-scheduler", undefined);
+			if (this.schedulerTimer || this.schedulerRetryTimer) {
+				this.stopScheduler();
+			}
 			return;
 		}
 


### PR DESCRIPTION
## What changed
- Scheduler only starts its 1s interval when tasks exist.
- Scheduler stops the heartbeat when the last task is removed.
- Compact-header computes command catalog once at mount instead of every render.
- Adds unit tests and tightens runtime churn benchmark assertions.

## Tests
- [x] Scheduler lifecycle tests for lazy start/stop
- [x] Compact-header caching test
- [x] Runtime churn benchmark now asserts scheduler idle scenario shows zero churn