### PR TITLE
fix(diagnostics): reduce widget render churn

### DIFF
--- a/.changeset/fix-diagnostics-render-churn.md
+++ b/.changeset/fix-diagnostics-render-churn.md
@@ -1,0 +1,5 @@
+---
+default: patch
+---
+
+Reduce diagnostics widget render churn while prompts or tools are active and make session-state restoration scan from the newest entries first.

--- a/packages/diagnostics/index.ts
+++ b/packages/diagnostics/index.ts
@@ -77,7 +77,7 @@ const SHORTCUT = "ctrl+shift+d";
 const DIAGNOSTICS_MESSAGE_TYPE = "pi-diagnostics:prompt";
 const DIAGNOSTICS_STATE_TYPE = "pi-diagnostics:state";
 const WIDGET_KEY = "diagnostics";
-const WIDGET_REFRESH_MS = 1000;
+const WIDGET_REFRESH_MS = 5000;
 const PROMPT_PREVIEW_MAX_LENGTH = 96;
 const RESPONSE_PREVIEW_MAX_LENGTH = 88;
 
@@ -345,30 +345,30 @@ function getBranchEntries(ctx: ExtensionContext): SessionEntryLike[] {
 }
 
 function restoreEnabledState(entries: SessionEntryLike[]): boolean | undefined {
-	let next: boolean | undefined;
-	for (const entry of entries) {
-		if (entry.type !== "custom" || entry.customType !== DIAGNOSTICS_STATE_TYPE) {
+	for (let index = entries.length - 1; index >= 0; index -= 1) {
+		const entry = entries[index];
+		if (entry?.type !== "custom" || entry.customType !== DIAGNOSTICS_STATE_TYPE) {
 			continue;
 		}
 		if (isDiagnosticsStateEntry(entry.data)) {
-			next = entry.data.enabled;
+			return entry.data.enabled;
 		}
 	}
-	return next;
+	return undefined;
 }
 
 function restoreLastCompletion(entries: SessionEntryLike[]): PromptCompletionDiagnostics | null {
-	let last: PromptCompletionDiagnostics | null = null;
-	for (const entry of entries) {
-		if (getMessageCustomType(entry) !== DIAGNOSTICS_MESSAGE_TYPE) {
+	for (let index = entries.length - 1; index >= 0; index -= 1) {
+		const entry = entries[index];
+		if (!entry || getMessageCustomType(entry) !== DIAGNOSTICS_MESSAGE_TYPE) {
 			continue;
 		}
 		const details = getMessageDetails(entry);
 		if (isPromptCompletionDiagnostics(details)) {
-			last = details;
+			return details;
 		}
 	}
-	return last;
+	return null;
 }
 
 export default function diagnosticsExtension(pi: ExtensionAPI): void {

--- a/packages/diagnostics/tests/diagnostics.test.ts
+++ b/packages/diagnostics/tests/diagnostics.test.ts
@@ -280,8 +280,12 @@ describe("diagnostics extension", () => {
 			harness.ctx,
 		);
 		expect(widget?.render(200).join("\n")).toContain("running");
+		requestRender.mockClear();
 
-		await vi.advanceTimersByTimeAsync(1_000);
+		await vi.advanceTimersByTimeAsync(4_999);
+		expect(requestRender).not.toHaveBeenCalled();
+
+		await vi.advanceTimersByTimeAsync(1);
 		expect(requestRender).toHaveBeenCalled();
 
 		await vi.advanceTimersByTimeAsync(250);
@@ -337,12 +341,12 @@ describe("diagnostics extension", () => {
 		};
 		expect(message.customType).toBe("pi-diagnostics:prompt");
 		expect(message.content).toContain("Prompt completed");
-		expect(message.content).toContain("duration 7.3s");
+		expect(message.content).toContain("duration 11s");
 		expect(message.details.promptPreview).toContain("Investigate the flaky test timeout");
-		expect(message.details.durationMs).toBe(7_250);
+		expect(message.details.durationMs).toBe(11_250);
 		expect(message.details.turnCount).toBe(2);
 		expect(message.details.toolCount).toBe(1);
-		expect(message.details.turns[0]?.completedAtLabel).toMatch(/2026-04-16 \d{2}:00:0[12]/);
+		expect(message.details.turns[0]?.completedAtLabel).toMatch(/2026-04-16 \d{2}:00:0[67]/);
 		expect(message.details.turns[0]?.toolCount).toBe(1);
 		expect(message.details.turns[1]?.responsePreview).toContain("Done.");
 		expect(widget?.render(200).join("\n")).toContain("completed");


### PR DESCRIPTION
## Summary
- reduce diagnostics widget active refresh from 1s to 5s to avoid unnecessary render churn during long prompts/tools
- restore diagnostics state by scanning newest session entries first instead of always walking the full branch
- add/update tests for the slower active refresh cadence

## Verification
- pnpm --filter @ifi/pi-diagnostics run build
- pnpm check