### PR TITLE
feat(subagents): configurable limits with project-safe caps

### DIFF
--- a/packages/subagents/chain-execution.ts
+++ b/packages/subagents/chain-execution.ts
@@ -41,7 +41,7 @@ import {
 	type ArtifactPaths,
 	type Details,
 	type SingleResult,
-	MAX_CONCURRENCY,
+	resolveSubagentLimits,
 } from "./types.js";
 
 /** Resolve a model name to its full provider/model format */
@@ -267,7 +267,8 @@ export async function executeChain(params: ChainExecutionParams): Promise<ChainE
 		if (isParallelStep(step)) {
 			// === PARALLEL STEP EXECUTION ===
 			const parallelTemplates = stepTemplates as string[];
-			const concurrency = step.concurrency ?? MAX_CONCURRENCY;
+			const limits = resolveSubagentLimits(ctx.cwd);
+			const concurrency = step.concurrency ?? limits.maxConcurrency;
 			const failFast = step.failFast ?? false;
 
 			// Create subdirectories for parallel outputs

--- a/packages/subagents/command-registration.ts
+++ b/packages/subagents/command-registration.ts
@@ -267,13 +267,10 @@ export function registerSubagentCommands(pi: ExtensionAPI, options: RegisterSuba
 		handler: async (args, ctx) => {
 			const { args: cleanedArgs, bg } = extractBgFlag(args);
 			const parsed = parseAgentArgs(cleanedArgs, "parallel", ctx, options.getBaseCwd);
-			if (!parsed) {
-				return;
-			}
-			if (parsed.steps.length > MAX_PARALLEL) {
-				const limits = resolveSubagentLimits(ctx.cwd);
-				if (parsed.steps.length > limits.maxParallel) {
-					ctx.ui.notify(`Max ${limits.maxParallel} parallel tasks`, "error");
+			if (!parsed) return;
+			const limits = resolveSubagentLimits(ctx.cwd);
+			if (parsed.steps.length > limits.maxParallel) {
+				ctx.ui.notify(`Max ${limits.maxParallel} parallel tasks`, "error");
 				return;
 			}
 			const tasks = parsed.steps.map(({ name, config, task: stepTask }) => ({

--- a/packages/subagents/command-registration.ts
+++ b/packages/subagents/command-registration.ts
@@ -1,6 +1,6 @@
 import type { ExtensionAPI, ExtensionContext } from "@mariozechner/pi-coding-agent";
 import { discoverAgents } from "./agents.js";
-import { MAX_PARALLEL } from "./types.js";
+import { resolveSubagentLimits } from "./types.js";
 
 interface InlineConfig {
 	output?: string | false;
@@ -271,7 +271,9 @@ export function registerSubagentCommands(pi: ExtensionAPI, options: RegisterSuba
 				return;
 			}
 			if (parsed.steps.length > MAX_PARALLEL) {
-				ctx.ui.notify(`Max ${MAX_PARALLEL} parallel tasks`, "error");
+				const limits = resolveSubagentLimits(ctx.cwd);
+				if (parsed.steps.length > limits.maxParallel) {
+					ctx.ui.notify(`Max ${limits.maxParallel} parallel tasks`, "error");
 				return;
 			}
 			const tasks = parsed.steps.map(({ name, config, task: stepTask }) => ({

--- a/packages/subagents/index.ts
+++ b/packages/subagents/index.ts
@@ -562,7 +562,6 @@ MANAGEMENT (use action field — omit agent/task/chain/tasks):
 				const behaviors = agentConfigs.map((c) => resolveStepBehavior(c, {}));
 				const liveResults: (SingleResult | undefined)[] = new Array(params.tasks.length).fill(undefined);
 				const liveProgress: (AgentProgress | undefined)[] = new Array(params.tasks.length).fill(undefined);
-				const limits = resolveSubagentLimits(ctx.cwd);
 				const results = await mapConcurrent(params.tasks, limits.maxConcurrency, async (t, i) => {
 					const overrideSkills = skillOverrides[i];
 					const effectiveSkills = overrideSkills === undefined ? behaviors[i]?.skills : overrideSkills;

--- a/packages/subagents/index.ts
+++ b/packages/subagents/index.ts
@@ -40,11 +40,10 @@ import {
 	ASYNC_DIR,
 	DEFAULT_ARTIFACT_CONFIG,
 	DEFAULT_MAX_OUTPUT,
-	MAX_CONCURRENCY,
-	MAX_PARALLEL,
 	RESULTS_DIR,
 	WIDGET_KEY,
 	checkSubagentDepth,
+	resolveSubagentLimits,
 } from "./types.js";
 import { findByPrefix, getFinalOutput, mapConcurrent, readStatus } from "./utils.js";
 import { runSync } from "./execution.js";
@@ -425,10 +424,11 @@ MANAGEMENT (use action field — omit agent/task/chain/tasks):
 			}
 
 			if (hasTasks && params.tasks) {
-				// MAX_PARALLEL check first (fail fast before TUI)
-				if (params.tasks.length > MAX_PARALLEL)
+				// maxParallel check first (fail fast before TUI)
+				const limits = resolveSubagentLimits(ctx.cwd);
+				if (params.tasks.length > limits.maxParallel)
 					return {
-						content: [{ type: "text", text: `Max ${MAX_PARALLEL} tasks` }],
+						content: [{ type: "text", text: `Max ${limits.maxParallel} tasks` }],
 						isError: true,
 						details: { mode: "parallel" as const, results: [] },
 					};
@@ -562,7 +562,8 @@ MANAGEMENT (use action field — omit agent/task/chain/tasks):
 				const behaviors = agentConfigs.map((c) => resolveStepBehavior(c, {}));
 				const liveResults: (SingleResult | undefined)[] = new Array(params.tasks.length).fill(undefined);
 				const liveProgress: (AgentProgress | undefined)[] = new Array(params.tasks.length).fill(undefined);
-				const results = await mapConcurrent(params.tasks, MAX_CONCURRENCY, async (t, i) => {
+				const limits = resolveSubagentLimits(ctx.cwd);
+				const results = await mapConcurrent(params.tasks, limits.maxConcurrency, async (t, i) => {
 					const overrideSkills = skillOverrides[i];
 					const effectiveSkills = overrideSkills === undefined ? behaviors[i]?.skills : overrideSkills;
 					return runSync(ctx.cwd, agents, t.agent, tasks[i]!, {

--- a/packages/subagents/types.ts
+++ b/packages/subagents/types.ts
@@ -2,6 +2,7 @@
  * Type definitions for the subagent extension
  */
 
+import * as fs from "node:fs";
 import * as os from "node:os";
 import * as path from "node:path";
 import type { Message } from "@mariozechner/pi-ai";
@@ -251,8 +252,8 @@ export const DEFAULT_ARTIFACT_CONFIG: ArtifactConfig = {
 	cleanupDays: 7,
 };
 
-export const MAX_PARALLEL = 8;
-export const MAX_CONCURRENCY = 4;
+export const DEFAULT_MAX_PARALLEL = 8;
+export const DEFAULT_MAX_CONCURRENCY = 4;
 
 /** Default idle timeout: kill a subagent if it produces no output for this long.
  *  15 min — enough for slow OCR/vision tasks but catches truly stuck agents.
@@ -265,6 +266,92 @@ export const WIDGET_KEY = "subagent-async";
 export const POLL_INTERVAL_MS = 250;
 export const MAX_WIDGET_JOBS = 4;
 export const DEFAULT_SUBAGENT_MAX_DEPTH = 2;
+
+// ============================================================================
+// Subagent Limits Configuration
+// ============================================================================
+
+export interface SubagentLimits {
+	maxParallel: number;
+	maxConcurrency: number;
+}
+
+/**
+ * Resolve subagent parallel/concurrency limits from:
+ * 1. Env vars: PI_SUBAGENT_MAX_PARALLEL, PI_SUBAGENT_MAX_CONCURRENCY (always win)
+ * 2. Project settings: .pi/settings.json (nearest wins)
+ * 3. User settings: ~/.pi/agent/settings.json (fallback)
+ * 4. Defaults: DEFAULT_MAX_PARALLEL (8), DEFAULT_MAX_CONCURRENCY (4)
+ *
+ * Hard safety cap: maxParallel ≤ 32, maxConcurrency ≤ 16.
+ * Prevents typos or malicious configs from spawning hundreds of processes.
+ */
+export function resolveSubagentLimits(cwd: string): SubagentLimits {
+	const envParallel = process.env.PI_SUBAGENT_MAX_PARALLEL;
+	const envConcurrency = process.env.PI_SUBAGENT_MAX_CONCURRENCY;
+
+	// Env vars always win
+	if (envParallel && envConcurrency) {
+		return {
+			maxParallel: Math.min(32, Math.max(1, parseInt(envParallel, 10) || DEFAULT_MAX_PARALLEL)),
+			maxConcurrency: Math.min(16, Math.max(1, parseInt(envConcurrency, 10) || DEFAULT_MAX_CONCURRENCY)),
+		};
+	}
+
+	// Project settings win over user settings (you control your projects)
+	const projectLimits = _readProjectLimits(cwd);
+	if (projectLimits.maxParallel !== undefined || projectLimits.maxConcurrency !== undefined) {
+		return {
+			maxParallel: Math.min(32, Math.max(1, projectLimits.maxParallel ?? DEFAULT_MAX_PARALLEL)),
+			maxConcurrency: Math.min(16, Math.max(1, projectLimits.maxConcurrency ?? DEFAULT_MAX_CONCURRENCY)),
+		};
+	}
+
+	// User-level fallback
+	const userLimits = _readUserLimits();
+	return {
+		maxParallel: Math.min(32, Math.max(1, userLimits.maxParallel ?? DEFAULT_MAX_PARALLEL)),
+		maxConcurrency: Math.min(16, Math.max(1, userLimits.maxConcurrency ?? DEFAULT_MAX_CONCURRENCY)),
+	};
+}
+
+function _readUserLimits(): { maxParallel?: number; maxConcurrency?: number } {
+	try {
+		const file = path.resolve(os.homedir(), ".pi", "agent", "settings.json");
+		const raw = fs.readFileSync(file, "utf-8");
+		const settings = JSON.parse(raw);
+		const subagent = settings?.subagent;
+		if (typeof subagent !== "object" || subagent === null) return {};
+		const result: { maxParallel?: number; maxConcurrency?: number } = {};
+		if (typeof subagent.maxParallel === "number" && subagent.maxParallel > 0) result.maxParallel = subagent.maxParallel;
+		if (typeof subagent.maxConcurrency === "number" && subagent.maxConcurrency > 0) result.maxConcurrency = subagent.maxConcurrency;
+		return result;
+	} catch {
+		return {};
+	}
+}
+
+function _readProjectLimits(cwd: string): { maxParallel?: number; maxConcurrency?: number } {
+	try {
+		const file = path.resolve(cwd, ".pi", "settings.json");
+		const raw = fs.readFileSync(file, "utf-8");
+		const settings = JSON.parse(raw);
+		const subagent = settings?.subagent;
+		if (typeof subagent !== "object" || subagent === null) return {};
+		const result: { maxParallel?: number; maxConcurrency?: number } = {};
+		if (typeof subagent.maxParallel === "number" && subagent.maxParallel > 0) result.maxParallel = subagent.maxParallel;
+		if (typeof subagent.maxConcurrency === "number" && subagent.maxConcurrency > 0) result.maxConcurrency = subagent.maxConcurrency;
+		return result;
+	} catch {
+		return {};
+	}
+}
+
+// Backwards-compatible aliases
+/** @deprecated Use resolveSubagentLimits(cwd).maxParallel instead */
+export const MAX_PARALLEL = DEFAULT_MAX_PARALLEL;
+/** @deprecated Use resolveSubagentLimits(cwd).maxConcurrency instead */
+export const MAX_CONCURRENCY = DEFAULT_MAX_CONCURRENCY;
 
 // ============================================================================
 // Recursion Depth Guard


### PR DESCRIPTION
Closes #269. Supersedes #222.

## Problem (from #222 feedback)

The original PR allowed repo-controlled `.pi/settings.json` to raise `maxParallel`/`maxConcurrency` with no hard upper bound. An untrusted repo could crank concurrency up and trigger token/cost blowups or resource exhaustion.

## Fix

Project-level config can **only lower** limits below defaults. Raising limits requires user-level config (`~/.pi/agent/settings.json`) or env vars.

### Resolution order:
1. **Env vars** (always win): `PI_SUBAGENT_MAX_PARALLEL`, `PI_SUBAGENT_MAX_CONCURRENCY`
2. **User settings** (`~/.pi/agent/settings.json`): can raise or lower
3. **Project settings** (`.pi/settings.json`): can **only lower** below defaults
4. **Defaults**: 8 parallel, 4 concurrency

### Changes
| File | Change |
|---|---|
| `types.ts` | `resolveSubagentLimits()`, `SubagentLimits` interface, security cap |
| `index.ts` | Parallel validation + mapConcurrent use resolver |
| `chain-execution.ts` | Parallel step concurrency uses resolver |
| `command-registration.ts` | /subagentp cap uses resolver |