### PR TITLE
fix(providers): use proper TUI components for provider login

### DIFF
--- a/.changeset/fix-provider-login-scrollable-ui.md
+++ b/.changeset/fix-provider-login-scrollable-ui.md
@@ -2,8 +2,12 @@
 default: patch
 ---
 
-fix(providers): use scrollable searchable list for provider login and add logout command
+fix(providers): use proper TUI components for provider login with height limiting and fuzzy search
 
-Replaced `ui.select` with `ui.custom` for the `/providers:login` provider picker, implementing a proper scrollable searchable list with height limiting (max 8 visible items), fuzzy filtering, and keyboard navigation matching pi's native OAuth selector UX.
+Replaced `ui.select` with `ui.custom` using proper TUI components (`Container`, `Input`, `TruncatedText`, `Spacer`, `fuzzyFilter`) from `@mariozechner/pi-tui`. This provides:
 
-Added `/providers:logout` command to remove stored provider credentials and clear cached state.
+- Height limiting: max 8 visible providers at a time (like pi's native `OAuthSelectorComponent`)
+- Fuzzy search: type to filter providers by name, ID, env vars, or API type
+- Keyboard navigation: Up/Down arrows (with wrap), Enter to confirm, Escape to cancel, Backspace to delete search
+- Scroll indicators: shows position when list exceeds visible area
+- Consistent UX with pi's built-in `/login` command

--- a/packages/providers/index.ts
+++ b/packages/providers/index.ts
@@ -456,7 +456,7 @@ async function selectProviderFromScrollableList(
 
 	return new Promise((resolve) => {
 		let selectedIndex = 0;
-		let filteredProviders = [...providers];
+		let filteredProviders: SupportedProviderDefinition[] = [...providers];
 
 		const container = new Container();
 		const searchInput = new Input();
@@ -497,10 +497,6 @@ async function selectProviderFromScrollableList(
 				: [...providers];
 			selectedIndex = Math.max(0, Math.min(selectedIndex, Math.max(0, filteredProviders.length - 1)));
 			updateList();
-		};
-
-		searchInput.onChange = (value: string) => {
-			filterProviders(value);
 		};
 
 		searchInput.onSubmit = () => {
@@ -564,16 +560,16 @@ async function selectProviderFromScrollableList(
 
 				// Backspace
 				if (data === "\u007f" || data === "\b") {
-					const current = searchInput.value;
-					searchInput.value = current.slice(0, -1);
-					filterProviders(searchInput.value);
+					const current = searchInput.getValue();
+					searchInput.setValue(current.slice(0, -1));
+					filterProviders(searchInput.getValue());
 					return;
 				}
 
 				// Regular character input for search
 				if (data.length === 1 && data >= " ") {
-					searchInput.value += data;
-					filterProviders(searchInput.value);
+					searchInput.setValue(searchInput.getValue() + data);
+					filterProviders(searchInput.getValue());
 					return;
 				}
 			},

--- a/packages/providers/index.ts
+++ b/packages/providers/index.ts
@@ -7,6 +7,7 @@ import type {
 /* C8 ignore file */
 
 import { AuthStorage } from "@mariozechner/pi-coding-agent";
+import { Container, fuzzyFilter, Input, Spacer, TruncatedText } from "@mariozechner/pi-tui";
 
 import type { ProviderCatalogCredentials, ProviderCatalogModel } from "./catalog.js";
 import type { SupportedProviderDefinition } from "./config.js";
@@ -443,30 +444,147 @@ async function resolveProviderSelection(
 	return await selectProviderFromScrollableList(ctx, matchedProviders);
 }
 
+const PROVIDER_MAX_VISIBLE = 8;
+
 async function selectProviderFromScrollableList(
 	ctx: ProviderCommandContext,
 	providers: readonly SupportedProviderDefinition[],
 ): Promise<SupportedProviderDefinition | null> {
-	if (typeof ctx.ui.select !== "function") {
+	if (typeof ctx.ui.custom !== "function") {
 		return providers[0] ?? null;
 	}
 
-	const options = providers.map((provider) => {
-		const status = hasStoredCredential(ctx, provider.id) ? " ✓ logged in" : getEnvApiKey(provider) ? " • env key" : "";
-		return { label: `${provider.name} — ${provider.id}${status}`, value: provider.id };
+	return new Promise((resolve) => {
+		let selectedIndex = 0;
+		let filteredProviders = [...providers];
+
+		const container = new Container();
+		const searchInput = new Input();
+		const listContainer = new Container();
+
+		const updateList = () => {
+			listContainer.clear();
+			const startIndex = Math.max(
+				0,
+				Math.min(selectedIndex - Math.floor(PROVIDER_MAX_VISIBLE / 2), filteredProviders.length - PROVIDER_MAX_VISIBLE),
+			);
+			const endIndex = Math.min(startIndex + PROVIDER_MAX_VISIBLE, filteredProviders.length);
+
+			for (let i = startIndex; i < endIndex; i++) {
+				const p = filteredProviders[i];
+				if (!p) continue;
+				const selected = i === selectedIndex;
+				const prefix = selected ? "→ " : "  ";
+				const status = hasStoredCredential(ctx, p.id) ? " ✓ logged in" : getEnvApiKey(p) ? " • env key" : "";
+				const line = `${prefix}${p.name} — ${p.id}${status}`;
+				listContainer.addChild(new TruncatedText(line, 1, 0));
+			}
+
+			if (startIndex > 0 || endIndex < filteredProviders.length) {
+				listContainer.addChild(
+					new TruncatedText(`  (${selectedIndex + 1}/${filteredProviders.length}) ↑↓ scroll`, 1, 0),
+				);
+			}
+
+			if (filteredProviders.length === 0) {
+				listContainer.addChild(new TruncatedText("  No providers match", 1, 0));
+			}
+		};
+
+		const filterProviders = (query: string) => {
+			filteredProviders = query
+				? fuzzyFilter(providers, query, (p) => `${p.name} ${p.id} ${p.env.join(" ")} ${p.api}`)
+				: [...providers];
+			selectedIndex = Math.max(0, Math.min(selectedIndex, Math.max(0, filteredProviders.length - 1)));
+			updateList();
+		};
+
+		searchInput.onChange = (value: string) => {
+			filterProviders(value);
+		};
+
+		searchInput.onSubmit = () => {
+			const selected = filteredProviders[selectedIndex];
+			if (selected) {
+				resolve(selected);
+			}
+		};
+
+		// Build the container
+		container.addChild(
+			new TruncatedText(`Select provider to log in (${filteredProviders.length}/${providers.length})`, 1, 0),
+		);
+		container.addChild(new Spacer(1));
+		container.addChild(searchInput);
+		container.addChild(new Spacer(1));
+		container.addChild(listContainer);
+		container.addChild(new Spacer(1));
+		container.addChild(new TruncatedText("  Enter to select · Esc to cancel", 1, 0));
+
+		// Initial render
+		filterProviders("");
+
+		ctx.ui.custom((_tui, _theme, _keybindings, done) => ({
+			dispose() {},
+			handleInput(data: string) {
+				// Up arrow
+				if (data === "\u001b[A" || data === "\u001bOA") {
+					if (filteredProviders.length > 0) {
+						selectedIndex = selectedIndex === 0 ? filteredProviders.length - 1 : selectedIndex - 1;
+						updateList();
+					}
+					return;
+				}
+
+				// Down arrow
+				if (data === "\u001b[B" || data === "\u001bOB") {
+					if (filteredProviders.length > 0) {
+						selectedIndex = selectedIndex === filteredProviders.length - 1 ? 0 : selectedIndex + 1;
+						updateList();
+					}
+					return;
+				}
+
+				// Enter - confirm selection
+				if (data === "\r" || data === "\n") {
+					const selected = filteredProviders[selectedIndex];
+					if (selected) {
+						done(selected);
+						resolve(selected);
+					}
+					return;
+				}
+
+				// Escape - cancel
+				if (data === "\u001b") {
+					done(null as never);
+					resolve(null);
+					return;
+				}
+
+				// Backspace
+				if (data === "\u007f" || data === "\b") {
+					const current = searchInput.value;
+					searchInput.value = current.slice(0, -1);
+					filterProviders(searchInput.value);
+					return;
+				}
+
+				// Regular character input for search
+				if (data.length === 1 && data >= " ") {
+					searchInput.value += data;
+					filterProviders(searchInput.value);
+					return;
+				}
+			},
+			invalidate() {
+				container.invalidate();
+			},
+			render(width: number) {
+				return container.render(width);
+			},
+		}));
 	});
-
-	const selectedId = await ctx.ui.select(
-		`Select provider to log in (${providers.length} total)`,
-		options.map((opt) => opt.label),
-	);
-
-	if (!selectedId) {
-		return null;
-	}
-
-	const selectedIndex = options.findIndex((opt) => opt.label === selectedId);
-	return selectedIndex >= 0 ? (providers[selectedIndex] ?? null) : null;
 }
 
 function buildProviderPickerOptions(

--- a/packages/providers/index.ts
+++ b/packages/providers/index.ts
@@ -493,7 +493,7 @@ async function selectProviderFromScrollableList(
 
 		const filterProviders = (query: string) => {
 			filteredProviders = query
-				? fuzzyFilter(providers, query, (p) => `${p.name} ${p.id} ${p.env.join(" ")} ${p.api}`)
+				? fuzzyFilter([...providers], query, (p) => `${p.name} ${p.id} ${p.env.join(" ")} ${p.api}`)
 				: [...providers];
 			selectedIndex = Math.max(0, Math.min(selectedIndex, Math.max(0, filteredProviders.length - 1)));
 			updateList();

--- a/packages/providers/tests/index.test.ts
+++ b/packages/providers/tests/index.test.ts
@@ -142,11 +142,16 @@ describe("provider catalog extension", () => {
 			registerProvider: vi.fn((name, config) => harness.pi.registerProvider(name, config)),
 		} as never;
 
-		harness.ctx.ui.select = vi.fn(async (_title: string, options: string[]) => {
-			// Return the label that matches the provider we want to select
-			return options.find((opt) => opt.includes(provider.id)) ?? options[10] ?? options[0];
+		harness.ctx.ui.select = vi.fn(async () => null) as never;
+		harness.ctx.ui.custom = vi.fn(async (factory: any) => {
+			const component = factory({}, {}, {}, () => {});
+			// Simulate typing the provider ID to filter
+			for (const char of provider.id) {
+				if (component?.handleInput) component.handleInput(char);
+			}
+			// Simulate pressing Enter to confirm selection
+			if (component?.handleInput) component.handleInput("\r");
 		}) as never;
-		harness.ctx.ui.custom = vi.fn(async () => null) as never;
 		harness.ctx.ui.input = vi.fn(async () => "provider-api-key") as never;
 
 		providerCatalogExtension(harness.pi as never);
@@ -154,8 +159,8 @@ describe("provider catalog extension", () => {
 		const command = harness.commands.get("providers:login");
 		await command.handler("", harness.ctx);
 
-		expect(harness.ctx.ui.select).toHaveBeenCalled();
-		expect(harness.ctx.ui.custom).not.toHaveBeenCalled();
+		expect(harness.ctx.ui.custom).toHaveBeenCalled();
+		expect(harness.ctx.ui.select).not.toHaveBeenCalled();
 
 		expect(harness.providers.has(provider.id)).toBe(true);
 		expect(stored.get(provider.id)).toMatchObject({
@@ -246,7 +251,11 @@ describe("provider catalog extension", () => {
 
 		// Simulate user cancelling the selection
 		harness.ctx.ui.select = vi.fn(async () => null) as never;
-		harness.ctx.ui.custom = vi.fn(async () => null) as never;
+		harness.ctx.ui.custom = vi.fn(async (factory: any) => {
+			const component = factory({}, {}, {}, () => {});
+			// Simulate pressing Escape to cancel
+			if (component?.handleInput) component.handleInput("\u001b");
+		}) as never;
 
 		providerCatalogExtension(harness.pi as never);
 		const command = harness.commands.get("providers:login");


### PR DESCRIPTION
## Summary

Replaced `ui.select` with `ui.custom` using proper TUI components for the provider login picker, matching pi's native `/login` UX.

## Changes

### Provider Login UI
Uses `ui.custom` with proper TUI components from `@mariozechner/pi-tui`:
- **Height limiting**: max 8 visible providers at a time (like pi's `OAuthSelectorComponent`
- **Fuzzy search**: type to filter providers by name, ID, env vars, or API type using 
- **Keyboard navigation**: Up/Down arrows (with wrap), Enter to confirm, Escape to cancel, Backspace to delete search
- **Scroll indicators**: shows position when list exceeds visible area
- **Consistent UX**: matches pi's built-in  command

## Testing
- All 17 tests pass
- Typecheck passes with 
- Formatted with 
EOF
)