### PR TITLE
fix(subagents): cascade parent project agents

### DIFF
--- a/.changeset/fix_cascading_project_agent_discovery.md
+++ b/.changeset/fix_cascading_project_agent_discovery.md
@@ -1,0 +1,7 @@
+---
+default: patch
+---
+
+Fix subagent project agent discovery to cascade through parent workspaces.
+
+Subagent agent and chain discovery now loads project-scoped definitions from every ancestor project agents directory, with the nearest project definition winning on name collisions while still keeping parent-only entries available.

--- a/packages/subagents/agents.ts
+++ b/packages/subagents/agents.ts
@@ -10,7 +10,7 @@ import { KNOWN_FIELDS } from "./agent-serializer.js";
 import { mergeAgentsForScope } from "./agent-selection.js";
 import { parseChain } from "./chain-serializer.js";
 import { getUserAgentsDir } from "./paths.js";
-import { findNearestProjectAgentsDir } from "./project-agents-storage.js";
+import { findNearestProjectAgentsDir, findProjectAgentsDirs } from "./project-agents-storage.js";
 
 export type AgentScope = "user" | "project" | "both";
 
@@ -231,13 +231,42 @@ function loadChainsFromDir(dir: string, source: AgentSource): ChainConfig[] {
 
 const BUILTIN_AGENTS_DIR = path.join(path.dirname(fileURLToPath(import.meta.url)), "agents");
 
+function mergeNamedConfigs<T extends { name: string }>(groups: T[][]): T[] {
+	const merged = new Map<string, T>();
+	for (const group of groups) {
+		for (const item of group) {
+			if (!merged.has(item.name)) {
+				merged.set(item.name, item);
+			}
+		}
+	}
+	return Array.from(merged.values());
+}
+
+function loadAgentsFromDirs(dirs: string[], source: AgentSource): AgentConfig[] {
+	const groups: AgentConfig[][] = [];
+	for (const dir of dirs) {
+		groups.push(loadAgentsFromDir(dir, source));
+	}
+	return mergeNamedConfigs(groups);
+}
+
+function loadChainsFromDirs(dirs: string[], source: AgentSource): ChainConfig[] {
+	const groups: ChainConfig[][] = [];
+	for (const dir of dirs) {
+		groups.push(loadChainsFromDir(dir, source));
+	}
+	return mergeNamedConfigs(groups);
+}
+
 export function discoverAgents(cwd: string, scope: AgentScope): AgentDiscoveryResult {
 	const userDir = getUserAgentsDir();
 	const projectAgentsDir = findNearestProjectAgentsDir(cwd);
+	const projectAgentDirs = findProjectAgentsDirs(cwd);
 
 	const builtinAgents = loadAgentsFromDir(BUILTIN_AGENTS_DIR, "builtin");
 	const userAgents = scope === "project" ? [] : loadAgentsFromDir(userDir, "user");
-	const projectAgents = scope === "user" || !projectAgentsDir ? [] : loadAgentsFromDir(projectAgentsDir, "project");
+	const projectAgents = scope === "user" ? [] : loadAgentsFromDirs(projectAgentDirs, "project");
 	const agents = mergeAgentsForScope(scope, userAgents, projectAgents, builtinAgents);
 
 	return { agents, projectAgentsDir };
@@ -253,14 +282,15 @@ export function discoverAgentsAll(cwd: string): {
 } {
 	const userDir = getUserAgentsDir();
 	const projectDir = findNearestProjectAgentsDir(cwd);
+	const projectDirs = findProjectAgentsDirs(cwd);
 
 	const builtin = loadAgentsFromDir(BUILTIN_AGENTS_DIR, "builtin");
 	const user = loadAgentsFromDir(userDir, "user");
-	const project = projectDir ? loadAgentsFromDir(projectDir, "project") : [];
-	const chains = [
-		...loadChainsFromDir(userDir, "user"),
-		...(projectDir ? loadChainsFromDir(projectDir, "project") : []),
-	];
+	const project = loadAgentsFromDirs(projectDirs, "project");
+	const chains = mergeNamedConfigs([
+		loadChainsFromDir(userDir, "user"),
+		loadChainsFromDirs(projectDirs, "project"),
+	]);
 
 	return { builtin, user, project, chains, userDir, projectDir };
 }

--- a/packages/subagents/project-agents-storage.ts
+++ b/packages/subagents/project-agents-storage.ts
@@ -171,17 +171,26 @@ semantics in both shared and project storage modes.
 
 <!-- {/subagentsFindNearestProjectAgentsDirDocs} -->
 */
-export function findNearestProjectAgentsDir(cwd: string, options?: ProjectAgentStorageOptions): string {
+function getProjectAgentsCandidateDir(cwd: string, options: Required<ProjectAgentStorageOptions>): string {
+	return options.mode === "project" ? getLegacyProjectAgentsDir(cwd) : getSharedProjectAgentsDir(cwd, options);
+}
+
+export function findProjectAgentsDirs(cwd: string, options?: ProjectAgentStorageOptions): string[] {
 	const resolved = resolveProjectAgentStorageOptions(options);
 	migrateLegacyProjectAgents(cwd, resolved);
 
+	const dirs: string[] = [];
 	for (const dir of parentDirs(cwd)) {
-		const candidate =
-			resolved.mode === "project" ? getLegacyProjectAgentsDir(dir) : getSharedProjectAgentsDir(dir, resolved);
+		const candidate = getProjectAgentsCandidateDir(dir, resolved);
 		if (isDirectory(candidate)) {
-			return candidate;
+			dirs.push(candidate);
 		}
 	}
+	return dirs;
+}
 
-	return resolved.mode === "project" ? getLegacyProjectAgentsDir(cwd) : getSharedProjectAgentsDir(cwd, resolved);
+export function findNearestProjectAgentsDir(cwd: string, options?: ProjectAgentStorageOptions): string {
+	const resolved = resolveProjectAgentStorageOptions(options);
+	const [nearestDir] = findProjectAgentsDirs(cwd, resolved);
+	return nearestDir ?? getProjectAgentsCandidateDir(cwd, resolved);
 }

--- a/packages/subagents/tests/agents.test.ts
+++ b/packages/subagents/tests/agents.test.ts
@@ -127,6 +127,45 @@ describe("discoverAgents", () => {
 		expect(result.projectAgentsDir).toBe(getSharedProjectAgentsDir(projectDir));
 	});
 
+	it("cascades shared project agents from parent directories with nearest overrides", () => {
+		const homeDir = createTempDir("subagents-cascade-home-");
+		const projectDir = createTempDir("subagents-cascade-project-");
+		const nestedProjectDir = path.join(projectDir, "packages", "feature");
+		const deepDir = path.join(nestedProjectDir, "src");
+		process.env.HOME = homeDir;
+		process.env.USERPROFILE = homeDir;
+		process.env.PI_SUBAGENT_PROJECT_AGENTS_MODE = "shared";
+		fs.mkdirSync(deepDir, { recursive: true });
+
+		writeAgentFile(
+			getSharedProjectAgentsDir(projectDir),
+			"scout.md",
+			"---\nname: scout\ndescription: Parent scout\n---\n\nParent prompt\n",
+		);
+		writeAgentFile(
+			getSharedProjectAgentsDir(projectDir),
+			"reviewer.md",
+			"---\nname: reviewer\ndescription: Parent reviewer\n---\n\nReviewer prompt\n",
+		);
+		writeAgentFile(
+			getSharedProjectAgentsDir(nestedProjectDir),
+			"scout.md",
+			"---\nname: scout\ndescription: Nested scout\n---\n\nNested prompt\n",
+		);
+		writeAgentFile(
+			getSharedProjectAgentsDir(nestedProjectDir),
+			"worker.md",
+			"---\nname: worker\ndescription: Nested worker\n---\n\nWorker prompt\n",
+		);
+
+		const result = discoverAgents(deepDir, "project");
+		const byName = new Map(result.agents.map((agent) => [agent.name, agent]));
+		expect(byName.get("scout")?.description).toBe("Nested scout");
+		expect(byName.get("worker")?.description).toBe("Nested worker");
+		expect(byName.get("reviewer")?.description).toBe("Parent reviewer");
+		expect(result.projectAgentsDir).toBe(getSharedProjectAgentsDir(nestedProjectDir));
+	});
+
 	it("migrates legacy .pi/agents into the shared store when shared mode is enabled", () => {
 		const homeDir = createTempDir("subagents-migrate-home-");
 		const projectDir = createTempDir("subagents-migrate-project-");
@@ -198,5 +237,62 @@ describe("discoverAgentsAll", () => {
 		const result = discoverAgentsAll(projectDir);
 		expect(result.project.map((agent) => agent.name)).toContain("custom-project");
 		expect(result.projectDir).toBe(path.join(projectDir, ".pi", "agents"));
+	});
+
+	it("cascades project agents and chains from parent directories with nearest overrides", () => {
+		const homeDir = createTempDir("subagents-all-cascade-home-");
+		const projectDir = createTempDir("subagents-all-cascade-project-");
+		const nestedProjectDir = path.join(projectDir, "apps", "desktop");
+		const deepDir = path.join(nestedProjectDir, "src");
+		process.env.HOME = homeDir;
+		process.env.USERPROFILE = homeDir;
+		process.env.PI_SUBAGENT_PROJECT_AGENTS_MODE = "shared";
+		fs.mkdirSync(deepDir, { recursive: true });
+
+		writeAgentFile(
+			getSharedProjectAgentsDir(projectDir),
+			"scout.md",
+			"---\nname: scout\ndescription: Parent scout\n---\n\nParent prompt\n",
+		);
+		writeAgentFile(
+			getSharedProjectAgentsDir(projectDir),
+			"reviewer.md",
+			"---\nname: reviewer\ndescription: Parent reviewer\n---\n\nReviewer prompt\n",
+		);
+		writeAgentFile(
+			getSharedProjectAgentsDir(projectDir),
+			"review-pipeline.chain.md",
+			"---\nname: review-pipeline\ndescription: Parent chain\n---\n\n## scout\n\nParent chain\n",
+		);
+		writeAgentFile(
+			getSharedProjectAgentsDir(nestedProjectDir),
+			"scout.md",
+			"---\nname: scout\ndescription: Nested scout\n---\n\nNested prompt\n",
+		);
+		writeAgentFile(
+			getSharedProjectAgentsDir(nestedProjectDir),
+			"worker.md",
+			"---\nname: worker\ndescription: Nested worker\n---\n\nWorker prompt\n",
+		);
+		writeAgentFile(
+			getSharedProjectAgentsDir(nestedProjectDir),
+			"review-pipeline.chain.md",
+			"---\nname: review-pipeline\ndescription: Nested chain\n---\n\n## worker\n\nNested chain\n",
+		);
+		writeAgentFile(
+			getSharedProjectAgentsDir(nestedProjectDir),
+			"ship.chain.md",
+			"---\nname: ship\ndescription: Ship chain\n---\n\n## reviewer\n\nShip it\n",
+		);
+
+		const result = discoverAgentsAll(deepDir);
+		const projectByName = new Map(result.project.map((agent) => [agent.name, agent]));
+		const chainsByName = new Map(result.chains.map((chain) => [chain.name, chain]));
+		expect(projectByName.get("scout")?.description).toBe("Nested scout");
+		expect(projectByName.get("worker")?.description).toBe("Nested worker");
+		expect(projectByName.get("reviewer")?.description).toBe("Parent reviewer");
+		expect(chainsByName.get("review-pipeline")?.description).toBe("Nested chain");
+		expect(chainsByName.get("ship")?.description).toBe("Ship chain");
+		expect(result.projectDir).toBe(getSharedProjectAgentsDir(nestedProjectDir));
 	});
 });


### PR DESCRIPTION
## Summary
- load project-scoped agents from every parent project agents directory instead of only the nearest one
- keep nearest project definitions winning on name collisions while still exposing parent-only agents and chains
- add regression coverage for cascading shared project agents and chains

## Testing
- pnpm test -- packages/subagents/tests/agents.test.ts
- pnpm lint
- pnpm typecheck
- pnpm security:check
- pnpm build

Closes #206