### PR TITLE
feat(subagents): dynamic agents with managed worktrees

### DIFF
--- a/packages/subagents/README.md
+++ b/packages/subagents/README.md
@@ -881,6 +881,50 @@ The `modelPolicy` field controls how the agent's model is resolved:
 - **`resolveDynamicModel(spec, options)`** — Pure function that resolves the effective model string based on the spec and available scoped models. Used internally by `runDynamicAgent`; exposed for unit testing and custom orchestrators.
 - **`runDynamicAgent(cwd, spec, task, options)`** — Create an ephemeral agent from `spec`, resolve its model, run it via `runSync`, then return the result. Optionally calls `onUsage` with final usage data for budget tracking across subagent calls.
 
+### Worktrees
+
+Dynamic agents can run inside freshly created managed git worktrees. This is useful when you need the agent to work on an isolated branch without polluting the main checkout.
+
+```typescript
+const result = await runDynamicAgent(
+  "/workspace",
+  {
+    name: "refactor-agent",
+    systemPrompt: "You are a refactoring specialist...",
+    tools: ["read", "edit", "write"],
+  },
+  "Refactor the auth module to use the new API",
+  {
+    currentModel: "anthropic/claude-sonnet-4",
+    availableModels: [...],
+    worktree: {
+      branch: "feat/auth-refactor",
+      purpose: "Isolated refactor of auth module",
+      baseRef: "main",        // optional — defaults to HEAD
+      cleanup: false,       // optional — remove worktree after execution (default: false)
+    },
+  },
+);
+
+// If a worktree was created, the result includes its path and branch:
+if (result.worktreePath) {
+  console.log(`Agent worked in: ${result.worktreePath} (${result.worktreeBranch})`);
+}
+```
+
+| Option    | Type      | Required | Default | Description                                  |
+| --------- | --------- | -------- | ------- | -------------------------------------------- |
+| `branch`  | `string`  | Yes      | —       | Branch name for the new worktree             |
+| `purpose` | `string`  | Yes      | —       | Reason for the worktree (stored in registry) |
+| `baseRef` | `string`  | No       | `HEAD`  | Base ref for the new branch                  |
+| `cleanup` | `boolean` | No       | `false` | Remove worktree after execution              |
+
+**Notes:**
+
+- Worktrees are created via the same `createManagedWorktree` primitive used by the worktree extension, so they appear in `\`pi worktree\` listings and are tracked in the pi worktree registry.
+- The worktree extension is a default extension, so dynamic agents can also create/access worktrees _internally_ via the `\`worktree\`` tool if they need additional isolation.
+- Cleanup runs in a `\`finally\`` block so the worktree is removed even if the agent throws. Cleanup failures are silently ignored (best-effort).
+
 ## Files
 
 ```

--- a/packages/subagents/dynamic-agent.ts
+++ b/packages/subagents/dynamic-agent.ts
@@ -6,6 +6,9 @@
  * runner (runSync) and cleaned up automatically.
  */
 
+import type { ManagedWorktreeMetadata } from "@ifi/oh-pi-core";
+
+import { createManagedWorktree, createOwnerMetadata, removeManagedWorktree } from "@ifi/oh-pi-core";
 import { randomUUID } from "node:crypto";
 
 import type { AgentConfig } from "./agents.js";
@@ -42,6 +45,17 @@ export interface DynamicAgentSpec {
 	idleTimeoutMs?: number;
 }
 
+export interface DynamicAgentWorktreeOptions {
+	/** Branch name for the new worktree (required) */
+	branch: string;
+	/** Why this worktree exists (required) */
+	purpose: string;
+	/** Base ref for the new branch (default: HEAD) */
+	baseRef?: string;
+	/** Remove the worktree after execution (default: false) */
+	cleanup?: boolean;
+}
+
 export interface RunDynamicOptions extends Omit<RunSyncOptions, "modelOverride" | "skills"> {
 	/** List of models the host has scoped */
 	availableModels?: AvailableModelRef[];
@@ -49,6 +63,8 @@ export interface RunDynamicOptions extends Omit<RunSyncOptions, "modelOverride" 
 	currentModel?: string;
 	/** Called when usage data is finalized (for budget tracking across subagent calls) */
 	onUsage?: (usage: SingleResult["usage"]) => void;
+	/** Create a managed worktree and run the agent inside it */
+	worktree?: DynamicAgentWorktreeOptions;
 }
 
 /**
@@ -120,28 +136,72 @@ export function createDynamicAgent(spec: DynamicAgentSpec): AgentConfig {
 /**
  * Create an ephemeral agent from a spec and run it immediately via runSync.
  * The agent config is discarded after execution; only the result is returned.
+ *
+ * When `options.worktree` is provided, the agent runs inside a newly created
+ * managed git worktree. If `cleanup: true`, the worktree is removed after
+ * execution regardless of success or failure.
  */
 export async function runDynamicAgent(
 	runtimeCwd: string,
 	spec: DynamicAgentSpec,
 	task: string,
 	options: RunDynamicOptions = { runId: randomUUID() },
-): Promise<SingleResult> {
+): Promise<SingleResult & { worktreePath?: string; worktreeBranch?: string }> {
 	const resolvedModel = resolveDynamicModel(spec, options);
+
+	// If worktree creation is requested, create it before spawning the agent
+	let worktreePath: string | undefined;
+	let worktreeBranch: string | undefined;
+	let worktreeCleanup = false;
+	let worktreeMetadata: ManagedWorktreeMetadata | undefined;
+	if (options.worktree) {
+		const owner = createOwnerMetadata({
+			instanceId: `dynamic-agent-${randomUUID()}`,
+			cwd: runtimeCwd,
+			sessionName: options.runId ?? undefined,
+		});
+
+		const result = createManagedWorktree({
+			cwd: runtimeCwd,
+			branch: options.worktree.branch,
+			purpose: options.worktree.purpose,
+			baseRef: options.worktree.baseRef,
+			owner,
+		});
+
+		worktreePath = result.worktreePath;
+		worktreeBranch = result.branch;
+		worktreeCleanup = options.worktree.cleanup ?? false;
+		worktreeMetadata = result.metadata;
+	}
 
 	const agent = createDynamicAgent({
 		...spec,
 		model: resolvedModel ?? spec.model,
 	});
 
-	const result = await runSync(runtimeCwd, [agent], agent.name, task, {
-		...options,
-		// modelOverride and skills are baked into the dynamic agent config
-	});
+	try {
+		const result = await runSync(worktreePath ?? runtimeCwd, [agent], agent.name, task, {
+			...options,
+			// modelOverride and skills are baked into the dynamic agent config
+		});
 
-	if (options.onUsage) {
-		options.onUsage(result.usage);
+		if (options.onUsage) {
+			options.onUsage(result.usage);
+		}
+
+		return {
+			...result,
+			worktreePath,
+			worktreeBranch,
+		};
+	} finally {
+		if (worktreeMetadata && worktreeCleanup) {
+			try {
+				removeManagedWorktree(worktreeMetadata);
+			} catch {
+				// Best-effort cleanup; ignore failures
+			}
+		}
 	}
-
-	return result;
 }

--- a/packages/subagents/tests/dynamic-agent.test.ts
+++ b/packages/subagents/tests/dynamic-agent.test.ts
@@ -2,9 +2,17 @@ import { afterEach, describe, expect, it, vi } from "vitest";
 
 const runSync = vi.hoisted(() => vi.fn());
 const findAvailableModel = vi.hoisted(() => vi.fn());
+const createManagedWorktree = vi.hoisted(() => vi.fn());
+const createOwnerMetadata = vi.hoisted(() => vi.fn());
+const removeManagedWorktree = vi.hoisted(() => vi.fn());
 
 vi.mock("../execution.js", () => ({ runSync }));
 vi.mock("../model-routing.js", () => ({ findAvailableModel }));
+vi.mock("@ifi/oh-pi-core", () => ({
+	createManagedWorktree,
+	createOwnerMetadata,
+	removeManagedWorktree,
+}));
 
 import { createDynamicAgent, resolveDynamicModel, runDynamicAgent } from "../dynamic-agent.js";
 
@@ -315,7 +323,7 @@ describe("runDynamicAgent", () => {
 		expect(onUsage).toHaveBeenCalledWith(usageData);
 	});
 
-	it("does not call onUsage when not provided", async () => {
+	it("calls onUsage when not provided", async () => {
 		findAvailableModel.mockReturnValue("anthropic/claude-sonnet-4");
 		runSync.mockResolvedValue({
 			usage: { input: 0, output: 0, cacheRead: 0, cacheWrite: 0, cost: 0 },
@@ -326,5 +334,195 @@ describe("runDynamicAgent", () => {
 
 		// onUsage not provided — no error thrown
 		expect(runSync).toHaveBeenCalledOnce();
+	});
+
+	it("creates a worktree and runs the agent inside it", async () => {
+		findAvailableModel.mockReturnValue("anthropic/claude-sonnet-4");
+		createOwnerMetadata.mockReturnValue({
+			instanceId: "owner-123",
+			hostname: "test",
+			pid: 1234,
+			createdFromCwd: "/workspace",
+			sessionFile: null,
+			sessionId: null,
+			sessionName: null,
+		});
+		createManagedWorktree.mockReturnValue({
+			worktreePath: "/wt/test-branch-abc",
+			branch: "test-branch",
+			createdBranch: true,
+			metadata: {},
+		});
+		runSync.mockResolvedValue({
+			usage: { input: 10, output: 5, cacheRead: 0, cacheWrite: 0, cost: 0 },
+			exitCode: 0,
+		});
+		removeManagedWorktree.mockReturnValue({
+			metadata: {},
+			removed: true,
+			removedFromGit: true,
+			removedRegistryEntry: true,
+			note: "ok",
+		});
+
+		const result = await runDynamicAgent("/workspace", { systemPrompt: "test" }, "task", {
+			runId: "run-wt",
+			worktree: { branch: "test-branch", purpose: "test purpose", baseRef: "main" },
+		});
+
+		expect(createOwnerMetadata).toHaveBeenCalledOnce();
+		expect(createManagedWorktree).toHaveBeenCalledWith({
+			cwd: "/workspace",
+			branch: "test-branch",
+			purpose: "test purpose",
+			baseRef: "main",
+			owner: {
+				instanceId: "owner-123",
+				hostname: "test",
+				pid: 1234,
+				createdFromCwd: "/workspace",
+				sessionFile: null,
+				sessionId: null,
+				sessionName: null,
+			},
+		});
+		expect(runSync).toHaveBeenCalledWith(
+			"/wt/test-branch-abc",
+			expect.any(Array),
+			expect.any(String),
+			"task",
+			expect.objectContaining({ runId: "run-wt" }),
+		);
+		expect(result.worktreePath).toBe("/wt/test-branch-abc");
+		expect(result.worktreeBranch).toBe("test-branch");
+		// cleanup defaults to false
+		expect(removeManagedWorktree).not.toHaveBeenCalled();
+	});
+
+	it("cleans up the worktree when cleanup: true", async () => {
+		findAvailableModel.mockReturnValue("anthropic/claude-sonnet-4");
+		createOwnerMetadata.mockReturnValue({
+			instanceId: "owner-456",
+			hostname: "test",
+			pid: 1234,
+			createdFromCwd: "/workspace",
+			sessionFile: null,
+			sessionId: null,
+			sessionName: null,
+		});
+		createManagedWorktree.mockReturnValue({
+			worktreePath: "/wt/cleanup-branch",
+			branch: "cleanup-branch",
+			createdBranch: true,
+			metadata: {
+				id: "wt-456",
+				repoRoot: "/repo",
+				worktreePath: "/wt/cleanup-branch",
+				branch: "cleanup-branch",
+				purpose: "test",
+				createdAt: "2024",
+				lastSeenAt: null,
+				owner: {
+					instanceId: "",
+					hostname: "",
+					pid: 0,
+					createdFromCwd: "",
+					sessionFile: null,
+					sessionId: null,
+					sessionName: null,
+				},
+				createdFromBranch: null,
+				createdFromRef: "HEAD",
+			},
+		});
+		runSync.mockResolvedValue({
+			usage: { input: 5, output: 2, cacheRead: 0, cacheWrite: 0, cost: 0 },
+			exitCode: 0,
+		});
+		removeManagedWorktree.mockReturnValue({
+			metadata: {},
+			removed: true,
+			removedFromGit: true,
+			removedRegistryEntry: true,
+			note: "ok",
+		});
+
+		await runDynamicAgent("/workspace", { systemPrompt: "test" }, "task", {
+			runId: "run-cleanup",
+			worktree: { branch: "cleanup-branch", purpose: "cleanup test", cleanup: true },
+		});
+
+		expect(removeManagedWorktree).toHaveBeenCalledOnce();
+		expect(removeManagedWorktree).toHaveBeenCalledWith(expect.objectContaining({ id: "wt-456" }));
+	});
+
+	it("cleans up the worktree even when runSync throws", async () => {
+		findAvailableModel.mockReturnValue("anthropic/claude-sonnet-4");
+		createOwnerMetadata.mockReturnValue({
+			instanceId: "owner-789",
+			hostname: "test",
+			pid: 1234,
+			createdFromCwd: "/workspace",
+			sessionFile: null,
+			sessionId: null,
+			sessionName: null,
+		});
+		createManagedWorktree.mockReturnValue({
+			worktreePath: "/wt/error-branch",
+			branch: "error-branch",
+			createdBranch: true,
+			metadata: {},
+		});
+		runSync.mockRejectedValue(new Error("runSync failed"));
+		removeManagedWorktree.mockReturnValue({
+			metadata: {},
+			removed: true,
+			removedFromGit: true,
+			removedRegistryEntry: true,
+			note: "ok",
+		});
+
+		await expect(
+			runDynamicAgent("/workspace", { systemPrompt: "test" }, "task", {
+				runId: "run-error",
+				worktree: { branch: "error-branch", purpose: "error test", cleanup: true },
+			}),
+		).rejects.toThrow("runSync failed");
+
+		expect(removeManagedWorktree).toHaveBeenCalledOnce();
+	});
+
+	it("ignores cleanup errors silently", async () => {
+		findAvailableModel.mockReturnValue("anthropic/claude-sonnet-4");
+		createOwnerMetadata.mockReturnValue({
+			instanceId: "owner-000",
+			hostname: "test",
+			pid: 1234,
+			createdFromCwd: "/workspace",
+			sessionFile: null,
+			sessionId: null,
+			sessionName: null,
+		});
+		createManagedWorktree.mockReturnValue({
+			worktreePath: "/wt/bad-branch",
+			branch: "bad-branch",
+			createdBranch: true,
+			metadata: {},
+		});
+		runSync.mockResolvedValue({
+			usage: { input: 1, output: 1, cacheRead: 0, cacheWrite: 0, cost: 0 },
+			exitCode: 0,
+		});
+		removeManagedWorktree.mockImplementation(() => {
+			throw new Error("cleanup failed");
+		});
+
+		const result = await runDynamicAgent("/workspace", { systemPrompt: "test" }, "task", {
+			runId: "run-bad-cleanup",
+			worktree: { branch: "bad-branch", purpose: "bad cleanup", cleanup: true },
+		});
+
+		expect(result.exitCode).toBe(0);
+		expect(removeManagedWorktree).toHaveBeenCalledOnce();
 	});
 });

--- a/packages/subagents/tests/dynamic-agent.test.ts
+++ b/packages/subagents/tests/dynamic-agent.test.ts
@@ -154,6 +154,20 @@ describe("resolveDynamicModel", () => {
 		).toThrow('Dynamic agent "unnamed" requested model "unknown-model" is not in the scoped model list');
 	});
 
+	it("falls back to currentModel when explicit model is unavailable and no availableModels list", () => {
+		findAvailableModel.mockReturnValue(undefined);
+
+		const result = resolveDynamicModel(
+			{ model: "unknown-model", systemPrompt: "test" },
+			{ currentModel: "openai/gpt-5-mini" },
+		);
+
+		// availableModels is undefined, so spec.model is not validated;
+		// falls through to currentModel since policy is inherit
+		expect(result).toBe("openai/gpt-5-mini");
+		expect(findAvailableModel).not.toHaveBeenCalled();
+	});
+
 	it("falls back to currentModel when no model is specified", () => {
 		findAvailableModel.mockImplementation((name) => (name === "openai/gpt-5-mini" ? "openai/gpt-5-mini" : undefined));
 
@@ -333,6 +347,30 @@ describe("runDynamicAgent", () => {
 		await runDynamicAgent("/workspace", { systemPrompt: "test" }, "task", { runId: "run-abc" });
 
 		// onUsage not provided — no error thrown
+		expect(runSync).toHaveBeenCalledOnce();
+	});
+
+	it("creates a worktree without runId (defaults runId)", async () => {
+		findAvailableModel.mockReturnValue("anthropic/claude-sonnet-4");
+		createOwnerMetadata.mockReturnValue({ instanceId: "owner-no-run", hostname: "test", pid: 1234, createdFromCwd: "/workspace", sessionFile: null, sessionId: null, sessionName: null });
+		createManagedWorktree.mockReturnValue({ worktreePath: "/wt/no-run", branch: "no-run", createdBranch: true, metadata: { id: "wt-nr", repoRoot: "/repo", worktreePath: "/wt/no-run", branch: "no-run", purpose: "test", createdAt: "2024", lastSeenAt: null, owner: { instanceId: "", hostname: "", pid: 0, createdFromCwd: "", sessionFile: null, sessionId: null, sessionName: null }, createdFromBranch: null, createdFromRef: "HEAD" } });
+		runSync.mockResolvedValue({
+			usage: { input: 1, output: 1, cacheRead: 0, cacheWrite: 0, cost: 0 },
+			exitCode: 0,
+		});
+
+		// Omit runId so options.runId ?? undefined is hit
+		const result = await runDynamicAgent(
+			"/workspace",
+			{ systemPrompt: "test" },
+			"task",
+			{
+				worktree: { branch: "no-run", purpose: "no runId test" },
+			},
+		);
+
+		expect(createOwnerMetadata).toHaveBeenCalledOnce();
+		expect(result.worktreePath).toBe("/wt/no-run");
 		expect(runSync).toHaveBeenCalledOnce();
 	});
 

--- a/packages/subagents/tests/dynamic-agent.test.ts
+++ b/packages/subagents/tests/dynamic-agent.test.ts
@@ -352,22 +352,49 @@ describe("runDynamicAgent", () => {
 
 	it("creates a worktree without runId (defaults runId)", async () => {
 		findAvailableModel.mockReturnValue("anthropic/claude-sonnet-4");
-		createOwnerMetadata.mockReturnValue({ instanceId: "owner-no-run", hostname: "test", pid: 1234, createdFromCwd: "/workspace", sessionFile: null, sessionId: null, sessionName: null });
-		createManagedWorktree.mockReturnValue({ worktreePath: "/wt/no-run", branch: "no-run", createdBranch: true, metadata: { id: "wt-nr", repoRoot: "/repo", worktreePath: "/wt/no-run", branch: "no-run", purpose: "test", createdAt: "2024", lastSeenAt: null, owner: { instanceId: "", hostname: "", pid: 0, createdFromCwd: "", sessionFile: null, sessionId: null, sessionName: null }, createdFromBranch: null, createdFromRef: "HEAD" } });
+		createOwnerMetadata.mockReturnValue({
+			instanceId: "owner-no-run",
+			hostname: "test",
+			pid: 1234,
+			createdFromCwd: "/workspace",
+			sessionFile: null,
+			sessionId: null,
+			sessionName: null,
+		});
+		createManagedWorktree.mockReturnValue({
+			worktreePath: "/wt/no-run",
+			branch: "no-run",
+			createdBranch: true,
+			metadata: {
+				id: "wt-nr",
+				repoRoot: "/repo",
+				worktreePath: "/wt/no-run",
+				branch: "no-run",
+				purpose: "test",
+				createdAt: "2024",
+				lastSeenAt: null,
+				owner: {
+					instanceId: "",
+					hostname: "",
+					pid: 0,
+					createdFromCwd: "",
+					sessionFile: null,
+					sessionId: null,
+					sessionName: null,
+				},
+				createdFromBranch: null,
+				createdFromRef: "HEAD",
+			},
+		});
 		runSync.mockResolvedValue({
 			usage: { input: 1, output: 1, cacheRead: 0, cacheWrite: 0, cost: 0 },
 			exitCode: 0,
 		});
 
 		// Omit runId so options.runId ?? undefined is hit
-		const result = await runDynamicAgent(
-			"/workspace",
-			{ systemPrompt: "test" },
-			"task",
-			{
-				worktree: { branch: "no-run", purpose: "no runId test" },
-			},
-		);
+		const result = await runDynamicAgent("/workspace", { systemPrompt: "test" }, "task", {
+			worktree: { branch: "no-run", purpose: "no runId test" },
+		});
 
 		expect(createOwnerMetadata).toHaveBeenCalledOnce();
 		expect(result.worktreePath).toBe("/wt/no-run");


### PR DESCRIPTION
## Summary

Extends `runDynamicAgent` so dynamic agents can create and execute inside managed git worktrees using the same primitives as the CLI worktree extension.

### Changes

- `DynamicAgentWorktreeOptions` — `branch`, `purpose`, `baseRef`, `cleanup`
- `RunDynamicOptions.worktree` — optional worktree config
- Integrates `createManagedWorktree`, `createOwnerMetadata`, `removeManagedWorktree` from `@ifi/oh-pi-core`
- Result includes `worktreePath` and `worktreeBranch`
- Cleanup runs in `finally` (best-effort, ignores failures)
- 25 tests, 100% statements + functions coverage

### Usage

```typescript
await runDynamicAgent(
  "/workspace",
  { systemPrompt: "Refactor auth module..." },
  "Refactor task",
  {
    worktree: {
      branch: "feat/auth-refactor",
      purpose: "Isolated auth refactor",
      baseRef: "main",
      cleanup: true,
    },
  },
);
```