### PR TITLE
fix(ollama): add deepseek v4 flash fallback model

### DIFF
--- a/.changeset/add-deepseek-v4-flash.md
+++ b/.changeset/add-deepseek-v4-flash.md
@@ -1,0 +1,8 @@
+---
+default: patch
+---
+
+Add missing `deepseek-v4-flash` to the Ollama Cloud fallback model catalog.
+
+- Register `ollama-cloud/deepseek-v4-flash` in `FALLBACK_OLLAMA_CLOUD_MODELS` with 1M context window, text input, and reasoning support
+

--- a/packages/ollama/models.ts
+++ b/packages/ollama/models.ts
@@ -96,6 +96,14 @@ const FALLBACK_OLLAMA_CLOUD_MODELS: OllamaProviderModel[] = [
 		source: "cloud",
 	}),
 	toOllamaModel({
+		contextWindow: 1_048_576,
+		id: "deepseek-v4-flash",
+		input: ["text"],
+		maxTokens: 65_536,
+		reasoning: true,
+		source: "cloud",
+	}),
+	toOllamaModel({
 		contextWindow: 262_144,
 		id: "devstral-2:123b",
 		input: ["text"],


### PR DESCRIPTION
## Summary
- Add `deepseek-v4-flash` to the Ollama Cloud fallback model catalog
- Configure the model with a 1M token context window, text input, reasoning support, and 65,536 max output tokens
- Add a patch changeset for the fallback catalog update

## Testing
- `pnpm install --frozen-lockfile`
- `pnpm test` (passed before rebase)
- Rebased onto latest `origin/main`
- `pnpm test` (passed after rebase: 198 files passed, 3 skipped; 1866 tests passed, 8 skipped)
