### PR TITLE
fix(oh-pi): add missing extensions to pi:local source switcher

### DIFF
--- a/.changeset/add-missing-extensions-to-switcher.md
+++ b/.changeset/add-missing-extensions-to-switcher.md
@@ -1,0 +1,10 @@
+---
+default: patch
+---
+
+Add missing extension packages to the `pi:local` source switcher.
+
+`@ifi/pi-bash-live-view`, `@ifi/pi-pretty`, `@ifi/pi-remote-tailscale`, and
+`@ifi/pi-analytics-extension` are now included in `SWITCHER_PACKAGES` so that
+`pnpm pi:local` points them at the local workspace sources along with every
+other oh-pi extension.

--- a/packages/oh-pi/bin/package-list.mjs
+++ b/packages/oh-pi/bin/package-list.mjs
@@ -24,6 +24,10 @@ export const EXPERIMENTAL_PACKAGES = [
 	"@ifi/pi-provider-catalog",
 	"@ifi/pi-provider-cursor",
 	"@ifi/pi-provider-ollama",
+	"@ifi/pi-bash-live-view",
+	"@ifi/pi-pretty",
+	"@ifi/pi-remote-tailscale",
+	"@ifi/pi-analytics-extension",
 ];
 
 export const SWITCHER_PACKAGES = [...INSTALLER_PACKAGES, ...EXPERIMENTAL_PACKAGES];

--- a/packages/oh-pi/bin/package-list.mts
+++ b/packages/oh-pi/bin/package-list.mts
@@ -40,6 +40,10 @@ Opt-in packages that stay separate from the default installer bundle:
 - `@ifi/pi-provider-catalog`
 - `@ifi/pi-provider-cursor`
 - `@ifi/pi-provider-ollama`
+- `@ifi/pi-bash-live-view`
+- `@ifi/pi-pretty`
+- `@ifi/pi-remote-tailscale`
+- `@ifi/pi-analytics-extension`
 
 <!-- {/repoExperimentalPackagesDocs} -->
 */
@@ -48,6 +52,10 @@ export const EXPERIMENTAL_PACKAGES = [
 	"@ifi/pi-provider-catalog",
 	"@ifi/pi-provider-cursor",
 	"@ifi/pi-provider-ollama",
+	"@ifi/pi-bash-live-view",
+	"@ifi/pi-pretty",
+	"@ifi/pi-remote-tailscale",
+	"@ifi/pi-analytics-extension",
 ];
 
 export const SWITCHER_PACKAGES = [...INSTALLER_PACKAGES, ...EXPERIMENTAL_PACKAGES];

--- a/scripts/pi-source-switch.mts
+++ b/scripts/pi-source-switch.mts
@@ -42,6 +42,10 @@ Managed local switching covers these packages:
 - `@ifi/pi-provider-catalog`
 - `@ifi/pi-provider-cursor`
 - `@ifi/pi-provider-ollama`
+- `@ifi/pi-bash-live-view`
+- `@ifi/pi-pretty`
+- `@ifi/pi-remote-tailscale`
+- `@ifi/pi-analytics-extension`
 
 <!-- {/repoPiLocalManagedPackagesDocs} -->
 


### PR DESCRIPTION
## Summary

Adds four missing extension packages to the `pi:local` source switcher so they are pointed at local workspace sources when running `pnpm pi:local`.

## Packages added

- `@ifi/pi-bash-live-view`
- `@ifi/pi-pretty`
- `@ifi/pi-remote-tailscale`
- `@ifi/pi-analytics-extension"

Fixes the issue where these extensions were installed on the published npm version instead of the local checkout.
