### PR TITLE
fix(extensions): guard ctx.model getter in compact-header and custom-footer render paths

### DIFF
--- a/.changeset/fix-header-footer-model-guard.md
+++ b/.changeset/fix-header-footer-model-guard.md
@@ -1,0 +1,7 @@
+---
+default: patch
+---
+
+fix(extensions): guard `ctx.model` getter in compact-header and custom-footer render paths
+
+The `ctx.model` getter throws when the underlying ExtensionRunner is no longer active (e.g. during session shutdown). Both `compact-header.ts` and `custom-footer.ts` access `ctx.model` inside TUI `render` callbacks that may fire asynchronously after the session ends. Wrapping those accesses in try/catch prevents the crash.

--- a/packages/extensions/extensions/compact-header.ts
+++ b/packages/extensions/extensions/compact-header.ts
@@ -108,10 +108,18 @@ export default function (pi: ExtensionAPI) {
 					const d = (s: string) => theme.fg("dim", s);
 					const a = (s: string) => theme.fg("accent", s);
 
-					const model = ctx.model ? `${ctx.model.id}` : "no model";
+					let model: string;
+					let provider: string;
+					try {
+						const m = ctx.model;
+						model = m ? `${m.id}` : "no model";
+						provider = m?.provider ?? "";
+					} catch {
+						model = "no model";
+						provider = "";
+					}
 					const { prompts, skills } = commandCatalog;
 					const thinking = pi.getThinkingLevel();
-					const provider = ctx.model?.provider ?? "";
 
 					const pad = (s: string, w: number) => s + " ".repeat(Math.max(0, w - visibleWidth(s)));
 					const t = (s: string) => truncateToWidth(s, width);

--- a/packages/extensions/extensions/custom-footer.ts
+++ b/packages/extensions/extensions/custom-footer.ts
@@ -333,7 +333,13 @@ export default function (pi: ExtensionAPI) {
 					const thinking = pi.getThinkingLevel();
 					const thinkColor =
 						thinking === "high" ? "warning" : thinking === "medium" ? "accent" : thinking === "low" ? "dim" : "muted";
-					const modelId = ctx.model?.id || "no-model";
+					const modelId = (() => {
+						try {
+							return ctx.model?.id || "no-model";
+						} catch {
+							return "no-model";
+						}
+					})();
 					const modelStr = `${theme.fg(thinkColor, "◆")} ${theme.fg("accent", modelId)}`;
 
 					const sep = theme.fg("dim", " | ");


### PR DESCRIPTION
The `ctx.model` getter throws when the underlying ExtensionRunner is no longer active (e.g. during session shutdown). Both `compact-header.ts` and `custom-footer.ts` access `ctx.model` inside TUI `render` callbacks that may fire asynchronously after the session ends. Wrapping those accesses in try/catch prevents the crash.