### PR TITLE
feat: migrate to tsdown and re-enable no-explicit-any

### DIFF
--- a/.oxlintrc.json
+++ b/.oxlintrc.json
@@ -10,7 +10,7 @@
 		"restriction": "off"
 	},
 	"rules": {
-		"typescript/no-explicit-any": "off",
+		"typescript/no-explicit-any": "error",
 		"no-console": "off",
 		"require-await": "off",
 		"no-inline-comments": "off",

--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -33,7 +33,7 @@
 	"types": "./dist/index.d.ts",
 	"scripts": {
 		"clean": "node -e \"import('node:fs').then(fs => fs.rmSync('dist',{ recursive: true, force: true }))\"",
-		"build": "pnpm clean && tsc -b",
+		"build": "tsdown --config tsdown.config.ts",
 		"build:fast": "pnpm clean && tsgo --project tsconfig.json",
 		"typecheck": "tsgo --project tsconfig.json --noEmit",
 		"test": "vitest run",

--- a/packages/cli/tsdown.config.ts
+++ b/packages/cli/tsdown.config.ts
@@ -1,0 +1,15 @@
+import { defineConfig } from "tsdown";
+
+export default defineConfig({
+	entry: ["src/index.ts", "src/bin/oh-pi.ts"],
+	outDir: "dist",
+	format: "esm",
+	clean: true,
+	platform: "node",
+	dts: {
+		sourcemap: true,
+	},
+	outExtensions() {
+		return { js: ".js", dts: ".d.ts" };
+	},
+});

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -36,7 +36,7 @@
 	},
 	"scripts": {
 		"clean": "node -e \"import('node:fs').then(fs => fs.rmSync('dist',{ recursive: true, force: true }))\"",
-		"build": "pnpm clean && tsc --project tsconfig.json",
+		"build": "tsdown --config tsdown.config.ts",
 		"build:fast": "pnpm clean && tsgo --project tsconfig.json",
 		"typecheck": "tsgo --project tsconfig.json --noEmit"
 	},

--- a/packages/core/tsdown.config.ts
+++ b/packages/core/tsdown.config.ts
@@ -1,0 +1,15 @@
+import { defineConfig } from "tsdown";
+
+export default defineConfig({
+	entry: ["src/index.ts"],
+	outDir: "dist",
+	format: "esm",
+	clean: true,
+	platform: "node",
+	dts: {
+		sourcemap: true,
+	},
+	outExtensions() {
+		return { js: ".js", dts: ".d.ts" };
+	},
+});

--- a/packages/cursor/provider.ts
+++ b/packages/cursor/provider.ts
@@ -35,6 +35,7 @@ import {
 	WriteResultSchema,
 	WriteShellStdinErrorSchema,
 	WriteShellStdinResultSchema,
+	type ExecServerMessage,
 } from "./proto/agent_pb.js";
 import {
 	buildCursorRequestPayload,
@@ -377,7 +378,7 @@ function handleServerMessage(options: {
 
 // oxlint-disable-next-line @typescript-eslint/no-explicit-any
 function handleExecServerMessage(
-	execMessage: any,
+	execMessage: ExecServerMessage,
 	run: ActiveCursorRun,
 	onToolExec: (pendingExec: PendingExec) => void,
 ): void {
@@ -390,8 +391,8 @@ function handleExecServerMessage(
 		const mcpArgs = execMessage.message.value;
 		onToolExec({
 			execId: execMessage.execId,
-			execMsgId: execMessage.id,
-			toolCallId: mcpArgs.toolCallId || randomUUID(),
+			execMsgId: String(execMessage.id),
+			toolCallId: String(mcpArgs.toolCallId || randomUUID()),
 			toolName: mcpArgs.toolName || mcpArgs.name,
 			decodedArgs: JSON.stringify(decodeMcpArgsMap(mcpArgs.args ?? {})),
 		});

--- a/packages/pi-pretty/package.json
+++ b/packages/pi-pretty/package.json
@@ -38,7 +38,7 @@
 	},
 	"scripts": {
 		"clean": "node -e \"import('node:fs').then(fs => fs.rmSync('dist',{ recursive: true, force: true }))\"",
-		"build": "pnpm clean && tsc --project tsconfig.json",
+		"build": "tsdown --config tsdown.config.ts",
 		"build:fast": "pnpm clean && tsgo --project tsconfig.json",
 		"typecheck": "tsgo --project tsconfig.json --noEmit",
 		"test": "vitest run --config ./vitest.config.ts",

--- a/packages/pi-pretty/src/fff-helpers.ts
+++ b/packages/pi-pretty/src/fff-helpers.ts
@@ -2,6 +2,13 @@ import { mkdirSync, existsSync } from "node:fs";
 import { join } from "node:path";
 import { homedir } from "node:os";
 
+interface FffModule {
+	CursorStore?: new () => {
+		rescan?: (cwd: string) => Promise<void>;
+		stats?: () => { fileCount?: number };
+	};
+}
+
 const FFF_DIR = join(homedir(), ".pi", "agent", "pi-pretty", "fff");
 
 function ensureFffDir(): void {
@@ -21,9 +28,8 @@ export async function checkHealth(): Promise<FffStatus> {
 	try {
 		ensureFffDir();
 		// Attempt to load FFF module; if unavailable, return degraded status
-		const fff = await import("@ff-labs/fff-node");
-		// Safe access to any API surface
-		const cursor = (fff as any).CursorStore ? new (fff as any).CursorStore() : null;
+		const fff = (await import("@ff-labs/fff-node")) as FffModule;
+		const cursor = fff.CursorStore ? new fff.CursorStore() : null;
 		const stats = cursor?.stats?.() ?? {};
 		return {
 			ok: true,
@@ -43,8 +49,8 @@ export async function checkHealth(): Promise<FffStatus> {
 export async function rescan(): Promise<FffStatus> {
 	try {
 		ensureFffDir();
-		const fff = await import("@ff-labs/fff-node");
-		const cursor = (fff as any).CursorStore ? new (fff as any).CursorStore() : null;
+		const fff = (await import("@ff-labs/fff-node")) as FffModule;
+		const cursor = fff.CursorStore ? new fff.CursorStore() : null;
 		if (cursor?.rescan) {
 			await cursor.rescan(process.cwd());
 			return {

--- a/packages/pi-pretty/tsdown.config.ts
+++ b/packages/pi-pretty/tsdown.config.ts
@@ -1,0 +1,15 @@
+import { defineConfig } from "tsdown";
+
+export default defineConfig({
+	entry: ["index.ts"],
+	outDir: "dist",
+	format: "esm",
+	clean: true,
+	platform: "node",
+	dts: {
+		sourcemap: true,
+	},
+	outExtensions() {
+		return { js: ".js", dts: ".d.ts" };
+	},
+});

--- a/packages/web-client/package.json
+++ b/packages/web-client/package.json
@@ -36,7 +36,7 @@
 	},
 	"scripts": {
 		"clean": "node -e \"import('node:fs').then(fs => fs.rmSync('dist',{ recursive: true, force: true }))\"",
-		"build": "pnpm clean && tsc --project tsconfig.json",
+		"build": "tsdown --config tsdown.config.ts",
 		"build:fast": "pnpm clean && tsgo --project tsconfig.json",
 		"typecheck": "tsgo --project tsconfig.json --noEmit"
 	},

--- a/packages/web-client/tsdown.config.ts
+++ b/packages/web-client/tsdown.config.ts
@@ -1,0 +1,15 @@
+import { defineConfig } from "tsdown";
+
+export default defineConfig({
+	entry: ["src/index.ts"],
+	outDir: "dist",
+	format: "esm",
+	clean: true,
+	platform: "node",
+	dts: {
+		sourcemap: true,
+	},
+	outExtensions() {
+		return { js: ".js", dts: ".d.ts" };
+	},
+});

--- a/packages/web-server/package.json
+++ b/packages/web-server/package.json
@@ -39,7 +39,7 @@
 	},
 	"scripts": {
 		"clean": "node -e \"import('node:fs').then(fs => fs.rmSync('dist',{ recursive: true, force: true }))\"",
-		"build": "pnpm clean && tsc --project tsconfig.json",
+		"build": "tsdown --config tsdown.config.ts",
 		"build:fast": "pnpm clean && tsgo --project tsconfig.json",
 		"typecheck": "tsgo --project tsconfig.json --noEmit"
 	},

--- a/packages/web-server/tsdown.config.ts
+++ b/packages/web-server/tsdown.config.ts
@@ -1,0 +1,15 @@
+import { defineConfig } from "tsdown";
+
+export default defineConfig({
+	entry: ["src/index.ts", "src/bin/pi-web.ts"],
+	outDir: "dist",
+	format: "esm",
+	clean: true,
+	platform: "node",
+	dts: {
+		sourcemap: true,
+	},
+	outExtensions() {
+		return { js: ".js", dts: ".d.ts" };
+	},
+});


### PR DESCRIPTION
- Migrate 5 packages from tsc build to tsdown (core, cli, web-client, web-server, pi-pretty)
- Re-enable typescript/no-explicit-any in oxlint (0 errors)
- Fix cursor/provider.ts and pi-pretty/fff-helpers.ts type safety issues
- All lint, format, typecheck, test, and build gates pass