### PR TITLE
fix(subagents): prefer current session model

### DIFF
--- a/.changeset/fix_subagent_routing_to_prefer_the_session_model.md
+++ b/.changeset/fix_subagent_routing_to_prefer_the_session_model.md
@@ -1,0 +1,7 @@
+---
+default: patch
+---
+
+Fix subagent routing to prefer the current session model before delegated adaptive routing.
+
+Subagents without an explicit runtime or frontmatter model now inherit the active session model when it is available, instead of silently switching providers through delegated category routing.

--- a/packages/subagents/model-routing.ts
+++ b/packages/subagents/model-routing.ts
@@ -386,15 +386,14 @@ export function resolveSubagentModelResolution(
 		}
 	}
 
-	const delegatedModel = resolveDelegatedAgentModel(agent, availableModels, options);
-	if (delegatedModel) {
-		return { model: delegatedModel, source: "delegated-category", category };
-	}
-
-	// Fall back to current session model if it's available
 	const sessionModel = findAvailableModel(options.currentModel, availableModels);
 	if (sessionModel) {
 		return { model: sessionModel, source: "session-default", category };
+	}
+
+	const delegatedModel = resolveDelegatedAgentModel(agent, availableModels, options);
+	if (delegatedModel) {
+		return { model: delegatedModel, source: "delegated-category", category };
 	}
 
 	return { source: "session-default", category };

--- a/packages/subagents/tests/model-routing.test.ts
+++ b/packages/subagents/tests/model-routing.test.ts
@@ -414,6 +414,54 @@ describe("resolveSubagentModelResolution", () => {
 			expect(result.category).toBeUndefined();
 		});
 
+		it("prefers the current session model over delegated routing", () => {
+			const tempAgentDir = mkdtempSync(join(tmpdir(), "subagent-routing-"));
+			getAgentDir.mockReturnValue(tempAgentDir);
+			mkdirSync(join(tempAgentDir, "extensions", "adaptive-routing"), { recursive: true });
+			writeFileSync(
+				join(tempAgentDir, "extensions", "adaptive-routing", "config.json"),
+				JSON.stringify(
+					{
+						delegatedRouting: {
+							enabled: true,
+							categories: {
+								"quick-discovery": {
+									candidates: ["google/gemini-2.5-flash"],
+									preferredProviders: ["google"],
+								},
+							},
+						},
+					},
+					null,
+					2,
+				),
+			);
+
+			try {
+				const result = resolveSubagentModelResolution(
+					{
+						name: "scout",
+						description: "Scout",
+						systemPrompt: "Prompt",
+						source: "builtin",
+						filePath: "/tmp/scout.md",
+						extraFields: { category: "quick-discovery" },
+					},
+					sampleModels,
+					undefined,
+					{ currentModel: "openai/gpt-5-mini" },
+				);
+
+				expect(result).toEqual({
+					model: "openai/gpt-5-mini",
+					source: "session-default",
+					category: "quick-discovery",
+				});
+			} finally {
+				rmSync(tempAgentDir, { recursive: true, force: true });
+			}
+		});
+
 		it("rejects unavailable session-default currentModel", () => {
 			const result = resolveSubagentModelResolution(
 				{


### PR DESCRIPTION
## Summary
- prefer the active session model before delegated adaptive routing when a subagent has no explicit model
- keep delegated routing as the fallback when no explicit or session model is available
- add regression coverage for session-model precedence over delegated routing

## Testing
- pnpm test -- packages/subagents/tests/model-routing.test.ts
- pnpm lint
- pnpm typecheck

Closes #204