### PR TITLE
perf: eliminate event-loop blocking from sync I/O in hot paths

### DIFF
--- a/packages/adaptive-routing/state.test.ts
+++ b/packages/adaptive-routing/state.test.ts
@@ -1,0 +1,64 @@
+import { describe, expect, it, vi } from "vitest";
+import { mkdtempSync, readFileSync, rmSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+
+const { getAgentDir } = vi.hoisted(() => ({
+	getAgentDir: vi.fn(() => "/mock-home/.pi/agent"),
+}));
+
+vi.mock("@mariozechner/pi-coding-agent", () => ({
+	getAgentDir,
+}));
+
+import { getAdaptiveRoutingStatePath, readAdaptiveRoutingState, writeAdaptiveRoutingState } from "./state.js";
+
+describe("adaptive routing state", () => {
+	it("reads default state when file does not exist", () => {
+		const state = readAdaptiveRoutingState();
+		expect(state).toEqual({});
+	});
+
+	it("debounces state writes", () => {
+		vi.useFakeTimers();
+		const tempDir = mkdtempSync(join(tmpdir(), "adaptive-routing-state-"));
+		getAgentDir.mockReturnValue(tempDir);
+
+		try {
+			writeAdaptiveRoutingState({ mode: "auto" });
+			// Before timer fires, file should not exist
+			expect(() => readFileSync(getAdaptiveRoutingStatePath(), "utf-8")).toThrow();
+
+			vi.advanceTimersByTime(2_100);
+
+			const raw = readFileSync(getAdaptiveRoutingStatePath(), "utf-8");
+			const parsed = JSON.parse(raw);
+			expect(parsed.mode).toBe("auto");
+		} finally {
+			vi.useRealTimers();
+			rmSync(tempDir, { recursive: true, force: true });
+		}
+	});
+
+	it("coalesces multiple rapid writes into one file write", () => {
+		vi.useFakeTimers();
+		const tempDir = mkdtempSync(join(tmpdir(), "adaptive-routing-state-"));
+		getAgentDir.mockReturnValue(tempDir);
+
+		try {
+			writeAdaptiveRoutingState({ mode: "auto" });
+			writeAdaptiveRoutingState({ mode: "shadow" });
+			writeAdaptiveRoutingState({ mode: "off" });
+
+			vi.advanceTimersByTime(2_100);
+
+			const raw = readFileSync(getAdaptiveRoutingStatePath(), "utf-8");
+			const parsed = JSON.parse(raw);
+			// Should contain the last value written
+			expect(parsed.mode).toBe("off");
+		} finally {
+			vi.useRealTimers();
+			rmSync(tempDir, { recursive: true, force: true });
+		}
+	});
+});

--- a/packages/adaptive-routing/state.ts
+++ b/packages/adaptive-routing/state.ts
@@ -22,12 +22,32 @@ export function readAdaptiveRoutingState(): AdaptiveRoutingState {
 	}
 }
 
+let pendingState: AdaptiveRoutingState | undefined;
+let stateSaveTimer: ReturnType<typeof setTimeout> | null = null;
+const STATE_PERSIST_DEBOUNCE_MS = 2_000;
+
+function scheduleStateSave(path: string): void {
+	if (stateSaveTimer) {
+		return;
+	}
+	stateSaveTimer = setTimeout(() => {
+		stateSaveTimer = null;
+		if (pendingState) {
+			const stateToWrite = pendingState;
+			pendingState = undefined;
+			try {
+				mkdirSync(dirname(path), { recursive: true });
+				writeFileSync(path, `${JSON.stringify(stateToWrite, null, 2)}\n`, "utf-8");
+			} catch {
+				// Non-critical persistence only.
+			}
+		}
+	}, STATE_PERSIST_DEBOUNCE_MS);
+	stateSaveTimer.unref?.();
+}
+
 export function writeAdaptiveRoutingState(state: AdaptiveRoutingState): void {
 	const path = getAdaptiveRoutingStatePath();
-	try {
-		mkdirSync(dirname(path), { recursive: true });
-		writeFileSync(path, `${JSON.stringify(state, null, 2)}\n`, "utf-8");
-	} catch {
-		// Non-critical persistence only.
-	}
+	pendingState = state;
+	scheduleStateSave(path);
 }

--- a/packages/adaptive-routing/telemetry.test.ts
+++ b/packages/adaptive-routing/telemetry.test.ts
@@ -116,4 +116,82 @@ describe("adaptive routing telemetry", () => {
 			rmSync(tempAgentDir, { recursive: true, force: true });
 		}
 	});
+
+	it("increments override count for route_override events", () => {
+		const tempAgentDir = mkdtempSync(join(tmpdir(), "adaptive-routing-telemetry-"));
+		getAgentDir.mockReturnValue(tempAgentDir);
+		mkdirSync(join(tempAgentDir, "adaptive-routing"), { recursive: true });
+
+		try {
+			appendTelemetryEvent(
+				{ mode: "local", privacy: "minimal" },
+				{
+					type: "route_override",
+					timestamp: 100,
+					decisionId: "d1",
+					from: { model: "openai/gpt-4", thinking: "high" },
+					to: { model: "anthropic/claude-3", thinking: "high" },
+					reason: "manual",
+				},
+			);
+
+			const aggregates = JSON.parse(readFileSync(getAdaptiveRoutingAggregatesPath(), "utf-8")) as {
+				overrides?: number;
+			};
+			expect(aggregates.overrides).toBe(1);
+		} finally {
+			rmSync(tempAgentDir, { recursive: true, force: true });
+		}
+	});
+
+	it("increments shadow disagreement count for route_shadow_disagreement events", () => {
+		const tempAgentDir = mkdtempSync(join(tmpdir(), "adaptive-routing-telemetry-"));
+		getAgentDir.mockReturnValue(tempAgentDir);
+		mkdirSync(join(tempAgentDir, "adaptive-routing"), { recursive: true });
+
+		try {
+			appendTelemetryEvent(
+				{ mode: "local", privacy: "minimal" },
+				{
+					type: "route_shadow_disagreement",
+					timestamp: 100,
+					decisionId: "d1",
+					suggested: { model: "anthropic/claude-3", thinking: "high" },
+					actual: { model: "openai/gpt-4", thinking: "high" },
+				},
+			);
+
+			const aggregates = JSON.parse(readFileSync(getAdaptiveRoutingAggregatesPath(), "utf-8")) as {
+				shadowDisagreements?: number;
+			};
+			expect(aggregates.shadowDisagreements).toBe(1);
+		} finally {
+			rmSync(tempAgentDir, { recursive: true, force: true });
+		}
+	});
+
+	it("increments feedback count for route_feedback events", () => {
+		const tempAgentDir = mkdtempSync(join(tmpdir(), "adaptive-routing-telemetry-"));
+		getAgentDir.mockReturnValue(tempAgentDir);
+		mkdirSync(join(tempAgentDir, "adaptive-routing"), { recursive: true });
+
+		try {
+			appendTelemetryEvent(
+				{ mode: "local", privacy: "minimal" },
+				{
+					type: "route_feedback",
+					timestamp: 100,
+					decisionId: "d1",
+					category: "good",
+				},
+			);
+
+			const aggregates = JSON.parse(readFileSync(getAdaptiveRoutingAggregatesPath(), "utf-8")) as {
+				feedback?: Record<string, number>;
+			};
+			expect(aggregates.feedback?.["good"]).toBe(1);
+		} finally {
+			rmSync(tempAgentDir, { recursive: true, force: true });
+		}
+	});
 });

--- a/packages/adaptive-routing/telemetry.ts
+++ b/packages/adaptive-routing/telemetry.ts
@@ -1,5 +1,5 @@
 import { createHash, randomUUID } from "node:crypto";
-import { existsSync, mkdirSync, readFileSync, writeFileSync } from "node:fs";
+import { appendFileSync, existsSync, mkdirSync, readFileSync, writeFileSync } from "node:fs";
 import { dirname, join } from "node:path";
 import { getAgentDir } from "@mariozechner/pi-coding-agent";
 import type {
@@ -30,6 +30,9 @@ export function createDecisionId(): string {
 	return randomUUID();
 }
 
+// In-memory stats accumulator so we don't re-read the entire events file on every append.
+let memoryStats: AdaptiveRoutingStats | undefined;
+
 export function appendTelemetryEvent(
 	config: AdaptiveRoutingTelemetryConfig,
 	event: AdaptiveRoutingTelemetryEvent,
@@ -41,15 +44,73 @@ export function appendTelemetryEvent(
 	const eventsPath = getAdaptiveRoutingEventsPath();
 	try {
 		mkdirSync(dirname(eventsPath), { recursive: true });
-		const payload = `${JSON.stringify(event)}\n`;
-		if (existsSync(eventsPath)) {
-			writeFileSync(eventsPath, readFileSync(eventsPath, "utf-8") + payload, "utf-8");
-		} else {
-			writeFileSync(eventsPath, payload, "utf-8");
+		// Append-only write — never read the entire file back just to add one line.
+		appendFileSync(eventsPath, `${JSON.stringify(event)}\n`, "utf-8");
+
+		// Update in-memory stats incrementally instead of re-reading the whole file.
+		if (!memoryStats) {
+			memoryStats = readAggregatesFromDisk();
 		}
-		writeAggregates(computeStats(readTelemetryEvents()));
+		updateStatsIncremental(memoryStats, event);
+		writeAggregates(memoryStats);
 	} catch {
 		// Telemetry is best-effort only.
+	}
+}
+
+function readAggregatesFromDisk(): AdaptiveRoutingStats {
+	const aggregatesPath = getAdaptiveRoutingAggregatesPath();
+	try {
+		if (!existsSync(aggregatesPath)) {
+			return emptyStats();
+		}
+		const raw = readFileSync(aggregatesPath, "utf-8");
+		const parsed = JSON.parse(raw) as AdaptiveRoutingStats;
+		if (parsed && typeof parsed === "object" && "decisions" in parsed) {
+			return parsed;
+		}
+		return emptyStats();
+	} catch {
+		return emptyStats();
+	}
+}
+
+function emptyStats(): AdaptiveRoutingStats {
+	return {
+		decisions: 0,
+		feedback: {},
+		overrides: 0,
+		shadowDisagreements: 0,
+		outcomes: 0,
+		perModelLatencyMs: {},
+	};
+}
+
+function updateStatsIncremental(stats: AdaptiveRoutingStats, event: AdaptiveRoutingTelemetryEvent): void {
+	if (event.type === "route_decision") {
+		stats.decisions += 1;
+		stats.lastDecisionAt = Math.max(stats.lastDecisionAt ?? 0, event.timestamp);
+	} else if (event.type === "route_override") {
+		stats.overrides += 1;
+	} else if (event.type === "route_shadow_disagreement") {
+		stats.shadowDisagreements += 1;
+	} else if (event.type === "route_feedback") {
+		stats.feedback[event.category] = (stats.feedback[event.category] ?? 0) + 1;
+	} else if (event.type === "route_outcome") {
+		stats.outcomes += 1;
+		if (typeof event.durationMs === "number" && Number.isFinite(event.durationMs)) {
+			const existing = stats.avgDurationMs ?? 0;
+			const count = stats.outcomes;
+			stats.avgDurationMs = Math.round(((existing * (count - 1) + event.durationMs) / count) * 10) / 10;
+			if (event.selectedModel) {
+				const m = stats.perModelLatencyMs[event.selectedModel] ?? { count: 0, avgMs: 0 };
+				const newCount = m.count + 1;
+				stats.perModelLatencyMs[event.selectedModel] = {
+					count: newCount,
+					avgMs: Math.round(((m.avgMs * m.count + event.durationMs) / newCount) * 10) / 10,
+				};
+			}
+		}
 	}
 }
 

--- a/packages/ant-colony/extensions/ant-colony/nest.ts
+++ b/packages/ant-colony/extensions/ant-colony/nest.ts
@@ -324,13 +324,18 @@ export class Nest {
 	 * Uses incremental reads to avoid re-parsing the entire log each time.
 	 */
 	getAllPheromones(): Pheromone[] {
-		if (!fs.existsSync(this.pheromoneFile)) {
+		const now = Date.now();
+		let stat: fs.Stats | undefined;
+		try {
+			stat = fs.statSync(this.pheromoneFile);
+		} catch {
 			return [];
 		}
-		const now = Date.now();
+		if (!stat) {
+			return [];
+		}
 
 		// Incremental read: only parse bytes added since last call
-		const stat = fs.statSync(this.pheromoneFile);
 		if (stat.size > this.pheromoneOffset) {
 			const fd = fs.openSync(this.pheromoneFile, "r");
 			const buf = Buffer.alloc(stat.size - this.pheromoneOffset);

--- a/packages/extensions/extensions/scheduler.test.ts
+++ b/packages/extensions/extensions/scheduler.test.ts
@@ -3062,3 +3062,82 @@ describe("edge cases", () => {
 		expect(runtime.getTask(task.id)).toBeUndefined();
 	});
 });
+
+describe("schedulePersistTasks debounce", () => {
+	let pi: ReturnType<typeof createMockPi>;
+	let ctx: ReturnType<typeof createMockCtx>;
+
+	beforeEach(() => {
+		vi.useFakeTimers();
+		vi.clearAllMocks();
+		(existsSync as ReturnType<typeof vi.fn>).mockReturnValue(false);
+		(readFileSync as ReturnType<typeof vi.fn>).mockReturnValue("{}");
+		(mkdirSync as ReturnType<typeof vi.fn>).mockImplementation(() => undefined);
+		(writeFileSync as ReturnType<typeof vi.fn>).mockImplementation(() => undefined);
+		(renameSync as ReturnType<typeof vi.fn>).mockImplementation(() => undefined);
+		(copyFileSync as ReturnType<typeof vi.fn>).mockImplementation(() => undefined);
+		(rmSync as ReturnType<typeof vi.fn>).mockImplementation(() => undefined);
+		(readdirSync as ReturnType<typeof vi.fn>).mockReturnValue([]);
+		(rmdirSync as ReturnType<typeof vi.fn>).mockImplementation(() => undefined);
+		pi = createMockPi();
+		ctx = createMockCtx();
+	});
+
+	afterEach(() => {
+		vi.useRealTimers();
+	});
+
+	it("debounces multiple persist calls into a single write", () => {
+		const runtime = new SchedulerRuntime(pi as any);
+		runtime.setRuntimeContext(ctx as any);
+
+		// Directly add a task without triggering persistTasks
+		const task1 = runtime.addOneShotTask("task 1", ONE_MINUTE);
+		// Stop the scheduler interval so it does not fire during timer advancement
+		// @ts-expect-error accessing private field for test
+		if (runtime.schedulerTimer) {
+			// @ts-expect-error accessing private field for test
+			clearInterval(runtime.schedulerTimer);
+			// @ts-expect-error accessing private field for test
+			runtime.schedulerTimer = undefined;
+		}
+		// Clear any direct persist calls from addOneShotTask
+		(writeFileSync as ReturnType<typeof vi.fn>).mockClear();
+
+		// Call schedulePersistTasks multiple times rapidly
+		runtime.schedulePersistTasks();
+		runtime.schedulePersistTasks();
+		runtime.schedulePersistTasks();
+
+		// Timer should be scheduled but not yet fired
+		expect(vi.mocked(writeFileSync)).not.toHaveBeenCalled();
+
+		// Advance past debounce — advance exactly to the timer to avoid
+		// triggering the scheduler tick interval (1s) extra times.
+		vi.advanceTimersByTime(2_000);
+
+		// Should have written exactly once since the timer fired
+		expect(vi.mocked(writeFileSync)).toHaveBeenCalledTimes(1);
+		expect(vi.mocked(writeFileSync)).toHaveBeenCalledWith(
+			expect.stringContaining(".tmp"),
+			expect.stringContaining(task1.id),
+			"utf-8",
+		);
+	});
+
+	it("does not schedule a second timer when one is already pending", () => {
+		const runtime = new SchedulerRuntime(pi as any);
+		runtime.setRuntimeContext(ctx as any);
+
+		// @ts-expect-error accessing private field for test
+		runtime.tasksDirty = true;
+		runtime.schedulePersistTasks();
+		// @ts-expect-error accessing private field for test
+		const firstTimer = runtime.tasksSaveTimer;
+
+		// Second call should not create a new timer
+		runtime.schedulePersistTasks();
+		// @ts-expect-error accessing private field for test
+		expect(runtime.tasksSaveTimer).toBe(firstTimer);
+	});
+});

--- a/packages/extensions/extensions/scheduler.ts
+++ b/packages/extensions/extensions/scheduler.ts
@@ -159,6 +159,16 @@ export class SchedulerRuntime {
 	private safeModeEnabled = false;
 	private awaitingTaskId: string | null = null;
 
+	// Lease cache to avoid readFileSync on every tick (hot-path perf)
+	private leaseCache: SchedulerLease | undefined;
+	private leaseCacheAt = 0;
+	private static readonly LEASE_CACHE_TTL_MS = 500;
+
+	// Debounced task persistence to avoid blocking the event loop
+	private tasksDirty = false;
+	private tasksSaveTimer: ReturnType<typeof setTimeout> | null = null;
+	private static readonly TASKS_PERSIST_DEBOUNCE_MS = 2_000;
+
 	constructor(private readonly pi: ExtensionAPI) {}
 
 	get taskCount(): number {
@@ -815,7 +825,7 @@ export class SchedulerRuntime {
 		}
 
 		if (mutated) {
-			this.persistTasks();
+			this.schedulePersistTasks();
 		}
 		this.updateStatus();
 
@@ -1579,17 +1589,29 @@ export class SchedulerRuntime {
 		if (!this.leasePath) {
 			return undefined;
 		}
+		const now = Date.now();
+		if (this.leaseCache && now - this.leaseCacheAt < SchedulerRuntime.LEASE_CACHE_TTL_MS) {
+			return this.leaseCache;
+		}
 		try {
 			if (!fs.existsSync(this.leasePath)) {
+				this.leaseCache = undefined;
+				this.leaseCacheAt = now;
 				return undefined;
 			}
 			const raw = fs.readFileSync(this.leasePath, "utf-8");
 			const parsed = JSON.parse(raw) as SchedulerLease;
 			if (!(parsed?.instanceId && Number.isFinite(parsed?.heartbeatAt))) {
+				this.leaseCache = undefined;
+				this.leaseCacheAt = now;
 				return undefined;
 			}
+			this.leaseCache = parsed;
+			this.leaseCacheAt = now;
 			return parsed;
 		} catch {
+			this.leaseCache = undefined;
+			this.leaseCacheAt = now;
 			return undefined;
 		}
 	}
@@ -1633,6 +1655,9 @@ export class SchedulerRuntime {
 			const tempPath = `${this.leasePath}.tmp`;
 			fs.writeFileSync(tempPath, JSON.stringify(lease, null, 2), "utf-8");
 			fs.renameSync(tempPath, this.leasePath);
+			// Update cache so subsequent reads in this tick don't hit disk
+			this.leaseCache = lease;
+			this.leaseCacheAt = now;
 			const confirmed = this.readLease();
 			return confirmed ? confirmed.instanceId === this.instanceId : true;
 		} catch {
@@ -1650,6 +1675,8 @@ export class SchedulerRuntime {
 				return;
 			}
 			fs.rmSync(this.leasePath, { force: true });
+			this.leaseCache = undefined;
+			this.leaseCacheAt = 0;
 		} catch {
 			// Best-effort cleanup.
 		}
@@ -2064,6 +2091,22 @@ export class SchedulerRuntime {
 			default:
 				return "overdue task";
 		}
+	}
+
+	/** Debounce task persistence so it doesn't block the event loop on every tick. */
+	schedulePersistTasks() {
+		this.tasksDirty = true;
+		if (this.tasksSaveTimer) {
+			return;
+		}
+		this.tasksSaveTimer = setTimeout(() => {
+			this.tasksSaveTimer = null;
+			if (this.tasksDirty) {
+				this.tasksDirty = false;
+				this.persistTasks();
+			}
+		}, SchedulerRuntime.TASKS_PERSIST_DEBOUNCE_MS);
+		this.tasksSaveTimer.unref?.();
 	}
 
 	persistTasks() {


### PR DESCRIPTION
## Problem

The watchdog is reporting critical event-loop delays (~384ms). Root cause: synchronous disk I/O running in hot paths that execute frequently.

## Changes

### Scheduler ()
- **Cached lease reads**: Added in-memory lease cache with 500ms TTL.  previously called  (→ ) **twice per tick** — now cached reads eliminate 2 sync disk ops per second.
- **Debounced task persistence**:  buffers tick-driven mutations with a 2s debounce instead of writing  synchronously on every tick mutation.
- **Cache invalidation**:  updates the cache;  clears it.

### Adaptive routing telemetry ()
- **Append-only writes**: Replaced O(n) read-the-entire-file + write-it-back with  for each event. Previously each event caused a full-file read that grew linearly with event count.
- **Incremental stats**: Maintains  in-memory and updates incrementally per event, avoiding  +  on every append.
- **Synchronous aggregate writes**: Still writes aggregates immediately (small JSON) but without the expensive full-file read.

### Adaptive routing state ()
- **Debounced writes**: 2s debounce on , matching the usage-tracker pattern.

### Ant colony nest ()
- **Faster pheromone stat**: Replaced  +  combo with a single  in try/catch, saving one sync syscall per  call.

## Verification
- All 1821 tests pass
- Type-check passes
- Build passes

Fixes repeated watchdog critical alerts.