### PR TITLE
build: use tsgo for dts generation

### DIFF
--- a/.changeset/fix-bash-live-view-build.md
+++ b/.changeset/fix-bash-live-view-build.md
@@ -1,0 +1,5 @@
+---
+default: patch
+---
+
+Fix the `@ifi/pi-bash-live-view` package build by running the normal package test suite during `pnpm build` and keeping coverage behind a dedicated `test:coverage` script.

--- a/.changeset/use-tsgo-for-dts.md
+++ b/.changeset/use-tsgo-for-dts.md
@@ -1,0 +1,5 @@
+---
+default: patch
+---
+
+Use `tsgo` for `tsdown` declaration generation in compiled packages and remove the native TypeScript compiler dependency.

--- a/package.json
+++ b/package.json
@@ -55,7 +55,6 @@
 		"oxlint-tsgolint": "^0.22.0",
 		"tsdown": "^0.21.10",
 		"tsx": "^4.20.6",
-		"typescript": "5.9.3",
 		"vitest": "^4.1.5"
 	},
 	"engines": {

--- a/packages/cli/tsdown.config.ts
+++ b/packages/cli/tsdown.config.ts
@@ -8,6 +8,7 @@ export default defineConfig({
 	platform: "node",
 	dts: {
 		sourcemap: true,
+		tsgo: true,
 	},
 	outExtensions() {
 		return { js: ".js", dts: ".d.ts" };

--- a/packages/core/tsdown.config.ts
+++ b/packages/core/tsdown.config.ts
@@ -8,6 +8,7 @@ export default defineConfig({
 	platform: "node",
 	dts: {
 		sourcemap: true,
+		tsgo: true,
 	},
 	outExtensions() {
 		return { js: ".js", dts: ".d.ts" };

--- a/packages/pi-pretty/tsdown.config.ts
+++ b/packages/pi-pretty/tsdown.config.ts
@@ -8,6 +8,7 @@ export default defineConfig({
 	platform: "node",
 	dts: {
 		sourcemap: true,
+		tsgo: true,
 	},
 	outExtensions() {
 		return { js: ".js", dts: ".d.ts" };

--- a/packages/web-client/tsdown.config.ts
+++ b/packages/web-client/tsdown.config.ts
@@ -8,6 +8,7 @@ export default defineConfig({
 	platform: "node",
 	dts: {
 		sourcemap: true,
+		tsgo: true,
 	},
 	outExtensions() {
 		return { js: ".js", dts: ".d.ts" };

--- a/packages/web-server/tsdown.config.ts
+++ b/packages/web-server/tsdown.config.ts
@@ -8,6 +8,7 @@ export default defineConfig({
 	platform: "node",
 	dts: {
 		sourcemap: true,
+		tsgo: true,
 	},
 	outExtensions() {
 		return { js: ".js", dts: ".d.ts" };

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -63,13 +63,10 @@ importers:
         version: 0.22.0
       tsdown:
         specifier: ^0.21.10
-        version: 0.21.10(@typescript/native-preview@7.0.0-dev.20260426.1)(typescript@5.9.3)
+        version: 0.21.10(@typescript/native-preview@7.0.0-dev.20260426.1)
       tsx:
         specifier: ^4.20.6
         version: 4.21.0
-      typescript:
-        specifier: 5.9.3
-        version: 5.9.3
       vitest:
         specifier: ^4.1.5
         version: 4.1.5(@types/node@22.19.17)(@vitest/browser-playwright@4.1.5)(@vitest/coverage-v8@4.1.5)(jsdom@26.1.0)(vite@8.0.9(@types/node@22.19.17)(esbuild@0.27.7)(jiti@2.6.1)(tsx@4.21.0)(yaml@2.8.3))
@@ -4946,11 +4943,6 @@ packages:
     resolution: {integrity: sha512-OZs6gsjF4vMp32qrCbiVSkrFmXtG/AZhY3t0iAMrMBiAZyV9oALtXO8hsrHbMXF9x6L3grlFuwW2oAz7cav+Gw==}
     engines: {node: '>= 0.6'}
 
-  typescript@5.9.3:
-    resolution: {integrity: sha512-jl1vZzPDinLr9eUt3J/t7V6FgNEw9QjvBPdysz9KfQDD41fQrC2Y4vKQdiaUpFT4bXlb1RHhLpp8wtm6M5TgSw==}
-    engines: {node: '>=14.17'}
-    hasBin: true
-
   uint8array-extras@1.5.0:
     resolution: {integrity: sha512-rvKSBiC5zqCCiDZ9kAOszZcDvdAHwwIKJG33Ykj43OKcWsnmcBRL09YTU4nOeHZ8Y2a7l1MgTd08SBe9A8Qj6A==}
     engines: {node: '>=18'}
@@ -9440,7 +9432,7 @@ snapshots:
 
   retry@0.13.1: {}
 
-  rolldown-plugin-dts@0.23.2(@typescript/native-preview@7.0.0-dev.20260426.1)(rolldown@1.0.0-rc.17)(typescript@5.9.3):
+  rolldown-plugin-dts@0.23.2(@typescript/native-preview@7.0.0-dev.20260426.1)(rolldown@1.0.0-rc.17):
     dependencies:
       '@babel/generator': 8.0.0-rc.3
       '@babel/helper-validator-identifier': 8.0.0-rc.3
@@ -9455,7 +9447,6 @@ snapshots:
       rolldown: 1.0.0-rc.17
     optionalDependencies:
       '@typescript/native-preview': 7.0.0-dev.20260426.1
-      typescript: 5.9.3
     transitivePeerDependencies:
       - oxc-resolver
 
@@ -9815,7 +9806,7 @@ snapshots:
 
   ts-algebra@2.0.0: {}
 
-  tsdown@0.21.10(@typescript/native-preview@7.0.0-dev.20260426.1)(typescript@5.9.3):
+  tsdown@0.21.10(@typescript/native-preview@7.0.0-dev.20260426.1):
     dependencies:
       ansis: 4.2.0
       cac: 7.0.0
@@ -9826,15 +9817,13 @@ snapshots:
       obug: 2.1.1
       picomatch: 4.0.4
       rolldown: 1.0.0-rc.17
-      rolldown-plugin-dts: 0.23.2(@typescript/native-preview@7.0.0-dev.20260426.1)(rolldown@1.0.0-rc.17)(typescript@5.9.3)
+      rolldown-plugin-dts: 0.23.2(@typescript/native-preview@7.0.0-dev.20260426.1)(rolldown@1.0.0-rc.17)
       semver: 7.7.4
       tinyexec: 1.1.1
       tinyglobby: 0.2.16
       tree-kill: 1.2.2
       unconfig-core: 7.5.0
       unrun: 0.2.37
-    optionalDependencies:
-      typescript: 5.9.3
     transitivePeerDependencies:
       - '@ts-macro/tsc'
       - '@typescript/native-preview'
@@ -9860,8 +9849,6 @@ snapshots:
       content-type: 1.0.5
       media-typer: 1.1.0
       mime-types: 3.0.2
-
-  typescript@5.9.3: {}
 
   uint8array-extras@1.5.0: {}
 


### PR DESCRIPTION
## Summary
- enable rolldown-plugin-dts/tsdown tsgo declaration generation for compiled packages
- remove the root TypeScript dependency from package.json and pnpm-lock.yaml
- keep bash live view package coverage behind a dedicated test:coverage script so pnpm build runs normal tests

## Verification
- pnpm build
- pnpm check