### PR TITLE
fix(ollama): preserve cached cloud model metadata

### DIFF
--- a/.changeset/bash-live-terminal-proposed-api.md
+++ b/.changeset/bash-live-terminal-proposed-api.md
@@ -1,0 +1,5 @@
+---
+default: patch
+---
+
+Enable xterm proposed API support in the bash live terminal emulator and preserve cached Ollama Cloud model metadata when refreshed discovery returns incomplete model details.

--- a/packages/ollama/models.ts
+++ b/packages/ollama/models.ts
@@ -106,6 +106,14 @@ const FALLBACK_OLLAMA_CLOUD_MODELS: OllamaProviderModel[] = [
 		source: "cloud",
 	}),
 	toOllamaModel({
+		contextWindow: 1_048_576,
+		id: "deepseek-v4-pro",
+		input: ["text"],
+		maxTokens: 65_536,
+		reasoning: true,
+		source: "cloud",
+	}),
+	toOllamaModel({
 		contextWindow: 262_144,
 		id: "devstral-2:123b",
 		input: ["text"],
@@ -413,17 +421,21 @@ export async function discoverOllamaCloudModelList(
 	});
 	if (modelIds.length === 0) return null;
 	return modelIds
-		.map((id) => normalizeDiscoveredModel(id, null, "cloud", fallbackModels))
+		.map((id) => normalizeDiscoveredModel(id, null, "cloud", fallbackModels, new Map()))
 		.filter((model) => model !== null);
 }
 
 export async function discoverOllamaCloudModels(
 	apiKey?: string,
-	options: { signal?: AbortSignal } = {},
+	options: {
+		signal?: AbortSignal;
+		cachedModels?: ReadonlyMap<string, OllamaProviderModel>;
+	} = {},
 ): Promise<OllamaProviderModel[] | null> {
 	const config = getOllamaCloudRuntimeConfig();
 	const fallbackModels = getFallbackOllamaCloudModels();
 	const publicModels = await discoverOllamaModels(config, {
+		cachedModels: options.cachedModels,
 		fallbackModels,
 		signal: options.signal,
 		source: "cloud",
@@ -433,6 +445,7 @@ export async function discoverOllamaCloudModels(
 	}
 	const authenticatedModels = await discoverOllamaModels(config, {
 		apiKey,
+		cachedModels: options.cachedModels,
 		fallbackModels,
 		signal: options.signal,
 		source: "cloud",
@@ -445,9 +458,11 @@ export async function enrichOllamaCloudCredentials(
 	options: { previous?: OllamaCloudCredentials; signal?: AbortSignal } = {},
 ): Promise<OllamaCloudCredentials> {
 	let models: OllamaProviderModel[] | undefined;
+	const cachedModels = buildCachedModelMap(options.previous?.models);
 	try {
 		models =
 			(await discoverOllamaCloudModels(credentials.access, {
+				cachedModels,
 				signal: options.signal,
 			})) ?? undefined;
 	} catch {
@@ -459,6 +474,17 @@ export async function enrichOllamaCloudCredentials(
 		lastModelRefresh: Date.now(),
 		models: models ?? options.previous?.models ?? getFallbackOllamaCloudModels(),
 	};
+}
+
+function buildCachedModelMap(
+	models: readonly OllamaProviderModel[] | undefined,
+): ReadonlyMap<string, OllamaProviderModel> {
+	if (!models || models.length === 0) return new Map();
+	const map = new Map<string, OllamaProviderModel>();
+	for (const model of models) {
+		map.set(model.id, model);
+	}
+	return map;
 }
 
 export function toProviderModels(models: OllamaProviderModel[]): OllamaProviderModel[] {
@@ -548,6 +574,7 @@ async function discoverOllamaModels(
 		source: OllamaModelSource;
 		apiKey?: string;
 		fallbackModels?: readonly OllamaProviderModel[];
+		cachedModels?: ReadonlyMap<string, OllamaProviderModel>;
 		signal?: AbortSignal;
 	},
 ): Promise<OllamaProviderModel[] | null> {
@@ -556,6 +583,7 @@ async function discoverOllamaModels(
 		return null;
 	}
 
+	const cachedModels = options.cachedModels ?? new Map();
 	const discovered = await mapConcurrent(modelIds, MAX_DISCOVERY_CONCURRENCY, async (id) => {
 		const payload = await fetchJson<OllamaShowResponse>(config.showUrl, {
 			body: JSON.stringify({ model: id, verbose: true }),
@@ -563,7 +591,7 @@ async function discoverOllamaModels(
 			method: "POST",
 			signal: options.signal,
 		}).catch(() => null);
-		return normalizeDiscoveredModel(id, payload, options.source, options.fallbackModels ?? []);
+		return normalizeDiscoveredModel(id, payload, options.source, options.fallbackModels ?? [], cachedModels);
 	});
 	const models = discovered.filter((model): model is OllamaProviderModel => model !== null);
 	return models.length > 0 ? models : null;
@@ -589,33 +617,44 @@ function normalizeDiscoveredModel(
 	payload: OllamaShowResponse | null,
 	source: OllamaModelSource,
 	fallbackModels: readonly OllamaProviderModel[],
+	cachedModels: ReadonlyMap<string, OllamaProviderModel>,
 ): OllamaProviderModel | null {
 	const fallback = fallbackModels.find((model) => model.id === id);
+	const cached = cachedModels.get(id);
 	if (!payload) {
 		return fallback
 			? cloneModel(fallback)
-			: toOllamaModel({
-					id,
-					localAvailability: source === "local" ? "installed" : undefined,
-					source,
-				});
+			: cached
+				? cloneModel(cached)
+				: toOllamaModel({
+						id,
+						localAvailability: source === "local" ? "installed" : undefined,
+						source,
+					});
 	}
 	const capabilities = Array.isArray(payload.capabilities)
 		? payload.capabilities.filter((capability): capability is string => typeof capability === "string")
 		: [];
 	const capabilitySet = new Set(capabilities.map((capability) => capability.toLowerCase()));
-	const contextWindow = extractContextWindow(payload.model_info) ?? fallback?.contextWindow ?? DEFAULT_CONTEXT_WINDOW;
+	const rawContext = extractContextWindow(payload.model_info);
+	const contextWindow = rawContext ?? fallback?.contextWindow ?? cached?.contextWindow ?? DEFAULT_CONTEXT_WINDOW;
+	const maxTokens =
+		fallback?.maxTokens ??
+		cached?.maxTokens ??
+		(rawContext ? inferMaxTokens(rawContext) : inferMaxTokens(contextWindow));
 	return toOllamaModel({
 		capabilities,
 		contextWindow,
-		family: extractDetailField(payload.details, "family") ?? fallback?.family,
+		family: extractDetailField(payload.details, "family") ?? fallback?.family ?? cached?.family,
 		id,
-		input: capabilitySet.has("vision") ? ["text", "image"] : (fallback?.input ?? ["text"]),
+		input: capabilitySet.has("vision") ? ["text", "image"] : (fallback?.input ?? cached?.input ?? ["text"]),
 		localAvailability: source === "local" ? "installed" : undefined,
-		maxTokens: fallback?.maxTokens ?? inferMaxTokens(contextWindow),
-		parameterSize: extractDetailField(payload.details, "parameter_size") ?? fallback?.parameterSize,
-		quantization: extractDetailField(payload.details, "quantization_level") ?? fallback?.quantization,
-		reasoning: capabilitySet.has("thinking") || fallback?.reasoning,
+		maxTokens,
+		parameterSize:
+			extractDetailField(payload.details, "parameter_size") ?? fallback?.parameterSize ?? cached?.parameterSize,
+		quantization:
+			extractDetailField(payload.details, "quantization_level") ?? fallback?.quantization ?? cached?.quantization,
+		reasoning: capabilitySet.has("thinking") || fallback?.reasoning || cached?.reasoning,
 		source,
 	});
 }

--- a/packages/ollama/tests/models.test.ts
+++ b/packages/ollama/tests/models.test.ts
@@ -32,6 +32,7 @@ describe("ollama models", () => {
 		expect(models.some((model) => model.id === "qwen3-vl:235b")).toBe(true);
 		expect(models.some((model) => model.id === "glm-5.1")).toBe(true);
 		expect(models.some((model) => model.id === "kimi-k2.6")).toBe(true);
+		expect(models.some((model) => model.id === "deepseek-v4-pro")).toBe(true);
 	});
 
 	it("normalizes model defaults", () => {
@@ -277,6 +278,42 @@ describe("ollama models", () => {
 		expect(models?.map((model) => model.id)).toEqual(["gpt-oss:120b", "qwen3-vl:235b"]);
 		expect(models?.[1]?.input).toEqual(["text", "image"]);
 		expect(models?.[1]?.reasoning).toBe(true);
+		await backend.close();
+	});
+
+	it("preserves cached cloud metadata when model show metadata is incomplete", async () => {
+		const backend = await createTestOllamaBackend();
+		backend.setModels([{ id: "new-cloud-model", capabilities: ["completion"] }]);
+		backend.setRejectedModelShows(["new-cloud-model"]);
+		process.env.PI_OLLAMA_CLOUD_API_URL = backend.apiUrl;
+		process.env.PI_OLLAMA_CLOUD_MODELS_URL = `${backend.apiUrl}/models`;
+		process.env.PI_OLLAMA_CLOUD_SHOW_URL = `${backend.origin}/api/show`;
+		const models = await discoverOllamaCloudModels("test-key", {
+			cachedModels: new Map([
+				[
+					"new-cloud-model",
+					toOllamaModel({
+						contextWindow: 524_288,
+						family: "cached-family",
+						id: "new-cloud-model",
+						input: ["text", "image"],
+						maxTokens: 65_536,
+						parameterSize: "999B",
+						reasoning: true,
+						source: "cloud",
+					}),
+				],
+			]),
+		});
+
+		expect(models?.[0]).toMatchObject({
+			contextWindow: 524_288,
+			family: "cached-family",
+			input: ["text", "image"],
+			maxTokens: 65_536,
+			parameterSize: "999B",
+			reasoning: true,
+		});
 		await backend.close();
 	});
 

--- a/packages/pi-bash-live-view/src/terminal-emulator.ts
+++ b/packages/pi-bash-live-view/src/terminal-emulator.ts
@@ -488,7 +488,7 @@ export async function createTerminalEmulator(options: CreateTerminalEmulatorOpti
 		}
 
 		const terminal = new headlessModule.Terminal({
-			allowProposedApi: false,
+			allowProposedApi: true,
 			cols: columns,
 			rows,
 			scrollback: rows * 4,

--- a/packages/pi-bash-live-view/tests/terminal-emulator.test.ts
+++ b/packages/pi-bash-live-view/tests/terminal-emulator.test.ts
@@ -115,7 +115,13 @@ describe("terminal emulator", () => {
 	});
 
 	it("uses the injected headless terminal loader when available", async () => {
+		let terminalOptions: unknown;
+
 		class FakeTerminal {
+			constructor(options: unknown) {
+				terminalOptions = options;
+			}
+
 			buffer = {
 				active: {
 					baseY: 1,
@@ -151,6 +157,7 @@ describe("terminal emulator", () => {
 
 		expect(emulator.getPlainText()).toBe("hello");
 		expect(emulator.toAnsiLines(2)).toEqual(["screen-2", "screen-3"]);
+		expect(terminalOptions).toMatchObject({ allowProposedApi: true, cols: 10, rows: 2 });
 		expect(terminalEmulatorInternals.decodeRgb(0x112233)).toEqual([17, 34, 51]);
 		expect(
 			terminalEmulatorInternals.stylesEqual(


### PR DESCRIPTION
## Summary
- add DeepSeek V4 Pro to the Ollama Cloud fallback catalog
- preserve cached Ollama Cloud model metadata when refreshed model-show details are unavailable or incomplete
- enable xterm headless proposed APIs for the bash live terminal emulator
- drop scratch context.md from the working tree

## Relevance check
- Still relevant after pulling latest main: none of these changes were included by PR #305/#306.
- Ollama cache preservation prevents known model metadata from regressing during refreshes.
- The live-view proposed API option remains isolated to xterm headless construction and is covered by regression assertion.

## Checks
- pnpm --filter @ifi/pi-provider-ollama test:worktree -- models.test.ts
- pnpm --filter @ifi/pi-provider-ollama typecheck
- pnpm --filter pi-bash-live-view test:worktree -- terminal-emulator.test.ts
- pnpm --filter pi-bash-live-view typecheck
- pnpm format:check
- pnpm lint
- pnpm docs:check
- pnpm typecheck
- pnpm test
- pnpm security:check
- pnpm build