### PR TITLE
fix(pty): chmod node-pty prebuild spawn helper

### DIFF
--- a/.changeset/fix-node-pty-prebuild-helper.md
+++ b/.changeset/fix-node-pty-prebuild-helper.md
@@ -1,0 +1,7 @@
+---
+default: patch
+---
+
+Fix PTY-backed `!` commands when `node-pty` installs its prebuilt `spawn-helper` without executable permissions.
+
+The bash live-view extension now checks the active `node-pty/prebuilds/<platform>-<arch>/spawn-helper` path as well as the legacy `build/Release` path and chmods the helper before launching PTY sessions.

--- a/packages/pi-bash-live-view/src/spawn-helper.ts
+++ b/packages/pi-bash-live-view/src/spawn-helper.ts
@@ -4,6 +4,7 @@ import path from "node:path";
 import { fileURLToPath } from "node:url";
 
 const SPAWN_HELPER_BASENAME = process.platform === "win32" ? "spawn-helper.exe" : "spawn-helper";
+const NODE_PTY_PREBUILD_DIR = `${process.platform}-${process.arch}`;
 const MODULE_DIR = path.dirname(fileURLToPath(import.meta.url));
 const PACKAGE_DIR = path.resolve(MODULE_DIR, "..");
 
@@ -27,13 +28,20 @@ function uniquePaths(candidates: Array<string | undefined>): string[] {
 	return deduped;
 }
 
+function getNodePtySpawnHelperCandidates(nodePtyPackageDir: string): string[] {
+	return [
+		path.join(nodePtyPackageDir, "prebuilds", NODE_PTY_PREBUILD_DIR, SPAWN_HELPER_BASENAME),
+		path.join(nodePtyPackageDir, "build", "Release", SPAWN_HELPER_BASENAME),
+	];
+}
+
 export function getSpawnHelperCandidates(explicitPath?: string): string[] {
 	return uniquePaths([
 		explicitPath,
 		process.env.NODE_PTY_SPAWN_HELPER,
-		path.join(PACKAGE_DIR, "node_modules", "node-pty", "build", "Release", SPAWN_HELPER_BASENAME),
-		path.join(PACKAGE_DIR, "..", "node_modules", "node-pty", "build", "Release", SPAWN_HELPER_BASENAME),
-		path.join(PACKAGE_DIR, "..", "..", "node_modules", "node-pty", "build", "Release", SPAWN_HELPER_BASENAME),
+		...getNodePtySpawnHelperCandidates(path.join(PACKAGE_DIR, "node_modules", "node-pty")),
+		...getNodePtySpawnHelperCandidates(path.join(PACKAGE_DIR, "..", "node_modules", "node-pty")),
+		...getNodePtySpawnHelperCandidates(path.join(PACKAGE_DIR, "..", "..", "node_modules", "node-pty")),
 		path.join(PACKAGE_DIR, "build", "Release", SPAWN_HELPER_BASENAME),
 	]);
 }

--- a/packages/pi-bash-live-view/tests/pty-execute.test.ts
+++ b/packages/pi-bash-live-view/tests/pty-execute.test.ts
@@ -1,3 +1,4 @@
+import path from "node:path";
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 import { executePtyCommand, ptyExecuteInternals, toAgentToolResult, toUserBashResult } from "../src/pty-execute.js";
 import { resetHeadlessModuleLoader, setHeadlessModuleLoader } from "../src/terminal-emulator.js";
@@ -432,6 +433,11 @@ describe("PTY execution", () => {
 
 		const candidates = getSpawnHelperCandidates("/tmp/chmod-me");
 		expect(candidates[0]).toBe("/tmp/chmod-me");
+		expect(
+			candidates.some((candidate) =>
+				candidate.includes(path.join("node-pty", "prebuilds", `${process.platform}-${process.arch}`, "spawn-helper")),
+			),
+		).toBe(true);
 		expect(spawnHelperInternals.uniquePaths(["a", "a", "b"])).toEqual(["a", "b"]);
 		expect(
 			await ensureSpawnHelperExecutable({


### PR DESCRIPTION
## Summary
- include node-pty prebuild spawn-helper paths when ensuring PTY helper executability
- keep the legacy build/Release helper fallback
- add a regression assertion for platform/arch prebuild helper discovery

## Verification
- pnpm --filter @ifi/pi-bash-live-view run build
- pnpm check