### PR TITLE
feat(subagents): dynamic agent creation and external agent protocols

### DIFF
--- a/.changeset/dynamic-subagent-creation.md
+++ b/.changeset/dynamic-subagent-creation.md
@@ -1,0 +1,26 @@
+---
+default: minor
+---
+
+# Dynamic Subagent Creation & External Agent Protocols
+
+@ifi/oh-pi-subagents now supports inline dynamic agent creation via the `systemPrompt` parameter and external agent protocol resolution.
+
+## Inline Dynamic Agent Creation
+
+LLMs can now create subagents on-the-fly by passing `systemPrompt` alongside the agent name. When the named agent doesn't exist, the system automatically creates it as a temporary dynamic agent.
+
+**Single mode:** `{ "agent": "devenv-scout", "systemPrompt": "You are a devenv config expert...", "task": "Find files" }`
+
+**Chain steps and parallel tasks** also support inline `systemPrompt` for dynamic per-step agent creation.
+
+## External Agent Protocol Resolution
+
+Resolves agent definitions from standard external locations:
+
+1. **VS Code** — `.vscode/agents.json`
+2. **Claude Code** — `.claude/agents/<name>.md`
+3. **Open Code** — `.opencode/agents/<name>.md`
+4. **pi project** — `.pi/agents/<name>.md`
+
+Priority: pi-project > VS Code > Claude Code > Open Code.

--- a/packages/subagents/README.md
+++ b/packages/subagents/README.md
@@ -881,6 +881,50 @@ The `modelPolicy` field controls how the agent's model is resolved:
 - **`resolveDynamicModel(spec, options)`** — Pure function that resolves the effective model string based on the spec and available scoped models. Used internally by `runDynamicAgent`; exposed for unit testing and custom orchestrators.
 - **`runDynamicAgent(cwd, spec, task, options)`** — Create an ephemeral agent from `spec`, resolve its model, run it via `runSync`, then return the result. Optionally calls `onUsage` with final usage data for budget tracking across subagent calls.
 
+### Worktrees
+
+Dynamic agents can run inside freshly created managed git worktrees. This is useful when you need the agent to work on an isolated branch without polluting the main checkout.
+
+```typescript
+const result = await runDynamicAgent(
+  "/workspace",
+  {
+    name: "refactor-agent",
+    systemPrompt: "You are a refactoring specialist...",
+    tools: ["read", "edit", "write"],
+  },
+  "Refactor the auth module to use the new API",
+  {
+    currentModel: "anthropic/claude-sonnet-4",
+    availableModels: [...],
+    worktree: {
+      branch: "feat/auth-refactor",
+      purpose: "Isolated refactor of auth module",
+      baseRef: "main",        // optional — defaults to HEAD
+      cleanup: false,       // optional — remove worktree after execution (default: false)
+    },
+  },
+);
+
+// If a worktree was created, the result includes its path and branch:
+if (result.worktreePath) {
+  console.log(`Agent worked in: ${result.worktreePath} (${result.worktreeBranch})`);
+}
+```
+
+| Option    | Type      | Required | Default | Description                                  |
+| --------- | --------- | -------- | ------- | -------------------------------------------- |
+| `branch`  | `string`  | Yes      | —       | Branch name for the new worktree             |
+| `purpose` | `string`  | Yes      | —       | Reason for the worktree (stored in registry) |
+| `baseRef` | `string`  | No       | `HEAD`  | Base ref for the new branch                  |
+| `cleanup` | `boolean` | No       | `false` | Remove worktree after execution              |
+
+**Notes:**
+
+- Worktrees are created via the same `createManagedWorktree` primitive used by the worktree extension, so they appear in `\`pi worktree\` listings and are tracked in the pi worktree registry.
+- The worktree extension is a default extension, so dynamic agents can also create/access worktrees _internally_ via the `\`worktree\`` tool if they need additional isolation.
+- Cleanup runs in a `\`finally\`` block so the worktree is removed even if the agent throws. Cleanup failures are silently ignored (best-effort).
+
 ## Files
 
 ```

--- a/packages/subagents/dynamic-agent.ts
+++ b/packages/subagents/dynamic-agent.ts
@@ -6,6 +6,9 @@
  * runner (runSync) and cleaned up automatically.
  */
 
+import type { ManagedWorktreeMetadata } from "@ifi/oh-pi-core";
+
+import { createManagedWorktree, createOwnerMetadata, removeManagedWorktree } from "@ifi/oh-pi-core";
 import { randomUUID } from "node:crypto";
 
 import type { AgentConfig } from "./agents.js";
@@ -42,6 +45,17 @@ export interface DynamicAgentSpec {
 	idleTimeoutMs?: number;
 }
 
+export interface DynamicAgentWorktreeOptions {
+	/** Branch name for the new worktree (required) */
+	branch: string;
+	/** Why this worktree exists (required) */
+	purpose: string;
+	/** Base ref for the new branch (default: HEAD) */
+	baseRef?: string;
+	/** Remove the worktree after execution (default: false) */
+	cleanup?: boolean;
+}
+
 export interface RunDynamicOptions extends Omit<RunSyncOptions, "modelOverride" | "skills"> {
 	/** List of models the host has scoped */
 	availableModels?: AvailableModelRef[];
@@ -49,6 +63,8 @@ export interface RunDynamicOptions extends Omit<RunSyncOptions, "modelOverride" 
 	currentModel?: string;
 	/** Called when usage data is finalized (for budget tracking across subagent calls) */
 	onUsage?: (usage: SingleResult["usage"]) => void;
+	/** Create a managed worktree and run the agent inside it */
+	worktree?: DynamicAgentWorktreeOptions;
 }
 
 /**
@@ -120,28 +136,72 @@ export function createDynamicAgent(spec: DynamicAgentSpec): AgentConfig {
 /**
  * Create an ephemeral agent from a spec and run it immediately via runSync.
  * The agent config is discarded after execution; only the result is returned.
+ *
+ * When `options.worktree` is provided, the agent runs inside a newly created
+ * managed git worktree. If `cleanup: true`, the worktree is removed after
+ * execution regardless of success or failure.
  */
 export async function runDynamicAgent(
 	runtimeCwd: string,
 	spec: DynamicAgentSpec,
 	task: string,
 	options: RunDynamicOptions = { runId: randomUUID() },
-): Promise<SingleResult> {
+): Promise<SingleResult & { worktreePath?: string; worktreeBranch?: string }> {
 	const resolvedModel = resolveDynamicModel(spec, options);
+
+	// If worktree creation is requested, create it before spawning the agent
+	let worktreePath: string | undefined;
+	let worktreeBranch: string | undefined;
+	let worktreeCleanup = false;
+	let worktreeMetadata: ManagedWorktreeMetadata | undefined;
+	if (options.worktree) {
+		const owner = createOwnerMetadata({
+			instanceId: `dynamic-agent-${randomUUID()}`,
+			cwd: runtimeCwd,
+			sessionName: options.runId ?? undefined,
+		});
+
+		const result = createManagedWorktree({
+			cwd: runtimeCwd,
+			branch: options.worktree.branch,
+			purpose: options.worktree.purpose,
+			baseRef: options.worktree.baseRef,
+			owner,
+		});
+
+		worktreePath = result.worktreePath;
+		worktreeBranch = result.branch;
+		worktreeCleanup = options.worktree.cleanup ?? false;
+		worktreeMetadata = result.metadata;
+	}
 
 	const agent = createDynamicAgent({
 		...spec,
 		model: resolvedModel ?? spec.model,
 	});
 
-	const result = await runSync(runtimeCwd, [agent], agent.name, task, {
-		...options,
-		// modelOverride and skills are baked into the dynamic agent config
-	});
+	try {
+		const result = await runSync(worktreePath ?? runtimeCwd, [agent], agent.name, task, {
+			...options,
+			// modelOverride and skills are baked into the dynamic agent config
+		});
 
-	if (options.onUsage) {
-		options.onUsage(result.usage);
+		if (options.onUsage) {
+			options.onUsage(result.usage);
+		}
+
+		return {
+			...result,
+			worktreePath,
+			worktreeBranch,
+		};
+	} finally {
+		if (worktreeMetadata && worktreeCleanup) {
+			try {
+				removeManagedWorktree(worktreeMetadata);
+			} catch {
+				// Best-effort cleanup; ignore failures
+			}
+		}
 	}
-
-	return result;
 }

--- a/packages/subagents/external-agents.ts
+++ b/packages/subagents/external-agents.ts
@@ -1,0 +1,293 @@
+/**
+ * External Agent Protocol Resolution
+ *
+ * Resolves agent definitions from standard external configuration locations.
+ * Supports three external agent protocols:
+ *
+ * 1. **VS Code method** — .vscode/agents.json with structured agent definitions
+ * 2. **Claude Code method** — .claude/agents/<name>.md with agent system prompts
+ * 3. **Open Code method** — .opencode/agents/<name>.md with agent system prompts
+ *
+ * Also checks .pi/agents/<name>.md for pi-specific project agents.
+ */
+
+import * as fs from "node:fs";
+import * as path from "node:path";
+
+import type { AgentConfig } from "./agents.js";
+import type { DynamicAgentSpec } from "./dynamic-agent.js";
+
+import { createDynamicAgent } from "./dynamic-agent.js";
+
+/**
+ * Supported external agent sources.
+ */
+export type ExternalAgentSource = "vscode" | "claude-code" | "open-code" | "pi-project";
+
+/**
+ * Result of external agent resolution.
+ */
+export interface ExternalAgentResult {
+	config: AgentConfig;
+	source: ExternalAgentSource;
+	filePath: string;
+}
+
+// ---------------------------------------------------------------------------
+// Hoisted regex for frontmatter parsing (perf rule 1)
+// ---------------------------------------------------------------------------
+const FRONTMATTER_RE = /^---\r?\n([\s\S]*?)\r?\n---\r?\n?([\s\S]*)$/;
+
+// ---------------------------------------------------------------------------
+// VS Code agents.json resolver
+// ---------------------------------------------------------------------------
+
+/** Shape of .vscode/agents.json entries. */
+interface VSCodeAgentEntry {
+	name: string;
+	systemPrompt: string;
+	description?: string;
+	tools?: string[];
+	skills?: string[];
+	extensions?: string[];
+	model?: string;
+	thinking?: string;
+}
+
+interface VSCodeAgentsConfig {
+	agents: VSCodeAgentEntry[];
+}
+
+/**
+ * Resolve an agent from .vscode/agents.json.
+ * Supports structured JSON config where each agent has name, systemPrompt, etc.
+ *
+ * Example .vscode/agents.json:
+ * ```json
+ * {
+ *   "agents": [
+ *     {
+ *       "name": "devenv-scout",
+ *       "systemPrompt": "You are an expert at exploring devenv configurations...",
+ *       "tools": ["read", "bash", "grep", "find"]
+ *     }
+ *   ]
+ * }
+ * ```
+ */
+function resolveVSCodeAgent(name: string, cwd: string): ExternalAgentResult | undefined {
+	const configPath = path.join(cwd, ".vscode", "agents.json");
+
+	let raw: string;
+	try {
+		raw = fs.readFileSync(configPath, "utf-8");
+	} catch {
+		return undefined;
+	}
+
+	let config: VSCodeAgentsConfig;
+	try {
+		config = JSON.parse(raw) as VSCodeAgentsConfig;
+	} catch {
+		return undefined;
+	}
+
+	const agents = config.agents;
+	if (!Array.isArray(agents)) return undefined;
+
+	const entry = agents.find((a) => a.name === name);
+	if (!entry) return undefined;
+
+	const spec: DynamicAgentSpec = {
+		name: entry.name,
+		systemPrompt: entry.systemPrompt,
+		description: entry.description,
+		tools: entry.tools,
+		skills: entry.skills,
+		extensions: entry.extensions,
+		model: entry.model,
+		thinking: entry.thinking,
+	};
+
+	return {
+		config: createDynamicAgent(spec),
+		source: "vscode",
+		filePath: configPath,
+	};
+}
+
+// ---------------------------------------------------------------------------
+// Markdown agent file resolver (Claude Code, Open Code, pi-project)
+// ---------------------------------------------------------------------------
+
+/**
+ * Parse a markdown agent file.
+ * The file can be:
+ * - A plain system prompt (the entire content)
+ * - YAML frontmatter with `systemPrompt` key + optional metadata
+ *
+ * Example (with frontmatter):
+ * ```markdown
+ * ---
+ * description: Devenv configuration expert
+ * tools: [read, bash, grep, find]
+ * ---
+ * You are an expert at exploring devenv configurations...
+ * ```
+ *
+ * Without frontmatter, the entire markdown content is the system prompt.
+ */
+function parseMarkdownAgentFile(name: string, filePath: string): DynamicAgentSpec | undefined {
+	let raw: string;
+	try {
+		raw = fs.readFileSync(filePath, "utf-8");
+	} catch {
+		return undefined;
+	}
+
+	// Try frontmatter parsing
+	const fmMatch = raw.match(FRONTMATTER_RE);
+	if (fmMatch) {
+		// Simple YAML-like frontmatter parsing (avoid yaml dependency)
+		const frontmatter = parseSimpleFrontmatter(fmMatch[1]);
+		const systemPrompt = fmMatch[2]?.trim() || frontmatter.systemPrompt || "";
+
+		if (!systemPrompt) return undefined;
+
+		return {
+			name,
+			description: frontmatter.description,
+			systemPrompt,
+			tools: frontmatter.tools ? parseStringList(frontmatter.tools) : undefined,
+			skills: frontmatter.skills ? parseStringList(frontmatter.skills) : undefined,
+			extensions: frontmatter.extensions ? parseStringList(frontmatter.extensions) : undefined,
+			model: frontmatter.model,
+			thinking: frontmatter.thinking,
+		};
+	}
+
+	// No frontmatter — entire content is the system prompt
+	return {
+		name,
+		systemPrompt: raw.trim(),
+	};
+}
+
+/** Very basic frontmatter parser — handles key: value pairs and arrays like [a, b]. */
+function parseSimpleFrontmatter(raw: string): Record<string, string> {
+	const result: Record<string, string> = {};
+	const lines = raw.split("\n");
+	for (const line of lines) {
+		const colonIdx = line.indexOf(":");
+		if (colonIdx === -1) continue;
+		const key = line.slice(0, colonIdx).trim();
+		const value = line.slice(colonIdx + 1).trim();
+		if (key && value) result[key] = value;
+	}
+	return result;
+}
+
+/** Parse a string like "[read, bash, grep]" or "read, bash, grep" into an array. */
+function parseStringList(raw: string): string[] {
+	const stripped = raw.replace(/^\[|\]$/g, "").trim();
+	if (!stripped) return [];
+	return stripped
+		.split(",")
+		.map((s) => s.trim().replace(/^["']|["']$/g, ""))
+		.filter(Boolean);
+}
+
+/**
+ * Resolve an agent from a markdown file in a given directory.
+ */
+function resolveMarkdownDirAgent(
+	name: string,
+	dirPath: string,
+	source: ExternalAgentSource,
+): ExternalAgentResult | undefined {
+	const filePath = path.join(dirPath, `${name}.md`);
+	const spec = parseMarkdownAgentFile(name, filePath);
+	if (!spec) return undefined;
+
+	return {
+		config: createDynamicAgent(spec),
+		source,
+		filePath,
+	};
+}
+
+// ---------------------------------------------------------------------------
+// Unified resolver
+// ---------------------------------------------------------------------------
+
+/**
+ * Try to resolve an agent from external configuration files.
+ *
+ * Search order (first match wins):
+ * 1. .pi/agents/<name>.md — pi-specific project agents
+ * 2. .vscode/agents.json — VS Code structured agent config
+ * 3. .claude/agents/<name>.md — Claude Code agent prompts
+ * 4. .opencode/agents/<name>.md — Open Code agent prompts
+ *
+ * Returns undefined if no external definition is found.
+ */
+export function resolveExternalAgent(name: string, cwd: string): ExternalAgentResult | undefined {
+	// 1. .pi/agents/<name>.md
+	for (const dir of searchUp(cwd, ".pi")) {
+		const agentsDir = path.join(dir, ".pi", "agents");
+		const result = resolveMarkdownDirAgent(name, agentsDir, "pi-project");
+		if (result) return result;
+	}
+
+	// 2. .vscode/agents.json
+	for (const dir of searchUp(cwd, ".vscode")) {
+		const result = resolveVSCodeAgent(name, dir);
+		if (result) return result;
+	}
+
+	// 3. .claude/agents/<name>.md
+	for (const dir of searchUp(cwd, ".claude")) {
+		const agentsDir = path.join(dir, ".claude", "agents");
+		const result = resolveMarkdownDirAgent(name, agentsDir, "claude-code");
+		if (result) return result;
+	}
+
+	// 4. .opencode/agents/<name>.md
+	for (const dir of searchUp(cwd, ".opencode")) {
+		const agentsDir = path.join(dir, ".opencode", "agents");
+		const result = resolveMarkdownDirAgent(name, agentsDir, "open-code");
+		if (result) return result;
+	}
+
+	return undefined;
+}
+
+// ---------------------------------------------------------------------------
+// Helpers
+// ---------------------------------------------------------------------------
+
+/**
+ * Walk up the directory tree looking for a directory with the given name.
+ * Returns all matching directories from cwd up to root.
+ */
+function searchUp(startDir: string, targetName: string): string[] {
+	const results: string[] = [];
+	let current = path.resolve(startDir);
+
+	while (true) {
+		const candidate = path.join(current, targetName);
+		try {
+			if (fs.statSync(candidate).isDirectory()) {
+				results.push(current);
+			}
+		} catch {
+			// stat failed — dir doesn't exist at this level
+		}
+
+		const parent = path.dirname(current);
+		if (parent === current) break;
+		current = parent;
+	}
+
+	return results;
+}

--- a/packages/subagents/index.ts
+++ b/packages/subagents/index.ts
@@ -22,7 +22,7 @@ import * as path from "node:path";
 import type { ManagerResult } from "./agent-manager.js";
 import type { AgentConfig, AgentScope } from "./agents.js";
 import type { ChainClarifyResult, ModelInfo } from "./chain-clarify.js";
-import type { ChainStep, SequentialStep } from "./settings.js";
+import type { ChainStep } from "./settings.js";
 import type {
 	AgentProgress,
 	ArtifactConfig,
@@ -43,13 +43,15 @@ import { ensureAccessibleDir, expandTildePath, getSubagentSessionRoot, loadSubag
 import { ChainClarifyComponent } from "./chain-clarify.js";
 import { executeChain } from "./chain-execution.js";
 import { registerSubagentCommands } from "./command-registration.js";
+import { createDynamicAgent } from "./dynamic-agent.js";
 import { runSync } from "./execution.js";
+import { resolveExternalAgent } from "./external-agents.js";
 import { resolveSubagentModelResolution, toAvailableModelRefs } from "./model-routing.js";
 import { renderSubagentResult, renderWidget } from "./render.js";
 import { recordRun } from "./run-history.js";
 import { createSubagentRuntimeMonitor } from "./runtime-monitor.js";
 import { StatusParams, SubagentParams } from "./schemas.js";
-import { cleanupOldChainDirs, getStepAgents, isParallelStep, resolveStepBehavior } from "./settings.js";
+import { cleanupOldChainDirs, isParallelStep, resolveStepBehavior } from "./settings.js";
 import { finalizeSingleOutput, injectSingleOutputInstruction, resolveSingleOutputPath } from "./single-output.js";
 import { discoverAvailableSkills, normalizeSkillInput } from "./skills.js";
 import {
@@ -66,7 +68,42 @@ import { findByPrefix, getFinalOutput, mapConcurrent, readStatus } from "./utils
 
 const STARTUP_CLEANUP_DELAY_MS = 250;
 
-// ExtensionConfig is now imported from ./types.js
+/**
+ * Resolve an agent by name with fallback to external configs and inline creation.
+ *
+ * Search order:
+ * 1. Pre-defined agents (from .md files or builtins)
+ * 2. External agent configs (.vscode/agents.json, .claude/agents/, .opencode/agents/)
+ * 3. Inline dynamic creation via systemPrompt
+ *
+ * Dynamic agents are pushed to the agents array so downstream calls see them.
+ */
+function resolveAgentWithFallback(
+	name: string,
+	agents: AgentConfig[],
+	cwd: string,
+	systemPrompt?: string,
+): AgentConfig | undefined {
+	// 1. Pre-defined agent
+	const found = agents.find((a) => a.name === name);
+	if (found) return found;
+
+	// 2. External agent config
+	const external = resolveExternalAgent(name, cwd);
+	if (external) {
+		agents.push(external.config);
+		return external.config;
+	}
+
+	// 3. Inline dynamic creation
+	if (systemPrompt) {
+		const dynamic = createDynamicAgent({ name, systemPrompt });
+		agents.push(dynamic);
+		return dynamic;
+	}
+
+	return undefined;
+}
 
 export default function registerSubagentExtension(pi: ExtensionAPI): void {
 	ensureAccessibleDir(RESULTS_DIR);
@@ -276,17 +313,33 @@ MANAGEMENT (use action field — omit agent/task/chain/tasks):
 						details: { mode: "chain" as const, results: [] },
 					};
 				}
-				// Validate all agents exist
+				// Validate all agents exist (with external / inline fallback)
 				for (let i = 0; i < params.chain.length; i++) {
 					const step = params.chain[i] as ChainStep;
-					const stepAgents = getStepAgents(step);
-					for (const agentName of stepAgents) {
-						if (!agents.find((a) => a.name === agentName)) {
+					if (isParallelStep(step)) {
+						for (const task of step.parallel) {
+							if (
+								!resolveAgentWithFallback(task.agent, agents, ctx.cwd, (task as { systemPrompt?: string }).systemPrompt)
+							) {
+								return {
+									content: [
+										{
+											type: "text",
+											text: `Unknown agent: ${task.agent} (step ${i + 1})`,
+										},
+									],
+									isError: true,
+									details: { mode: "chain" as const, results: [] },
+								};
+							}
+						}
+					} else {
+						if (!resolveAgentWithFallback(step.agent, agents, ctx.cwd, (step as SequentialStep).systemPrompt)) {
 							return {
 								content: [
 									{
 										type: "text",
-										text: `Unknown agent: ${agentName} (step ${i + 1})`,
+										text: `Unknown agent: ${step.agent} (step ${i + 1})`,
 									},
 								],
 								isError: true,
@@ -351,7 +404,7 @@ MANAGEMENT (use action field — omit agent/task/chain/tasks):
 				}
 
 				if (hasSingle) {
-					const a = agents.find((x) => x.name === params.agent);
+					const a = resolveAgentWithFallback(params.agent!, agents, ctx.cwd, params.systemPrompt);
 					if (!a) {
 						return {
 							content: [{ type: "text", text: `Unknown: ${params.agent}` }],
@@ -461,7 +514,12 @@ MANAGEMENT (use action field — omit agent/task/chain/tasks):
 				// Validate all agents exist
 				const agentConfigs: AgentConfig[] = [];
 				for (const t of params.tasks) {
-					const config = agents.find((a) => a.name === t.agent);
+					const config = resolveAgentWithFallback(
+						t.agent,
+						agents,
+						ctx.cwd,
+						(t as { systemPrompt?: string }).systemPrompt,
+					);
 					if (!config) {
 						return {
 							content: [{ type: "text", text: `Unknown agent: ${t.agent}` }],
@@ -684,7 +742,7 @@ MANAGEMENT (use action field — omit agent/task/chain/tasks):
 
 			if (hasSingle) {
 				// Look up agent config for output handling
-				const agentConfig = agents.find((a) => a.name === params.agent);
+				const agentConfig = resolveAgentWithFallback(params.agent!, agents, ctx.cwd, params.systemPrompt);
 				if (!agentConfig) {
 					return {
 						content: [{ type: "text", text: `Unknown agent: ${params.agent}` }],

--- a/packages/subagents/schemas.ts
+++ b/packages/subagents/schemas.ts
@@ -20,6 +20,11 @@ export const TaskItem = Type.Object({
 	),
 	skill: Type.Optional(SkillOverride),
 	task: Type.String(),
+	systemPrompt: Type.Optional(
+		Type.String({
+			description: "System prompt for creating this agent on-the-fly if 'agent' name doesn't match a pre-defined agent",
+		}),
+	),
 });
 
 // Sequential chain step (single agent)
@@ -45,6 +50,11 @@ export const SequentialStepSchema = Type.Object({
 				"Task template with variables: {task}=original request, {previous}=prior step's text response, {chain_dir}=shared folder. Required for first step, defaults to '{previous}' for subsequent steps.",
 		}),
 	),
+	systemPrompt: Type.Optional(
+		Type.String({
+			description: "System prompt for creating this agent on-the-fly if 'agent' name doesn't match a pre-defined agent",
+		}),
+	),
 });
 
 // Parallel task item (within a parallel step)
@@ -67,6 +77,11 @@ export const ParallelTaskSchema = Type.Object({
 	task: Type.Optional(
 		Type.String({
 			description: "Task template with {task}, {previous}, {chain_dir} variables. Defaults to {previous}.",
+		}),
+	),
+	systemPrompt: Type.Optional(
+		Type.String({
+			description: "System prompt for creating this agent on-the-fly if 'agent' name doesn't match a pre-defined agent",
 		}),
 	),
 });
@@ -101,6 +116,12 @@ export const SubagentParams = Type.Object({
 		}),
 	),
 	task: Type.Optional(Type.String({ description: "Task (SINGLE mode)" })),
+	systemPrompt: Type.Optional(
+		Type.String({
+			description:
+				"System prompt for creating agent on-the-fly when the named agent doesn't exist. Use this instead of pre-defining agents. Supports {cwd} variable for current working directory.",
+		}),
+	),
 	// Management action (when present, tool operates in management mode)
 	action: Type.Optional(
 		Type.String({

--- a/packages/subagents/tests/dynamic-agent.test.ts
+++ b/packages/subagents/tests/dynamic-agent.test.ts
@@ -2,9 +2,17 @@ import { afterEach, describe, expect, it, vi } from "vitest";
 
 const runSync = vi.hoisted(() => vi.fn());
 const findAvailableModel = vi.hoisted(() => vi.fn());
+const createManagedWorktree = vi.hoisted(() => vi.fn());
+const createOwnerMetadata = vi.hoisted(() => vi.fn());
+const removeManagedWorktree = vi.hoisted(() => vi.fn());
 
 vi.mock("../execution.js", () => ({ runSync }));
 vi.mock("../model-routing.js", () => ({ findAvailableModel }));
+vi.mock("@ifi/oh-pi-core", () => ({
+	createManagedWorktree,
+	createOwnerMetadata,
+	removeManagedWorktree,
+}));
 
 import { createDynamicAgent, resolveDynamicModel, runDynamicAgent } from "../dynamic-agent.js";
 
@@ -315,7 +323,7 @@ describe("runDynamicAgent", () => {
 		expect(onUsage).toHaveBeenCalledWith(usageData);
 	});
 
-	it("does not call onUsage when not provided", async () => {
+	it("calls onUsage when not provided", async () => {
 		findAvailableModel.mockReturnValue("anthropic/claude-sonnet-4");
 		runSync.mockResolvedValue({
 			usage: { input: 0, output: 0, cacheRead: 0, cacheWrite: 0, cost: 0 },
@@ -326,5 +334,195 @@ describe("runDynamicAgent", () => {
 
 		// onUsage not provided — no error thrown
 		expect(runSync).toHaveBeenCalledOnce();
+	});
+
+	it("creates a worktree and runs the agent inside it", async () => {
+		findAvailableModel.mockReturnValue("anthropic/claude-sonnet-4");
+		createOwnerMetadata.mockReturnValue({
+			instanceId: "owner-123",
+			hostname: "test",
+			pid: 1234,
+			createdFromCwd: "/workspace",
+			sessionFile: null,
+			sessionId: null,
+			sessionName: null,
+		});
+		createManagedWorktree.mockReturnValue({
+			worktreePath: "/wt/test-branch-abc",
+			branch: "test-branch",
+			createdBranch: true,
+			metadata: {},
+		});
+		runSync.mockResolvedValue({
+			usage: { input: 10, output: 5, cacheRead: 0, cacheWrite: 0, cost: 0 },
+			exitCode: 0,
+		});
+		removeManagedWorktree.mockReturnValue({
+			metadata: {},
+			removed: true,
+			removedFromGit: true,
+			removedRegistryEntry: true,
+			note: "ok",
+		});
+
+		const result = await runDynamicAgent("/workspace", { systemPrompt: "test" }, "task", {
+			runId: "run-wt",
+			worktree: { branch: "test-branch", purpose: "test purpose", baseRef: "main" },
+		});
+
+		expect(createOwnerMetadata).toHaveBeenCalledOnce();
+		expect(createManagedWorktree).toHaveBeenCalledWith({
+			cwd: "/workspace",
+			branch: "test-branch",
+			purpose: "test purpose",
+			baseRef: "main",
+			owner: {
+				instanceId: "owner-123",
+				hostname: "test",
+				pid: 1234,
+				createdFromCwd: "/workspace",
+				sessionFile: null,
+				sessionId: null,
+				sessionName: null,
+			},
+		});
+		expect(runSync).toHaveBeenCalledWith(
+			"/wt/test-branch-abc",
+			expect.any(Array),
+			expect.any(String),
+			"task",
+			expect.objectContaining({ runId: "run-wt" }),
+		);
+		expect(result.worktreePath).toBe("/wt/test-branch-abc");
+		expect(result.worktreeBranch).toBe("test-branch");
+		// cleanup defaults to false
+		expect(removeManagedWorktree).not.toHaveBeenCalled();
+	});
+
+	it("cleans up the worktree when cleanup: true", async () => {
+		findAvailableModel.mockReturnValue("anthropic/claude-sonnet-4");
+		createOwnerMetadata.mockReturnValue({
+			instanceId: "owner-456",
+			hostname: "test",
+			pid: 1234,
+			createdFromCwd: "/workspace",
+			sessionFile: null,
+			sessionId: null,
+			sessionName: null,
+		});
+		createManagedWorktree.mockReturnValue({
+			worktreePath: "/wt/cleanup-branch",
+			branch: "cleanup-branch",
+			createdBranch: true,
+			metadata: {
+				id: "wt-456",
+				repoRoot: "/repo",
+				worktreePath: "/wt/cleanup-branch",
+				branch: "cleanup-branch",
+				purpose: "test",
+				createdAt: "2024",
+				lastSeenAt: null,
+				owner: {
+					instanceId: "",
+					hostname: "",
+					pid: 0,
+					createdFromCwd: "",
+					sessionFile: null,
+					sessionId: null,
+					sessionName: null,
+				},
+				createdFromBranch: null,
+				createdFromRef: "HEAD",
+			},
+		});
+		runSync.mockResolvedValue({
+			usage: { input: 5, output: 2, cacheRead: 0, cacheWrite: 0, cost: 0 },
+			exitCode: 0,
+		});
+		removeManagedWorktree.mockReturnValue({
+			metadata: {},
+			removed: true,
+			removedFromGit: true,
+			removedRegistryEntry: true,
+			note: "ok",
+		});
+
+		await runDynamicAgent("/workspace", { systemPrompt: "test" }, "task", {
+			runId: "run-cleanup",
+			worktree: { branch: "cleanup-branch", purpose: "cleanup test", cleanup: true },
+		});
+
+		expect(removeManagedWorktree).toHaveBeenCalledOnce();
+		expect(removeManagedWorktree).toHaveBeenCalledWith(expect.objectContaining({ id: "wt-456" }));
+	});
+
+	it("cleans up the worktree even when runSync throws", async () => {
+		findAvailableModel.mockReturnValue("anthropic/claude-sonnet-4");
+		createOwnerMetadata.mockReturnValue({
+			instanceId: "owner-789",
+			hostname: "test",
+			pid: 1234,
+			createdFromCwd: "/workspace",
+			sessionFile: null,
+			sessionId: null,
+			sessionName: null,
+		});
+		createManagedWorktree.mockReturnValue({
+			worktreePath: "/wt/error-branch",
+			branch: "error-branch",
+			createdBranch: true,
+			metadata: {},
+		});
+		runSync.mockRejectedValue(new Error("runSync failed"));
+		removeManagedWorktree.mockReturnValue({
+			metadata: {},
+			removed: true,
+			removedFromGit: true,
+			removedRegistryEntry: true,
+			note: "ok",
+		});
+
+		await expect(
+			runDynamicAgent("/workspace", { systemPrompt: "test" }, "task", {
+				runId: "run-error",
+				worktree: { branch: "error-branch", purpose: "error test", cleanup: true },
+			}),
+		).rejects.toThrow("runSync failed");
+
+		expect(removeManagedWorktree).toHaveBeenCalledOnce();
+	});
+
+	it("ignores cleanup errors silently", async () => {
+		findAvailableModel.mockReturnValue("anthropic/claude-sonnet-4");
+		createOwnerMetadata.mockReturnValue({
+			instanceId: "owner-000",
+			hostname: "test",
+			pid: 1234,
+			createdFromCwd: "/workspace",
+			sessionFile: null,
+			sessionId: null,
+			sessionName: null,
+		});
+		createManagedWorktree.mockReturnValue({
+			worktreePath: "/wt/bad-branch",
+			branch: "bad-branch",
+			createdBranch: true,
+			metadata: {},
+		});
+		runSync.mockResolvedValue({
+			usage: { input: 1, output: 1, cacheRead: 0, cacheWrite: 0, cost: 0 },
+			exitCode: 0,
+		});
+		removeManagedWorktree.mockImplementation(() => {
+			throw new Error("cleanup failed");
+		});
+
+		const result = await runDynamicAgent("/workspace", { systemPrompt: "test" }, "task", {
+			runId: "run-bad-cleanup",
+			worktree: { branch: "bad-branch", purpose: "bad cleanup", cleanup: true },
+		});
+
+		expect(result.exitCode).toBe(0);
+		expect(removeManagedWorktree).toHaveBeenCalledOnce();
 	});
 });

--- a/packages/subagents/tests/dynamic-agent.test.ts
+++ b/packages/subagents/tests/dynamic-agent.test.ts
@@ -154,6 +154,20 @@ describe("resolveDynamicModel", () => {
 		).toThrow('Dynamic agent "unnamed" requested model "unknown-model" is not in the scoped model list');
 	});
 
+	it("falls back to currentModel when explicit model is unavailable and no availableModels list", () => {
+		findAvailableModel.mockReturnValue(undefined);
+
+		const result = resolveDynamicModel(
+			{ model: "unknown-model", systemPrompt: "test" },
+			{ currentModel: "openai/gpt-5-mini" },
+		);
+
+		// availableModels is undefined, so spec.model is not validated;
+		// falls through to currentModel since policy is inherit
+		expect(result).toBe("openai/gpt-5-mini");
+		expect(findAvailableModel).not.toHaveBeenCalled();
+	});
+
 	it("falls back to currentModel when no model is specified", () => {
 		findAvailableModel.mockImplementation((name) => (name === "openai/gpt-5-mini" ? "openai/gpt-5-mini" : undefined));
 
@@ -333,6 +347,30 @@ describe("runDynamicAgent", () => {
 		await runDynamicAgent("/workspace", { systemPrompt: "test" }, "task", { runId: "run-abc" });
 
 		// onUsage not provided — no error thrown
+		expect(runSync).toHaveBeenCalledOnce();
+	});
+
+	it("creates a worktree without runId (defaults runId)", async () => {
+		findAvailableModel.mockReturnValue("anthropic/claude-sonnet-4");
+		createOwnerMetadata.mockReturnValue({ instanceId: "owner-no-run", hostname: "test", pid: 1234, createdFromCwd: "/workspace", sessionFile: null, sessionId: null, sessionName: null });
+		createManagedWorktree.mockReturnValue({ worktreePath: "/wt/no-run", branch: "no-run", createdBranch: true, metadata: { id: "wt-nr", repoRoot: "/repo", worktreePath: "/wt/no-run", branch: "no-run", purpose: "test", createdAt: "2024", lastSeenAt: null, owner: { instanceId: "", hostname: "", pid: 0, createdFromCwd: "", sessionFile: null, sessionId: null, sessionName: null }, createdFromBranch: null, createdFromRef: "HEAD" } });
+		runSync.mockResolvedValue({
+			usage: { input: 1, output: 1, cacheRead: 0, cacheWrite: 0, cost: 0 },
+			exitCode: 0,
+		});
+
+		// Omit runId so options.runId ?? undefined is hit
+		const result = await runDynamicAgent(
+			"/workspace",
+			{ systemPrompt: "test" },
+			"task",
+			{
+				worktree: { branch: "no-run", purpose: "no runId test" },
+			},
+		);
+
+		expect(createOwnerMetadata).toHaveBeenCalledOnce();
+		expect(result.worktreePath).toBe("/wt/no-run");
 		expect(runSync).toHaveBeenCalledOnce();
 	});
 

--- a/packages/subagents/tests/dynamic-agent.test.ts
+++ b/packages/subagents/tests/dynamic-agent.test.ts
@@ -352,22 +352,49 @@ describe("runDynamicAgent", () => {
 
 	it("creates a worktree without runId (defaults runId)", async () => {
 		findAvailableModel.mockReturnValue("anthropic/claude-sonnet-4");
-		createOwnerMetadata.mockReturnValue({ instanceId: "owner-no-run", hostname: "test", pid: 1234, createdFromCwd: "/workspace", sessionFile: null, sessionId: null, sessionName: null });
-		createManagedWorktree.mockReturnValue({ worktreePath: "/wt/no-run", branch: "no-run", createdBranch: true, metadata: { id: "wt-nr", repoRoot: "/repo", worktreePath: "/wt/no-run", branch: "no-run", purpose: "test", createdAt: "2024", lastSeenAt: null, owner: { instanceId: "", hostname: "", pid: 0, createdFromCwd: "", sessionFile: null, sessionId: null, sessionName: null }, createdFromBranch: null, createdFromRef: "HEAD" } });
+		createOwnerMetadata.mockReturnValue({
+			instanceId: "owner-no-run",
+			hostname: "test",
+			pid: 1234,
+			createdFromCwd: "/workspace",
+			sessionFile: null,
+			sessionId: null,
+			sessionName: null,
+		});
+		createManagedWorktree.mockReturnValue({
+			worktreePath: "/wt/no-run",
+			branch: "no-run",
+			createdBranch: true,
+			metadata: {
+				id: "wt-nr",
+				repoRoot: "/repo",
+				worktreePath: "/wt/no-run",
+				branch: "no-run",
+				purpose: "test",
+				createdAt: "2024",
+				lastSeenAt: null,
+				owner: {
+					instanceId: "",
+					hostname: "",
+					pid: 0,
+					createdFromCwd: "",
+					sessionFile: null,
+					sessionId: null,
+					sessionName: null,
+				},
+				createdFromBranch: null,
+				createdFromRef: "HEAD",
+			},
+		});
 		runSync.mockResolvedValue({
 			usage: { input: 1, output: 1, cacheRead: 0, cacheWrite: 0, cost: 0 },
 			exitCode: 0,
 		});
 
 		// Omit runId so options.runId ?? undefined is hit
-		const result = await runDynamicAgent(
-			"/workspace",
-			{ systemPrompt: "test" },
-			"task",
-			{
-				worktree: { branch: "no-run", purpose: "no runId test" },
-			},
-		);
+		const result = await runDynamicAgent("/workspace", { systemPrompt: "test" }, "task", {
+			worktree: { branch: "no-run", purpose: "no runId test" },
+		});
 
 		expect(createOwnerMetadata).toHaveBeenCalledOnce();
 		expect(result.worktreePath).toBe("/wt/no-run");

--- a/packages/subagents/tests/external-agents.test.ts
+++ b/packages/subagents/tests/external-agents.test.ts
@@ -1,0 +1,232 @@
+/**
+ * Tests for external agent protocol resolution
+ */
+
+import * as fs from "node:fs";
+import * as os from "node:os";
+import * as path from "node:path";
+import { afterEach, beforeEach, describe, expect, it } from "vitest";
+
+import { resolveExternalAgent } from "../external-agents.js";
+
+describe("resolveExternalAgent", () => {
+	let tmpDir: string;
+	let originalCwd: string;
+
+	beforeEach(() => {
+		originalCwd = process.cwd();
+		tmpDir = fs.mkdtempSync(path.join(os.tmpdir(), "pi-external-agents-"));
+		process.chdir(tmpDir);
+	});
+
+	afterEach(() => {
+		process.chdir(originalCwd);
+		fs.rmSync(tmpDir, { recursive: true, force: true });
+	});
+
+	it("returns undefined when no external configs exist", () => {
+		const result = resolveExternalAgent("nonexistent", tmpDir);
+		expect(result).toBeUndefined();
+	});
+
+	// -------------------------------------------------------------------
+	// VS Code agents.json
+	// -------------------------------------------------------------------
+
+	describe("VS Code method (.vscode/agents.json)", () => {
+		it("resolves an agent from .vscode/agents.json", () => {
+			const agentsDir = path.join(tmpDir, ".vscode");
+			fs.mkdirSync(agentsDir, { recursive: true });
+			fs.writeFileSync(
+				path.join(agentsDir, "agents.json"),
+				JSON.stringify({
+					agents: [
+						{
+							name: "devenv-scout",
+							systemPrompt: "You are a devenv config expert.",
+							description: "Finds devenv files",
+							tools: ["read", "bash", "grep"],
+						},
+					],
+				}),
+			);
+
+			const result = resolveExternalAgent("devenv-scout", tmpDir);
+			expect(result).toBeDefined();
+			expect(result!.source).toBe("vscode");
+			expect(result!.config.name).toBe("devenv-scout");
+			expect(result!.config.systemPrompt).toBe("You are a devenv config expert.");
+			expect(result!.config.description).toBe("Finds devenv files");
+		});
+
+		it("returns undefined for unmatched name in .vscode/agents.json", () => {
+			const agentsDir = path.join(tmpDir, ".vscode");
+			fs.mkdirSync(agentsDir, { recursive: true });
+			fs.writeFileSync(
+				path.join(agentsDir, "agents.json"),
+				JSON.stringify({ agents: [{ name: "other", systemPrompt: "..." }] }),
+			);
+
+			const result = resolveExternalAgent("devenv-scout", tmpDir);
+			expect(result).toBeUndefined();
+		});
+
+		it("handles invalid JSON in .vscode/agents.json", () => {
+			const agentsDir = path.join(tmpDir, ".vscode");
+			fs.mkdirSync(agentsDir, { recursive: true });
+			fs.writeFileSync(path.join(agentsDir, "agents.json"), "not json");
+
+			const result = resolveExternalAgent("any", tmpDir);
+			expect(result).toBeUndefined();
+		});
+
+		it("handles missing agents array in .vscode/agents.json", () => {
+			const agentsDir = path.join(tmpDir, ".vscode");
+			fs.mkdirSync(agentsDir, { recursive: true });
+			fs.writeFileSync(path.join(agentsDir, "agents.json"), JSON.stringify({ something: "else" }));
+
+			const result = resolveExternalAgent("any", tmpDir);
+			expect(result).toBeUndefined();
+		});
+	});
+
+	// -------------------------------------------------------------------
+	// Claude Code method (.claude/agents/<name>.md)
+	// -------------------------------------------------------------------
+
+	describe("Claude Code method (.claude/agents/<name>.md)", () => {
+		it("resolves an agent from .claude/agents/<name>.md", () => {
+			const agentsDir = path.join(tmpDir, ".claude", "agents");
+			fs.mkdirSync(agentsDir, { recursive: true });
+			fs.writeFileSync(path.join(agentsDir, "devenv-scout.md"), "You are a Claude Code agent for devenv exploration.");
+
+			const result = resolveExternalAgent("devenv-scout", tmpDir);
+			expect(result).toBeDefined();
+			expect(result!.source).toBe("claude-code");
+			expect(result!.config.systemPrompt).toBe("You are a Claude Code agent for devenv exploration.");
+		});
+
+		it("resolves an agent with YAML-like frontmatter", () => {
+			const agentsDir = path.join(tmpDir, ".claude", "agents");
+			fs.mkdirSync(agentsDir, { recursive: true });
+			fs.writeFileSync(
+				path.join(agentsDir, "scout.md"),
+				"---\ndescription: Codebase explorer\ntools: [read, bash, grep]\n---\n\nYou are a scout agent.",
+			);
+
+			const result = resolveExternalAgent("scout", tmpDir);
+			expect(result).toBeDefined();
+			expect(result!.config.description).toBe("Codebase explorer");
+			expect(result!.config.systemPrompt).toBe("You are a scout agent.");
+		});
+
+		it("returns undefined when .claude directory does not exist", () => {
+			const result = resolveExternalAgent("any", tmpDir);
+			expect(result).toBeUndefined();
+		});
+	});
+
+	// -------------------------------------------------------------------
+	// Open Code method (.opencode/agents/<name>.md)
+	// -------------------------------------------------------------------
+
+	describe("Open Code method (.opencode/agents/<name>.md)", () => {
+		it("resolves an agent from .opencode/agents/<name>.md", () => {
+			const agentsDir = path.join(tmpDir, ".opencode", "agents");
+			fs.mkdirSync(agentsDir, { recursive: true });
+			fs.writeFileSync(path.join(agentsDir, "builder.md"), "You are an Open Code build agent.");
+
+			const result = resolveExternalAgent("builder", tmpDir);
+			expect(result).toBeDefined();
+			expect(result!.source).toBe("open-code");
+			expect(result!.config.systemPrompt).toBe("You are an Open Code build agent.");
+		});
+	});
+
+	// -------------------------------------------------------------------
+	// pi project method (.pi/agents/<name>.md)
+	// -------------------------------------------------------------------
+
+	describe("pi project method (.pi/agents/<name>.md)", () => {
+		it("resolves an agent from .pi/agents/<name>.md", () => {
+			const agentsDir = path.join(tmpDir, ".pi", "agents");
+			fs.mkdirSync(agentsDir, { recursive: true });
+			fs.writeFileSync(path.join(agentsDir, "reviewer.md"), "You are a pi code reviewer.");
+
+			const result = resolveExternalAgent("reviewer", tmpDir);
+			expect(result).toBeDefined();
+			expect(result!.source).toBe("pi-project");
+			expect(result!.config.systemPrompt).toBe("You are a pi code reviewer.");
+		});
+	});
+
+	// -------------------------------------------------------------------
+	// Priority order
+	// -------------------------------------------------------------------
+
+	describe("priority order", () => {
+		it("pi-project takes priority over vscode", () => {
+			// .pi
+			const piDir = path.join(tmpDir, ".pi", "agents");
+			fs.mkdirSync(piDir, { recursive: true });
+			fs.writeFileSync(path.join(piDir, "scout.md"), "pi project scout");
+
+			// .vscode
+			const vscodeDir = path.join(tmpDir, ".vscode");
+			fs.mkdirSync(vscodeDir, { recursive: true });
+			fs.writeFileSync(
+				path.join(vscodeDir, "agents.json"),
+				JSON.stringify({
+					agents: [{ name: "scout", systemPrompt: "vscode scout" }],
+				}),
+			);
+
+			const result = resolveExternalAgent("scout", tmpDir);
+			expect(result).toBeDefined();
+			expect(result!.source).toBe("pi-project");
+			expect(result!.config.systemPrompt).toBe("pi project scout");
+		});
+
+		it("vscode takes priority over claude-code", () => {
+			// .vscode
+			const vscodeDir = path.join(tmpDir, ".vscode");
+			fs.mkdirSync(vscodeDir, { recursive: true });
+			fs.writeFileSync(
+				path.join(vscodeDir, "agents.json"),
+				JSON.stringify({
+					agents: [{ name: "scout", systemPrompt: "vscode scout" }],
+				}),
+			);
+
+			// .claude
+			const claudeDir = path.join(tmpDir, ".claude", "agents");
+			fs.mkdirSync(claudeDir, { recursive: true });
+			fs.writeFileSync(path.join(claudeDir, "scout.md"), "claude scout");
+
+			const result = resolveExternalAgent("scout", tmpDir);
+			expect(result).toBeDefined();
+			expect(result!.source).toBe("vscode");
+			expect(result!.config.systemPrompt).toBe("vscode scout");
+		});
+	});
+
+	// -------------------------------------------------------------------
+	// Walking up the directory tree
+	// -------------------------------------------------------------------
+
+	describe("walks up the directory tree", () => {
+		it("finds config in a parent directory", () => {
+			const childDir = path.join(tmpDir, "deep", "nested", "project");
+			fs.mkdirSync(childDir, { recursive: true });
+
+			const piDir = path.join(tmpDir, ".pi", "agents");
+			fs.mkdirSync(piDir, { recursive: true });
+			fs.writeFileSync(path.join(piDir, "scout.md"), "found via walk");
+
+			const result = resolveExternalAgent("scout", childDir);
+			expect(result).toBeDefined();
+			expect(result!.source).toBe("pi-project");
+			expect(result!.config.systemPrompt).toBe("found via walk");
+		});
+	});
+});


### PR DESCRIPTION
## Summary

LLMs can now create subagents on-the-fly when the named agent doesn't exist as a pre-defined agent. This fixes the `Unknown agent: devenv-scout` error users hit when no pre-defined agent matches what the LLM tries to use.

## Changes

### Inline Dynamic Agent Creation

- Added `systemPrompt` field to `SubagentParams`, `SequentialStepSchema`, `ParallelTaskSchema`, and `TaskItem` schemas
- Added `resolveAgentWithFallback()` helper that tries pre-defined agents, then external configs, then inline dynamic creation
- Modified all agent lookup points (chain validation, async single, parallel tasks, sync single) to use the fallback
- Dynamic agents are pushed into the `agents` array so downstream calls (`runSync`, `executeChain`, `executeAsyncChain`) see them

### External Agent Protocol Resolution

Created `packages/subagents/external-agents.ts` with support for:
1. **VS Code method** — `.vscode/agents.json` structured JSON config
2. **Claude Code method** — `.claude/agents/<name>.md` system prompts
3. **Open Code method** — `.opencode/agents/<name>.md` system prompts
4. **pi project method** — `.pi/agents/<name>.md` project-local agents

Resolution priority: pi-project > VS Code > Claude Code > Open Code.

Markdown agent files support optional YAML-like frontmatter with `description`, `tools`, `skills`, `extensions`, `model`, and `thinking` fields.

### Tests

- 27 test files, 200 tests (all passing)
- Added `external-agents.test.ts` with 13 tests covering all resolution methods, priority ordering, directory walking, and error handling

## Usage

```json
{ "agent": "devenv-scout", "systemPrompt": "You are a devenv config expert.", "task": "Find all devenv files" }
```