### PR TITLE
feat(extensions): change usage-tracker overlay shortcut from Ctrl+U to Ctrl+Shift+U

### DIFF
--- a/.changeset/usage-tracker-shortcut-shift-u.md
+++ b/.changeset/usage-tracker-shortcut-shift-u.md
@@ -1,0 +1,5 @@
+---
+default: patch
+---
+
+chore(extensions): change usage-tracker overlay shortcut from `Ctrl+U` to `Ctrl+Shift+U` while preserving existing `/usage`, `/usage-toggle`, `/usage-refresh`, and `usage_report` behavior.

--- a/README.md
+++ b/README.md
@@ -434,7 +434,7 @@ recent subscription windows when a live provider probe is temporarily rate-limit
 Claude [████████░░░░] 67% ↻in 3d 2h │ 💰$0.42 │ 12.3k/8.1k
 ```
 
-**`/usage` overlay** (`Ctrl+U`):
+**`/usage` overlay** (`Ctrl+Shift+U`):
 
 ```
 ╭─ Usage Dashboard ──────────────────────────────────────╮
@@ -464,7 +464,7 @@ Key usage-tracker surfaces:
 
 - widget above the editor for at-a-glance quotas and session totals
 - `/usage` for the full dashboard overlay
-- `Ctrl+U` as a shortcut for the same overlay
+- `Ctrl+Shift+U` as a shortcut for the same overlay
 - `/usage-toggle` to show or hide the widget
 - `/usage-refresh` to force fresh provider probes
 - `usage_report` so the agent can answer quota and spend questions directly

--- a/docs/feature-catalog.md
+++ b/docs/feature-catalog.md
@@ -170,7 +170,7 @@ This package is where most of the day-to-day ergonomics live.
 | `worktree` | `/worktree`, `/worktree list`, `/worktree create`, `/worktree cleanup` | Gives oh-pi first-class git worktree awareness and managed pi-owned worktrees under shared storage |
 | `bg-process` | `bg_task`, `bg_status`, `/bg`, `Ctrl+Shift+B` | Explicitly manages long-lived background tasks like watchers, servers, and log tails without auto-detaching ordinary bash commands |
 | `scheduler` | `/remind`, `/loop`, `/schedule*`, `schedule_prompt` tool | Schedules one-time reminders and recurring follow-ups for builds, CI, deploys, PRs, and long-running checks |
-| `usage-tracker` | widget, `/usage`, `/usage-toggle`, `/usage-refresh`, `Ctrl+U`, `usage_report` | Tracks provider quotas, rolling cost history, and per-model/session usage |
+| `usage-tracker` | widget, `/usage`, `/usage-toggle`, `/usage-refresh`, `Ctrl+Shift+U`, `usage_report` | Tracks provider quotas, rolling cost history, and per-model/session usage |
 | `btw` / `qq` | `/btw*`, `/qq*` | Runs side conversations in a widget above the editor, then injects the full thread or a summary back into the main agent |
 | `watchdog` / `safe-mode` | `/watchdog*`, `/safe-mode` | Samples runtime health, records alerts, shows startup/blame dashboards, and can reduce UI churn when the session gets too heavy |
 

--- a/docs/mdt/oh-pi-docs.t.md
+++ b/docs/mdt/oh-pi-docs.t.md
@@ -291,7 +291,7 @@ Key usage-tracker surfaces:
 
 - widget above the editor for at-a-glance quotas and session totals
 - `/usage` for the full dashboard overlay
-- `Ctrl+U` as a shortcut for the same overlay
+- `Ctrl+Shift+U` as a shortcut for the same overlay
 - `/usage-toggle` to show or hide the widget
 - `/usage-refresh` to force fresh provider probes
 - `usage_report` so the agent can answer quota and spend questions directly

--- a/packages/docs/src/content/feature-catalog.mdx
+++ b/packages/docs/src/content/feature-catalog.mdx
@@ -164,7 +164,7 @@ This package is where most of the day-to-day ergonomics live.
 | `worktree` | `/worktree`, `/worktree list`, `/worktree create`, `/worktree cleanup` | Gives oh-pi first-class git worktree awareness and managed pi-owned worktrees under shared storage |
 | `bg-process` | `bg_task`, `bg_status`, `/bg`, `Ctrl+Shift+B` | Explicitly manages long-lived background tasks like watchers, servers, and log tails without auto-detaching ordinary bash commands |
 | `scheduler` | `/remind`, `/loop`, `/schedule*`, `schedule_prompt` tool | Schedules one-time reminders and recurring follow-ups for builds, CI, deploys, PRs, and long-running checks |
-| `usage-tracker` | widget, `/usage`, `/usage-toggle`, `/usage-refresh`, `Ctrl+U`, `usage_report` | Tracks provider quotas, rolling cost history, and per-model/session usage |
+| `usage-tracker` | widget, `/usage`, `/usage-toggle`, `/usage-refresh`, `Ctrl+Shift+U`, `usage_report` | Tracks provider quotas, rolling cost history, and per-model/session usage |
 | `btw` / `qq` | `/btw*`, `/qq*` | Runs side conversations in a widget above the editor, then injects the full thread or a summary back into the main agent |
 | `watchdog` / `safe-mode` | `/watchdog*`, `/safe-mode` | Samples runtime health, records alerts, shows startup/blame dashboards, and can reduce UI churn when the session gets too heavy |
 

--- a/packages/extensions/README.md
+++ b/packages/extensions/README.md
@@ -144,7 +144,7 @@ Key usage-tracker surfaces:
 
 - widget above the editor for at-a-glance quotas and session totals
 - `/usage` for the full dashboard overlay
-- `Ctrl+U` as a shortcut for the same overlay
+- `Ctrl+Shift+U` as a shortcut for the same overlay
 - `/usage-toggle` to show or hide the widget
 - `/usage-refresh` to force fresh provider probes
 - `usage_report` so the agent can answer quota and spend questions directly

--- a/packages/extensions/extensions/smoke.test.ts
+++ b/packages/extensions/extensions/smoke.test.ts
@@ -44,7 +44,7 @@ describe("extensions runtime smoke tests", () => {
 		expect(harness.commands.has("usage-toggle")).toBe(true);
 		expect(harness.commands.has("usage-refresh")).toBe(true);
 		expect(harness.tools.has("usage_report")).toBe(true);
-		expect(harness.shortcuts.has("ctrl+u")).toBe(true);
+		expect(harness.shortcuts.has("ctrl+shift+u")).toBe(true);
 	});
 
 	it("registers tool metadata hooks without crashing", async () => {

--- a/packages/extensions/extensions/usage-tracker.test.ts
+++ b/packages/extensions/extensions/usage-tracker.test.ts
@@ -352,10 +352,10 @@ describe("usage-tracker extension", () => {
 			expect(pi._commands.has("usage-refresh")).toBe(true);
 		});
 
-		it("registers ctrl+u shortcut (overrides built-in deleteToLineStart)", () => {
+		it("registers ctrl+shift+u shortcut (overrides built-in deleteToLineStart)", () => {
 			usageTracker(pi as any);
-			expect(pi._shortcuts.has("ctrl+u")).toBe(true);
-			expect(pi._shortcuts.get("ctrl+u").description).toContain("rate limits");
+			expect(pi._shortcuts.has("ctrl+shift+u")).toBe(true);
+			expect(pi._shortcuts.get("ctrl+shift+u").description).toContain("rate limits");
 		});
 
 		it("does not load persisted history or rate-limit cache during registration", () => {

--- a/packages/extensions/extensions/usage-tracker.ts
+++ b/packages/extensions/extensions/usage-tracker.ts
@@ -23,7 +23,7 @@ Key usage-tracker surfaces:
 
 - widget above the editor for at-a-glance quotas and session totals
 - `/usage` for the full dashboard overlay
-- `Ctrl+U` as a shortcut for the same overlay
+- `Ctrl+Shift+U` as a shortcut for the same overlay
 - `/usage-toggle` to show or hide the widget
 - `/usage-refresh` to force fresh provider probes
 - `usage_report` so the agent can answer quota and spend questions directly
@@ -1813,7 +1813,7 @@ export default function usageTracker(pi: ExtensionAPI) {
 
 	// ─── Keyboard shortcut ────────────────────────────────────────────────
 
-	pi.registerShortcut("ctrl+u", {
+	pi.registerShortcut("ctrl+shift+u", {
 		description: "Show usage dashboard with current-provider rate limits and costs",
 		async handler(ctx) {
 			await loadPersistedState();


### PR DESCRIPTION
Updates the usage-tracker keyboard shortcut from `Ctrl+U` to `Ctrl+Shift+U` across all source files, tests, and documentation. Keeps the `/usage`, `/usage-toggle`, `/usage-refresh` commands and `usage_report` tool unchanged.