### PR TITLE
fix: track diagnostics for user prompts only

### DIFF
--- a/.changeset/diagnostics-user-prompts.md
+++ b/.changeset/diagnostics-user-prompts.md
@@ -2,4 +2,4 @@
 default: patch
 ---
 
-diagnostics: only report user-authored prompt completions and nest interrupted user prompts
+diagnostics: only report meaningful top-level prompt completions, preserve idle extension prompts, add history, and nest interrupted user prompts

--- a/.changeset/diagnostics-user-prompts.md
+++ b/.changeset/diagnostics-user-prompts.md
@@ -1,0 +1,5 @@
+---
+default: patch
+---
+
+diagnostics: only report user-authored prompt completions and nest interrupted user prompts

--- a/packages/diagnostics/index.ts
+++ b/packages/diagnostics/index.ts
@@ -50,6 +50,13 @@ interface DiagnosticsStateEntry {
 	updatedAt?: number;
 }
 
+interface PromptHistoryDiagnostics {
+	displayedCount: number;
+	items: PromptCompletionDiagnostics[];
+	requestedCount: number;
+	totalCount: number;
+}
+
 interface ActivePromptRun {
 	promptPreview: string;
 	startedAt: number;
@@ -97,6 +104,7 @@ type ThemeLike = Theme;
 const COMMAND = "diagnostics";
 const SHORTCUT = "ctrl+shift+d";
 const DIAGNOSTICS_MESSAGE_TYPE = "pi-diagnostics:prompt";
+const DIAGNOSTICS_HISTORY_MESSAGE_TYPE = "pi-diagnostics:history";
 const DIAGNOSTICS_STATE_TYPE = "pi-diagnostics:state";
 const WIDGET_KEY = "diagnostics";
 const WIDGET_REFRESH_MS = 5000;
@@ -104,7 +112,11 @@ const PROMPT_PREVIEW_MAX_LENGTH = 96;
 const RESPONSE_PREVIEW_MAX_LENGTH = 88;
 const PENDING_USER_PROMPT_MAX_COUNT = 8;
 const PENDING_USER_PROMPT_MAX_AGE_MS = 30 * 60_000;
+const HISTORY_DEFAULT_COUNT = 10;
+const HISTORY_MAX_COUNT = 50;
+const HISTORY_COLLAPSED_COUNT = 5;
 const EMPTY_PROMPT_PREVIEW = "(empty prompt)";
+const ARGUMENT_SPLIT_REGEX = /\s+/;
 
 function pluralize(count: number, noun: string): string {
 	return `${count} ${noun}${count === 1 ? "" : "s"}`;
@@ -138,6 +150,15 @@ function isPromptCompletionDiagnostics(value: unknown): value is PromptCompletio
 
 function isDiagnosticsStateEntry(value: unknown): value is DiagnosticsStateEntry {
 	return Boolean(value) && typeof value === "object" && typeof (value as { enabled?: unknown }).enabled === "boolean";
+}
+
+function isPromptHistoryDiagnostics(value: unknown): value is PromptHistoryDiagnostics {
+	return (
+		Boolean(value) &&
+		typeof value === "object" &&
+		Array.isArray((value as { items?: unknown }).items) &&
+		typeof (value as { displayedCount?: unknown }).displayedCount === "number"
+	);
 }
 
 function getMessageDetails(entry: SessionEntryLike): unknown {
@@ -501,6 +522,51 @@ function renderPromptCompletionMessage(
 	return render(lines.join("\n"));
 }
 
+function renderPromptHistoryMessage(
+	message: { content?: unknown; details?: unknown },
+	expanded: boolean,
+	theme: ThemeLike,
+) {
+	const details = isPromptHistoryDiagnostics(message.details) ? message.details : undefined;
+	const render = (text: string) => new Text(text, 1, 0, (segment: string) => theme.bg("customMessageBg", segment));
+	if (!details) {
+		return render(String(message.content ?? "Prompt diagnostics history"));
+	}
+
+	const lines = [theme.fg("accent", theme.bold("⏱ Diagnostics history"))];
+	if (details.items.length === 0) {
+		lines.push(theme.fg("dim", "No prompt diagnostics have been recorded in this session branch."));
+		return render(lines.join("\n"));
+	}
+
+	lines.push(
+		theme.fg(
+			"muted",
+			`Showing ${pluralize(details.displayedCount, "run")} of ${pluralize(details.totalCount, "recorded run")}.`,
+		),
+	);
+
+	const limit = expanded ? details.items.length : Math.min(details.items.length, HISTORY_COLLAPSED_COUNT);
+	for (let index = 0; index < limit; index += 1) {
+		const item = details.items[index];
+		if (!item) {
+			continue;
+		}
+		const childPromptCount = typeof item.childPromptCount === "number" ? item.childPromptCount : 0;
+		const childPrompts = childPromptCount > 0 ? ` · ${pluralize(childPromptCount, "nested prompt")}` : "";
+		lines.push(
+			`${theme.fg("dim", `#${index + 1}`)} ${item.statusLabel} ${item.completedAtLabel} · ${item.durationLabel} · ${pluralize(item.turnCount, "turn")} · ${pluralize(item.toolCount, "tool")}${childPrompts}`,
+		);
+		lines.push(`  ${theme.fg("muted", item.promptPreview)}`);
+	}
+
+	if (!expanded && details.items.length > limit) {
+		lines.push(theme.fg("dim", `Expand to show ${pluralize(details.items.length - limit, "more diagnostics run")}.`));
+	}
+
+	return render(lines.join("\n"));
+}
+
 function getBranchEntries(ctx: ExtensionContext): SessionEntryLike[] {
 	const entries = ctx.sessionManager?.getBranch?.();
 	return Array.isArray(entries) ? (entries as SessionEntryLike[]) : [];
@@ -531,6 +597,66 @@ function restoreLastCompletion(entries: SessionEntryLike[]): PromptCompletionDia
 		}
 	}
 	return null;
+}
+
+function parseHistoryCount(value: string | undefined): number {
+	if (!value) {
+		return HISTORY_DEFAULT_COUNT;
+	}
+
+	const parsed = Number.parseInt(value, 10);
+	if (!Number.isFinite(parsed) || parsed <= 0) {
+		return HISTORY_DEFAULT_COUNT;
+	}
+
+	return Math.min(parsed, HISTORY_MAX_COUNT);
+}
+
+function collectPromptHistory(entries: SessionEntryLike[], requestedCount: number): PromptHistoryDiagnostics {
+	const items: PromptCompletionDiagnostics[] = [];
+	let totalCount = 0;
+	for (let index = entries.length - 1; index >= 0; index -= 1) {
+		const entry = entries[index];
+		if (!entry || getMessageCustomType(entry) !== DIAGNOSTICS_MESSAGE_TYPE) {
+			continue;
+		}
+
+		const details = getMessageDetails(entry);
+		if (!isPromptCompletionDiagnostics(details)) {
+			continue;
+		}
+
+		totalCount += 1;
+		if (items.length < requestedCount) {
+			items.push(details);
+		}
+	}
+
+	return {
+		displayedCount: items.length,
+		items,
+		requestedCount,
+		totalCount,
+	};
+}
+
+function shouldEmitPromptCompletion(completion: PromptCompletionDiagnostics): boolean {
+	return !(
+		completion.promptPreview === EMPTY_PROMPT_PREVIEW &&
+		completion.turnCount === 0 &&
+		completion.toolCount === 0 &&
+		completion.childPromptCount === 0
+	);
+}
+
+function parseCommandArgs(args: string): { action: string; countArg: string | undefined } {
+	const trimmedArgs = args.trim().toLowerCase();
+	if (!trimmedArgs) {
+		return { action: "status", countArg: undefined };
+	}
+
+	const [action = "status", countArg] = trimmedArgs.split(ARGUMENT_SPLIT_REGEX);
+	return { action, countArg };
 }
 
 export default function diagnosticsExtension(pi: ExtensionAPI): void {
@@ -695,8 +821,24 @@ export default function diagnosticsExtension(pi: ExtensionAPI): void {
 		ctx.ui.notify(`Diagnostics ${currentStatus}. ${currentPromptLine}. ${lastLine}.`, "info");
 	};
 
+	const showHistory = (ctx: ExtensionCommandContext, requestedCount: number) => {
+		const history = collectPromptHistory(getBranchEntries(ctx as ExtensionContext), requestedCount);
+		pi.sendMessage({
+			content:
+				history.displayedCount === 0
+					? "No prompt diagnostics have been recorded in this session branch."
+					: `Diagnostics history: ${pluralize(history.displayedCount, "run")}`,
+			customType: DIAGNOSTICS_HISTORY_MESSAGE_TYPE,
+			details: history,
+			display: true,
+		});
+	};
+
 	pi.registerMessageRenderer(DIAGNOSTICS_MESSAGE_TYPE, (message, { expanded }, theme) =>
 		renderPromptCompletionMessage(message, expanded, theme),
+	);
+	pi.registerMessageRenderer(DIAGNOSTICS_HISTORY_MESSAGE_TYPE, (message, { expanded }, theme) =>
+		renderPromptHistoryMessage(message, expanded, theme),
 	);
 
 	pi.on("session_start", (_event, ctx) => {
@@ -716,7 +858,12 @@ export default function diagnosticsExtension(pi: ExtensionAPI): void {
 	});
 
 	pi.on("input", (event) => {
-		if (!enabled || !hasUserPromptContent(event.text, event.images) || event.source === "extension") {
+		const hasActivePrompt = Boolean(currentPrompt || getActivePromptRun(activePromptRuns));
+		if (
+			!enabled ||
+			!hasUserPromptContent(event.text, event.images) ||
+			(event.source === "extension" && hasActivePrompt)
+		) {
 			return { action: "continue" };
 		}
 
@@ -847,9 +994,13 @@ export default function diagnosticsExtension(pi: ExtensionAPI): void {
 
 		const completedAt = Date.now();
 		const completion = buildPromptCompletion(currentPrompt, event.messages, completedAt);
-		lastCompletion = completion;
 		currentPrompt = null;
 		activePromptRuns.length = 0;
+		if (!shouldEmitPromptCompletion(completion)) {
+			requestWidgetRender?.();
+			return;
+		}
+		lastCompletion = completion;
 		requestWidgetRender?.();
 		pi.sendMessage({
 			content: buildPromptSummaryText(completion),
@@ -872,6 +1023,7 @@ export default function diagnosticsExtension(pi: ExtensionAPI): void {
 		getArgumentCompletions(prefix) {
 			const options = [
 				{ description: "Show the current diagnostics state", label: "status", value: "status" },
+				{ description: "Show recent prompt diagnostics from this branch", label: "history", value: "history" },
 				{ description: "Toggle diagnostics logging on or off", label: "toggle", value: "toggle" },
 				{ description: "Enable diagnostics logging and widget output", label: "on", value: "on" },
 				{ description: "Disable diagnostics logging and widget output", label: "off", value: "off" },
@@ -880,9 +1032,14 @@ export default function diagnosticsExtension(pi: ExtensionAPI): void {
 			return filtered.length > 0 ? filtered : null;
 		},
 		handler: async (args, ctx) => {
-			const action = (args.trim().toLowerCase() || "status") as "status" | "toggle" | "on" | "off";
+			const { action, countArg } = parseCommandArgs(args);
 			if (action === "status") {
 				showStatus(ctx);
+				return;
+			}
+
+			if (action === "history") {
+				showHistory(ctx, parseHistoryCount(countArg));
 				return;
 			}
 
@@ -920,6 +1077,7 @@ export const diagnosticsInternals = {
 	buildPromptCompletion,
 	buildPromptSummaryText,
 	classifyStopReason,
+	collectPromptHistory,
 	countToolResults,
 	findLastAssistantMessage,
 	findPromptPreviewFromMessages,
@@ -931,9 +1089,14 @@ export const diagnosticsInternals = {
 	getMessageDetails,
 	isDiagnosticsStateEntry,
 	isPromptCompletionDiagnostics,
+	isPromptHistoryDiagnostics,
+	parseCommandArgs,
+	parseHistoryCount,
 	renderPromptCompletionMessage,
+	renderPromptHistoryMessage,
 	restoreEnabledState,
 	restoreLastCompletion,
+	shouldEmitPromptCompletion,
 	summarizePrompt,
 	summarizeResponsePreview,
 };

--- a/packages/diagnostics/index.ts
+++ b/packages/diagnostics/index.ts
@@ -13,6 +13,20 @@ interface PromptTurnDiagnostics {
 	responsePreview: string;
 }
 
+interface NestedPromptDiagnostics {
+	promptPreview: string;
+	startedAt: number;
+	startedAtLabel: string;
+	completedAt: number;
+	completedAtLabel: string;
+	durationMs: number;
+	durationLabel: string;
+	turnCount: number;
+	toolCount: number;
+	turns: PromptTurnDiagnostics[];
+	children: NestedPromptDiagnostics[];
+}
+
 export interface PromptCompletionDiagnostics {
 	promptPreview: string;
 	startedAt: number;
@@ -23,10 +37,12 @@ export interface PromptCompletionDiagnostics {
 	durationLabel: string;
 	turnCount: number;
 	toolCount: number;
+	childPromptCount: number;
 	status: "completed" | "aborted" | "error" | "unknown";
 	statusLabel: string;
 	stopReason: string | null;
 	turns: PromptTurnDiagnostics[];
+	children: NestedPromptDiagnostics[];
 }
 
 interface DiagnosticsStateEntry {
@@ -39,6 +55,12 @@ interface ActivePromptRun {
 	startedAt: number;
 	startedAtLabel: string;
 	turns: PromptTurnDiagnostics[];
+	children: ActivePromptRun[];
+}
+
+interface PendingUserPrompt {
+	preview: string;
+	receivedAt: number;
 }
 
 interface ActiveToolRun {
@@ -80,6 +102,9 @@ const WIDGET_KEY = "diagnostics";
 const WIDGET_REFRESH_MS = 5000;
 const PROMPT_PREVIEW_MAX_LENGTH = 96;
 const RESPONSE_PREVIEW_MAX_LENGTH = 88;
+const PENDING_USER_PROMPT_MAX_COUNT = 8;
+const PENDING_USER_PROMPT_MAX_AGE_MS = 30 * 60_000;
+const EMPTY_PROMPT_PREVIEW = "(empty prompt)";
 
 function pluralize(count: number, noun: string): string {
 	return `${count} ${noun}${count === 1 ? "" : "s"}`;
@@ -150,7 +175,55 @@ function summarizePrompt(prompt: string | undefined, images: unknown): string {
 		return imageCount === 1 ? "1 image prompt" : `${imageCount} image prompt`;
 	}
 
-	return "(empty prompt)";
+	return EMPTY_PROMPT_PREVIEW;
+}
+
+function hasUserPromptContent(prompt: string | undefined, images: unknown): boolean {
+	return (
+		summarizeText(prompt ?? "", PROMPT_PREVIEW_MAX_LENGTH).length > 0 || (Array.isArray(images) && images.length > 0)
+	);
+}
+
+function prunePendingUserPrompts(pendingUserPrompts: PendingUserPrompt[], now: number): void {
+	let write = 0;
+	for (let read = 0; read < pendingUserPrompts.length; read += 1) {
+		const prompt = pendingUserPrompts[read];
+		if (prompt && now - prompt.receivedAt <= PENDING_USER_PROMPT_MAX_AGE_MS) {
+			pendingUserPrompts[write] = prompt;
+			write += 1;
+		}
+	}
+	pendingUserPrompts.length = write;
+	if (pendingUserPrompts.length <= PENDING_USER_PROMPT_MAX_COUNT) {
+		return;
+	}
+
+	const dropCount = pendingUserPrompts.length - PENDING_USER_PROMPT_MAX_COUNT;
+	write = 0;
+	for (let read = dropCount; read < pendingUserPrompts.length; read += 1) {
+		const prompt = pendingUserPrompts[read];
+		if (prompt) {
+			pendingUserPrompts[write] = prompt;
+			write += 1;
+		}
+	}
+	pendingUserPrompts.length = write;
+}
+
+function consumePendingUserPrompt(
+	pendingUserPrompts: PendingUserPrompt[],
+	preview: string,
+	now: number,
+): PendingUserPrompt | null {
+	prunePendingUserPrompts(pendingUserPrompts, now);
+	for (let index = 0; index < pendingUserPrompts.length; index += 1) {
+		const prompt = pendingUserPrompts[index];
+		if (prompt?.preview === preview) {
+			pendingUserPrompts.splice(index, 1);
+			return prompt;
+		}
+	}
+	return pendingUserPrompts.length === 1 ? (pendingUserPrompts.shift() ?? null) : null;
 }
 
 function countToolResults(toolResults: unknown): number {
@@ -235,7 +308,7 @@ function findLastAssistantMessage(messages: unknown): AgentMessageLike | null {
 
 function findPromptPreviewFromMessages(messages: unknown): string {
 	if (!Array.isArray(messages)) {
-		return "(empty prompt)";
+		return EMPTY_PROMPT_PREVIEW;
 	}
 
 	for (const message of messages) {
@@ -250,19 +323,81 @@ function findPromptPreviewFromMessages(messages: unknown): string {
 		}
 	}
 
-	return "(empty prompt)";
+	return EMPTY_PROMPT_PREVIEW;
+}
+
+function getActivePromptRun(activePromptRuns: Array<ActivePromptRun | null>): ActivePromptRun | null {
+	for (let index = activePromptRuns.length - 1; index >= 0; index -= 1) {
+		const run = activePromptRuns[index];
+		if (run) {
+			return run;
+		}
+	}
+	return null;
+}
+
+function getCurrentAgentPromptRun(activePromptRuns: Array<ActivePromptRun | null>): ActivePromptRun | null {
+	return activePromptRuns[activePromptRuns.length - 1] ?? null;
+}
+
+function countActiveChildPrompts(run: ActivePromptRun): number {
+	let count = 0;
+	for (const child of run.children) {
+		count += 1 + countActiveChildPrompts(child);
+	}
+	return count;
+}
+
+function buildNestedPromptDiagnostics(run: ActivePromptRun, completedAt: number): NestedPromptDiagnostics {
+	let toolCount = 0;
+	for (const turn of run.turns) toolCount += turn.toolCount;
+	const durationMs = Math.max(0, completedAt - run.startedAt);
+	const children = run.children.map((child) => buildNestedPromptDiagnostics(child, completedAt));
+	let childTurnCount = 0;
+	for (const child of children) {
+		childTurnCount += child.turnCount;
+		toolCount += child.toolCount;
+	}
+
+	return {
+		children,
+		completedAt,
+		completedAtLabel: formatTimestamp(completedAt),
+		durationLabel: formatDuration(durationMs),
+		durationMs,
+		promptPreview: run.promptPreview,
+		startedAt: run.startedAt,
+		startedAtLabel: run.startedAtLabel,
+		toolCount,
+		turnCount: run.turns.length + childTurnCount,
+		turns: [...run.turns],
+	};
+}
+
+function countNestedPrompts(children: NestedPromptDiagnostics[]): number {
+	let count = 0;
+	for (const child of children) {
+		count += 1 + countNestedPrompts(child.children);
+	}
+	return count;
 }
 
 function buildPromptSummaryText(details: PromptCompletionDiagnostics): string {
+	const childPromptCount = typeof details.childPromptCount === "number" ? details.childPromptCount : 0;
 	const timing = [
 		`${details.statusLabel} ${details.completedAtLabel}`,
 		`started ${details.startedAtLabel}`,
 		`duration ${details.durationLabel}`,
 		pluralize(details.turnCount, "turn"),
 		pluralize(details.toolCount, "tool"),
-	].join(" · ");
+	];
+	if (childPromptCount > 0) {
+		timing.push(pluralize(childPromptCount, "nested prompt"));
+	}
 
-	return `Prompt ${timing}\n${details.promptPreview}`;
+	const timingText = timing.join(" · ");
+
+	return `Prompt ${timingText}\n${details.promptPreview}`;
 }
 
 function buildPromptCompletion(
@@ -272,10 +407,19 @@ function buildPromptCompletion(
 ): PromptCompletionDiagnostics {
 	const lastAssistant = findLastAssistantMessage(messages);
 	const classification = classifyStopReason(lastAssistant?.stopReason ?? null);
-	const toolCount = run.turns.reduce((sum, turn) => sum + turn.toolCount, 0);
+	let toolCount = 0;
+	for (const turn of run.turns) toolCount += turn.toolCount;
+	const children = run.children.map((child) => buildNestedPromptDiagnostics(child, completedAt));
+	let childTurnCount = 0;
+	for (const child of children) {
+		childTurnCount += child.turnCount;
+		toolCount += child.toolCount;
+	}
 	const durationMs = Math.max(0, completedAt - run.startedAt);
 
 	return {
+		childPromptCount: countNestedPrompts(children),
+		children,
 		completedAt,
 		completedAtLabel: formatTimestamp(completedAt),
 		durationLabel: formatDuration(durationMs),
@@ -287,7 +431,7 @@ function buildPromptCompletion(
 		statusLabel: classification.statusLabel,
 		stopReason: lastAssistant?.stopReason ?? null,
 		toolCount,
-		turnCount: run.turns.length,
+		turnCount: run.turns.length + childTurnCount,
 		turns: [...run.turns],
 	};
 }
@@ -305,6 +449,8 @@ function renderPromptCompletionMessage(
 		return render(String(message.content ?? "Prompt diagnostics"));
 	}
 
+	const childPromptCount = typeof details.childPromptCount === "number" ? details.childPromptCount : 0;
+	const children = Array.isArray(details.children) ? details.children : [];
 	const lines = [
 		`${theme.fg(classification.color, theme.bold(`⏱ Prompt ${details.statusLabel}`))}`,
 		`${theme.fg("muted", "Prompt")}: ${details.promptPreview}`,
@@ -312,9 +458,12 @@ function renderPromptCompletionMessage(
 		`${theme.fg("muted", "Completed")}: ${details.completedAtLabel}`,
 		`${theme.fg("muted", "Duration")}: ${details.durationLabel} · ${pluralize(details.turnCount, "turn")} · ${pluralize(details.toolCount, "tool")}`,
 	];
+	if (childPromptCount > 0) {
+		lines.push(`${theme.fg("muted", "Nested")}: ${pluralize(childPromptCount, "prompt")}`);
+	}
 
 	if (!expanded) {
-		if (details.turns.length > 0) {
+		if (details.turns.length > 0 || childPromptCount > 0) {
 			lines.push(theme.fg("dim", "Expand to inspect per-turn completion timestamps."));
 		}
 		return render(lines.join("\n"));
@@ -323,7 +472,9 @@ function renderPromptCompletionMessage(
 	if (details.turns.length === 0) {
 		lines.push("");
 		lines.push(theme.fg("dim", "No assistant turns were recorded for this prompt."));
-		return render(lines.join("\n"));
+		if (children.length === 0) {
+			return render(lines.join("\n"));
+		}
 	}
 
 	lines.push("");
@@ -334,6 +485,17 @@ function renderPromptCompletionMessage(
 			`${theme.fg("dim", `#${turn.turnIndex + 1}`)} ${turn.completedAtLabel} · ${turn.elapsedLabel} · ${pluralize(turn.toolCount, "tool")}${stopReasonSuffix}`,
 		);
 		lines.push(`  ${theme.fg("muted", turn.responsePreview)}`);
+	}
+
+	if (children.length > 0) {
+		lines.push("");
+		lines.push(theme.fg("accent", theme.bold("Nested prompts")));
+		for (const child of children) {
+			lines.push(
+				`${theme.fg("dim", "↳")} ${child.startedAtLabel} → ${child.completedAtLabel} · ${child.durationLabel} · ${pluralize(child.turnCount, "turn")} · ${pluralize(child.toolCount, "tool")}`,
+			);
+			lines.push(`  ${theme.fg("muted", child.promptPreview)}`);
+		}
 	}
 
 	return render(lines.join("\n"));
@@ -377,7 +539,9 @@ export default function diagnosticsExtension(pi: ExtensionAPI): void {
 	let currentPrompt: ActivePromptRun | null = null;
 	let lastCompletion: PromptCompletionDiagnostics | null = null;
 	let requestWidgetRender: (() => void) | null = null;
+	const activePromptRuns: Array<ActivePromptRun | null> = [];
 	const activeToolRuns = new Map<string, ActiveToolRun>();
+	const pendingUserPrompts: PendingUserPrompt[] = [];
 
 	const persistEnabledState = () => {
 		pi.appendEntry(DIAGNOSTICS_STATE_TYPE, {
@@ -392,13 +556,15 @@ export default function diagnosticsExtension(pi: ExtensionAPI): void {
 			const startedAt = currentPrompt?.startedAt ?? activeToolSummary?.earliestStartedAt ?? Date.now();
 			const startedAtLabel = currentPrompt?.startedAtLabel ?? formatTimestamp(startedAt);
 			const promptPreview = currentPrompt?.promptPreview ?? activeToolSummary?.promptPreview ?? "(unknown prompt)";
+			const childPromptCount = currentPrompt ? countActiveChildPrompts(currentPrompt) : 0;
 			const recordedTurns = currentPrompt ? ` · ${pluralize(currentPrompt.turns.length, "turn")} recorded` : "";
+			const nestedPrompts = childPromptCount > 0 ? ` · ${pluralize(childPromptCount, "nested prompt")}` : "";
 			const runningTools = activeToolSummary
 				? ` · ${pluralize(activeToolRuns.size, "tool")} running (${activeToolSummary.toolNames})`
 				: "";
 			return [
 				`${theme.fg("accent", theme.bold("⏱ Diagnostics"))} ${theme.fg("success", "running")} · ${startedAtLabel} · ${formatDuration(Date.now() - startedAt)} elapsed`,
-				`${theme.fg("muted", promptPreview)}${recordedTurns}${runningTools}`,
+				`${theme.fg("muted", promptPreview)}${recordedTurns}${nestedPrompts}${runningTools}`,
 			];
 		}
 
@@ -483,9 +649,30 @@ export default function diagnosticsExtension(pi: ExtensionAPI): void {
 		}
 		lastCompletion = restoreLastCompletion(entries);
 		currentPrompt = null;
+		activePromptRuns.length = 0;
 		activeToolRuns.clear();
+		pendingUserPrompts.length = 0;
 		syncWidget(ctx);
 		requestWidgetRender?.();
+	};
+
+	const startPromptRun = (promptPreview: string, startedAt: number): ActivePromptRun => {
+		const run: ActivePromptRun = {
+			children: [],
+			promptPreview,
+			startedAt,
+			startedAtLabel: formatTimestamp(startedAt),
+			turns: [],
+		};
+		const parent = getActivePromptRun(activePromptRuns);
+		if (parent) {
+			parent.children.push(run);
+		} else {
+			currentPrompt = run;
+		}
+		activePromptRuns.push(run);
+		requestWidgetRender?.();
+		return run;
 	};
 
 	const applyToggle = (ctx: ExtensionContext, nextEnabled: boolean, source: "command" | "shortcut") => {
@@ -528,19 +715,53 @@ export default function diagnosticsExtension(pi: ExtensionAPI): void {
 		restoreSessionState(ctx);
 	});
 
+	pi.on("input", (event) => {
+		if (!enabled || !hasUserPromptContent(event.text, event.images) || event.source === "extension") {
+			return { action: "continue" };
+		}
+
+		const now = Date.now();
+		pendingUserPrompts.push({ preview: summarizePrompt(event.text, event.images), receivedAt: now });
+		prunePendingUserPrompts(pendingUserPrompts, now);
+		return { action: "continue" };
+	});
+
 	pi.on("before_agent_start", (event, ctx) => {
 		activeCtx = ctx;
+		const now = Date.now();
+		const promptPreview = summarizePrompt(event.prompt, event.images);
 		if (!enabled) {
+			pendingUserPrompts.length = 0;
+			activePromptRuns.push(null);
+			return;
+		}
+		if (!hasUserPromptContent(event.prompt, event.images)) {
+			activePromptRuns.push(null);
+			return;
+		}
+		const pendingPrompt = consumePendingUserPrompt(pendingUserPrompts, promptPreview, now);
+		if (!pendingPrompt) {
+			activePromptRuns.push(null);
 			return;
 		}
 
-		currentPrompt = {
-			promptPreview: summarizePrompt(event.prompt, event.images),
-			startedAt: Date.now(),
-			startedAtLabel: formatTimestamp(Date.now()),
-			turns: [],
-		};
-		requestWidgetRender?.();
+		startPromptRun(pendingPrompt.preview, now);
+	});
+
+	pi.on("message_start", (event, ctx) => {
+		activeCtx = ctx;
+		if (!(enabled && currentPrompt && event.message?.role === "user")) {
+			return;
+		}
+
+		const now = Date.now();
+		const promptPreview = summarizeContent(event.message.content, PROMPT_PREVIEW_MAX_LENGTH) || EMPTY_PROMPT_PREVIEW;
+		const pendingPrompt = consumePendingUserPrompt(pendingUserPrompts, promptPreview, now);
+		if (!pendingPrompt) {
+			return;
+		}
+
+		startPromptRun(pendingPrompt.preview, now);
 	});
 
 	pi.on("tool_execution_start", (event, ctx) => {
@@ -554,8 +775,13 @@ export default function diagnosticsExtension(pi: ExtensionAPI): void {
 			return;
 		}
 
+		const activePrompt = getCurrentAgentPromptRun(activePromptRuns);
+		if (!activePrompt) {
+			return;
+		}
+
 		activeToolRuns.set(toolCallId, {
-			promptPreview: currentPrompt?.promptPreview ?? "(unknown prompt)",
+			promptPreview: activePrompt.promptPreview,
 			startedAt: Date.now(),
 			toolName: getToolName(event),
 		});
@@ -573,15 +799,16 @@ export default function diagnosticsExtension(pi: ExtensionAPI): void {
 
 	pi.on("turn_end", (event, ctx) => {
 		activeCtx = ctx;
-		if (!(enabled && currentPrompt && event.message?.role === "assistant")) {
+		const activePrompt = getCurrentAgentPromptRun(activePromptRuns);
+		if (!(enabled && activePrompt && event.message?.role === "assistant")) {
 			return;
 		}
 
 		const completedAt = Date.now();
 		const stopReason = typeof event.message.stopReason === "string" ? event.message.stopReason : null;
 		const toolCount = countToolResults(event.toolResults);
-		const elapsedMs = Math.max(0, completedAt - currentPrompt.startedAt);
-		currentPrompt.turns.push({
+		const elapsedMs = Math.max(0, completedAt - activePrompt.startedAt);
+		activePrompt.turns.push({
 			completedAt,
 			completedAtLabel: formatTimestamp(completedAt),
 			elapsedLabel: formatDuration(elapsedMs),
@@ -589,8 +816,11 @@ export default function diagnosticsExtension(pi: ExtensionAPI): void {
 			responsePreview: summarizeResponsePreview(event.message.content, toolCount, stopReason),
 			stopReason,
 			toolCount,
-			turnIndex: typeof event.turnIndex === "number" ? event.turnIndex : currentPrompt.turns.length,
+			turnIndex: typeof event.turnIndex === "number" ? event.turnIndex : activePrompt.turns.length,
 		});
+		if (activePrompt !== currentPrompt && stopReason !== "toolUse") {
+			activePromptRuns.pop();
+		}
 		requestWidgetRender?.();
 	});
 
@@ -598,20 +828,28 @@ export default function diagnosticsExtension(pi: ExtensionAPI): void {
 		activeCtx = ctx;
 		if (!enabled) {
 			currentPrompt = null;
+			activePromptRuns.length = 0;
+			requestWidgetRender?.();
+			return;
+		}
+
+		const run = activePromptRuns.pop();
+		if (!run) {
+			requestWidgetRender?.();
+			return;
+		}
+		if (!currentPrompt || (run !== currentPrompt && !activePromptRuns.includes(currentPrompt))) {
+			currentPrompt = null;
+			activePromptRuns.length = 0;
 			requestWidgetRender?.();
 			return;
 		}
 
 		const completedAt = Date.now();
-		const run = currentPrompt ?? {
-			promptPreview: findPromptPreviewFromMessages(event.messages),
-			startedAt: completedAt,
-			startedAtLabel: formatTimestamp(completedAt),
-			turns: [],
-		};
-		const completion = buildPromptCompletion(run, event.messages, completedAt);
+		const completion = buildPromptCompletion(currentPrompt, event.messages, completedAt);
 		lastCompletion = completion;
 		currentPrompt = null;
+		activePromptRuns.length = 0;
 		requestWidgetRender?.();
 		pi.sendMessage({
 			content: buildPromptSummaryText(completion),
@@ -623,7 +861,9 @@ export default function diagnosticsExtension(pi: ExtensionAPI): void {
 
 	pi.on("session_shutdown", () => {
 		currentPrompt = null;
+		activePromptRuns.length = 0;
 		activeToolRuns.clear();
+		pendingUserPrompts.length = 0;
 		requestWidgetRender = null;
 	});
 

--- a/packages/diagnostics/tests/diagnostics.test.ts
+++ b/packages/diagnostics/tests/diagnostics.test.ts
@@ -202,6 +202,18 @@ describe("diagnostics extension", () => {
 				]),
 			).toMatchObject({ promptPreview: "Most recent completion" });
 			expect(diagnosticsInternals.restoreLastCompletion([])).toBeNull();
+			expect(diagnosticsInternals.shouldEmitPromptCompletion(makeCompletion())).toBe(true);
+			expect(
+				diagnosticsInternals.shouldEmitPromptCompletion(
+					makeCompletion({
+						childPromptCount: 0,
+						promptPreview: "(empty prompt)",
+						toolCount: 0,
+						turnCount: 0,
+						turns: [],
+					}),
+				),
+			).toBe(false);
 		});
 
 		it("renders fallback, collapsed, and expanded completion messages", () => {
@@ -281,6 +293,46 @@ describe("diagnostics extension", () => {
 			expect(renderText(nestedExpanded)).toContain("Nested prompts");
 			expect(renderText(nestedExpanded)).toContain("Actually prioritize tests");
 		});
+
+		it("collects and renders prompt diagnostics history", () => {
+			const first = makeCompletion({ completedAt: 1, promptPreview: "First run" });
+			const second = makeCompletion({ completedAt: 2, promptPreview: "Second run" });
+			const entries = [
+				{ type: "custom_message", customType: "pi-diagnostics:prompt", details: first },
+				{ type: "custom_message", customType: "other", details: makeCompletion({ promptPreview: "Ignored" }) },
+				{ type: "message", message: { role: "custom", customType: "pi-diagnostics:prompt", details: second } },
+			];
+
+			expect(diagnosticsInternals.parseHistoryCount(undefined)).toBe(10);
+			expect(diagnosticsInternals.parseHistoryCount("0")).toBe(10);
+			expect(diagnosticsInternals.parseHistoryCount("100")).toBe(50);
+			expect(diagnosticsInternals.parseCommandArgs("")).toEqual({ action: "status", countArg: undefined });
+			expect(diagnosticsInternals.parseCommandArgs("history 3")).toEqual({ action: "history", countArg: "3" });
+			expect(diagnosticsInternals.isPromptHistoryDiagnostics({ displayedCount: 1, items: [] })).toBe(true);
+			expect(diagnosticsInternals.isPromptHistoryDiagnostics({ items: [] })).toBe(false);
+
+			const history = diagnosticsInternals.collectPromptHistory(entries, 1);
+			expect(history).toMatchObject({ displayedCount: 1, requestedCount: 1, totalCount: 2 });
+			expect(history.items[0]?.promptPreview).toBe("Second run");
+
+			const collapsed = diagnosticsInternals.renderPromptHistoryMessage({ details: history }, false, theme as never);
+			expect(renderText(collapsed)).toContain("Diagnostics history");
+			expect(renderText(collapsed)).toContain("Second run");
+
+			const fallback = diagnosticsInternals.renderPromptHistoryMessage(
+				{ content: "History fallback" },
+				false,
+				theme as never,
+			);
+			expect(renderText(fallback)).toContain("History fallback");
+
+			const empty = diagnosticsInternals.renderPromptHistoryMessage(
+				{ details: diagnosticsInternals.collectPromptHistory([], 10) },
+				false,
+				theme as never,
+			);
+			expect(renderText(empty)).toContain("No prompt diagnostics have been recorded");
+		});
 	});
 
 	it("registers the diagnostics command, shortcut, and message renderer", () => {
@@ -290,6 +342,7 @@ describe("diagnostics extension", () => {
 		expect(harness.commands.has("diagnostics")).toBe(true);
 		expect(harness.shortcuts.has("ctrl+shift+d")).toBe(true);
 		expect(harness.messageRenderers.has("pi-diagnostics:prompt")).toBe(true);
+		expect(harness.messageRenderers.has("pi-diagnostics:history")).toBe(true);
 		const rendered = harness.messageRenderers.get("pi-diagnostics:prompt")?.(
 			{ details: makeCompletion() },
 			{ expanded: false },
@@ -496,8 +549,13 @@ describe("diagnostics extension", () => {
 		);
 		expect(command.getArgumentCompletions("zzz")).toBeNull();
 
+		await command.handler("", harness.ctx);
+		expect(harness.notifications.at(-1)?.msg).toContain("Last completed");
 		await command.handler("status", harness.ctx);
 		expect(harness.notifications.at(-1)?.msg).toContain("Last completed");
+
+		await command.handler("history 2", harness.ctx);
+		expect(harness.messages.at(-1)).toMatchObject({ customType: "pi-diagnostics:history", display: true });
 
 		const freshHarness = createExtensionHarness();
 		freshHarness.ctx.ui.setWidget = vi.fn();
@@ -533,7 +591,7 @@ describe("diagnostics extension", () => {
 		expect(harness.pi.appendEntry).toHaveBeenCalled();
 	});
 
-	it("ignores extension and empty prompt completions", () => {
+	it("tracks idle extension prompts but ignores empty or active extension completions", () => {
 		const harness = createExtensionHarness();
 		harness.ctx.ui.setWidget = vi.fn();
 		diagnosticsExtension(harness.pi as never);
@@ -562,7 +620,10 @@ describe("diagnostics extension", () => {
 			harness.ctx,
 		);
 
-		expect(harness.messages).toHaveLength(0);
+		expect(harness.messages).toHaveLength(1);
+		expect((harness.messages[0] as { details: PromptCompletionDiagnostics }).details.promptPreview).toBe(
+			"Scheduled follow-up",
+		);
 	});
 
 	it("nests an interrupted user prompt under the active prompt completion", () => {

--- a/packages/diagnostics/tests/diagnostics.test.ts
+++ b/packages/diagnostics/tests/diagnostics.test.ts
@@ -29,6 +29,8 @@ function makeCompletion(overrides: Partial<PromptCompletionDiagnostics> = {}): P
 		durationLabel: "7.3s",
 		turnCount: 2,
 		toolCount: 1,
+		childPromptCount: 0,
+		children: [],
 		status: "completed",
 		statusLabel: "completed",
 		stopReason: "stop",
@@ -151,6 +153,7 @@ describe("diagnostics extension", () => {
 				startedAt: Date.UTC(2026, 3, 16, 11, 0, 0),
 				startedAtLabel: "2026-04-16 11:00:00",
 				turns: makeCompletion().turns,
+				children: [],
 			};
 			const completion = diagnosticsInternals.buildPromptCompletion(
 				run,
@@ -209,6 +212,19 @@ describe("diagnostics extension", () => {
 			);
 			expect(renderText(fallback)).toContain("Prompt diagnostics");
 
+			const legacyDetails = makeCompletion() as Omit<PromptCompletionDiagnostics, "childPromptCount" | "children"> & {
+				childPromptCount?: number;
+				children?: unknown[];
+			};
+			delete legacyDetails.childPromptCount;
+			delete legacyDetails.children;
+			const legacyExpanded = diagnosticsInternals.renderPromptCompletionMessage(
+				{ details: legacyDetails },
+				true,
+				theme as never,
+			);
+			expect(renderText(legacyExpanded)).toContain("Turn completions");
+
 			const collapsed = diagnosticsInternals.renderPromptCompletionMessage(
 				{ details: makeCompletion() },
 				false,
@@ -232,6 +248,38 @@ describe("diagnostics extension", () => {
 			expect(rendered).toContain("Turn completions");
 			expect(rendered).toContain("#1");
 			expect(rendered).toContain("toolUse");
+
+			const nestedDetails = makeCompletion({
+				childPromptCount: 1,
+				children: [
+					{
+						promptPreview: "Actually prioritize tests",
+						startedAt: Date.UTC(2026, 3, 16, 11, 0, 2),
+						startedAtLabel: "2026-04-16 11:00:02",
+						completedAt: Date.UTC(2026, 3, 16, 11, 0, 7),
+						completedAtLabel: "2026-04-16 11:00:07",
+						durationMs: 5_000,
+						durationLabel: "5s",
+						turnCount: 1,
+						toolCount: 0,
+						turns: [],
+						children: [],
+					},
+				],
+			});
+			const nestedCollapsed = diagnosticsInternals.renderPromptCompletionMessage(
+				{ details: nestedDetails },
+				false,
+				theme as never,
+			);
+			const nestedExpanded = diagnosticsInternals.renderPromptCompletionMessage(
+				{ details: nestedDetails },
+				true,
+				theme as never,
+			);
+			expect(renderText(nestedCollapsed)).toContain("Nested: 1 prompt");
+			expect(renderText(nestedExpanded)).toContain("Nested prompts");
+			expect(renderText(nestedExpanded)).toContain("Actually prioritize tests");
 		});
 	});
 
@@ -274,6 +322,11 @@ describe("diagnostics extension", () => {
 		await vi.advanceTimersByTimeAsync(1_000);
 		expect(requestRender).not.toHaveBeenCalled();
 
+		harness.emit(
+			"input",
+			{ type: "input", text: "Investigate the flaky test timeout in CI.", images: [], source: "interactive" },
+			harness.ctx,
+		);
 		harness.emit(
 			"before_agent_start",
 			{ type: "before_agent_start", prompt: "Investigate the flaky test timeout in CI.", images: [] },
@@ -389,6 +442,16 @@ describe("diagnostics extension", () => {
 
 		requestRender.mockClear();
 		harness.emit(
+			"input",
+			{ type: "input", text: "Run the failing tests.", images: [], source: "interactive" },
+			harness.ctx,
+		);
+		harness.emit(
+			"before_agent_start",
+			{ type: "before_agent_start", prompt: "Run the failing tests.", images: [] },
+			harness.ctx,
+		);
+		harness.emit(
 			"tool_execution_start",
 			{ type: "tool_execution_start", toolCallId: "tool-1", toolName: "bash", args: { command: "pnpm test" } },
 			harness.ctx,
@@ -405,7 +468,7 @@ describe("diagnostics extension", () => {
 			{ type: "tool_execution_end", toolCallId: "tool-1", toolName: "bash", result: "ok" },
 			harness.ctx,
 		);
-		expect(renderText(widget!)).toContain("errored");
+		expect(renderText(widget!)).toContain("running");
 
 		widget?.dispose();
 	});
@@ -470,7 +533,274 @@ describe("diagnostics extension", () => {
 		expect(harness.pi.appendEntry).toHaveBeenCalled();
 	});
 
-	it("builds a fallback completion when agent_end arrives without an active prompt", () => {
+	it("ignores extension and empty prompt completions", () => {
+		const harness = createExtensionHarness();
+		harness.ctx.ui.setWidget = vi.fn();
+		diagnosticsExtension(harness.pi as never);
+		harness.emit("session_start", { type: "session_start" }, harness.ctx);
+
+		harness.emit("input", { type: "input", text: "", images: [], source: "extension" }, harness.ctx);
+		harness.emit("before_agent_start", { type: "before_agent_start", prompt: "", images: [] }, harness.ctx);
+		harness.emit(
+			"agent_end",
+			{ type: "agent_end", messages: [{ role: "assistant", stopReason: "stop", content: [] }] },
+			harness.ctx,
+		);
+
+		harness.emit("input", { type: "input", text: "Scheduled follow-up", images: [], source: "extension" }, harness.ctx);
+		harness.emit(
+			"before_agent_start",
+			{ type: "before_agent_start", prompt: "Scheduled follow-up", images: [] },
+			harness.ctx,
+		);
+		harness.emit(
+			"agent_end",
+			{
+				type: "agent_end",
+				messages: [{ role: "assistant", stopReason: "stop", content: [{ type: "text", text: "Done" }] }],
+			},
+			harness.ctx,
+		);
+
+		expect(harness.messages).toHaveLength(0);
+	});
+
+	it("nests an interrupted user prompt under the active prompt completion", () => {
+		const harness = createExtensionHarness();
+		harness.ctx.ui.setWidget = vi.fn();
+		diagnosticsExtension(harness.pi as never);
+		harness.emit("session_start", { type: "session_start" }, harness.ctx);
+
+		harness.emit(
+			"input",
+			{ type: "input", text: "Implement the feature", images: [], source: "interactive" },
+			harness.ctx,
+		);
+		harness.emit(
+			"before_agent_start",
+			{ type: "before_agent_start", prompt: "Implement the feature", images: [] },
+			harness.ctx,
+		);
+		harness.emit(
+			"message_start",
+			{ type: "message_start", message: { role: "user", content: [{ type: "text", text: "Implement the feature" }] } },
+			harness.ctx,
+		);
+		harness.emit(
+			"turn_end",
+			{
+				type: "turn_end",
+				turnIndex: 0,
+				message: { role: "assistant", stopReason: "toolUse", content: [{ type: "text", text: "Starting work." }] },
+				toolResults: [{ toolName: "read" }],
+			},
+			harness.ctx,
+		);
+
+		harness.emit(
+			"input",
+			{ type: "input", text: "Actually prioritize tests", images: [], source: "interactive" },
+			harness.ctx,
+		);
+		harness.emit(
+			"message_start",
+			{
+				type: "message_start",
+				message: { role: "user", content: [{ type: "text", text: "Actually prioritize tests" }] },
+			},
+			harness.ctx,
+		);
+		harness.emit(
+			"turn_end",
+			{
+				type: "turn_end",
+				turnIndex: 1,
+				message: { role: "assistant", stopReason: "toolUse", content: [{ type: "text", text: "Tests first." }] },
+				toolResults: [{ toolName: "bash" }],
+			},
+			harness.ctx,
+		);
+		harness.emit(
+			"turn_end",
+			{
+				type: "turn_end",
+				turnIndex: 2,
+				message: { role: "assistant", stopReason: "stop", content: [{ type: "text", text: "Feature done." }] },
+				toolResults: [],
+			},
+			harness.ctx,
+		);
+		harness.emit(
+			"agent_end",
+			{
+				type: "agent_end",
+				messages: [{ role: "assistant", stopReason: "stop", content: [{ type: "text", text: "Feature done." }] }],
+			},
+			harness.ctx,
+		);
+
+		expect(harness.messages).toHaveLength(1);
+		const message = harness.messages[0] as { content: string; details: PromptCompletionDiagnostics };
+		const completion = message.details;
+		expect(message.content).toContain("1 nested prompt");
+		expect(completion.promptPreview).toBe("Implement the feature");
+		expect(completion.childPromptCount).toBe(1);
+		expect(completion.children[0]?.promptPreview).toBe("Actually prioritize tests");
+		expect(completion.children[0]?.turnCount).toBe(2);
+		expect(completion.turnCount).toBe(3);
+		expect(completion.toolCount).toBe(2);
+	});
+
+	it("uses the original input preview when prompt expansion changes before_agent_start text", () => {
+		const harness = createExtensionHarness();
+		harness.ctx.ui.setWidget = vi.fn();
+		diagnosticsExtension(harness.pi as never);
+		harness.emit("session_start", { type: "session_start" }, harness.ctx);
+
+		harness.emit(
+			"input",
+			{ type: "input", text: "/skill:debug-helper diagnose CI", images: [], source: "interactive" },
+			harness.ctx,
+		);
+		harness.emit(
+			"before_agent_start",
+			{
+				type: "before_agent_start",
+				prompt: '<skill name="debug-helper">Lots of instructions</skill>\n\ndiagnose CI',
+				images: [],
+			},
+			harness.ctx,
+		);
+		harness.emit(
+			"turn_end",
+			{
+				type: "turn_end",
+				turnIndex: 0,
+				message: { role: "assistant", stopReason: "stop", content: [{ type: "text", text: "Done." }] },
+				toolResults: [],
+			},
+			harness.ctx,
+		);
+		harness.emit(
+			"agent_end",
+			{ type: "agent_end", messages: [{ role: "assistant", stopReason: "stop", content: [] }] },
+			harness.ctx,
+		);
+
+		expect(harness.messages).toHaveLength(1);
+		const completion = (harness.messages[0] as { details: PromptCompletionDiagnostics }).details;
+		expect(completion.promptPreview).toBe("/skill:debug-helper diagnose CI");
+	});
+
+	it("accepts rpc input as user-authored but ignores stale or evicted pending input", async () => {
+		const staleHarness = createExtensionHarness();
+		staleHarness.ctx.ui.setWidget = vi.fn();
+		diagnosticsExtension(staleHarness.pi as never);
+		staleHarness.emit("session_start", { type: "session_start" }, staleHarness.ctx);
+		staleHarness.emit("input", { type: "input", text: "Old prompt", images: [], source: "rpc" }, staleHarness.ctx);
+		await vi.advanceTimersByTimeAsync(30 * 60_000 + 1);
+		staleHarness.emit(
+			"before_agent_start",
+			{ type: "before_agent_start", prompt: "Old prompt", images: [] },
+			staleHarness.ctx,
+		);
+		staleHarness.emit(
+			"agent_end",
+			{ type: "agent_end", messages: [{ role: "assistant", stopReason: "stop", content: [] }] },
+			staleHarness.ctx,
+		);
+		expect(staleHarness.messages).toHaveLength(0);
+
+		const boundedHarness = createExtensionHarness();
+		boundedHarness.ctx.ui.setWidget = vi.fn();
+		diagnosticsExtension(boundedHarness.pi as never);
+		boundedHarness.emit("session_start", { type: "session_start" }, boundedHarness.ctx);
+		for (let index = 0; index < 9; index += 1) {
+			boundedHarness.emit(
+				"input",
+				{ type: "input", text: `Prompt ${index}`, images: [], source: "rpc" },
+				boundedHarness.ctx,
+			);
+		}
+		boundedHarness.emit(
+			"before_agent_start",
+			{ type: "before_agent_start", prompt: "Prompt 0", images: [] },
+			boundedHarness.ctx,
+		);
+		boundedHarness.emit(
+			"agent_end",
+			{ type: "agent_end", messages: [{ role: "assistant", stopReason: "stop", content: [] }] },
+			boundedHarness.ctx,
+		);
+		expect(boundedHarness.messages).toHaveLength(0);
+
+		boundedHarness.emit(
+			"before_agent_start",
+			{ type: "before_agent_start", prompt: "Prompt 8", images: [] },
+			boundedHarness.ctx,
+		);
+		boundedHarness.emit(
+			"turn_end",
+			{
+				type: "turn_end",
+				turnIndex: 0,
+				message: { role: "assistant", stopReason: "stop", content: [{ type: "text", text: "Done." }] },
+				toolResults: [],
+			},
+			boundedHarness.ctx,
+		);
+		boundedHarness.emit(
+			"agent_end",
+			{ type: "agent_end", messages: [{ role: "assistant", stopReason: "stop", content: [] }] },
+			boundedHarness.ctx,
+		);
+		expect(boundedHarness.messages).toHaveLength(1);
+		const completion = (boundedHarness.messages[0] as { details: PromptCompletionDiagnostics }).details;
+		expect(completion.promptPreview).toBe("Prompt 8");
+	});
+
+	it("does not let internal prompts reset an active user prompt", () => {
+		const harness = createExtensionHarness();
+		harness.ctx.ui.setWidget = vi.fn();
+		diagnosticsExtension(harness.pi as never);
+		harness.emit("session_start", { type: "session_start" }, harness.ctx);
+
+		harness.emit("input", { type: "input", text: "User task", images: [], source: "interactive" }, harness.ctx);
+		harness.emit("before_agent_start", { type: "before_agent_start", prompt: "User task", images: [] }, harness.ctx);
+		harness.emit("input", { type: "input", text: "Scheduled task", images: [], source: "extension" }, harness.ctx);
+		harness.emit(
+			"before_agent_start",
+			{ type: "before_agent_start", prompt: "Scheduled task", images: [] },
+			harness.ctx,
+		);
+		harness.emit(
+			"agent_end",
+			{ type: "agent_end", messages: [{ role: "assistant", stopReason: "stop", content: [] }] },
+			harness.ctx,
+		);
+		expect(harness.messages).toHaveLength(0);
+
+		harness.emit(
+			"turn_end",
+			{
+				type: "turn_end",
+				turnIndex: 0,
+				message: { role: "assistant", stopReason: "stop", content: [{ type: "text", text: "Done." }] },
+				toolResults: [],
+			},
+			harness.ctx,
+		);
+		harness.emit(
+			"agent_end",
+			{ type: "agent_end", messages: [{ role: "assistant", stopReason: "stop", content: [] }] },
+			harness.ctx,
+		);
+		expect(harness.messages).toHaveLength(1);
+		const completion = (harness.messages[0] as { details: PromptCompletionDiagnostics }).details;
+		expect(completion.promptPreview).toBe("User task");
+	});
+
+	it("ignores agent_end when no user-authored prompt is active", () => {
 		const harness = createExtensionHarness();
 		harness.ctx.ui.setWidget = vi.fn();
 		diagnosticsExtension(harness.pi as never);
@@ -488,11 +818,7 @@ describe("diagnostics extension", () => {
 			harness.ctx,
 		);
 
-		expect((harness.messages[0] as { details: PromptCompletionDiagnostics }).details).toMatchObject({
-			promptPreview: "Summarize the release plan.",
-			status: "aborted",
-			turnCount: 0,
-		});
+		expect(harness.messages).toHaveLength(0);
 	});
 
 	it("ignores non-assistant turns and stops logging after diagnostics is turned off", async () => {
@@ -501,6 +827,7 @@ describe("diagnostics extension", () => {
 		diagnosticsExtension(harness.pi as never);
 		harness.emit("session_start", { type: "session_start" }, harness.ctx);
 
+		harness.emit("input", { type: "input", text: "", images: ["img"], source: "interactive" }, harness.ctx);
 		harness.emit("before_agent_start", { type: "before_agent_start", prompt: undefined, images: ["img"] }, harness.ctx);
 		await harness.commands.get("diagnostics")?.handler("status", harness.ctx);
 		expect(harness.notifications.at(-1)?.msg).toContain("Running: 1 image prompt");


### PR DESCRIPTION
## Summary
- correlate diagnostics with non-extension input events so empty/internal/scheduled runs do not emit prompt-completion messages
- keep user-facing previews based on the original input even when skill/template expansion changes the LLM prompt
- nest queued/interrupted user prompts under the active prompt diagnostics and surface nested counts in summaries/widgets/renderers
- add regression coverage for extension/empty prompts, rpc input, stale/evicted pending prompts, transformed prompts, nested message_start follow-ups, legacy renderer details, and internal prompts during active user runs

## Verification
- pnpm --filter @ifi/pi-diagnostics build
- pnpm format:check packages/diagnostics/index.ts packages/diagnostics/tests/diagnostics.test.ts .changeset/diagnostics-user-prompts.md
- pnpm lint -- packages/diagnostics
- pnpm typecheck