### PR TITLE
fix(extensions): avoid bash tool conflicts between pretty and live view

### DIFF
--- a/.changeset/fix-bash-tool-extension-conflicts.md
+++ b/.changeset/fix-bash-tool-extension-conflicts.md
@@ -1,0 +1,15 @@
+---
+default: patch
+---
+
+Avoid `bash` tool conflicts between `@ifi/pi-bash-live-view` and `@ifi/pi-pretty`.
+
+Both extensions were registering a tool named `bash`, which made them conflict when
+loaded together via `pnpm pi:local`. They now expose explicit alternative tools
+instead:
+
+- `bash_live_view` for PTY-backed terminal rendering
+- `bash_pretty` for formatted command output summaries
+
+The built-in `bash` tool is left untouched, and regression tests now verify these
+extensions can be loaded together without duplicate tool registrations.

--- a/docs/feature-catalog.md
+++ b/docs/feature-catalog.md
@@ -149,8 +149,8 @@ so build those when you are working on them directly.
 | [`@ifi/pi-provider-cursor`](../packages/cursor) | No | `/login cursor`, `/cursor*` | Experimental Cursor OAuth provider with model discovery and direct AgentService streaming |
 | [`@ifi/pi-provider-ollama`](../packages/ollama) | No | `/login ollama-cloud`, `/ollama*`, `/model` | Experimental Ollama local + cloud provider integration |
 | [`@ifi/pi-remote-tailscale`](../packages/pi-remote-tailscale) | No | `/remote`, `/remote:widget`, `/remote:stop` | Secure remote session sharing via Tailscale HTTPS with PTY, WebSocket, QR codes, and token auth |
-| [`@ifi/pi-bash-live-view`](../packages/pi-bash-live-view) | No | `/bash-pty`, `bash` tool override with `usePTY` | PTY-backed live terminal viewing with real-time widget and `/xterm/headless` ANSI rendering |
-| [`@ifi/pi-pretty`](../packages/pi-pretty) | No | wrapped `read`, `bash`, `ls`, `find`, `grep` tools | Syntax highlighting via Shiki, Nerd Font icons, tree-view listings, colored bash summaries, FFF search |
+| [`@ifi/pi-bash-live-view`](../packages/pi-bash-live-view) | No | `/bash-pty`, `bash_live_view` tool with `usePTY` | PTY-backed live terminal viewing with real-time widget and `/xterm/headless` ANSI rendering |
+| [`@ifi/pi-pretty`](../packages/pi-pretty) | No | wrapped `read`, `bash_pretty`, `ls`, `find`, `grep` tools | Syntax highlighting via Shiki, Nerd Font icons, tree-view listings, colored bash summaries, FFF search |
 
 ## `@ifi/oh-pi-extensions`: core extension pack
 

--- a/packages/pi-bash-live-view/README.md
+++ b/packages/pi-bash-live-view/README.md
@@ -14,7 +14,7 @@ The built-in `bash` tool is great for batch output, but it does not preserve a t
 
 ## What it provides
 
-- `bash` tool override with `usePTY?: boolean`
+- `bash_live_view` tool with `usePTY?: boolean`
 - live terminal widget while PTY commands run
 - `@xterm/headless` terminal snapshots rendered back into ANSI lines
 - `node-pty` session management with timeout, abort, and cleanup handling
@@ -28,14 +28,14 @@ The built-in `bash` tool is great for batch output, but it does not preserve a t
 ### Agent tool call
 
 ```ts
-await bash({
+await bash_live_view({
   command: "pnpm test --watch",
   timeout: 30,
   usePTY: true,
 });
 ```
 
-`usePTY` defaults to `false`, so ordinary `bash` calls still use pi's original built-in tool behavior.
+`usePTY` defaults to `false`, so `bash_live_view` can still delegate to pi's original built-in `bash` behavior when you don't need a PTY.
 
 ### Slash command
 

--- a/packages/pi-bash-live-view/index.ts
+++ b/packages/pi-bash-live-view/index.ts
@@ -4,6 +4,7 @@ import { Type } from "@sinclair/typebox";
 import { executePtyCommand, toAgentToolResult, toUserBashResult } from "./src/pty-execute.js";
 import { PtySessionManager } from "./src/pty-session.js";
 
+export const BASH_LIVE_VIEW_TOOL = "bash_live_view";
 export const BASH_PTY_COMMAND = "bash-pty";
 const BASH_PTY_MESSAGE_TYPE = "pi-bash-live-view:result";
 
@@ -55,7 +56,7 @@ export default function bashLiveViewExtension(pi: ExtensionAPI): void {
 	});
 
 	pi.registerTool({
-		name: "bash",
+		name: BASH_LIVE_VIEW_TOOL,
 		label: bashTemplate.label ?? "Bash",
 		description: buildToolDescription(bashTemplate.description),
 		parameters: BASH_TOOL_PARAMETERS,

--- a/packages/pi-bash-live-view/tests/index.test.ts
+++ b/packages/pi-bash-live-view/tests/index.test.ts
@@ -64,7 +64,7 @@ vi.mock("../src/pty-session.js", () => ({
 	},
 }));
 
-import bashLiveViewExtension, { BASH_PTY_COMMAND, bashLiveViewInternals } from "../index.js";
+import bashLiveViewExtension, { BASH_LIVE_VIEW_TOOL, BASH_PTY_COMMAND, bashLiveViewInternals } from "../index.js";
 
 describe("@ifi/pi-bash-live-view index", () => {
 	beforeEach(() => {
@@ -73,7 +73,7 @@ describe("@ifi/pi-bash-live-view index", () => {
 		mocks.executePtyCommand.mockResolvedValue({ sessionId: "pty-1" });
 	});
 
-	it("registers the bash override and slash command", () => {
+	it("registers the live-view bash tool and slash command", () => {
 		mocks.createBashTool.mockImplementationOnce(
 			() =>
 				({
@@ -87,9 +87,9 @@ describe("@ifi/pi-bash-live-view index", () => {
 		const harness = createExtensionHarness();
 		bashLiveViewExtension(harness.pi as never);
 
-		expect(harness.tools.has("bash")).toBe(true);
+		expect(harness.tools.has(BASH_LIVE_VIEW_TOOL)).toBe(true);
 		expect(harness.commands.has(BASH_PTY_COMMAND)).toBe(true);
-		expect(harness.tools.get("bash")?.description).toContain("usePTY=true");
+		expect(harness.tools.get(BASH_LIVE_VIEW_TOOL)?.description).toContain("usePTY=true");
 		expect(bashLiveViewInternals.buildToolDescription("base")).toContain("pseudo-terminal");
 		expect(bashLiveViewInternals.resolveCwd({ cwd: "/ctx" } as never, { cwd: "/fallback" } as never, "/explicit")).toBe(
 			"/explicit",
@@ -107,7 +107,7 @@ describe("@ifi/pi-bash-live-view index", () => {
 		bashLiveViewExtension(harness.pi as never);
 		harness.emit("session_start", { type: "session_start" }, harness.ctx);
 
-		const result = await harness.tools.get("bash")?.execute("tool-1", {
+		const result = await harness.tools.get(BASH_LIVE_VIEW_TOOL)?.execute("tool-1", {
 			command: "echo delegated",
 			timeout: 5,
 			usePTY: false,
@@ -122,7 +122,7 @@ describe("@ifi/pi-bash-live-view index", () => {
 		harness.ctx.cwd = "/workspace/b";
 		bashLiveViewExtension(harness.pi as never);
 
-		const result = await harness.tools.get("bash")?.execute(
+		const result = await harness.tools.get(BASH_LIVE_VIEW_TOOL)?.execute(
 			"tool-2",
 			{
 				command: "pnpm dev",
@@ -146,7 +146,7 @@ describe("@ifi/pi-bash-live-view index", () => {
 		bashLiveViewExtension(harness.pi as never);
 		mocks.executePtyCommand.mockRejectedValueOnce(new Error("boom"));
 
-		const result = await harness.tools.get("bash")?.execute("tool-3", { command: "broken", usePTY: true }, undefined, undefined, harness.ctx);
+		const result = await harness.tools.get(BASH_LIVE_VIEW_TOOL)?.execute("tool-3", { command: "broken", usePTY: true }, undefined, undefined, harness.ctx);
 		expect(result).toMatchObject({
 			content: [{ text: "PTY execution failed: boom" }],
 			details: { error: true, pty: true },

--- a/packages/pi-bash-live-view/tests/tool-conflicts.test.ts
+++ b/packages/pi-bash-live-view/tests/tool-conflicts.test.ts
@@ -1,0 +1,46 @@
+import { describe, expect, it, vi } from "vitest";
+import { createExtensionHarness } from "../../../test-utils/extension-runtime-harness.js";
+
+vi.mock("@mariozechner/pi-coding-agent", async () => {
+	const actual = await vi.importActual<typeof import("@mariozechner/pi-coding-agent")>("@mariozechner/pi-coding-agent");
+	return {
+		...actual,
+		createBashTool: vi.fn(() => ({
+			name: "bash",
+			label: "Bash",
+			description: "Built-in bash",
+			renderCall: undefined,
+			renderResult: undefined,
+			execute: vi.fn(async () => ({ content: [{ type: "text", text: "ok" }] })),
+		})),
+	};
+});
+
+import backgroundTasksExtension from "../../background-tasks/index.js";
+import bashLiveViewExtension, { BASH_LIVE_VIEW_TOOL } from "../index.js";
+import { enhanceBashTool, PRETTY_BASH_TOOL } from "../../pi-pretty/src/bash.js";
+
+describe("bash tool conflict regression", () => {
+	it("registers distinct tool names across background, live-view, and pretty extensions", () => {
+		const harness = createExtensionHarness();
+		const registeredToolNames: string[] = [];
+		const registerTool = harness.pi.registerTool.bind(harness.pi);
+		harness.pi.registerTool = ((tool: { name: string }) => {
+			registeredToolNames.push(tool.name);
+			registerTool(tool);
+		}) as typeof harness.pi.registerTool;
+
+		backgroundTasksExtension(harness.pi as never);
+		bashLiveViewExtension(harness.pi as never);
+		enhanceBashTool(harness.pi as never);
+
+		expect(harness.tools.has("bg_task")).toBe(true);
+		expect(harness.tools.has("bg_status")).toBe(true);
+		expect(harness.tools.has(BASH_LIVE_VIEW_TOOL)).toBe(true);
+		expect(harness.tools.has(PRETTY_BASH_TOOL)).toBe(true);
+		expect(harness.tools.has("bash")).toBe(false);
+
+		const duplicateToolNames = registeredToolNames.filter((name, index) => registeredToolNames.indexOf(name) !== index);
+		expect(duplicateToolNames).toEqual([]);
+	});
+});

--- a/packages/pi-pretty/README.md
+++ b/packages/pi-pretty/README.md
@@ -5,7 +5,7 @@ Pretty terminal output for pi built-in tools.
 ## Features
 
 - **`read`** — Syntax-highlighted file content with line numbers + inline image rendering
-- **`bash`** — Colored exit status with output preview
+- **`bash_pretty`** — Colored exit status with output preview
 - **`ls`** — Tree-view directory listing with Nerd Font file type icons
 - **`find`** / **`grep`** — FFF-backed frecency-aware search with grouped/highlighted rendering
 - **`multi_grep`** — OR-search across multiple patterns
@@ -24,11 +24,11 @@ pi -e ./packages/pi-pretty/index.ts
 
 ## Usage
 
-Use built-in tools normally — `pi-pretty` enhances them transparently:
+Use the wrapped tools directly:
 
 ```text
 read path="src/index.ts"
-bash command="pnpm test"
+bash_pretty command="pnpm test"
 ls path="src"
 grep pattern="handleRequest" glob="*.ts"
 ```

--- a/packages/pi-pretty/src/bash.ts
+++ b/packages/pi-pretty/src/bash.ts
@@ -2,11 +2,14 @@ import type { ExtensionAPI, AgentToolResult } from "@mariozechner/pi-coding-agen
 import { createBashTool } from "@mariozechner/pi-coding-agent";
 import { FG_GREEN, FG_RED, FG_YELLOW, fillToolBackground, resolveBaseBackground } from "./theme.js";
 
+export const PRETTY_BASH_TOOL = "bash_pretty";
+
 export function enhanceBashTool(pi: ExtensionAPI): void {
 	const original = createBashTool(process.cwd());
 
 	pi.registerTool({
 		...original,
+		name: PRETTY_BASH_TOOL,
 		async execute(toolCallId, params, signal, onUpdate): Promise<AgentToolResult<unknown>> {
 			resolveBaseBackground(null);
 			const result = await original.execute(toolCallId, params, signal, onUpdate);

--- a/packages/pi-pretty/tests/bash.test.ts
+++ b/packages/pi-pretty/tests/bash.test.ts
@@ -23,10 +23,10 @@ describe("enhanceBashTool", () => {
 		vi.clearAllMocks();
 	});
 
-	it("registers bash tool enhancement", async () => {
-		const { enhanceBashTool } = await import("../src/bash.js");
+	it("registers pretty bash as a separate tool", async () => {
+		const { PRETTY_BASH_TOOL, enhanceBashTool } = await import("../src/bash.js");
 		enhanceBashTool(mockExtensionAPI as any);
-		expect(mockRegisterTool).toHaveBeenCalledWith(expect.objectContaining({ name: "bash" }));
+		expect(mockRegisterTool).toHaveBeenCalledWith(expect.objectContaining({ name: PRETTY_BASH_TOOL }));
 	});
 
 	it("returns enhanced content for exit code 0", async () => {


### PR DESCRIPTION
## Summary

Fixes the remaining tool-name conflict after `pnpm pi:local`.

`@ifi/pi-bash-live-view` and `@ifi/pi-pretty` were both registering a tool named `bash`, so loading them together failed with:

> Tool "bash" conflicts with ...

This change stops both extensions from overriding the built-in `bash` tool and gives the agent explicit alternatives instead:

- `bash_live_view` — PTY-backed live terminal rendering
- `bash_pretty` — formatted command output summaries

The built-in `bash` tool is left untouched.

## Tests

- added a regression test that loads background-tasks + bash-live-view + pretty together and verifies there are no duplicate tool registrations
- updated package tests for the new explicit tool names
- verified `@ifi/pi-bash-live-view` tests pass
- verified `@ifi/pi-pretty` tests pass
