### PR TITLE
fix(subagents): wrap async widget debug output

### DIFF
--- a/.changeset/fix_async_subagent_widget_debug_output_wrapping.md
+++ b/.changeset/fix_async_subagent_widget_debug_output_wrapping.md
@@ -1,0 +1,5 @@
+---
+default: patch
+---
+
+Wrap async subagent widget debug tail lines instead of truncating them with ellipses so long model, cwd, and tool details stay readable in narrow terminals.

--- a/packages/subagents/render.ts
+++ b/packages/subagents/render.ts
@@ -4,7 +4,16 @@
 
 import type { AgentToolResult } from "@mariozechner/pi-agent-core";
 import { getMarkdownTheme, type ExtensionContext } from "@mariozechner/pi-coding-agent";
-import { Container, Markdown, Spacer, Text, truncateToWidth, visibleWidth, type Widget } from "@mariozechner/pi-tui";
+import {
+	Container,
+	Markdown,
+	Spacer,
+	Text,
+	truncateToWidth,
+	visibleWidth,
+	wrapTextWithAnsi,
+	type Widget,
+} from "@mariozechner/pi-tui";
 import { type AsyncJobState, type Details, MAX_WIDGET_JOBS, WIDGET_KEY } from "./types.js";
 import { formatTokens, formatUsage, formatDuration, formatToolCall, shortenPath } from "./formatters.js";
 import { getFinalOutput, getDisplayItems, getOutputTail, getLastActivity } from "./utils.js";
@@ -165,7 +174,8 @@ export function renderWidget(ctx: ExtensionContext, jobs: AsyncJobState[], optio
 		if (job.status === "running" && job.outputFile) {
 			const tail = getOutputTail(job.outputFile, 3);
 			for (const line of tail) {
-				lines.push(truncLine(theme.fg("dim", `  > ${line}`), w));
+				const wrapped = wrapTextWithAnsi(theme.fg("dim", `  > ${line}`), w);
+				lines.push(...wrapped);
 			}
 		}
 	}

--- a/packages/subagents/tests/render.test.ts
+++ b/packages/subagents/tests/render.test.ts
@@ -38,6 +38,16 @@ vi.mock("@mariozechner/pi-tui", () => ({
 	},
 	truncateToWidth: (text: string, width: number) => (text.length <= width ? text : `${text.slice(0, width - 1)}…`),
 	visibleWidth: (text: string) => text.replaceAll("\u001b[0m", "").length,
+	wrapTextWithAnsi: (text: string, width: number) => {
+		if (text.length <= width) {
+			return [text];
+		}
+		const lines: string[] = [];
+		for (let start = 0; start < text.length; start += width) {
+			lines.push(text.slice(start, start + width));
+		}
+		return lines;
+	},
 }));
 
 vi.mock("../formatters.js", () => ({
@@ -155,6 +165,38 @@ describe("subagent async widget rendering", () => {
 		renderWidget(ctx as never, [completedJob]);
 		renderWidget(ctx as never, [completedJob]);
 		expect(ctx._setWidget.mock.calls.length).toBe(callsBefore + 1);
+	});
+
+	it("wraps running debug tail lines while keeping the status header truncated", () => {
+		const originalColumns = process.stdout.columns;
+		process.stdout.columns = 30;
+		renderMocks.getOutputTail.mockReturnValue(["MODEL -> session-default: openai/gpt-5-mini with a long suffix"]);
+
+		try {
+			const ctx = createCtx();
+			renderWidget(ctx as never, [
+				{
+					asyncId: "abcdef123456",
+					asyncDir: "/tmp/run",
+					status: "running",
+					mode: "single",
+					agents: ["very-long-agent-name"],
+					updatedAt: Date.now(),
+					startedAt: Date.now() - 1000,
+					outputFile: "/tmp/out.log",
+					totalTokens: { input: 10, output: 5, total: 15 },
+				},
+			]);
+
+			const lines = ctx._widgets.get(WIDGET_KEY) as string[];
+			expect(lines[1]).toContain("…");
+			expect(lines.slice(2)).toHaveLength(3);
+			expect(lines[2]?.trimEnd()).toBe("  > MODEL -> session-default:");
+			expect(lines.slice(2).join("")).toBe("  > MODEL -> session-default: openai/gpt-5-mini with a long suffix");
+			expect(lines.slice(2).join("\n")).not.toContain("…");
+		} finally {
+			process.stdout.columns = originalColumns;
+		}
 	});
 });
 


### PR DESCRIPTION
## Summary
- wrap async widget debug tail lines with `wrapTextWithAnsi()` instead of truncating them
- keep the single-line async status header truncated as before
- add regression coverage proving wrapped debug output stays readable in narrow terminals

Closes #217