### PR TITLE
fix(ollama): discover cloud models at startup

### DIFF
--- a/.changeset/refresh-ollama-cloud-models.md
+++ b/.changeset/refresh-ollama-cloud-models.md
@@ -1,0 +1,9 @@
+---
+default: patch
+---
+
+Refresh Ollama Cloud models during startup so newly released cloud models can be registered before model scope resolution.
+
+- Prime the cloud provider from the live `/v1/models` catalog before registration, with a bounded timeout and fallback behavior.
+- Persist discovered cloud models to a local startup cache so later offline starts can still resolve recently discovered models.
+- Keep the static fallback catalog as a resilient baseline instead of requiring every new cloud model to be added manually.

--- a/packages/ollama/cache.ts
+++ b/packages/ollama/cache.ts
@@ -1,0 +1,57 @@
+import { existsSync, readFileSync } from "node:fs";
+import { mkdir, writeFile } from "node:fs/promises";
+import { homedir } from "node:os";
+import { dirname, join } from "node:path";
+import { toOllamaModel, type OllamaProviderModel } from "./models.js";
+
+const CACHE_VERSION = 1;
+const DEFAULT_CACHE_PATH = join(homedir(), ".pi", "agent", "cache", "ollama-cloud-models.json");
+const CACHE_PATH_ENV = "PI_OLLAMA_CLOUD_CACHE_PATH";
+
+interface OllamaCloudModelCache {
+	version?: number;
+	refreshedAt?: number;
+	models?: unknown;
+}
+
+export function getOllamaCloudModelCachePath(): string {
+	return process.env[CACHE_PATH_ENV]?.trim() || DEFAULT_CACHE_PATH;
+}
+
+export function loadCachedOllamaCloudModels(): OllamaProviderModel[] {
+	const cachePath = getOllamaCloudModelCachePath();
+	try {
+		// Startup-only sync I/O: provider registration must have cached models before pi resolves model scopes.
+		if (!existsSync(cachePath)) return [];
+		const payload = JSON.parse(readFileSync(cachePath, "utf8")) as OllamaCloudModelCache;
+		return sanitizeCachedModels(payload.models);
+	} catch {
+		return [];
+	}
+}
+
+export async function saveCachedOllamaCloudModels(models: readonly OllamaProviderModel[]): Promise<void> {
+	const sanitized = sanitizeCachedModels(models);
+	if (sanitized.length === 0) return;
+
+	const cachePath = getOllamaCloudModelCachePath();
+	const payload: OllamaCloudModelCache = {
+		models: sanitized,
+		refreshedAt: Date.now(),
+		version: CACHE_VERSION,
+	};
+	await mkdir(dirname(cachePath), { recursive: true });
+	await writeFile(cachePath, `${JSON.stringify(payload, null, "\t")}\n`, "utf8");
+}
+
+function sanitizeCachedModels(models: unknown): OllamaProviderModel[] {
+	if (!Array.isArray(models)) return [];
+	const sanitized: OllamaProviderModel[] = [];
+	for (const model of models) {
+		if (!model || typeof model !== "object") continue;
+		const id = (model as { id?: unknown }).id;
+		if (typeof id !== "string" || id.trim().length === 0) continue;
+		sanitized.push(toOllamaModel({ ...(model as Partial<OllamaProviderModel>), id: id.trim(), source: "cloud" }));
+	}
+	return sanitized;
+}

--- a/packages/ollama/index.ts
+++ b/packages/ollama/index.ts
@@ -14,6 +14,7 @@ import {
 	refreshOllamaCloudCredential,
 	refreshOllamaCloudCredentialModels,
 } from "./auth.js";
+import { loadCachedOllamaCloudModels, saveCachedOllamaCloudModels } from "./cache.js";
 import {
 	OLLAMA_API,
 	OLLAMA_CLOUD_API_KEY_ENV,
@@ -25,6 +26,7 @@ import {
 } from "./config.js";
 import { clearOllamaCliStatusCache, getOllamaCliStatus, pullOllamaModel, type OllamaCliStatus } from "./local.js";
 import {
+	discoverOllamaCloudModelList,
 	discoverOllamaCloudModels,
 	discoverOllamaLocalModels,
 	getCredentialModels,
@@ -69,6 +71,26 @@ type CollectedOllamaModel = OllamaProviderModel & {
 	baseUrl: string;
 };
 
+function getInitialOllamaCloudModels(): OllamaProviderModel[] {
+	return mergeOllamaModelCatalogs(loadCachedOllamaCloudModels(), getFallbackOllamaCloudModels());
+}
+
+function mergeOllamaModelCatalogs(
+	primaryModels: readonly OllamaProviderModel[],
+	secondaryModels: readonly OllamaProviderModel[],
+): OllamaProviderModel[] {
+	const models = new Map<string, OllamaProviderModel>();
+	for (const model of secondaryModels) models.set(model.id, model);
+	for (const model of primaryModels) models.set(model.id, model);
+	return [...models.values()].toSorted((left, right) => left.id.localeCompare(right.id));
+}
+
+function saveOllamaCloudModelCache(models: readonly OllamaProviderModel[]): void {
+	void saveCachedOllamaCloudModels(models).catch(() => {
+		// Cache persistence must never make provider registration fail.
+	});
+}
+
 const localDiscoveryState: RuntimeDiscoveryState = {
 	models: [],
 	lastRefresh: null,
@@ -76,7 +98,7 @@ const localDiscoveryState: RuntimeDiscoveryState = {
 };
 
 const cloudEnvDiscoveryState: RuntimeDiscoveryState = {
-	models: getFallbackOllamaCloudModels(),
+	models: getInitialOllamaCloudModels(),
 	lastRefresh: null,
 	lastError: null,
 };
@@ -85,6 +107,7 @@ const activeLocalPulls = new Map<string, Promise<boolean>>();
 const PULL_STATUS_KEY = "ollama.pull";
 const OLLAMA_STARTUP_CLI_REFRESH_DELAY_MS = 250;
 const OLLAMA_STARTUP_CLOUD_REFRESH_DELAY_MS = 250;
+const OLLAMA_STARTUP_CLOUD_DISCOVERY_TIMEOUT_MS = 5_000;
 
 let ollamaCliStatus: OllamaCliStatus | null = null;
 let missingCliWarningShown = false;
@@ -140,10 +163,12 @@ async function refreshRegisteredCloudEnvModels(pi: ExtensionAPI): Promise<Ollama
 	const apiKey = process.env[OLLAMA_CLOUD_API_KEY_ENV]?.trim();
 
 	try {
-		cloudEnvDiscoveryState.models = (await discoverOllamaCloudModels(apiKey)) ?? getFallbackOllamaCloudModels();
+		const discoveredModels = await discoverOllamaCloudModels(apiKey);
+		cloudEnvDiscoveryState.models = discoveredModels ?? getInitialOllamaCloudModels();
+		if (discoveredModels) saveOllamaCloudModelCache(discoveredModels);
 		cloudEnvDiscoveryState.lastError = null;
 	} catch (error) {
-		cloudEnvDiscoveryState.models = getFallbackOllamaCloudModels();
+		cloudEnvDiscoveryState.models = getInitialOllamaCloudModels();
 		cloudEnvDiscoveryState.lastError = error instanceof Error ? error.message : String(error);
 	}
 
@@ -879,6 +904,25 @@ function createOllamaProcessEnv(): NodeJS.ProcessEnv {
 	return env;
 }
 
+async function primeOllamaCloudModelsBeforeRegistration(): Promise<void> {
+	const abortController = new AbortController();
+	const timeout = setTimeout(() => abortController.abort(), OLLAMA_STARTUP_CLOUD_DISCOVERY_TIMEOUT_MS);
+	timeout.unref?.();
+	try {
+		const apiKey = process.env[OLLAMA_CLOUD_API_KEY_ENV]?.trim();
+		const discoveredModels = await discoverOllamaCloudModelList(apiKey, { signal: abortController.signal });
+		if (!discoveredModels) return;
+		cloudEnvDiscoveryState.models = mergeOllamaModelCatalogs(discoveredModels, getInitialOllamaCloudModels());
+		cloudEnvDiscoveryState.lastError = null;
+		cloudEnvDiscoveryState.lastRefresh = Date.now();
+		saveOllamaCloudModelCache(cloudEnvDiscoveryState.models);
+	} catch (error) {
+		cloudEnvDiscoveryState.lastError = error instanceof Error ? error.message : String(error);
+	} finally {
+		clearTimeout(timeout);
+	}
+}
+
 function bootstrapOllamaProviders(
 	pi: ExtensionAPI,
 	scheduleRefreshes: { scheduleCloudBootstrapRefresh: () => void; scheduleLocalBootstrapRefresh: () => void },
@@ -891,6 +935,7 @@ function bootstrapOllamaProviders(
 
 export {
 	createOllamaCloudOAuthProvider,
+	discoverOllamaCloudModelList,
 	discoverOllamaCloudModels,
 	discoverOllamaLocalModels,
 	getCredentialModels,
@@ -901,7 +946,8 @@ export {
 };
 export { toOllamaModel, toOllamaCloudModel, type OllamaCloudCredentials, type OllamaProviderModel } from "./models.js";
 
-export default function ollamaProviderExtension(pi: ExtensionAPI): void {
+export default async function ollamaProviderExtension(pi: ExtensionAPI): Promise<void> {
+	await primeOllamaCloudModelsBeforeRegistration();
 	const registerLifecycle = registerOllamaLifecycle(pi);
 	bootstrapOllamaProviders(pi, registerLifecycle);
 	registerOllamaCommands(pi);

--- a/packages/ollama/models.ts
+++ b/packages/ollama/models.ts
@@ -399,6 +399,19 @@ export async function discoverOllamaLocalModels(
 	});
 }
 
+export async function discoverOllamaCloudModelList(
+	apiKey?: string,
+	options: { signal?: AbortSignal } = {},
+): Promise<OllamaProviderModel[] | null> {
+	const config = getOllamaCloudRuntimeConfig();
+	const fallbackModels = getFallbackOllamaCloudModels();
+	const modelIds = await discoverOllamaModelIds(config, { apiKey, signal: options.signal });
+	if (modelIds.length === 0) return null;
+	return modelIds
+		.map((id) => normalizeDiscoveredModel(id, null, "cloud", fallbackModels))
+		.filter((model) => model !== null);
+}
+
 export async function discoverOllamaCloudModels(
 	apiKey?: string,
 	options: { signal?: AbortSignal } = {},
@@ -501,6 +514,22 @@ export function toOllamaModel(
 
 export const toOllamaCloudModel = toOllamaModel;
 
+async function discoverOllamaModelIds(
+	config: OllamaRuntimeConfig,
+	options: { apiKey?: string; signal?: AbortSignal },
+): Promise<string[]> {
+	const listed = await fetchJson<{ data?: OllamaListedModel[] }>(config.modelsUrl, {
+		headers: createDiscoveryHeaders(options.apiKey),
+		signal: options.signal,
+	});
+	return Array.isArray(listed.data)
+		? listed.data
+				.map((entry) => (typeof entry?.id === "string" ? entry.id.trim() : ""))
+				.filter(Boolean)
+				.toSorted((left, right) => left.localeCompare(right))
+		: [];
+}
+
 async function discoverOllamaModels(
 	config: OllamaRuntimeConfig,
 	options: {
@@ -510,16 +539,7 @@ async function discoverOllamaModels(
 		signal?: AbortSignal;
 	},
 ): Promise<OllamaProviderModel[] | null> {
-	const listed = await fetchJson<{ data?: OllamaListedModel[] }>(config.modelsUrl, {
-		headers: createDiscoveryHeaders(options.apiKey),
-		signal: options.signal,
-	});
-	const modelIds = Array.isArray(listed.data)
-		? listed.data
-				.map((entry) => (typeof entry?.id === "string" ? entry.id.trim() : ""))
-				.filter(Boolean)
-				.toSorted((left, right) => left.localeCompare(right))
-		: [];
+	const modelIds = await discoverOllamaModelIds(config, options);
 	if (modelIds.length === 0) {
 		return null;
 	}

--- a/packages/ollama/tests/download.test.ts
+++ b/packages/ollama/tests/download.test.ts
@@ -66,7 +66,7 @@ describe("ollama local downloads", () => {
 
 		const { default: ollamaProviderExtension } = await import("../index.js");
 		const harness = createExtensionHarness();
-		ollamaProviderExtension(harness.pi as never);
+		await ollamaProviderExtension(harness.pi as never);
 
 		await waitFor(
 			() => ((harness.providers.get("ollama")?.models as Array<{ id: string }> | undefined)?.length ?? 0) === 2,
@@ -128,7 +128,7 @@ describe("ollama local downloads", () => {
 		const harness = createExtensionHarness();
 		harness.ctx.ui.confirm = vi.fn(async () => true);
 		(harness.ctx.modelRegistry as { refresh?: ReturnType<typeof vi.fn> }).refresh = vi.fn();
-		ollamaProviderExtension(harness.pi as never);
+		await ollamaProviderExtension(harness.pi as never);
 
 		await waitFor(
 			() => ((harness.providers.get("ollama")?.models as Array<{ id: string }> | undefined)?.length ?? 0) === 1,
@@ -176,7 +176,7 @@ describe("ollama local downloads", () => {
 
 		const { default: ollamaProviderExtension } = await import("../index.js");
 		const harness = createExtensionHarness();
-		ollamaProviderExtension(harness.pi as never);
+		await ollamaProviderExtension(harness.pi as never);
 		expect(execFileMock).not.toHaveBeenCalled();
 
 		const sessionStart = harness.emitAsync("session_start", { type: "session_start" }, harness.ctx);

--- a/packages/ollama/tests/models.test.ts
+++ b/packages/ollama/tests/models.test.ts
@@ -1,5 +1,10 @@
+import { mkdtemp, rm } from "node:fs/promises";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
 import { afterEach, describe, expect, it } from "vitest";
+import { loadCachedOllamaCloudModels, saveCachedOllamaCloudModels } from "../cache.js";
 import {
+	discoverOllamaCloudModelList,
 	discoverOllamaCloudModels,
 	discoverOllamaLocalModels,
 	getCredentialModels,
@@ -56,6 +61,32 @@ describe("ollama models", () => {
 		expect(compat?.supportsReasoningEffort).toBe(false);
 		expect(compat?.thinkingFormat).toBe("zai");
 		expect(compat?.zaiToolStream).toBe(true);
+	});
+
+	it("discovers cloud model ids before metadata enrichment", async () => {
+		const backend = await createTestOllamaBackend();
+		backend.setModels([{ id: "brand-new-cloud-model" }, { id: "gpt-oss:120b" }]);
+		backend.setRejectedModelShows(["brand-new-cloud-model", "gpt-oss:120b"]);
+		process.env.PI_OLLAMA_CLOUD_API_URL = backend.apiUrl;
+		process.env.PI_OLLAMA_CLOUD_MODELS_URL = `${backend.apiUrl}/models`;
+		process.env.PI_OLLAMA_CLOUD_SHOW_URL = `${backend.origin}/api/show`;
+		const models = await discoverOllamaCloudModelList("test-key");
+		expect(models?.map((model) => model.id)).toEqual(["brand-new-cloud-model", "gpt-oss:120b"]);
+		expect(models?.[0]?.source).toBe("cloud");
+		expect(backend.getAuthHeaders()).toEqual(["Bearer test-key"]);
+		await backend.close();
+	});
+
+	it("loads cloud models from the startup cache", async () => {
+		const cacheDir = await mkdtemp(join(tmpdir(), "pi-ollama-cache-"));
+		process.env.PI_OLLAMA_CLOUD_CACHE_PATH = join(cacheDir, "models.json");
+		await saveCachedOllamaCloudModels([
+			toOllamaModel({ id: "brand-new-cloud-model", reasoning: true, source: "cloud" }),
+		]);
+		const models = loadCachedOllamaCloudModels();
+		expect(models.map((model) => model.id)).toEqual(["brand-new-cloud-model"]);
+		expect(models[0]?.reasoning).toBe(true);
+		await rm(cacheDir, { force: true, recursive: true });
 	});
 
 	it("discovers cloud models with bearer auth", async () => {

--- a/packages/ollama/tests/smoke.test.ts
+++ b/packages/ollama/tests/smoke.test.ts
@@ -85,10 +85,10 @@ afterEach(async () => {
 });
 
 describe("ollama provider smoke tests", () => {
-	it("registers local + cloud ollama providers and commands without crashing", () => {
+	it("registers local + cloud ollama providers and commands without crashing", async () => {
 		const harness = createExtensionHarness();
 		harnesses.push(harness);
-		ollamaProviderExtension(harness.pi as never);
+		await ollamaProviderExtension(harness.pi as never);
 
 		expect(harness.commands.has("ollama")).toBe(true);
 		expect(harness.commands.has("ollama:status")).toBe(true);
@@ -117,7 +117,7 @@ describe("ollama provider smoke tests", () => {
 				set() {},
 			},
 		};
-		ollamaProviderExtension(harness.pi as never);
+		await ollamaProviderExtension(harness.pi as never);
 
 		await expect(harness.emitAsync("session_start", { type: "session_start" }, harness.ctx)).resolves.toBeDefined();
 		await backend.close();
@@ -132,7 +132,7 @@ describe("ollama provider smoke tests", () => {
 
 		const harness = createExtensionHarness();
 		harnesses.push(harness);
-		ollamaProviderExtension(harness.pi as never);
+		await ollamaProviderExtension(harness.pi as never);
 
 		const startedAt = Date.now();
 		await expect(harness.emitAsync("session_start", { type: "session_start" }, harness.ctx)).resolves.toBeDefined();
@@ -150,7 +150,7 @@ describe("ollama provider smoke tests", () => {
 
 		const harness = createExtensionHarness();
 		harnesses.push(harness);
-		ollamaProviderExtension(harness.pi as never);
+		await ollamaProviderExtension(harness.pi as never);
 
 		const initialModels = harness.providers.get("ollama-cloud")?.models as Array<{ id: string }> | undefined;
 		expect(initialModels?.some((model) => model.id === "glm-5.1")).toBe(true);
@@ -171,7 +171,7 @@ describe("ollama provider smoke tests", () => {
 
 		const harness = createExtensionHarness();
 		harnesses.push(harness);
-		ollamaProviderExtension(harness.pi as never);
+		await ollamaProviderExtension(harness.pi as never);
 
 		for (let attempt = 0; attempt < 80; attempt += 1) {
 			const models = harness.providers.get("ollama-cloud")?.models as Array<{ id: string }> | undefined;
@@ -184,7 +184,7 @@ describe("ollama provider smoke tests", () => {
 		expect(
 			(harness.providers.get("ollama-cloud")?.models as Array<{ id: string }> | undefined)?.map((model) => model.id),
 		).toEqual(["glm-5.1", "kimi-k2.5"]);
-		expect(backend.getAuthHeaders()).toEqual(["", "", ""]);
+		expect(backend.getAuthHeaders()).toEqual(["", "", "", ""]);
 		await backend.close();
 	});
 
@@ -198,7 +198,7 @@ describe("ollama provider smoke tests", () => {
 				set: vi.fn(),
 			},
 		};
-		ollamaProviderExtension(harness.pi as never);
+		await ollamaProviderExtension(harness.pi as never);
 
 		await harness.commands.get("ollama:pull")?.handler?.("", harness.ctx as never);
 		expect(harness.notifications.at(-1)?.msg).toContain("Usage: /ollama:pull <model>");
@@ -221,7 +221,7 @@ describe("ollama provider smoke tests", () => {
 		vi.spyOn(modelsModule, "discoverOllamaLocalModels").mockResolvedValue([]);
 		const harness = createExtensionHarness();
 		harnesses.push(harness);
-		ollamaProviderExtension(harness.pi as never);
+		await ollamaProviderExtension(harness.pi as never);
 
 		await harness.emitAsync("session_start", { type: "session_start" }, harness.ctx);
 		await new Promise((resolve) => setTimeout(resolve, 300));

--- a/packages/ollama/tests/stream.test.ts
+++ b/packages/ollama/tests/stream.test.ts
@@ -189,7 +189,7 @@ describe("ollama glm cloud streaming", () => {
 	it("keeps cloud glm requests on the cloud path even when the local provider registers last", async () => {
 		const backend = await createReasoningAwareChatBackend();
 		const harness = createExtensionHarness();
-		ollamaProviderExtension(harness.pi as never);
+		await ollamaProviderExtension(harness.pi as never);
 
 		const cloudProvider = harness.providers.get("ollama-cloud");
 		const localProvider = harness.providers.get("ollama");


### PR DESCRIPTION
## Summary
- prime Ollama Cloud provider registration from the live /v1/models catalog with a bounded startup timeout
- cache discovered cloud model IDs locally for later offline startup resolution
- keep fallback cloud models as a resilient baseline without requiring every new model to be added manually

## Validation
- pnpm --filter @ifi/pi-provider-ollama build
- pnpm format:check
- pnpm lint -- packages/ollama