### PR TITLE
fix(subagents): resolve package skills with default manager

### DIFF
--- a/.changeset/subagent-package-skill-resolution.md
+++ b/.changeset/subagent-package-skill-resolution.md
@@ -1,0 +1,7 @@
+---
+default: patch
+---
+
+# Subagent package skill resolution
+
+Subagent execution now resolves skill packages through pi's `DefaultPackageManager`, so package-provided skills installed for the main pi instance are available when injecting skills into subagent prompts.

--- a/packages/subagents/async-execution.ts
+++ b/packages/subagents/async-execution.ts
@@ -22,7 +22,7 @@ import { resolveSubagentModelResolution } from "./model-routing.js";
 import { resolvePiPackageRoot } from "./pi-spawn.js";
 import { isParallelStep, resolveStepBehavior } from "./settings.js";
 import { injectSingleOutputInstruction, resolveSingleOutputPath } from "./single-output.js";
-import { buildSkillInjection, normalizeSkillInput, resolveSkills } from "./skills.js";
+import { buildSkillInjection, normalizeSkillInput, resolveSkillsAsync } from "./skills.js";
 import { ASYNC_DIR, RESULTS_DIR } from "./types.js";
 
 const require = createRequire(import.meta.url);
@@ -123,7 +123,7 @@ function spawnRunner(cfg: object, suffix: string, cwd: string): number | undefin
 /**
  * Execute a chain asynchronously
  */
-export function executeAsyncChain(id: string, params: AsyncChainParams): AsyncExecutionResult {
+export async function executeAsyncChain(id: string, params: AsyncChainParams): Promise<AsyncExecutionResult> {
 	const { chain, agents, ctx, cwd, maxOutput, artifactsDir, artifactConfig, shareEnabled, sessionRoot } = params;
 	const chainSkills = params.chainSkills ?? [];
 
@@ -147,13 +147,13 @@ export function executeAsyncChain(id: string, params: AsyncChainParams): AsyncEx
 	} catch {}
 
 	/** Build a resolved runner step from a SequentialStep */
-	const buildSeqStep = (s: SequentialStep) => {
+	const buildSeqStep = async (s: SequentialStep) => {
 		const a = agents.find((x) => x.name === s.agent)!;
 		const stepSkillInput = normalizeSkillInput(s.skill);
 		const stepOverrides: StepOverrides = { skills: stepSkillInput };
 		const behavior = resolveStepBehavior(a, stepOverrides, chainSkills);
 		const skillNames = behavior.skills === false ? [] : behavior.skills;
-		const { resolved: resolvedSkills } = resolveSkills(skillNames, s.cwd ?? cwd ?? ctx.cwd);
+		const { resolved: resolvedSkills } = await resolveSkillsAsync(skillNames, s.cwd ?? cwd ?? ctx.cwd);
 
 		let systemPrompt = a.systemPrompt?.trim() || null;
 		if (resolvedSkills.length > 0) {
@@ -187,14 +187,13 @@ export function executeAsyncChain(id: string, params: AsyncChainParams): AsyncEx
 
 	// Build runner steps — sequential steps become flat objects,
 	// Parallel steps become { parallel: [...], concurrency?, failFast? }
-	const steps: RunnerStep[] = chain.map((s) => {
+	const steps: RunnerStep[] = [];
+	for (const s of chain) {
 		if (isParallelStep(s)) {
-			return {
-				concurrency: s.concurrency,
-				failFast: s.failFast,
-				continueOnError: s.continueOnError,
-				parallel: s.parallel.map((t) =>
-					buildSeqStep({
+			const parallel = [];
+			for (const t of s.parallel) {
+				parallel.push(
+					await buildSeqStep({
 						agent: t.agent,
 						task: t.task,
 						cwd: t.cwd,
@@ -202,11 +201,18 @@ export function executeAsyncChain(id: string, params: AsyncChainParams): AsyncEx
 						model: t.model,
 						output: t.output,
 					}),
-				),
-			};
+				);
+			}
+			steps.push({
+				concurrency: s.concurrency,
+				failFast: s.failFast,
+				continueOnError: s.continueOnError,
+				parallel,
+			});
+			continue;
 		}
-		return buildSeqStep(s as SequentialStep);
-	});
+		steps.push(await buildSeqStep(s as SequentialStep));
+	}
 
 	const runnerCwd = cwd ?? ctx.cwd;
 	const pid = spawnRunner(
@@ -263,11 +269,11 @@ export function executeAsyncChain(id: string, params: AsyncChainParams): AsyncEx
 /**
  * Execute a single agent asynchronously
  */
-export function executeAsyncSingle(id: string, params: AsyncSingleParams): AsyncExecutionResult {
+export async function executeAsyncSingle(id: string, params: AsyncSingleParams): Promise<AsyncExecutionResult> {
 	const { agent, task, agentConfig, ctx, cwd, maxOutput, artifactsDir, artifactConfig, shareEnabled, sessionRoot } =
 		params;
 	const skillNames = params.skills ?? agentConfig.skills ?? [];
-	const { resolved: resolvedSkills } = resolveSkills(skillNames, cwd ?? ctx.cwd);
+	const { resolved: resolvedSkills } = await resolveSkillsAsync(skillNames, cwd ?? ctx.cwd);
 	let systemPrompt = agentConfig.systemPrompt?.trim() || null;
 	if (resolvedSkills.length > 0) {
 		const injection = buildSkillInjection(resolvedSkills);

--- a/packages/subagents/execution.ts
+++ b/packages/subagents/execution.ts
@@ -15,7 +15,7 @@ import type { AgentProgress, ArtifactPaths, RunSyncOptions, SingleResult } from 
 import { ensureArtifactsDir, getArtifactPaths, writeArtifact, writeMetadata } from "./artifacts.js";
 import { createJsonlWriter } from "./jsonl-writer.js";
 import { getPiSpawnCommand } from "./pi-spawn.js";
-import { buildSkillInjection, resolveSkills } from "./skills.js";
+import { buildSkillInjection, resolveSkillsAsync } from "./skills.js";
 import { DEFAULT_IDLE_TIMEOUT_MS, DEFAULT_MAX_OUTPUT, getSubagentDepthEnv, truncateOutput } from "./types.js";
 import {
 	detectSubagentError,
@@ -124,7 +124,7 @@ export async function runSync(
 	}
 
 	const skillNames = options.skills ?? agent.skills ?? [];
-	const { resolved: resolvedSkills, missing: missingSkills } = resolveSkills(skillNames, cwd ?? runtimeCwd);
+	const { resolved: resolvedSkills, missing: missingSkills } = await resolveSkillsAsync(skillNames, cwd ?? runtimeCwd);
 
 	// When explicit skills are specified (via options or agent config), disable
 	// Pi's own skill discovery so the spawned process doesn't inject the full

--- a/packages/subagents/skills.ts
+++ b/packages/subagents/skills.ts
@@ -2,10 +2,10 @@
  * Skill resolution and caching for subagent extension
  */
 
-import type { Skill } from "@mariozechner/pi-coding-agent";
+import type { ResolvedResource, Skill } from "@mariozechner/pi-coding-agent";
 
 import { expandHomeDir } from "@ifi/oh-pi-core";
-import { loadSkills } from "@mariozechner/pi-coding-agent";
+import { DefaultPackageManager, loadSkills, SettingsManager } from "@mariozechner/pi-coding-agent";
 import { execSync } from "node:child_process";
 import * as fs from "node:fs";
 import * as path from "node:path";
@@ -47,6 +47,11 @@ const skillCache = new Map<string, SkillCacheEntry>();
 const MAX_CACHE_SIZE = 50;
 
 let loadSkillsCache: {
+	cwd: string;
+	skills: CachedSkillEntry[];
+	timestamp: number;
+} | null = null;
+let asyncLoadSkillsCache: {
 	cwd: string;
 	skills: CachedSkillEntry[];
 	timestamp: number;
@@ -291,6 +296,63 @@ function chooseHigherPrioritySkill(
 	return candidate.order < existing.order ? candidate : existing;
 }
 
+function sourceFromPackageMetadata(resource: ResolvedResource): SkillSource {
+	const { scope, origin } = resource.metadata;
+	if (origin === "package") {
+		return scope === "project" ? "project-package" : "user-package";
+	}
+	if (scope === "project") {
+		return "project";
+	}
+	if (scope === "user") {
+		return "user";
+	}
+	return "unknown";
+}
+
+function sourceFromSkill(skill: Skill, cwd: string, resourcesByPath?: Map<string, ResolvedResource>): SkillSource {
+	const resource = resourcesByPath?.get(skill.filePath);
+	if (resource) {
+		return sourceFromPackageMetadata(resource);
+	}
+	const sourceInfo = (skill as { sourceInfo?: { origin?: string; scope?: string } }).sourceInfo;
+	if (sourceInfo) {
+		if (sourceInfo.origin === "package") {
+			return sourceInfo.scope === "project" ? "project-package" : "user-package";
+		}
+		if (sourceInfo.scope === "project") {
+			return "project";
+		}
+		if (sourceInfo.scope === "user") {
+			return "user";
+		}
+	}
+	return inferSkillSource((skill as { source?: unknown }).source, skill.filePath, cwd);
+}
+
+function dedupeLoadedSkills(
+	loadedSkills: Skill[],
+	cwd: string,
+	resourcesByPath?: Map<string, ResolvedResource>,
+): CachedSkillEntry[] {
+	const dedupedByName = new Map<string, CachedSkillEntry>();
+
+	for (let i = 0; i < loadedSkills.length; i++) {
+		const skill = loadedSkills[i] as Skill;
+		const entry: CachedSkillEntry = {
+			description: skill.description,
+			filePath: skill.filePath,
+			name: skill.name,
+			order: i,
+			source: sourceFromSkill(skill, cwd, resourcesByPath),
+		};
+		const current = dedupedByName.get(entry.name);
+		dedupedByName.set(entry.name, chooseHigherPrioritySkill(current, entry));
+	}
+
+	return [...dedupedByName.values()].toSorted((a, b) => a.order - b.order);
+}
+
 function getCachedSkills(cwd: string): CachedSkillEntry[] {
 	const now = Date.now();
 	if (loadSkillsCache && loadSkillsCache.cwd === cwd && now - loadSkillsCache.timestamp < LOAD_SKILLS_CACHE_TTL_MS) {
@@ -298,24 +360,36 @@ function getCachedSkills(cwd: string): CachedSkillEntry[] {
 	}
 
 	const skillPaths = buildSkillPaths(cwd);
-	const loaded = loadSkills({ cwd, includeDefaults: false, skillPaths });
-	const dedupedByName = new Map<string, CachedSkillEntry>();
+	const loaded = loadSkills({ cwd, agentDir: AGENT_DIR, includeDefaults: false, skillPaths });
+	const skills = dedupeLoadedSkills(loaded.skills, cwd);
+	loadSkillsCache = { cwd, skills, timestamp: now };
+	return skills;
+}
 
-	for (let i = 0; i < loaded.skills.length; i++) {
-		const skill = loaded.skills[i] as Skill;
-		const entry: CachedSkillEntry = {
-			description: skill.description,
-			filePath: skill.filePath,
-			name: skill.name,
-			order: i,
-			source: inferSkillSource((skill as { source?: unknown }).source, skill.filePath, cwd),
-		};
-		const current = dedupedByName.get(entry.name);
-		dedupedByName.set(entry.name, chooseHigherPrioritySkill(current, entry));
+async function getCachedSkillsAsync(cwd: string): Promise<CachedSkillEntry[]> {
+	const now = Date.now();
+	if (
+		asyncLoadSkillsCache &&
+		asyncLoadSkillsCache.cwd === cwd &&
+		now - asyncLoadSkillsCache.timestamp < LOAD_SKILLS_CACHE_TTL_MS
+	) {
+		return asyncLoadSkillsCache.skills;
 	}
 
-	const skills = [...dedupedByName.values()].toSorted((a, b) => a.order - b.order);
-	loadSkillsCache = { cwd, skills, timestamp: now };
+	const settingsManager = SettingsManager.create(cwd, AGENT_DIR);
+	const packageManager = new DefaultPackageManager({ agentDir: AGENT_DIR, cwd, settingsManager });
+	const resolvedPaths = await packageManager.resolve(async () => "skip");
+	const enabledResources = resolvedPaths.skills.filter((resource) => resource.enabled);
+	const resourcesByPath = new Map<string, ResolvedResource>();
+	const skillPaths: string[] = [];
+	for (const resource of enabledResources) {
+		skillPaths.push(resource.path);
+		resourcesByPath.set(resource.path, resource);
+	}
+
+	const loaded = loadSkills({ cwd, agentDir: AGENT_DIR, includeDefaults: false, skillPaths });
+	const skills = dedupeLoadedSkills(loaded.skills, cwd, resourcesByPath);
+	asyncLoadSkillsCache = { cwd, skills, timestamp: now };
 	return skills;
 }
 
@@ -376,6 +450,40 @@ export function resolveSkills(skillNames: string[], cwd: string): { resolved: Re
 		}
 
 		const skill = readSkill(trimmed, location.path, location.source);
+		if (skill) {
+			resolved.push(skill);
+		} else {
+			missing.push(trimmed);
+		}
+	}
+
+	return { missing, resolved };
+}
+
+export async function resolveSkillsAsync(
+	skillNames: string[],
+	cwd: string,
+): Promise<{ resolved: ResolvedSkill[]; missing: string[] }> {
+	const available = await getCachedSkillsAsync(cwd);
+	const byName = new Map<string, CachedSkillEntry>();
+	for (const skill of available) {
+		byName.set(skill.name, skill);
+	}
+
+	const resolved: ResolvedSkill[] = [];
+	const missing: string[] = [];
+
+	for (const name of skillNames) {
+		const trimmed = name.trim();
+		if (!trimmed) {
+			continue;
+		}
+		const location = byName.get(trimmed);
+		if (!location) {
+			missing.push(trimmed);
+			continue;
+		}
+		const skill = readSkill(trimmed, location.filePath, location.source);
 		if (skill) {
 			resolved.push(skill);
 		} else {
@@ -447,4 +555,5 @@ export function discoverAvailableSkills(cwd: string): {
 export function clearSkillCache(): void {
 	skillCache.clear();
 	loadSkillsCache = null;
+	asyncLoadSkillsCache = null;
 }

--- a/packages/subagents/tests/async-execution.test.ts
+++ b/packages/subagents/tests/async-execution.test.ts
@@ -40,7 +40,7 @@ const asyncMocks = vi.hoisted(() => {
 			(skills: Array<{ name: string }>) => `INJECT:${skills.map((skill) => skill.name).join(",")}`,
 		),
 		normalizeSkillInput: vi.fn((value: unknown) => value),
-		resolveSkills: vi.fn((skillNames: string[]) => ({
+		resolveSkillsAsync: vi.fn(async (skillNames: string[]) => ({
 			resolved: skillNames.map((name) => ({ name })),
 			missing: [],
 		})),
@@ -80,7 +80,7 @@ vi.mock("../pi-spawn.js", () => ({
 vi.mock("../skills.js", () => ({
 	buildSkillInjection: asyncMocks.buildSkillInjection,
 	normalizeSkillInput: asyncMocks.normalizeSkillInput,
-	resolveSkills: asyncMocks.resolveSkills,
+	resolveSkillsAsync: asyncMocks.resolveSkillsAsync,
 }));
 vi.mock("../types.js", () => ({
 	ASYNC_DIR: "/tmp/pi-async-subagent-runs",
@@ -140,7 +140,7 @@ beforeEach(() => {
 	asyncMocks.resolveStepBehavior.mockImplementation((_agent: any, stepOverrides: any, chainSkills: string[]) => ({
 		skills: stepOverrides.skills ?? chainSkills,
 	}));
-	asyncMocks.resolveSkills.mockImplementation((skillNames: string[]) => ({
+	asyncMocks.resolveSkillsAsync.mockImplementation(async (skillNames: string[]) => ({
 		resolved: skillNames.map((name) => ({ name })),
 		missing: [],
 	}));
@@ -170,9 +170,9 @@ describe("async execution helpers", () => {
 		expect(isAsyncAvailable()).toBe(true);
 	});
 
-	it("builds async single-runner configs, injects output instructions, and emits start events", () => {
+	it("builds async single-runner configs, injects output instructions, and emits start events", async () => {
 		const ctx = createCtx();
-		const result = executeAsyncSingle("run-1", {
+		const result = await executeAsyncSingle("run-1", {
 			agent: "scout",
 			task: "Inspect the repo",
 			agentConfig: {
@@ -240,7 +240,7 @@ describe("async execution helpers", () => {
 			skills: ["git", "context7"],
 			outputPath: "/workspace/report.md",
 		});
-		expect(asyncMocks.resolveSkills).toHaveBeenCalledWith(["git", "context7"], "/workspace");
+		expect(asyncMocks.resolveSkillsAsync).toHaveBeenCalledWith(["git", "context7"], "/workspace");
 		expect(config.steps[0].systemPrompt).toBe("Base system prompt\n\nINJECT:git,context7");
 		expect(ctx.pi.events.emit).toHaveBeenCalledWith("subagent:started", {
 			id: "run-1",
@@ -252,9 +252,9 @@ describe("async execution helpers", () => {
 		});
 	});
 
-	it("fails fast for unknown agents in async chains", () => {
+	it("fails fast for unknown agents in async chains", async () => {
 		const ctx = createCtx();
-		const result = executeAsyncChain("chain-1", {
+		const result = await executeAsyncChain("chain-1", {
 			chain: [{ agent: "missing", task: "Inspect" }],
 			agents: [{ name: "scout" }],
 			ctx,
@@ -267,7 +267,7 @@ describe("async execution helpers", () => {
 		expect(asyncMocks.spawn).not.toHaveBeenCalled();
 	});
 
-	it("builds sequential and parallel async chain configs with resolved skills and outputs", () => {
+	it("builds sequential and parallel async chain configs with resolved skills and outputs", async () => {
 		const ctx = createCtx();
 		asyncMocks.resolveSubagentModelResolution
 			.mockReturnValueOnce({
@@ -281,7 +281,7 @@ describe("async execution helpers", () => {
 				category: undefined,
 			});
 
-		const result = executeAsyncChain("chain-2", {
+		const result = await executeAsyncChain("chain-2", {
 			chain: [
 				{
 					agent: "scout",
@@ -357,9 +357,9 @@ describe("async execution helpers", () => {
 			model: "anthropic/claude-sonnet-4",
 			skills: ["context7"],
 		});
-		expect(asyncMocks.resolveSkills).toHaveBeenNthCalledWith(1, ["git"], "/workspace");
-		expect(asyncMocks.resolveSkills).toHaveBeenNthCalledWith(2, ["shared-skill"], "/workspace/a");
-		expect(asyncMocks.resolveSkills).toHaveBeenNthCalledWith(3, ["context7"], "/workspace");
+		expect(asyncMocks.resolveSkillsAsync).toHaveBeenNthCalledWith(1, ["git"], "/workspace");
+		expect(asyncMocks.resolveSkillsAsync).toHaveBeenNthCalledWith(2, ["shared-skill"], "/workspace/a");
+		expect(asyncMocks.resolveSkillsAsync).toHaveBeenNthCalledWith(3, ["context7"], "/workspace");
 		expect(ctx.pi.events.emit).toHaveBeenCalledWith("subagent:started", {
 			id: "chain-2",
 			pid: 4242,

--- a/packages/subagents/tests/execution.test.ts
+++ b/packages/subagents/tests/execution.test.ts
@@ -63,7 +63,7 @@ const executionMocks = vi.hoisted(() => {
 		buildSkillInjection: vi.fn(
 			(skills: Array<{ name: string }>) => `INJECT:${skills.map((skill) => skill.name).join(",")}`,
 		),
-		resolveSkills: vi.fn((skills: string[]) => ({
+		resolveSkillsAsync: vi.fn(async (skills: string[]) => ({
 			resolved: skills
 				.filter((skill) => skill !== "missing")
 				.map((name) => ({
@@ -119,7 +119,7 @@ vi.mock("../utils.js", () => ({
 }));
 vi.mock("../skills.js", () => ({
 	buildSkillInjection: executionMocks.buildSkillInjection,
-	resolveSkills: executionMocks.resolveSkills,
+	resolveSkillsAsync: executionMocks.resolveSkillsAsync,
 }));
 vi.mock("../pi-spawn.js", () => ({
 	getPiSpawnCommand: executionMocks.getPiSpawnCommand,
@@ -193,7 +193,7 @@ beforeEach(() => {
 		executionMocks.procs.push(proc);
 		return proc;
 	});
-	executionMocks.resolveSkills.mockImplementation((skills: string[]) => ({
+	executionMocks.resolveSkillsAsync.mockImplementation(async (skills: string[]) => ({
 		resolved: skills
 			.filter((skill) => skill !== "missing")
 			.map((name) => ({
@@ -245,11 +245,12 @@ describe("runSync", () => {
 			{ cwd: "/legal/project", share: false },
 		);
 
+		await vi.waitFor(() => expect(executionMocks.procs).toHaveLength(1));
 		const proc = executionMocks.procs[0];
 		proc.emit("close", 0);
 		await runPromise;
 
-		expect(executionMocks.resolveSkills).toHaveBeenCalledWith(["ecsc-reviewer"], "/legal/project");
+		expect(executionMocks.resolveSkillsAsync).toHaveBeenCalledWith(["ecsc-reviewer"], "/legal/project");
 	});
 
 	it("streams successful runs, writes artifacts, and records truncation + shared sessions", async () => {
@@ -287,6 +288,7 @@ describe("runSync", () => {
 			},
 		);
 
+		await vi.waitFor(() => expect(executionMocks.procs).toHaveLength(1));
 		const proc = executionMocks.procs[0];
 		emitStdoutLines(proc, [
 			JSON.stringify({
@@ -322,7 +324,7 @@ describe("runSync", () => {
 
 		const result = await runPromise;
 
-		expect(executionMocks.resolveSkills).toHaveBeenCalledWith(["git", "missing"], "/workspace");
+		expect(executionMocks.resolveSkillsAsync).toHaveBeenCalledWith(["git", "missing"], "/workspace");
 		expect(executionMocks.spawn).toHaveBeenCalledWith(
 			"pi",
 			expect.arrayContaining([
@@ -429,6 +431,7 @@ describe("runSync", () => {
 			{ signal: controller.signal, share: false },
 		);
 
+		await vi.waitFor(() => expect(executionMocks.procs).toHaveLength(1));
 		const proc = executionMocks.procs[0];
 		emitStdoutLines(proc, ["not-json"]);
 		controller.abort();
@@ -436,7 +439,7 @@ describe("runSync", () => {
 		proc.emit("close", 0);
 
 		const result = await runPromise;
-		expect(executionMocks.resolveSkills).toHaveBeenCalledWith([], "/repo");
+		expect(executionMocks.resolveSkillsAsync).toHaveBeenCalledWith([], "/repo");
 		expect(proc.kill).toHaveBeenCalledWith("SIGTERM");
 		expect(proc.kill).toHaveBeenCalledWith("SIGKILL");
 		expect(result).toMatchObject({

--- a/packages/subagents/tests/skills.test.ts
+++ b/packages/subagents/tests/skills.test.ts
@@ -7,6 +7,8 @@ const skillsMocks = vi.hoisted(() => ({
 	execSync: vi.fn(() => "/tmp/global-node-modules\n"),
 	expandHomeDir: vi.fn((value: string) => value.replace(/^~\//, "/tmp/home/")),
 	loadSkills: vi.fn(() => ({ skills: [] })),
+	packageResolve: vi.fn(async () => ({ skills: [] })),
+	settingsCreate: vi.fn(() => ({ settings: {} })),
 	resolveAgentDir: vi.fn(() => "/tmp/pi-agent"),
 }));
 
@@ -19,6 +21,12 @@ vi.mock("@ifi/oh-pi-core", () => ({
 }));
 
 vi.mock("@mariozechner/pi-coding-agent", () => ({
+	DefaultPackageManager: class {
+		resolve = skillsMocks.packageResolve;
+	},
+	SettingsManager: {
+		create: skillsMocks.settingsCreate,
+	},
 	loadSkills: skillsMocks.loadSkills,
 }));
 
@@ -33,6 +41,7 @@ import {
 	normalizeSkillInput,
 	resolveSkillPath,
 	resolveSkills,
+	resolveSkillsAsync,
 } from "../skills.js";
 
 const tempDirs: string[] = [];
@@ -295,5 +304,54 @@ describe("subagent skills", () => {
 			},
 		]);
 		expect(resolved.missing).toEqual(["missing", "broken"]);
+	});
+
+	it("resolves package skills through the default package manager", async () => {
+		const cwd = createTempDir("subagents-package-skills-");
+		const packageSkillFile = path.join(cwd, "node_modules", "@ifi", "oh-pi-skills", "skills", "devenv", "SKILL.md");
+		fs.mkdirSync(path.dirname(packageSkillFile), { recursive: true });
+		fs.writeFileSync(packageSkillFile, "Devenv instructions\n");
+
+		skillsMocks.packageResolve.mockResolvedValue({
+			skills: [
+				{
+					path: packageSkillFile,
+					enabled: true,
+					metadata: { scope: "project", origin: "package" },
+				},
+			],
+		});
+		skillsMocks.loadSkills.mockReturnValue({
+			skills: [
+				{
+					name: "devenv",
+					filePath: packageSkillFile,
+					description: "Use devenv",
+					sourceInfo: { scope: "project", origin: "package" },
+				},
+			],
+		});
+
+		const resolved = await resolveSkillsAsync(["devenv", "missing"], cwd);
+
+		expect(skillsMocks.settingsCreate).toHaveBeenCalledWith(cwd, "/tmp/pi-agent");
+		expect(skillsMocks.packageResolve).toHaveBeenCalledTimes(1);
+		expect(skillsMocks.loadSkills).toHaveBeenCalledWith({
+			cwd,
+			agentDir: "/tmp/pi-agent",
+			includeDefaults: false,
+			skillPaths: [packageSkillFile],
+		});
+		expect(resolved).toEqual({
+			resolved: [
+				{
+					name: "devenv",
+					path: packageSkillFile,
+					content: "Devenv instructions\n",
+					source: "project-package",
+				},
+			],
+			missing: ["missing"],
+		});
 	});
 });


### PR DESCRIPTION
## Summary
- use pi's DefaultPackageManager for async subagent skill resolution
- keep parent-side skill injection while allowing package-provided skills to resolve like the main pi instance
- add tests for package skill discovery and async subagent skill injection

## Validation
- `pnpm exec vitest run packages/subagents/tests/skills.test.ts packages/subagents/tests/async-execution.test.ts`
- `pnpm exec oxlint packages/subagents/skills.ts packages/subagents/async-execution.ts packages/subagents/execution.ts packages/subagents/tests/skills.test.ts packages/subagents/tests/async-execution.test.ts`

Note: attempted `pnpm build --filter @ifi/pi-extension-subagents`, but the root build script forwards `--filter` into workspace build scripts and Vitest rejects it as an unknown option.
