### PR TITLE
fix(live-view): bound widget line width

### DIFF
--- a/.changeset/live-view-widget-width.md
+++ b/.changeset/live-view-widget-width.md
@@ -1,0 +1,5 @@
+---
+"default": patch
+---
+
+Bound pi-bash-live-view widget lines to a safe visible width so long PTY progress output cannot overflow the TUI renderer.

--- a/packages/pi-bash-live-view/src/widget.ts
+++ b/packages/pi-bash-live-view/src/widget.ts
@@ -1,7 +1,9 @@
 const DEFAULT_WIDGET_KEY_PREFIX = "pi-bash-live-view";
 const DEFAULT_WIDGET_MAX_LINES = 12;
+const DEFAULT_WIDGET_MAX_WIDTH = 100;
 const DEFAULT_RENDER_DEBOUNCE_MS = 120;
 const ELAPSED_TICK_MS = 1_000;
+const ANSI_SEQUENCE_REGEX = /\u001B\[[0-?]*[ -/]*[@-~]/g;
 
 export type WidgetStatus = "running" | "completed" | "failed" | "cancelled" | "timed_out";
 
@@ -32,16 +34,63 @@ export interface WidgetContextLike {
 export interface PtyLiveWidgetOptions {
 	key?: string;
 	maxLines?: number;
+	maxWidth?: number;
 	placement?: "aboveEditor" | "belowEditor";
 	renderDebounceMs?: number;
 }
 
-function truncateCommand(command: string, maxLength = 96): string {
-	if (command.length <= maxLength) {
-		return command;
+function truncateVisibleLine(line: string, maxWidth = DEFAULT_WIDGET_MAX_WIDTH): string {
+	if (maxWidth <= 0) {
+		return "";
 	}
 
-	return `${command.slice(0, maxLength - 1)}…`;
+	let visibleWidth = 0;
+	let output = "";
+	let lastIndex = 0;
+	ANSI_SEQUENCE_REGEX.lastIndex = 0;
+
+	for (const match of line.matchAll(ANSI_SEQUENCE_REGEX)) {
+		const text = line.slice(lastIndex, match.index);
+		const truncatedText = appendVisibleText(text, maxWidth, visibleWidth);
+		output += truncatedText.text;
+		visibleWidth = truncatedText.visibleWidth;
+		if (truncatedText.truncated) {
+			return `${output}…`;
+		}
+
+		output += match[0];
+		lastIndex = match.index + match[0].length;
+	}
+
+	const truncatedText = appendVisibleText(line.slice(lastIndex), maxWidth, visibleWidth);
+	output += truncatedText.text;
+	return truncatedText.truncated ? `${output}…` : output;
+}
+
+function appendVisibleText(
+	text: string,
+	maxWidth: number,
+	visibleWidth: number,
+): {
+	text: string;
+	visibleWidth: number;
+	truncated: boolean;
+} {
+	let output = "";
+	for (const char of text) {
+		if (visibleWidth >= maxWidth - 1) {
+			return { text: output, visibleWidth, truncated: true };
+		}
+
+		output += char;
+		visibleWidth++;
+	}
+
+	return { text: output, visibleWidth, truncated: false };
+}
+
+function truncateCommand(command: string, maxLength = 96): string {
+	return truncateVisibleLine(command, maxLength);
 }
 
 function toStatusColor(status: WidgetStatus): string {
@@ -77,28 +126,32 @@ export function formatElapsedMmSs(elapsedMs: number): string {
 export function buildWidgetLines(
 	theme: WidgetThemeLike,
 	state: WidgetState,
-	options: Pick<PtyLiveWidgetOptions, "maxLines"> = {},
+	options: Pick<PtyLiveWidgetOptions, "maxLines" | "maxWidth"> = {},
 	now = Date.now(),
 ): string[] {
 	const maxLines = options.maxLines ?? DEFAULT_WIDGET_MAX_LINES;
+	const maxWidth = options.maxWidth ?? DEFAULT_WIDGET_MAX_WIDTH;
 	const statusColor = toStatusColor(state.status);
 	const header = `${theme.fg("accent", theme.bold("🖥 Bash PTY"))} ${theme.fg(
 		statusColor,
 		toStatusLabel(state.status),
 	)} · ${formatElapsedMmSs(now - state.startedAt)}`;
-	const commandLine = theme.fg("dim", truncateCommand(state.command));
+	const commandLine = theme.fg("dim", truncateCommand(state.command, maxWidth));
 	const bodyLines = state.ansiLines.length > maxLines ? state.ansiLines.slice(-maxLines) : state.ansiLines;
 
 	if (bodyLines.length === 0) {
-		return [header, commandLine, theme.fg("dim", "(waiting for output)")];
+		return [header, commandLine, theme.fg("dim", "(waiting for output)")].map((line) =>
+			truncateVisibleLine(line, maxWidth),
+		);
 	}
 
-	return [header, commandLine, ...bodyLines];
+	return [header, commandLine, ...bodyLines].map((line) => truncateVisibleLine(line, maxWidth));
 }
 
 export class PtyLiveWidgetController {
 	private readonly key: string;
 	private readonly maxLines: number;
+	private readonly maxWidth: number;
 	private readonly placement: "aboveEditor" | "belowEditor";
 	private readonly renderDebounceMs: number;
 	private state: WidgetState | null = null;
@@ -113,6 +166,7 @@ export class PtyLiveWidgetController {
 	) {
 		this.key = options.key ?? `${DEFAULT_WIDGET_KEY_PREFIX}:${Math.random().toString(36).slice(2, 8)}`;
 		this.maxLines = options.maxLines ?? DEFAULT_WIDGET_MAX_LINES;
+		this.maxWidth = options.maxWidth ?? DEFAULT_WIDGET_MAX_WIDTH;
 		this.placement = options.placement ?? "belowEditor";
 		this.renderDebounceMs = Math.max(
 			DEFAULT_RENDER_DEBOUNCE_MS,
@@ -174,6 +228,7 @@ export class PtyLiveWidgetController {
 						}
 						return buildWidgetLines(theme, this.state, {
 							maxLines: this.maxLines,
+							maxWidth: this.maxWidth,
 						});
 					},
 				};
@@ -229,6 +284,7 @@ export class PtyLiveWidgetController {
 
 export const widgetInternals = {
 	truncateCommand,
+	truncateVisibleLine,
 	toStatusColor,
 	toStatusLabel,
 };

--- a/packages/pi-bash-live-view/tests/widget.test.ts
+++ b/packages/pi-bash-live-view/tests/widget.test.ts
@@ -51,6 +51,28 @@ describe("PTY live widget", () => {
 		).toContain("(waiting for output)");
 	});
 
+	it("bounds rendered line width for cargo progress output", () => {
+		const cargoLine =
+			"Building [=======================> ] 2/607: proc-macro2(build.rs), libc(build.rs), log, bitflags, itoa, libc(build.rs)";
+		const lines = buildWidgetLines(
+			theme,
+			{
+				command: "pnpm build",
+				startedAt: Date.now(),
+				ansiLines: [cargoLine],
+				status: "running",
+				exitCode: null,
+			},
+			{ maxWidth: 80 },
+			Date.now(),
+		);
+
+		for (const line of lines) {
+			expect(line.length).toBeLessThanOrEqual(80);
+		}
+		expect(lines.at(-1)).toBe(`${cargoLine.slice(0, 79)}…`);
+	});
+
 	it("mounts, debounces renders, updates elapsed time, and clears the widget", async () => {
 		const setWidget = vi.fn();
 		const controller = new PtyLiveWidgetController(


### PR DESCRIPTION
## Summary
- bound pi-bash-live-view widget output to a safe visible width before rendering
- added a regression test for long Cargo-style progress lines
- documented the patch changeset

## Checks
- pnpm --filter pi-bash-live-view typecheck
- pnpm --filter pi-bash-live-view test:worktree -- widget.test.ts
- pnpm format:check
- pnpm lint