### PR TITLE
docs: document analytics packages and oh-pi-docs

### DIFF
--- a/.changeset/docs-audit-and-update.md
+++ b/.changeset/docs-audit-and-update.md
@@ -1,0 +1,12 @@
+---
+default: patch
+---
+
+Update documentation to include all analytics packages and docs site.
+
+- Added `@ifi/pi-analytics-extension` to architecture diagrams, package lists, and managed local switching
+- Added `@ifi/pi-analytics-db`, `@ifi/pi-analytics-dashboard`, and `@ifi/oh-pi-docs` to contributor-facing documentation
+- Added dedicated "Analytics stack" section in `docs/feature-catalog.md` with details on extension, DB, and dashboard
+- Updated `README.md` packages table, project structure, and opt-in packages note
+- Updated `docs/agent-rules/engineering.md` and `docs/agent-rules/packaging-and-release.md` package references
+- MDT blocks auto-propagated to `docs/00-index.md`, `docs/feature-catalog.md`, `README.md`, and `packages/oh-pi/README.md`

--- a/README.md
+++ b/README.md
@@ -71,6 +71,7 @@ oh-pi repo
 │   ├── provider-catalog
 │   ├── provider-cursor
 │   ├── provider-ollama
+│   ├── analytics-extension
 │   ├── pi-remote-tailscale
 │   ├── pi-bash-live-view
 │   └── pi-pretty
@@ -79,7 +80,10 @@ oh-pi repo
     ├── cli
     ├── shared-qna
     ├── web-client
-    └── web-server
+    ├── web-server
+    ├── analytics-db
+    ├── analytics-dashboard
+    └── docs
 ```
 
 <!-- {/repoArchitectureAtAGlanceDocs} -->
@@ -125,9 +129,14 @@ This is a monorepo. Install everything at once with `npx @ifi/oh-pi`, or pick in
 | [`@ifi/pi-shared-qna`](./packages/shared-qna)                       | Shared Q&A TUI helpers                                                    | (library, not installed directly)                   |
 | [`@ifi/pi-web-client`](./packages/web-client)                       | Platform-agnostic remote session client library                           | `pnpm add @ifi/pi-web-client`                       |
 | [`@ifi/pi-web-server`](./packages/web-server)                       | Embeddable remote session server                                          | `pnpm add @ifi/pi-web-server`                       |
+| [`@ifi/pi-analytics-extension`](./packages/analytics-extension)   | Analytics tracking extension with SQLite persistence and browser dashboard | `pi install npm:@ifi/pi-analytics-extension`          |
+| [`@ifi/pi-analytics-db`](./packages/analytics-db)                  | SQLite schema and Drizzle ORM client for analytics data                     | (library, not installed directly)                   |
+| [`@ifi/pi-analytics-dashboard`](./packages/analytics-dashboard)     | React dashboard for visualizing AI usage (private package)                | (private, run `pnpm dev` in package)                |
+| [`@ifi/oh-pi-docs`](./packages/docs)                              | Documentation site for oh-pi (private package)                            | (private, run `pnpm dev` in package)                |
 
-`@ifi/pi-extension-adaptive-routing`, `@ifi/pi-provider-catalog`, `@ifi/pi-provider-cursor`, and
-`@ifi/pi-provider-ollama` stay opt-in for now and are **not** installed by `npx @ifi/oh-pi`.
+`@ifi/pi-extension-adaptive-routing`, `@ifi/pi-provider-catalog`, `@ifi/pi-provider-cursor`,
+`@ifi/pi-provider-ollama`, and `@ifi/pi-analytics-extension` stay opt-in for now and are **not**
+installed by `npx @ifi/oh-pi`.
 They are intentionally shipped as separate optional packages.
 
 ### Full Feature Catalog
@@ -758,6 +767,7 @@ Managed local switching covers these packages:
 - `@ifi/pi-provider-catalog`
 - `@ifi/pi-provider-cursor`
 - `@ifi/pi-provider-ollama`
+- `@ifi/pi-analytics-extension`
 
 <!-- {/repoPiLocalManagedPackagesDocs} -->
 
@@ -869,6 +879,10 @@ oh-pi/
 │   ├── web-client/             Remote session client library (compiled)
 │   ├── web-server/             Remote session server library (compiled)
 │   ├── shared-qna/             Shared Q&A TUI helper library (raw .ts)
+│   ├── analytics-db/             SQLite schema and Drizzle ORM client for analytics data
+│   ├── analytics-dashboard/      React dashboard for visualizing AI usage (private app)
+│   ├── analytics-extension/      Analytics tracking extension for pi (raw .ts)
+│   ├── docs/                     Documentation site for oh-pi (private app)
 │   ├── themes/                 6 JSON theme files
 │   ├── prompts/                10 markdown prompt templates
 │   ├── skills/                 17 skill directories

--- a/docs/00-index.md
+++ b/docs/00-index.md
@@ -123,6 +123,7 @@ oh-pi repo
 │   ├── provider-catalog
 │   ├── provider-cursor
 │   ├── provider-ollama
+│   ├── analytics-extension
 │   ├── pi-remote-tailscale
 │   ├── pi-bash-live-view
 │   └── pi-pretty
@@ -131,7 +132,10 @@ oh-pi repo
     ├── cli
     ├── shared-qna
     ├── web-client
-    └── web-server
+    ├── web-server
+    ├── analytics-db
+    ├── analytics-dashboard
+    └── docs
 ```
 
 <!-- {/repoArchitectureAtAGlanceDocs} -->

--- a/docs/agent-rules/engineering.md
+++ b/docs/agent-rules/engineering.md
@@ -76,6 +76,10 @@ packages/
   spec/                   → @ifi/pi-spec (raw .ts spec-driven workflow package)
   cursor/                 → @ifi/pi-provider-cursor (raw .ts experimental Cursor provider package)
   ollama/                 → @ifi/pi-provider-ollama (raw .ts experimental Ollama local + cloud provider package)
+  analytics-db/           → @ifi/pi-analytics-db (SQLite schema and Drizzle ORM client for analytics data)
+  analytics-dashboard/    → @ifi/pi-analytics-dashboard (private React dashboard for visualizing AI usage)
+  analytics-extension/    → @ifi/pi-analytics-extension (raw .ts analytics tracking extension for pi)
+  docs/                   → @ifi/oh-pi-docs (private documentation site for oh-pi)
   oh-pi/                  → @ifi/oh-pi (installer CLI: `npx @ifi/oh-pi`)
 ```
 

--- a/docs/agent-rules/packaging-and-release.md
+++ b/docs/agent-rules/packaging-and-release.md
@@ -57,6 +57,10 @@ pi install npm:@ifi/pi-plan
 pi install npm:@ifi/pi-spec
 pi install npm:@ifi/pi-provider-cursor
 pi install npm:@ifi/pi-provider-ollama
+pi install npm:@ifi/pi-analytics-extension
+pi install npm:@ifi/pi-remote-tailscale
+pi install npm:@ifi/pi-bash-live-view
+pi install npm:@ifi/pi-pretty
 ```
 
 Do not use `bundledDependencies` in `@ifi/oh-pi`.

--- a/docs/feature-catalog.md
+++ b/docs/feature-catalog.md
@@ -49,6 +49,7 @@ oh-pi repo
 │   ├── provider-catalog
 │   ├── provider-cursor
 │   ├── provider-ollama
+│   ├── analytics-extension
 │   ├── pi-remote-tailscale
 │   ├── pi-bash-live-view
 │   └── pi-pretty
@@ -57,7 +58,10 @@ oh-pi repo
     ├── cli
     ├── shared-qna
     ├── web-client
-    └── web-server
+    ├── web-server
+    ├── analytics-db
+    ├── analytics-dashboard
+    └── docs
 ```
 
 <!-- {/repoArchitectureAtAGlanceDocs} -->
@@ -106,6 +110,7 @@ Opt-in packages that stay separate from the default installer bundle:
 - `@ifi/pi-provider-catalog`
 - `@ifi/pi-provider-cursor`
 - `@ifi/pi-provider-ollama`
+- `@ifi/pi-analytics-extension`
 - `@ifi/pi-remote-tailscale`
 - `@ifi/pi-bash-live-view`
 - `@ifi/pi-pretty`
@@ -148,6 +153,7 @@ so build those when you are working on them directly.
 | [`@ifi/pi-provider-catalog`](../packages/providers)                  | No                  | `/providers*`                                                                           | Multi-provider catalog and lazy API-key login backed by `models.dev`                                                                     |
 | [`@ifi/pi-provider-cursor`](../packages/cursor)                      | No                  | `/login cursor`, `/cursor*`                                                             | Experimental Cursor OAuth provider with model discovery and direct AgentService streaming                                                |
 | [`@ifi/pi-provider-ollama`](../packages/ollama)                      | No                  | `/login ollama-cloud`, `/ollama*`, `/model`                                             | Experimental Ollama local + cloud provider integration                                                                                   |
+| [`@ifi/pi-analytics-extension`](../packages/analytics-extension)     | No                  | `/analytics`, `/analytics-dashboard`                                                     | Analytics tracking extension with SQLite persistence and browser dashboard                                                             |
 | [`@ifi/pi-remote-tailscale`](../packages/pi-remote-tailscale)        | No                  | `/remote`, `/remote:widget`, `/remote:stop`                                             | Secure remote session sharing via Tailscale HTTPS with PTY, WebSocket, QR codes, and token auth                                          |
 | [`@ifi/pi-bash-live-view`](../packages/pi-bash-live-view)            | No                  | `/bash-pty`, `bash_live_view` tool with `usePTY`                                        | PTY-backed live terminal viewing with real-time widget and `/xterm/headless` ANSI rendering                                              |
 | [`@ifi/pi-pretty`](../packages/pi-pretty)                            | No                  | wrapped `read`, `bash_pretty`, `ls`, `find`, `grep` tools                               | Syntax highlighting via Shiki, Nerd Font icons, tree-view listings, colored bash summaries, FFF search                                   |
@@ -483,6 +489,34 @@ Primary commands:
 - `/ollama:pull <model>`
 - `/login ollama-cloud`
 
+## Analytics stack
+
+### `@ifi/pi-analytics-extension`
+
+Purpose:
+
+- Tracks session-level and turn-level analytics (models, tokens, costs, codebases)
+- Persists data to SQLite via `@ifi/pi-analytics-db`
+- Provides `/analytics` for quick terminal stats
+- Provides `/analytics-dashboard` to open the browser dashboard
+
+### `@ifi/pi-analytics-db`
+
+Purpose:
+
+- SQLite database layer with Drizzle ORM schema
+- Stores sessions, turns, models, providers, codebases, and time-bucketed aggregations
+- Includes migrations and typed query helpers
+
+### `@ifi/pi-analytics-dashboard`
+
+Purpose:
+
+- React 19 + Vite 8 SPA for visualizing AI usage
+- Pages: Overview, Models, Codebases, Insights (emotions, words, misspellings)
+- Mock data mode for development, real API mode via Express server
+- Private package — run `pnpm dev` inside `packages/analytics-dashboard/`
+
 ## Content packs
 
 ## `@ifi/oh-pi-prompts`
@@ -561,6 +595,9 @@ The AGENTS template pack currently ships 5 templates.
 | [`@ifi/pi-shared-qna`](../packages/shared-qna) | Reusable TUI Q&A helpers and shared `pi-tui` loading logic                                             |
 | [`@ifi/pi-web-client`](../packages/web-client) | Platform-agnostic TypeScript client for custom remote session UIs                                      |
 | [`@ifi/pi-web-server`](../packages/web-server) | Embeddable HTTP + WebSocket remote session server                                                      |
+| [`@ifi/pi-analytics-db`](../packages/analytics-db) | SQLite schema and Drizzle ORM client for analytics data                                                |
+| [`@ifi/pi-analytics-dashboard`](../packages/analytics-dashboard) | React dashboard for visualizing AI usage (private package)                                               |
+| [`@ifi/oh-pi-docs`](../packages/docs) | Documentation site for oh-pi (private package)                                                         |
 
 ## Which feature should I reach for?
 
@@ -578,6 +615,7 @@ The AGENTS template pack currently ships 5 templates.
 - **Automatic or explainable model routing** → `@ifi/pi-extension-adaptive-routing`
 - **Extra API-key providers** → `@ifi/pi-provider-catalog`
 - **Cursor integration** → `@ifi/pi-provider-cursor`
+- **Usage analytics and browser dashboard for your AI sessions** → `@ifi/pi-analytics-extension`
 - **Ollama local/cloud integration** → `@ifi/pi-provider-ollama`
 
 For the local development loop that points a real pi install at this checkout, see the root

--- a/docs/mdt/oh-pi-docs.t.md
+++ b/docs/mdt/oh-pi-docs.t.md
@@ -354,6 +354,7 @@ oh-pi repo
 │   ├── provider-catalog
 │   ├── provider-cursor
 │   ├── provider-ollama
+│   ├── analytics-extension
 │   ├── pi-remote-tailscale
 │   ├── pi-bash-live-view
 │   └── pi-pretty
@@ -362,7 +363,10 @@ oh-pi repo
     ├── cli
     ├── shared-qna
     ├── web-client
-    └── web-server
+    ├── web-server
+    ├── analytics-db
+    ├── analytics-dashboard
+    └── docs
 ```
 
 <!-- {/repoArchitectureAtAGlanceDocs} -->
@@ -393,6 +397,7 @@ Opt-in packages that stay separate from the default installer bundle:
 - `@ifi/pi-provider-catalog`
 - `@ifi/pi-provider-cursor`
 - `@ifi/pi-provider-ollama`
+- `@ifi/pi-analytics-extension`
 - `@ifi/pi-remote-tailscale`
 - `@ifi/pi-bash-live-view`
 - `@ifi/pi-pretty`
@@ -458,6 +463,7 @@ Managed local switching covers these packages:
 - `@ifi/pi-provider-catalog`
 - `@ifi/pi-provider-cursor`
 - `@ifi/pi-provider-ollama`
+- `@ifi/pi-analytics-extension`
 
 <!-- {/repoPiLocalManagedPackagesDocs} -->
 

--- a/packages/oh-pi/README.md
+++ b/packages/oh-pi/README.md
@@ -60,6 +60,7 @@ oh-pi repo
 │   ├── provider-catalog
 │   ├── provider-cursor
 │   ├── provider-ollama
+│   ├── analytics-extension
 │   ├── pi-remote-tailscale
 │   ├── pi-bash-live-view
 │   └── pi-pretty
@@ -68,7 +69,10 @@ oh-pi repo
     ├── cli
     ├── shared-qna
     ├── web-client
-    └── web-server
+    ├── web-server
+    ├── analytics-db
+    ├── analytics-dashboard
+    └── docs
 ```
 
 <!-- {/repoArchitectureAtAGlanceDocs} -->
@@ -100,6 +104,7 @@ Opt-in packages that stay separate from the default installer bundle:
 - `@ifi/pi-provider-catalog`
 - `@ifi/pi-provider-cursor`
 - `@ifi/pi-provider-ollama`
+- `@ifi/pi-analytics-extension`
 - `@ifi/pi-remote-tailscale`
 - `@ifi/pi-bash-live-view`
 - `@ifi/pi-pretty`


### PR DESCRIPTION
## Summary
- Add `@ifi/pi-analytics-extension` to architecture diagrams, package lists, feature references, and managed local switching docs
- Add `@ifi/pi-analytics-db`, `@ifi/pi-analytics-dashboard`, and `@ifi/oh-pi-docs` to contributor-facing package documentation
- Add a dedicated Analytics stack section in `docs/feature-catalog.md`
- Update engineering and packaging/release agent rules for current package references
- Add a patch changeset for the documentation audit

## Testing
- `pnpm install --frozen-lockfile`
- `pnpm test` (initial run hit a timing-sensitive benchmark assertion; targeted rerun passed)
- `pnpm exec vitest run benchmarks/shared/benchmark.test.ts` (passed)
- `pnpm test` (passed before rebase)
- Rebased onto latest `origin/main`
- `pnpm test` (passed after rebase: 198 files passed, 3 skipped; 1866 tests passed, 8 skipped)
- `pnpm mdt check` (passed)
