### PR TITLE
fix(extensions): hoist assertActive-guarded calls out of compact-header render

### DIFF
--- a/.changeset/fix-compact-header-stale-render-crash.md
+++ b/.changeset/fix-compact-header-stale-render-crash.md
@@ -1,0 +1,19 @@
+---
+default: patch
+---
+
+Fix stale extension context crash in compact-header on quit.
+
+`pi.getThinkingLevel()` and `ctx.model` both call `assertActive()` on the
+extension runner and throw `"This extension instance is stale after session
+replacement or reload."` if accessed after the runner is invalidated.
+
+The TUI render loop schedules its final render via `setTimeout`, which fires
+during pi's `drainInput` shutdown window — after `extensionRunner.invalidate()`
+but before `process.exit(0)`. Any `render()` callback that calls back into
+`pi.*` or `ctx.*` at that point crashes the process instead of exiting cleanly.
+
+`commandCatalog` was already hoisted out of `render()` in a previous fix, but
+`ctx.model` and `pi.getThinkingLevel()` were still called on every render tick.
+Both are now captured as plain values at `session_start` time, outside the
+render closure, so the render function is free of all assertActive-guarded calls.

--- a/packages/extensions/extensions/compact-header.ts
+++ b/packages/extensions/extensions/compact-header.ts
@@ -94,9 +94,17 @@ export default function (pi: ExtensionAPI) {
 			return;
 		}
 
+		// Snapshot session-bound values once — pi.* and ctx.model both call
+		// assertActive() and will throw if accessed after session teardown.
+		// The TUI render loop fires one final tick via setTimeout after the
+		// extension runner is invalidated on quit, so render() must not call
+		// them directly.
+		const commandCatalog = buildCommandCatalog(pi.getCommands());
+		const initialModel = ctx.model;
+		const initialThinking = pi.getThinkingLevel();
+
 		ctx.ui.setHeader((tui, theme) => {
 			const unsubSafeMode = subscribeSafeMode(() => tui.requestRender());
-			const commandCatalog = buildCommandCatalog(pi.getCommands());
 			return {
 				dispose() {
 					unsubSafeMode();
@@ -108,10 +116,10 @@ export default function (pi: ExtensionAPI) {
 					const d = (s: string) => theme.fg("dim", s);
 					const a = (s: string) => theme.fg("accent", s);
 
-					const model = ctx.model ? `${ctx.model.id}` : "no model";
+					const model = initialModel ? `${initialModel.id}` : "no model";
 					const { prompts, skills } = commandCatalog;
-					const thinking = pi.getThinkingLevel();
-					const provider = ctx.model?.provider ?? "";
+					const thinking = initialThinking;
+					const provider = initialModel?.provider ?? "";
 
 					const pad = (s: string, w: number) => s + " ".repeat(Math.max(0, w - visibleWidth(s)));
 					const t = (s: string) => truncateToWidth(s, width);


### PR DESCRIPTION
## Problem

Quitting pi with `oh-pi-extensions` active intermittently crashes with:

```
Error: This extension instance is stale after session replacement or reload.
    at Object.assertActive (loader.js:112:19)
    at Object.getThinkingLevel (loader.js:316:3)
    at Object.render (compact-header.ts:...)
    at TUI.doRender (tui.js:691:29)
    at Timeout._onTimeout (tui.js:350:18)
```

## Root cause

Both `pi.getThinkingLevel()` and `ctx.model` call `assertActive()` on the extension runner — confirmed in `runner.ts:592` and `loader.ts:315`. The TUI schedules its renders via an internal `setTimeout`, which fires during pi's 50 ms `drainInput` shutdown window — after `extensionRunner.invalidate()` but before `process.exit(0)`. Any `render()` callback that calls back into `pi.*` or `ctx.*` at that point crashes the process.

`pi.getCommands()` was already hoisted out of `render()` as `commandCatalog` in a previous fix, but `ctx.model` and `pi.getThinkingLevel()` were still being called on every render tick.

## Why it's intermittent

The crash only happens if the TUI's `setTimeout`-scheduled render fires during the ~50 ms window between `invalidate()` and `process.exit(0)`. Whether it fires in that window depends on event loop scheduling, making it non-deterministic.

## Fix

Snapshot both values as plain locals at `session_start` time, outside the render closure, alongside the existing `commandCatalog` pattern:

```ts
const commandCatalog = buildCommandCatalog(pi.getCommands());
const initialModel = ctx.model;       // ← captured once, safe in render
const initialThinking = pi.getThinkingLevel();  // ← captured once, safe in render
```

The render closure now contains no `assertActive`-guarded calls and is safe to execute at any point in the shutdown sequence.

## Checked for prior art

No existing issues or PRs address this specific call site. The `fix-providers-stale-session-crash` changeset addresses the same class of bug in the provider catalog package.