### PR TITLE
feat(extensions): show worktree folder and branch in footer

### DIFF
--- a/.changeset/worktree-footer-show-folder.md
+++ b/.changeset/worktree-footer-show-folder.md
@@ -1,0 +1,5 @@
+---
+default: patch
+---
+
+The footer worktree indicator now shows the worktree folder name alongside the branch name, making it easy to identify which worktree you're working in. When the folder name differs from the branch (common with slash-containing branch names), both are displayed as `wt <folder> (<branch>)`. When they match, only the branch is shown. Detached worktrees show just the folder name.

--- a/packages/extensions/extensions/custom-footer.test.ts
+++ b/packages/extensions/extensions/custom-footer.test.ts
@@ -530,15 +530,16 @@ describe("custom-footer extension", () => {
 	});
 
 	describe("worktree folder display in footer", () => {
-		function makeWorktreeContext(overrides: {
-			branch?: string | null;
-			isManaged?: boolean;
-			worktreeRoot?: string;
-			repoRoot?: string;
-		} = {}) {
+		function makeWorktreeContext(
+			overrides: {
+				branch?: string | null;
+				isManaged?: boolean;
+				worktreeRoot?: string;
+				repoRoot?: string;
+			} = {},
+		) {
 			const repoRoot = overrides.repoRoot ?? "/Users/dev/oh-pi";
-			const worktreeRoot =
-				overrides.worktreeRoot ?? "/Users/dev/.pi/worktrees/feat-worktree-footer-show-path";
+			const worktreeRoot = overrides.worktreeRoot ?? "/Users/dev/.pi/worktrees/feat-worktree-footer-show-path";
 			const branch = "branch" in overrides ? overrides.branch : "feat/my-branch";
 			return {
 				cwd: worktreeRoot,
@@ -563,7 +564,7 @@ describe("custom-footer extension", () => {
 								createdAt: new Date().toISOString(),
 								owner: { instanceId: "test-instance" },
 							}
-							: null,
+						: null,
 				},
 			} as const;
 		}
@@ -573,12 +574,8 @@ describe("custom-footer extension", () => {
 		});
 
 		async function renderWithWorktreeContext(worktreeCtx: ReturnType<typeof makeWorktreeContext>) {
-			vi.spyOn(worktreeShared, "getCachedRepoWorktreeContext").mockReturnValue(
-				worktreeCtx as never,
-			);
-			vi.spyOn(worktreeShared, "refreshRepoWorktreeContext").mockResolvedValue(
-				worktreeCtx as never,
-			);
+			vi.spyOn(worktreeShared, "getCachedRepoWorktreeContext").mockReturnValue(worktreeCtx as never);
+			vi.spyOn(worktreeShared, "refreshRepoWorktreeContext").mockResolvedValue(worktreeCtx as never);
 
 			const pi = createMockPi();
 			customFooter(pi as never);

--- a/packages/extensions/extensions/custom-footer.test.ts
+++ b/packages/extensions/extensions/custom-footer.test.ts
@@ -528,4 +528,183 @@ describe("custom-footer extension", () => {
 		expect(rendered).toContain("watchdog");
 		expect(rendered).toContain("cpu 12%");
 	});
+
+	describe("worktree folder display in footer", () => {
+		function makeWorktreeContext(overrides: {
+			branch?: string | null;
+			isManaged?: boolean;
+			worktreeRoot?: string;
+			repoRoot?: string;
+		} = {}) {
+			const repoRoot = overrides.repoRoot ?? "/Users/dev/oh-pi";
+			const worktreeRoot =
+				overrides.worktreeRoot ?? "/Users/dev/.pi/worktrees/feat-worktree-footer-show-path";
+			const branch = "branch" in overrides ? overrides.branch : "feat/my-branch";
+			return {
+				cwd: worktreeRoot,
+				repoRoot,
+				currentWorktreeRoot: worktreeRoot,
+				mainWorktreeRoot: repoRoot,
+				commonDir: `${repoRoot}/.git`,
+				gitDir: `${worktreeRoot}/.git`,
+				currentBranch: branch ?? null,
+				isLinkedWorktree: true,
+				current: {
+					path: worktreeRoot,
+					branch: branch ?? null,
+					isMain: false,
+					isManaged: overrides.isManaged ?? false,
+					metadata: overrides.isManaged
+						? {
+								id: "test-id",
+								branch: branch ?? "(detached)",
+								worktreePath: worktreeRoot,
+								purpose: "test purpose",
+								createdAt: new Date().toISOString(),
+								owner: { instanceId: "test-instance" },
+							}
+							: null,
+				},
+			} as const;
+		}
+
+		afterEach(() => {
+			vi.restoreAllMocks();
+		});
+
+		async function renderWithWorktreeContext(worktreeCtx: ReturnType<typeof makeWorktreeContext>) {
+			vi.spyOn(worktreeShared, "getCachedRepoWorktreeContext").mockReturnValue(
+				worktreeCtx as never,
+			);
+			vi.spyOn(worktreeShared, "refreshRepoWorktreeContext").mockResolvedValue(
+				worktreeCtx as never,
+			);
+
+			const pi = createMockPi();
+			customFooter(pi as never);
+
+			let footerFactory: any;
+			const ctx = {
+				model: { id: "claude-sonnet", provider: "anthropic" },
+				getContextUsage: () => ({ percent: 12 }),
+				sessionManager: { getBranch: () => [] },
+				ui: {
+					setFooter(factory: any) {
+						footerFactory = factory;
+					},
+				},
+			};
+
+			await pi._emit("session_start", {}, ctx);
+			const component = footerFactory(
+				{ requestRender: vi.fn() },
+				{ fg: (_color: string, text: string) => text },
+				{ onBranchChange: () => () => undefined, getGitBranch: () => "main" },
+			);
+			return component.render(300)[0] as string;
+		}
+
+		it("shows branch name when folder basename matches branch", async () => {
+			const rendered = await renderWithWorktreeContext(
+				makeWorktreeContext({
+					branch: "my-feature",
+					worktreeRoot: "/Users/dev/.pi/worktrees/my-feature",
+				}),
+			);
+			expect(rendered).toContain("wt my-feature");
+			expect(rendered).not.toContain("(");
+		});
+
+		it("shows folder and branch when branch has slashes", async () => {
+			const rendered = await renderWithWorktreeContext(
+				makeWorktreeContext({
+					branch: "feat/my-branch",
+					worktreeRoot: "/Users/dev/.pi/worktrees/feat-my-branch",
+				}),
+			);
+			expect(rendered).toContain("wt feat-my-branch (feat/my-branch)");
+		});
+
+		it("shows folder and branch when they differ", async () => {
+			const rendered = await renderWithWorktreeContext(
+				makeWorktreeContext({
+					branch: "feat/some-feature",
+					worktreeRoot: "/Users/dev/.pi/worktrees/my-worktree-folder",
+				}),
+			);
+			expect(rendered).toContain("wt my-worktree-folder (feat/some-feature)");
+		});
+
+		it("shows folder name when detached (no branch)", async () => {
+			const rendered = await renderWithWorktreeContext(
+				makeWorktreeContext({
+					branch: null,
+					worktreeRoot: "/Users/dev/.pi/worktrees/detached-head",
+				}),
+			);
+			expect(rendered).toContain("wt detached-head");
+			expect(rendered).not.toContain("(");
+		});
+
+		it("appends ' pi' suffix for managed worktrees with matching folder name", async () => {
+			const rendered = await renderWithWorktreeContext(
+				makeWorktreeContext({
+					branch: "my-feature",
+					isManaged: true,
+					worktreeRoot: "/Users/dev/.pi/worktrees/my-feature",
+				}),
+			);
+			expect(rendered).toContain("wt my-feature pi");
+		});
+
+		it("shows folder, branch, and pi suffix for managed worktrees with different folder name", async () => {
+			const rendered = await renderWithWorktreeContext(
+				makeWorktreeContext({
+					branch: "feat/some-feature",
+					isManaged: true,
+					worktreeRoot: "/Users/dev/.pi/worktrees/my-folder",
+				}),
+			);
+			expect(rendered).toContain("wt my-folder (feat/some-feature) pi");
+		});
+
+		it("does not show worktree indicator for main checkout", async () => {
+			vi.spyOn(worktreeShared, "getCachedRepoWorktreeContext").mockReturnValue({
+				cwd: "/Users/dev/oh-pi",
+				repoRoot: "/Users/dev/oh-pi",
+				currentWorktreeRoot: "/Users/dev/oh-pi",
+				mainWorktreeRoot: "/Users/dev/oh-pi",
+				commonDir: "/Users/dev/oh-pi/.git",
+				gitDir: "/Users/dev/oh-pi/.git",
+				currentBranch: "main",
+				isLinkedWorktree: false,
+				current: null,
+			} as never);
+			vi.spyOn(worktreeShared, "refreshRepoWorktreeContext").mockResolvedValue(null as never);
+
+			const pi = createMockPi();
+			customFooter(pi as never);
+
+			let footerFactory: any;
+			const ctx = {
+				model: { id: "claude-sonnet", provider: "anthropic" },
+				getContextUsage: () => ({ percent: 12 }),
+				sessionManager: { getBranch: () => [] },
+				ui: {
+					setFooter(factory: any) {
+						footerFactory = factory;
+					},
+				},
+			};
+
+			await pi._emit("session_start", {}, ctx);
+			const component = footerFactory(
+				{ requestRender: vi.fn() },
+				{ fg: (_color: string, text: string) => text },
+				{ onBranchChange: () => () => undefined, getGitBranch: () => "main" },
+			);
+			const rendered = component.render(300)[0] as string;
+			expect(rendered).not.toContain("wt ");
+		});
+	});
 });

--- a/packages/extensions/extensions/custom-footer.ts
+++ b/packages/extensions/extensions/custom-footer.ts
@@ -333,9 +333,7 @@ export default function (pi: ExtensionAPI) {
 								const wtBranch = worktreeContext.current?.branch;
 								const wtFolder = path.basename(worktreeContext.currentWorktreeRoot);
 								const wtLabel =
-									wtBranch && wtBranch !== wtFolder
-										? `${wtFolder} (${wtBranch})`
-										: wtBranch ?? wtFolder;
+									wtBranch && wtBranch !== wtFolder ? `${wtFolder} (${wtBranch})` : (wtBranch ?? wtFolder);
 								return theme.fg(
 									worktreeContext.current?.isManaged ? "warning" : "muted",
 									`wt ${wtLabel}${worktreeContext.current?.isManaged ? " pi" : ""}`,

--- a/packages/extensions/extensions/custom-footer.ts
+++ b/packages/extensions/extensions/custom-footer.ts
@@ -329,12 +329,18 @@ export default function (pi: ExtensionAPI) {
 					const worktreeContext = getWorktreeContext();
 					const repoStr = worktreeContext ? theme.fg("muted", `repo ${path.basename(worktreeContext.repoRoot)}`) : "";
 					const worktreeStr = worktreeContext?.isLinkedWorktree
-						? theme.fg(
-								worktreeContext.current?.isManaged ? "warning" : "muted",
-								`wt ${
-									worktreeContext.current?.branch ?? path.basename(worktreeContext.currentWorktreeRoot)
-								}${worktreeContext.current?.isManaged ? " pi" : ""}`,
-							)
+						? (() => {
+								const wtBranch = worktreeContext.current?.branch;
+								const wtFolder = path.basename(worktreeContext.currentWorktreeRoot);
+								const wtLabel =
+									wtBranch && wtBranch !== wtFolder
+										? `${wtFolder} (${wtBranch})`
+										: wtBranch ?? wtFolder;
+								return theme.fg(
+									worktreeContext.current?.isManaged ? "warning" : "muted",
+									`wt ${wtLabel}${worktreeContext.current?.isManaged ? " pi" : ""}`,
+								);
+							})()
 						: "";
 
 					const branch = worktreeContext?.current?.branch ?? footerData.getGitBranch();


### PR DESCRIPTION
## Summary

The footer worktree indicator now shows both the **worktree folder name** and **branch name**, making it easy to identify which worktree you're working in at a glance.

### Display format

| Scenario | Display |
|---|---|
| Folder matches branch |  |
| Folder differs from branch |  |
| Detached (no branch) |  |
| Managed (pi-owned) | Appends  suffix |

### Changes

- ****: Updated worktree label logic to show folder basename, with branch in parentheses when they differ
- ****: Added 6 new tests covering all display scenarios + main checkout (no indicator)
- **Changeset**: 

### Why this matters

Previously, the footer only showed the branch name. When branch names contain slashes (e.g. `feat/my-branch`), git creates worktree folders with dashes (e.g. `feat-my-branch`), making it impossible to tell which folder you were in. Now both are visible.