### PR TITLE
feat(extensions): add shell-format extension and nushell skill

### DIFF
--- a/.changeset/shell-format-nushell-skill.md
+++ b/.changeset/shell-format-nushell-skill.md
@@ -1,0 +1,9 @@
+---
+default: minor
+---
+
+# Shell Format Extension & Nushell Skill
+
+Add `shell-format` extension that detects the user's login shell (Nushell, Fish, Zsh, etc.) and injects system prompt instructions so the LLM formats all shell commands in the user's native shell dialect.
+
+Add `nushell` skill with comprehensive Nushell syntax reference (variables, pipelines, tables, custom commands, control flow, Bash-to-Nu equivalents, and common gotchas) that the extension directs the LLM to load for detailed guidance.

--- a/package.json
+++ b/package.json
@@ -99,6 +99,7 @@
 			"./packages/extensions/extensions/external-editor.ts",
 			"./packages/extensions/extensions/git-guard.ts",
 			"./packages/extensions/extensions/scheduler.ts",
+			"./packages/extensions/extensions/shell-format.ts",
 			"./packages/extensions/extensions/tool-metadata.ts",
 			"./packages/extensions/extensions/usage-tracker.ts",
 			"./packages/extensions/extensions/worktree.ts",

--- a/packages/extensions/extensions/btw.test.ts
+++ b/packages/extensions/extensions/btw.test.ts
@@ -193,7 +193,10 @@ describe("btw commands and rendering", () => {
 		btwExtension(harness.pi as never);
 		await harness.commands.get("btw:clear").handler("", harness.ctx);
 
-		expect(appendEntry).toHaveBeenCalledWith("btw-thread-reset", expect.objectContaining({ timestamp: expect.any(Number) }));
+		expect(appendEntry).toHaveBeenCalledWith(
+			"btw-thread-reset",
+			expect.objectContaining({ timestamp: expect.any(Number) }),
+		);
 		expect(harness.notifications).toContainEqual({
 			msg: "Cleared BTW thread.",
 			type: "info",
@@ -278,9 +281,7 @@ describe("btw commands and rendering", () => {
 		// Then inject it
 		await harness.commands.get("btw:inject").handler("", harness.ctx);
 
-		expect(sendUserMessage).toHaveBeenCalledWith(
-			expect.stringContaining("side conversation"),
-		);
+		expect(sendUserMessage).toHaveBeenCalledWith(expect.stringContaining("side conversation"));
 		expect(appendEntry).toHaveBeenCalledWith("btw-thread-reset", expect.any(Object));
 	});
 

--- a/packages/extensions/extensions/btw.ts
+++ b/packages/extensions/extensions/btw.ts
@@ -18,6 +18,7 @@
  * Adapted from https://github.com/dbachelder/pi-btw by Dan Bachelder (MIT).
  */
 
+import { type AssistantMessage, type Message, type ThinkingLevel as AiThinkingLevel } from "@mariozechner/pi-ai";
 import {
 	buildSessionContext,
 	createAgentSession,
@@ -31,7 +32,6 @@ import {
 	type ExtensionContext,
 	type ResourceLoader,
 } from "@mariozechner/pi-coding-agent";
-import { type AssistantMessage, type Message, type ThinkingLevel as AiThinkingLevel } from "@mariozechner/pi-ai";
 import {
 	Container,
 	Input,
@@ -172,7 +172,10 @@ function buildSeedMessages(ctx: ExtensionContext, thread: BtwDetails[]): Message
 	const seed: Message[] = [];
 
 	try {
-		const contextMessages = buildSessionContext(ctx.sessionManager.getEntries(), ctx.sessionManager.getLeafId()).messages;
+		const contextMessages = buildSessionContext(
+			ctx.sessionManager.getEntries(),
+			ctx.sessionManager.getLeafId(),
+		).messages;
 		seed.push(...(contextMessages.filter((message) => "role" in message) as Message[]));
 	} catch {
 		// Ignore context seed failures and continue with an empty side thread.
@@ -191,16 +194,14 @@ function buildSeedMessages(ctx: ExtensionContext, thread: BtwDetails[]): Message
 				provider: item.provider,
 				model: item.model,
 				api: ctx.model?.api ?? "openai-responses",
-				usage:
-					item.usage ??
-					{
-						input: 0,
-						output: 0,
-						cacheRead: 0,
-						cacheWrite: 0,
-						totalTokens: 0,
-						cost: { input: 0, output: 0, cacheRead: 0, cacheWrite: 0, total: 0 },
-					},
+				usage: item.usage ?? {
+					input: 0,
+					output: 0,
+					cacheRead: 0,
+					cacheWrite: 0,
+					totalTokens: 0,
+					cost: { input: 0, output: 0, cacheRead: 0, cacheWrite: 0, total: 0 },
+				},
 				stopReason: "stop",
 				timestamp: item.timestamp,
 			},
@@ -211,9 +212,7 @@ function buildSeedMessages(ctx: ExtensionContext, thread: BtwDetails[]): Message
 }
 
 function formatThread(thread: BtwDetails[]): string {
-	return thread
-		.map((item) => `User: ${item.question.trim()}\nAssistant: ${item.answer.trim()}`)
-		.join("\n\n---\n\n");
+	return thread.map((item) => `User: ${item.question.trim()}\nAssistant: ${item.answer.trim()}`).join("\n\n---\n\n");
 }
 
 function formatToolArgs(toolName: string, args: unknown): string {
@@ -243,7 +242,11 @@ function isVisibleBtwMessage(message: { role: string; customType?: string }): bo
 	return message.role === "custom" && message.customType === BTW_MESSAGE_TYPE;
 }
 
-function notify(ctx: ExtensionContext | ExtensionCommandContext, message: string, level: "info" | "warning" | "error"): void {
+function notify(
+	ctx: ExtensionContext | ExtensionCommandContext,
+	message: string,
+	level: "info" | "warning" | "error",
+): void {
 	if (ctx.hasUI) {
 		ctx.ui.notify(message, level);
 	}
@@ -394,9 +397,7 @@ class BtwOverlay extends Container implements Focusable {
 
 		lines.push(this.theme.fg("borderMuted", `├${"─".repeat(innerWidth)}┤`));
 		lines.push(this.frameLine(this.theme.fg("warning", status), innerWidth));
-		lines.push(
-			`${this.theme.fg("borderMuted", "│")}${inputLine}${this.theme.fg("borderMuted", "│")}`,
-		);
+		lines.push(`${this.theme.fg("borderMuted", "│")}${inputLine}${this.theme.fg("borderMuted", "│")}`);
 		lines.push(this.frameLine(this.theme.fg("dim", "Enter submit · Esc close"), innerWidth));
 		lines.push(this.borderLine(innerWidth, "bottom"));
 
@@ -704,7 +705,10 @@ export default function (pi: ExtensionAPI) {
 						pendingAnswer = streamed;
 						pendingError = null;
 					}
-					setOverlayStatus(event.type === "message_end" ? "Finalizing side response..." : "Streaming side response...", true);
+					setOverlayStatus(
+						event.type === "message_end" ? "Finalizing side response..." : "Streaming side response...",
+						true,
+					);
 					return;
 				}
 				case "tool_execution_start": {
@@ -724,9 +728,7 @@ export default function (pi: ExtensionAPI) {
 				}
 				case "tool_execution_end": {
 					const endToolName = (event as { toolName?: string }).toolName ?? "unknown";
-					const tc = pendingToolCalls.find(
-						(t) => t.toolName === endToolName && t.status === "running",
-					);
+					const tc = pendingToolCalls.find((t) => t.toolName === endToolName && t.status === "running");
 					if (tc) {
 						tc.status = (event as { isError?: boolean }).isError ? "error" : "done";
 					}
@@ -1069,10 +1071,7 @@ export default function (pi: ExtensionAPI) {
 
 		if (!question) {
 			if (thread.length > 0 && ctx.hasUI) {
-				const choice = await ctx.ui.select("BTW side chat:", [
-					"Continue previous conversation",
-					"Start fresh",
-				]);
+				const choice = await ctx.ui.select("BTW side chat:", ["Continue previous conversation", "Start fresh"]);
 				if (choice === "Continue previous conversation") {
 					// Dispose session so it's recreated with fresh main context on next submit
 					await disposeSideSession();
@@ -1139,7 +1138,8 @@ export default function (pi: ExtensionAPI) {
 	// ── Register /btw commands ────────────────────────────────────────────────
 
 	pi.registerCommand("btw", {
-		description: "Open a BTW side-chat overlay. `/btw <text>` asks immediately, `/btw` opens the side thread, `/btw --save` persists a visible note.",
+		description:
+			"Open a BTW side-chat overlay. `/btw <text>` asks immediately, `/btw` opens the side thread, `/btw --save` persists a visible note.",
 		handler: btwHandler,
 	});
 

--- a/packages/extensions/extensions/shell-format.ts
+++ b/packages/extensions/extensions/shell-format.ts
@@ -1,0 +1,191 @@
+/**
+ * Shell-Format Extension
+ *
+ * Detects the user's login shell and instructs the LLM to format all shell
+ * commands for that shell rather than defaulting to Bash syntax. This means
+ * nushell users get nushell commands, fish users get fish commands, etc.
+ *
+ * For supported shells (nu, fish, zsh), a companion skill is available at
+ * ~/.pi/agent/skills/<shell>/SKILL.md that the LLM can load for detailed
+ * syntax reference.
+ *
+ * Usage:
+ * 1. Copy this file to ~/.pi/agent/extensions/ (already there!)
+ * 2. Restart pi or run /reload
+ */
+
+import type { ExtensionAPI } from "@mariozechner/pi-coding-agent";
+
+// ---- Shell detection ----
+
+/** Shell profile with optional companion skill reference. */
+interface ShellProfile {
+  name: string;
+  /** Skill name (e.g., "nushell") if a companion SKILL.md exists */
+  skill?: string;
+  note: string;
+}
+
+/**
+ * Map of shell binary names to profiles.
+ * Shells with `skill` set have a companion skill file the LLM can load.
+ */
+const SHELL_PROFILES: Record<string, ShellProfile> = {
+  nu: {
+    name: "Nushell",
+    skill: "nushell",
+    note:
+      "Commands run through a bash execution backend but you MUST write them in Nushell syntax.\n" +
+      "The `nushell` skill is available — use the `read` tool to load\n" +
+      "`~/.pi/agent/skills/nushell/SKILL.md` when you need detailed Nushell syntax reference\n" +
+      "(variables, tables, pipelines, strings, custom commands, control flow, etc.).\n" +
+      "Key differences from Bash:\n" +
+      "- Variables: `$var` not `${var}`; use `$env.VAR` for environment variables\n" +
+      "- Lists: `[a b c]` not quoted space-separated strings\n" +
+      "- Pipes: `|` works but structured data flows through records/tables\n" +
+      "- Commands: `ls`, `open`, `each`, `where`, `select`, `str replace`, `def`\n" +
+      "- No `&&` chaining; use `;` or `and`/`or` keywords\n" +
+      "- String interpolation: `$\"Hello ($name)\"`\n" +
+      "- Use `^` prefix to run external commands directly (e.g., `^git status`)\n" +
+      "- Shell variables set with `let`, mutable with `mut`",
+  },
+  fish: {
+    name: "Fish",
+    skill: "fish",
+    note:
+      "Commands run through a bash execution backend but you MUST write them in Fish syntax.\n" +
+      "Key differences from Bash:\n" +
+      "- Variables: `set var value`, use `$var`\n" +
+      "- No `$()` command substitution; use `(command)` directly\n" +
+      "- `and`/`or` instead of `&&`/`||`\n" +
+      "- `end` instead of `fi`/`done`/`esac`\n" +
+      "- String manipulation: `string replace`, `string split`, etc.\n" +
+      "- Functions: `function name ... end`",
+  },
+  bash: {
+    name: "Bash",
+    note: "Use standard Bash/POSIX shell syntax.",
+  },
+  sh: {
+    name: "POSIX shell",
+    note: "Use POSIX-compatible shell syntax (dash, ash, BusyBox sh).",
+  },
+  zsh: {
+    name: "Zsh",
+    note:
+      "Commands run through a bash execution backend. Zsh and Bash have very similar syntax.\n" +
+      "You may use Zsh-specific features like glob qualifiers, `=(cmd)`, `{a,b}` expansions,\n" +
+      "but be aware the backend is bash — test advanced Zsh features first.",
+  },
+};
+
+/** Detect the user's shell from environment variables. */
+function detectShell(): { key: string; info: ShellProfile } {
+  // 1. NU_VERSION → Nushell
+  if (process.env.NU_VERSION) {
+    return { key: "nu", info: SHELL_PROFILES.nu };
+  }
+
+  // 2. FISH_VERSION → Fish
+  if (process.env.FISH_VERSION) {
+    return { key: "fish", info: SHELL_PROFILES.fish };
+  }
+
+  // 3. ZSH_VERSION → Zsh
+  if (process.env.ZSH_VERSION) {
+    return { key: "zsh", info: SHELL_PROFILES.zsh };
+  }
+
+  // 4. BASH_VERSION → Bash
+  if (process.env.BASH_VERSION) {
+    return { key: "bash", info: SHELL_PROFILES.bash };
+  }
+
+  // 5. Parse $SHELL path
+  const shellPath = process.env.SHELL ?? "";
+  const shellBin = shellPath.split("/").pop()?.toLowerCase() ?? "";
+  const baseName = shellBin.replace(/[-.]\d.*$/, "");
+
+  if (baseName in SHELL_PROFILES) {
+    return { key: baseName, info: SHELL_PROFILES[baseName] };
+  }
+
+  // Fallback: unknown shell
+  return {
+    key: baseName || "unknown",
+    info: {
+      name: baseName || "unknown shell",
+      note:
+        `Could not determine shell type from $SHELL="${shellPath}". ` +
+        `Use standard POSIX syntax.`,
+    },
+  };
+}
+
+// ---- System prompt injection ----
+
+const { key: shellKey, info } = detectShell();
+
+const SHELL_INSTRUCTION = `
+## Shell Syntax
+
+**IMPORTANT:** The user's login shell is **${info.name}**, NOT Bash. When providing
+shell commands (including commands passed to the \`bash\` tool), you MUST format
+them using ${info.name} syntax.
+`;
+
+const SKILL_REFERENCE = info.skill
+  ? `A comprehensive \`${info.skill}\` skill is available. Use the \`read\` tool to load
+\`~/.pi/agent/skills/${info.skill}/SKILL.md\` for complete ${info.name} syntax
+reference (command equivalents, pipelines, data types, common patterns, and gotchas).
+
+`
+  : "";
+
+const SINK = `
+${info.note}
+
+Always provide commands in ${info.name} syntax. The bash tool will execute them;
+the execution backend handles compatibility. Your job is to give the user commands
+they can understand, reuse, and learn from — in their native shell dialect.
+`;
+
+const FULL_INSTRUCTION = SHELL_INSTRUCTION + SKILL_REFERENCE + SINK;
+
+/** Slug for display in status bar. */
+const STATUS_LABEL = `${info.name} shell-format`;
+
+/** Whether we need to inject shell instructions (skip for bash/sh/unknown). */
+const isSupported = shellKey !== "bash" && shellKey !== "sh" && shellKey !== "unknown";
+
+// ---- Extension entry point ----
+
+export default function (pi: ExtensionAPI) {
+  pi.on("session_start", (_event, ctx) => {
+    if (isSupported) {
+      ctx.ui.setStatus("shell-format", STATUS_LABEL);
+      ctx.ui.notify(
+        `Shell format: commands will use ${info.name} syntax` +
+          (info.skill ? ` (${info.skill} skill available)` : ""),
+        "info",
+      );
+    }
+  });
+
+  pi.on("before_agent_start", (event) => {
+    if (!isSupported) return;
+
+    const { systemPrompt } = event;
+
+    // Avoid double-injection
+    if (systemPrompt.includes("The user's login shell is")) return;
+
+    return {
+      systemPrompt: systemPrompt + FULL_INSTRUCTION,
+    };
+  });
+
+  pi.on("session_shutdown", (_event, ctx) => {
+    ctx.ui.setStatus("shell-format", undefined);
+  });
+}

--- a/packages/extensions/extensions/shell-format.ts
+++ b/packages/extensions/extensions/shell-format.ts
@@ -20,10 +20,10 @@ import type { ExtensionAPI } from "@mariozechner/pi-coding-agent";
 
 /** Shell profile with optional companion skill reference. */
 interface ShellProfile {
-  name: string;
-  /** Skill name (e.g., "nushell") if a companion SKILL.md exists */
-  skill?: string;
-  note: string;
+	name: string;
+	/** Skill name (e.g., "nushell") if a companion SKILL.md exists */
+	skill?: string;
+	note: string;
 }
 
 /**
@@ -31,95 +31,108 @@ interface ShellProfile {
  * Shells with `skill` set have a companion skill file the LLM can load.
  */
 const SHELL_PROFILES: Record<string, ShellProfile> = {
-  nu: {
-    name: "Nushell",
-    skill: "nushell",
-    note:
-      "Commands run through a bash execution backend but you MUST write them in Nushell syntax.\n" +
-      "The `nushell` skill is available — use the `read` tool to load\n" +
-      "`~/.pi/agent/skills/nushell/SKILL.md` when you need detailed Nushell syntax reference\n" +
-      "(variables, tables, pipelines, strings, custom commands, control flow, etc.).\n" +
-      "Key differences from Bash:\n" +
-      "- Variables: `$var` not `${var}`; use `$env.VAR` for environment variables\n" +
-      "- Lists: `[a b c]` not quoted space-separated strings\n" +
-      "- Pipes: `|` works but structured data flows through records/tables\n" +
-      "- Commands: `ls`, `open`, `each`, `where`, `select`, `str replace`, `def`\n" +
-      "- No `&&` chaining; use `;` or `and`/`or` keywords\n" +
-      "- String interpolation: `$\"Hello ($name)\"`\n" +
-      "- Use `^` prefix to run external commands directly (e.g., `^git status`)\n" +
-      "- Shell variables set with `let`, mutable with `mut`",
-  },
-  fish: {
-    name: "Fish",
-    skill: "fish",
-    note:
-      "Commands run through a bash execution backend but you MUST write them in Fish syntax.\n" +
-      "Key differences from Bash:\n" +
-      "- Variables: `set var value`, use `$var`\n" +
-      "- No `$()` command substitution; use `(command)` directly\n" +
-      "- `and`/`or` instead of `&&`/`||`\n" +
-      "- `end` instead of `fi`/`done`/`esac`\n" +
-      "- String manipulation: `string replace`, `string split`, etc.\n" +
-      "- Functions: `function name ... end`",
-  },
-  bash: {
-    name: "Bash",
-    note: "Use standard Bash/POSIX shell syntax.",
-  },
-  sh: {
-    name: "POSIX shell",
-    note: "Use POSIX-compatible shell syntax (dash, ash, BusyBox sh).",
-  },
-  zsh: {
-    name: "Zsh",
-    note:
-      "Commands run through a bash execution backend. Zsh and Bash have very similar syntax.\n" +
-      "You may use Zsh-specific features like glob qualifiers, `=(cmd)`, `{a,b}` expansions,\n" +
-      "but be aware the backend is bash — test advanced Zsh features first.",
-  },
+	nu: {
+		name: "Nushell",
+		skill: "nushell",
+		note:
+			"Commands run through a bash execution backend but you MUST write them in Nushell syntax.\n" +
+			"The `nushell` skill is available — use the `read` tool to load\n" +
+			"`~/.pi/agent/skills/nushell/SKILL.md` when you need detailed Nushell syntax reference\n" +
+			"(variables, tables, pipelines, strings, custom commands, control flow, etc.).\n" +
+			"Key differences from Bash:\n" +
+			"- Variables: `$var` not `${var}`; use `$env.VAR` for environment variables\n" +
+			"- Lists: `[a b c]` not quoted space-separated strings\n" +
+			"- Pipes: `|` works but structured data flows through records/tables\n" +
+			"- Commands: `ls`, `open`, `each`, `where`, `select`, `str replace`, `def`\n" +
+			"- No `&&` chaining; use `;` or `and`/`or` keywords\n" +
+			'- String interpolation: `$"Hello ($name)"`\n' +
+			"- Use `^` prefix to run external commands directly (e.g., `^git status`)\n" +
+			"- Shell variables set with `let`, mutable with `mut`",
+	},
+	fish: {
+		name: "Fish",
+		skill: "fish",
+		note:
+			"Commands run through a bash execution backend but you MUST write them in Fish syntax.\n" +
+			"The `fish` skill is available — use `read` to load\n" +
+			"`~/.pi/agent/skills/fish/SKILL.md` for detailed Fish syntax reference.\n" +
+			"Key differences from Bash:\n" +
+			"- Variables: `set var value`, use `$var`\n" +
+			"- No `$()` command substitution; use `(command)` directly\n" +
+			"- `and`/`or` instead of `&&`/`||`\n" +
+			"- `end` instead of `fi`/`done`/`esac`\n" +
+			"- String manipulation: `string replace`, `string split`, etc.\n" +
+			"- Functions: `function name ... end`",
+	},
+	bash: {
+		name: "Bash",
+		note: "Use standard Bash/POSIX shell syntax.",
+	},
+	sh: {
+		name: "POSIX shell",
+		note: "Use POSIX-compatible shell syntax (dash, ash, BusyBox sh).",
+	},
+	zsh: {
+		name: "Zsh",
+		note:
+			"Commands run through a bash execution backend. Zsh and Bash have very similar syntax.\n" +
+			"You may use Zsh-specific features like glob qualifiers, `=(cmd)`, `{a,b}` expansions,\n" +
+			"but be aware the backend is bash — test advanced Zsh features first.",
+	},
+	pwsh: {
+		name: "PowerShell",
+		skill: "pwsh",
+		note:
+			"Commands run through a bash execution backend but you MUST write them in PowerShell syntax.\n" +
+			"The `pwsh` skill is available — use `read` to load\n" +
+			"`~/.pi/agent/skills/pwsh/SKILL.md` for detailed PowerShell syntax reference.\n" +
+			"Key differences:\n" +
+			"- Variables: `$var`, environment: `$env:VAR`\n" +
+			"- Commands: Verb-Noun pattern (Get-Content, Set-Location, etc.)\n" +
+			"- Pipes pass objects, not text\n" +
+			"- No `grep`/`sed`/`awk`; use `Select-String`, `-replace`, `Where-Object`",
+	},
 };
 
 /** Detect the user's shell from environment variables. */
 function detectShell(): { key: string; info: ShellProfile } {
-  // 1. NU_VERSION → Nushell
-  if (process.env.NU_VERSION) {
-    return { key: "nu", info: SHELL_PROFILES.nu };
-  }
+	// 1. NU_VERSION → Nushell
+	if (process.env.NU_VERSION) {
+		return { key: "nu", info: SHELL_PROFILES.nu };
+	}
 
-  // 2. FISH_VERSION → Fish
-  if (process.env.FISH_VERSION) {
-    return { key: "fish", info: SHELL_PROFILES.fish };
-  }
+	// 2. FISH_VERSION → Fish
+	if (process.env.FISH_VERSION) {
+		return { key: "fish", info: SHELL_PROFILES.fish };
+	}
 
-  // 3. ZSH_VERSION → Zsh
-  if (process.env.ZSH_VERSION) {
-    return { key: "zsh", info: SHELL_PROFILES.zsh };
-  }
+	// 3. ZSH_VERSION → Zsh
+	if (process.env.ZSH_VERSION) {
+		return { key: "zsh", info: SHELL_PROFILES.zsh };
+	}
 
-  // 4. BASH_VERSION → Bash
-  if (process.env.BASH_VERSION) {
-    return { key: "bash", info: SHELL_PROFILES.bash };
-  }
+	// 4. BASH_VERSION → Bash
+	if (process.env.BASH_VERSION) {
+		return { key: "bash", info: SHELL_PROFILES.bash };
+	}
 
-  // 5. Parse $SHELL path
-  const shellPath = process.env.SHELL ?? "";
-  const shellBin = shellPath.split("/").pop()?.toLowerCase() ?? "";
-  const baseName = shellBin.replace(/[-.]\d.*$/, "");
+	// 5. Parse $SHELL path
+	const shellPath = process.env.SHELL ?? "";
+	const shellBin = shellPath.split("/").pop()?.toLowerCase() ?? "";
+	const baseName = shellBin.replace(/[-.]\d.*$/, "");
 
-  if (baseName in SHELL_PROFILES) {
-    return { key: baseName, info: SHELL_PROFILES[baseName] };
-  }
+	if (baseName in SHELL_PROFILES) {
+		return { key: baseName, info: SHELL_PROFILES[baseName] };
+	}
 
-  // Fallback: unknown shell
-  return {
-    key: baseName || "unknown",
-    info: {
-      name: baseName || "unknown shell",
-      note:
-        `Could not determine shell type from $SHELL="${shellPath}". ` +
-        `Use standard POSIX syntax.`,
-    },
-  };
+	// Fallback: unknown shell
+	return {
+		key: baseName || "unknown",
+		info: {
+			name: baseName || "unknown shell",
+			note: `Could not determine shell type from $SHELL="${shellPath}". ` + `Use standard POSIX syntax.`,
+		},
+	};
 }
 
 // ---- System prompt injection ----
@@ -135,12 +148,12 @@ them using ${info.name} syntax.
 `;
 
 const SKILL_REFERENCE = info.skill
-  ? `A comprehensive \`${info.skill}\` skill is available. Use the \`read\` tool to load
+	? `A comprehensive \`${info.skill}\` skill is available. Use the \`read\` tool to load
 \`~/.pi/agent/skills/${info.skill}/SKILL.md\` for complete ${info.name} syntax
 reference (command equivalents, pipelines, data types, common patterns, and gotchas).
 
 `
-  : "";
+	: "";
 
 const SINK = `
 ${info.note}
@@ -161,31 +174,30 @@ const isSupported = shellKey !== "bash" && shellKey !== "sh" && shellKey !== "un
 // ---- Extension entry point ----
 
 export default function (pi: ExtensionAPI) {
-  pi.on("session_start", (_event, ctx) => {
-    if (isSupported) {
-      ctx.ui.setStatus("shell-format", STATUS_LABEL);
-      ctx.ui.notify(
-        `Shell format: commands will use ${info.name} syntax` +
-          (info.skill ? ` (${info.skill} skill available)` : ""),
-        "info",
-      );
-    }
-  });
+	pi.on("session_start", (_event, ctx) => {
+		if (isSupported) {
+			ctx.ui.setStatus("shell-format", STATUS_LABEL);
+			ctx.ui.notify(
+				`Shell format: commands will use ${info.name} syntax` + (info.skill ? ` (${info.skill} skill available)` : ""),
+				"info",
+			);
+		}
+	});
 
-  pi.on("before_agent_start", (event) => {
-    if (!isSupported) return;
+	pi.on("before_agent_start", (event) => {
+		if (!isSupported) return;
 
-    const { systemPrompt } = event;
+		const { systemPrompt } = event;
 
-    // Avoid double-injection
-    if (systemPrompt.includes("The user's login shell is")) return;
+		// Avoid double-injection
+		if (systemPrompt.includes("The user's login shell is")) return;
 
-    return {
-      systemPrompt: systemPrompt + FULL_INSTRUCTION,
-    };
-  });
+		return {
+			systemPrompt: systemPrompt + FULL_INSTRUCTION,
+		};
+	});
 
-  pi.on("session_shutdown", (_event, ctx) => {
-    ctx.ui.setStatus("shell-format", undefined);
-  });
+	pi.on("session_shutdown", (_event, ctx) => {
+		ctx.ui.setStatus("shell-format", undefined);
+	});
 }

--- a/packages/extensions/package.json
+++ b/packages/extensions/package.json
@@ -1,7 +1,7 @@
 {
 	"name": "@ifi/oh-pi-extensions",
 	"version": "0.5.1",
-	"description": "Core pi extensions: git-guard, auto-session, custom-footer, and more.",
+	"description": "Core pi extensions: git-guard, auto-session, custom-footer, shell-format, and more.",
 	"keywords": [
 		"pi-package"
 	],
@@ -45,6 +45,7 @@
 			"./extensions/external-editor.ts",
 			"./extensions/git-guard.ts",
 			"./extensions/scheduler.ts",
+			"./extensions/shell-format.ts",
 			"./extensions/tool-metadata.ts",
 			"./extensions/usage-tracker.ts",
 			"./extensions/worktree.ts"

--- a/packages/skills/skills/fish/SKILL.md
+++ b/packages/skills/skills/fish/SKILL.md
@@ -1,0 +1,332 @@
+# Fish Shell Skill
+
+Use this skill whenever the user's shell is Fish. All shell commands provided to the user must use Fish syntax, not Bash/POSIX syntax.
+
+## Core Concepts
+
+Fish is intentionally not POSIX-compatible. It emphasizes commands over syntax — most string manipulation, math, and text processing uses builtin commands rather than arcane syntax.
+
+## Variables
+
+```fish
+# Set variables with `set`, NOT `VAR=VAL`
+set NAME value
+set -g NAME value            # Global scope
+set -l NAME value            # Local scope
+set -gx NAME value           # Global + exported (like bash `export`)
+set -U NAME value            # Universal (persists across sessions)
+
+# Lists (all variables are lists)
+set items foo bar baz
+echo $items                  # prints all elements as separate args
+echo $items[1]               # first element (1-indexed!)
+echo $items[-1]              # last element
+echo $items[2..3]            # range: elements 2-3
+
+# Set to command output
+set lines (cat file.txt)     # Each line is one list element
+
+# Erase
+set -e NAME
+
+# Environment overrides (for one command)
+VAR=VAL command
+
+# Special variables
+echo $status                 # Exit code of last command (bash $?)
+echo $fish_pid               # Current PID (bash $$)
+echo $last_pid               # PID of last background process (bash $!)
+echo $argv                   # Script arguments (bash $@)
+count $argv                  # Number of args (bash $#)
+```
+
+## Command Substitution
+
+```fish
+# Use (command) or $(command) — NOT backticks
+echo (date)
+for file in (ls *.txt)
+    echo $file
+end
+
+# Split on nulls (safe for filenames)
+for i in (find . -print0 | string split0)
+    echo $i
+end
+```
+
+## Command Equivalents
+
+| Task                  | Bash                            | Fish                              |
+| --------------------- | ------------------------------- | --------------------------------- |
+| List files            | `ls -la`                        | `ls -la`                          |
+| Find files            | `find . -name '*.rs'`           | Uses external `find` or globs     |
+| Filter text           | `grep pattern`                  | `string match -r 'pattern'`       |
+| Search in files       | `grep -r pattern dir/`          | `rg` (external) or `string match` |
+| Replace in strings    | `sed 's/a/b/g'`                 | `string replace -a 'a' 'b'`       |
+| String operations     | `${var#prefix}`                 | `string replace` or `string sub`  |
+| Uppercase             | `tr '[:lower:]' '[:upper:]'`    | `string upper`                    |
+| Lowercase             | `tr '[:upper:]' '[:lower:]'`    | `string lower`                    |
+| Split string          | `IFS=, read -ra arr <<< "$str"` | `string split "," $str`           |
+| Join strings          | `paste -sd,`                    | `string join "," $items`          |
+| Count lines           | `wc -l`                         | `count $lines`                    |
+| Math                  | `$((1 + 2))`                    | `math "1 + 2"`                    |
+| Float math            | needs `bc`                      | `math "3.14 * 2"` (builtin!)      |
+| Read file             | `cat file.txt`                  | `cat file.txt` (external cmd)     |
+| Write file            | `echo "text" > f.txt`           | `echo "text" > f.txt`             |
+| Append to file        | `echo "text" >> f.txt`          | `echo "text" >> f.txt`            |
+| Process status        | `$?`                            | `$status` (0 = success)           |
+| Get help              | `man cmd`                       | `cmd --help` or `man cmd`         |
+| Source file           | `. file.sh`                     | `source file.fish`                |
+| Check variable exists | `[[ -n $VAR ]]`                 | `set -q VAR`                      |
+
+## Strings
+
+```fish
+# Replace
+string replace "old" "new" "hello old world"
+string replace -a "o" "O" "hello world"    # Replace all
+
+# Match/regex
+string match -r '^\d+$' "123"
+echo "hello" | string match -r 'ell'
+
+# Split/join
+string split "," "a,b,c"
+string join "," a b c
+
+# Case
+string upper "hello"        # => HELLO
+string lower "HELLO"        # => hello
+
+# Trim/pad
+string trim "  hello  "
+string pad -c x -w 20 "hello"
+
+# Substring
+string sub -s 1 -l 5 "hello world"    # Start at 1, length 5
+# Or: string sub --start 1 --length 5
+
+# Length/width
+string length "hello"
+string length --visible "héllo"       # Visible width (terminal cells)
+
+# Escape
+string escape "text with $pecial"
+```
+
+## Math (Arithmetic)
+
+```fish
+# Use `math` instead of $((...))
+math "1 + 2"
+math "3.14 * 2"
+math "sin(0.5)"
+math "log(100)"
+
+# Store result
+set result (math "10 / 3")
+echo $result                    # 3.333333...
+
+# Use in conditionals
+if test (math "$count % 2") -eq 0
+    echo even
+end
+
+# Note: * must be quoted (or use x for multiplication)
+math "3 * 4"           # OK (quoted)
+math 3 x 4             # OK (x for multiply)
+# math 3 * 4           # ERROR: * expands as glob
+```
+
+## Control Flow
+
+```fish
+# If/else — no `then`, ends with `end`
+if test -f "config.fish"
+    echo "Found config"
+else if test -f "config.local.fish"
+    echo "Found local config"
+else
+    echo "No config found"
+end
+
+# For loop — no `do`, ends with `end`
+for file in (ls *.txt)
+    echo "Processing $file"
+end
+
+# While loop
+while true
+    echo "Running..."
+    sleep 1
+end
+
+# Switch/case
+switch $color
+    case red
+        echo "Stop"
+    case yellow
+        echo "Caution"
+    case green
+        echo "Go"
+    case '*'
+        echo "Unknown"
+end
+
+# Logical operators
+command1; and command2     # Run cmd2 only if cmd1 succeeds
+command1; or command2      # Run cmd2 only if cmd1 fails
+not command                # Negate
+
+# Begin/end block (like bash { ... })
+begin
+    command1
+    command2
+end | grep something
+```
+
+## Functions
+
+```fish
+# Define with `function ... end`
+function greet
+    echo "Hello, $argv[1]!"
+end
+
+# With arguments
+function greet -a name
+    echo "Hello, $name!"
+end
+
+# With description (for autocomplete)
+function greet --description "Greet someone"
+    echo "Hello, $argv!"
+end
+
+# Argparse for option parsing
+function mycmd
+    argparse 'n/name=' 'v/verbose' -- $argv
+    or return
+
+    if set -q _flag_verbose
+        echo "Verbose mode"
+    end
+    if set -q _flag_name
+        echo "Name: $_flag_name"
+    end
+end
+mycmd --name Alice -v
+```
+
+## Process Substitution
+
+```fish
+# Instead of bash <(command), use `psub`
+diff (command1 | psub) (command2 | psub)
+
+# No equivalent to bash >(command)
+# Use pipes instead
+```
+
+## Heredocs (Not Supported)
+
+```fish
+# Fish does NOT have <<EOF heredocs. Use alternatives:
+
+# Multi-line string with quotes
+echo "line 1
+line 2
+line 3"
+
+# Or with printf
+printf '%s\n' "line 1" "line 2" "line 3"
+
+# Pipe content to a command
+echo "xterm
+rxvt-unicode" | pacman --remove -
+```
+
+## Wildcards (Globs)
+
+```fish
+# * matches any string (non-recursive)
+ls *.fish
+
+# ** matches recursively
+ls **/*.fish
+
+# Globs fail if no match (like bash failglob)
+# Except in for loops, set, and count (behaves like nullglob)
+
+# No globbing on variables — use external find or string match
+set files (find . -name '*.fish')
+```
+
+## Aliases and Abbreviations
+
+```fish
+# Alias (persistent with alias --save)
+alias gs "git status"
+alias gc "git commit"
+
+# Save for future sessions
+alias --save gs "git status"
+
+# Abbreviations (expand on space/enter at command line)
+abbr --add gs git status
+```
+
+## Common Patterns
+
+```fish
+# Process files
+for f in *.txt
+    echo "Processing $f"
+    string replace "foo" "bar" < $f > $f.new
+end
+
+# Check command success
+if command
+    echo "Success"
+else
+    echo "Failed with status $status"
+end
+
+# Safe count of lines
+set lines (cat file.txt | count)
+# or
+count (cat file.txt)
+
+# Loop with index
+set items a b c
+set i 1
+for item in $items
+    echo "$i: $item"
+    set i (math "$i + 1")
+end
+
+# Pipe to while read (no subshell!)
+echo -e "a\nb\nc" | while read -l line
+    echo "Got: $line"
+end
+
+# Background job
+long_running_command &
+echo "PID: $last_pid"
+```
+
+## Key Gotchas
+
+1. **`=` is not for assignment** — use `set NAME value`, NOT `NAME=value`
+2. **No `&&` / `||`** — use `; and` / `; or` (note the semicolon!)
+3. **No `$((...))`** — use `math "expression"`
+4. **No `${var#prefix}` etc.** — use `string` builtin
+5. **No backtick command substitution** — use `(command)` or `$(command)`
+6. **No word splitting** — variables keep their values intact
+7. **No `[[` or `((`** — use `test` or `[` (POSIX)
+8. **Conditional chaining needs semicolons** — `cmd; and cmd2` not `cmd && cmd2`
+9. **List indices are 1-based** — `$list[1]` is the first element
+10. **No subshells** — variables set in pipes/loops are visible outside
+11. **No heredocs** — use `echo "multi\nline"` or `printf`
+12. **Functions end with `end`**, not `}`

--- a/packages/skills/skills/nushell/SKILL.md
+++ b/packages/skills/skills/nushell/SKILL.md
@@ -1,0 +1,328 @@
+# Nushell Skill
+
+Use this skill whenever the user's shell is Nushell (nu). All shell commands provided to the user must use Nushell syntax, not Bash/POSIX syntax.
+
+## Core Concepts
+
+Nushell treats everything as structured data. Pipelines pass tables, lists, and records — not plain text. This is the single biggest difference from Bash.
+
+## Variables
+
+```nu
+# Immutable (preferred)
+let name = "world"
+let files = (ls)                    # Parentheses for subexpressions
+let big = (ls | where size > 10kb)
+
+# Mutable
+mut count = 0
+$count += 1
+
+# Constants (parse-time evaluation)
+const config_dir = "~/.config"
+
+# Environment variables — use $env.VAR, NOT $VAR
+$env.PATH
+$env.HOME
+$env.PWD
+let path = $env.PATH | append "/usr/local/bin"
+
+# $in — the current pipeline input
+[1 2 3] | $in.1                     # => 2
+ls | $in | where size > 1mb
+```
+
+## Commands (not like Bash)
+
+Nushell has **structured commands**, not text-processing tools:
+
+| Task | Bash | Nushell |
+|------|------|---------|
+| List files | `ls -la` | `ls` (already structured) |
+| Long listing | `ls -la` | `ls -l` or `ls --long` |
+| Find files recursively | `find . -name '*.rs'` | `ls **/*.rs` |
+| Filter by condition | `grep pattern` | `where name =~ "pattern"` or `find "text"` |
+| Sort | `sort` | `sort-by size` |
+| Take first N | `head -5` | `first 5` |
+| Take last N | `tail -3` | `last 3` |
+| Skip N | `tail -n +5` | `skip 4` |
+| Read file | `cat file.txt` | `open file.txt` or `open --raw file.txt` |
+| Write file | `echo "text" > f.txt` | `"text" \| save f.txt` |
+| Append to file | `echo "text" >> f.txt` | `"text" \| save --append f.txt` |
+| Parse CSV | complex | `open data.csv` (auto-detects) |
+| Parse JSON | `jq` | `open data.json` (auto-detects) |
+| Count lines | `wc -l` | `length` |
+| Search in files | `grep -r pattern dir/` | `rg` (via `^rg`) or `ls **/*.rs \| where (open $in.name \| str contains "TODO")` |
+| Replace in strings | `sed 's/a/b/g'` | `str replace --all 'a' 'b'` |
+| Parse date | `date -d "..."` | `"2024-01-01" \| into datetime` |
+| Get help | `man cmd` | `help cmd` or `help commands \| find substring` |
+
+## Pipelines
+
+```nu
+# Data flows left to right as structured values
+ls | where type == dir | sort-by modified | first 5
+
+# Multi-line pipelines in parentheses
+let result = (
+    ls
+    | where size > 10kb
+    | sort-by name
+    | select name size
+)
+
+# Chaining: use ; (not &&)
+cmd1; cmd2                          # Sequential, no output piping between them
+cmd1; cmd2 | cmd3                   # cmd1 runs, output discarded; cmd2 pipes to cmd3
+
+# Logical chaining uses and/or (not &&/||)
+cmd1 and cmd2                       # Run cmd2 only if cmd1 succeeds
+cmd1 or cmd2                        # Run cmd2 only if cmd1 fails
+```
+
+## Tables and Data
+
+```nu
+# Create a table inline
+[[name, size]; [file1.txt, 100] [file2.txt, 200]]
+
+# Select columns
+ls | select name size modified
+
+# Reject (drop) columns
+ls | reject type
+
+# Filter rows
+ls | where size > 1mb and type == file
+ls | where name =~ "\.rs$"          # Regex match
+ls | where name starts-with "D"
+
+# Sort
+ls | sort-by size --reverse
+
+# Iterate over rows
+ls | each { |file| $"($file.name) is ($file.size)" }
+ls | each { |it| $it.name }         # Shorthand: $it is the current item
+
+# Access nested data with dots
+{ a: { b: 3 } } | get a.b           # => 3
+ls | get name.0                      # First filename
+
+# Update/add record fields
+{ name: "nu", stars: 5 } | upsert language "Rust"
+
+# Merge records
+{ a: 1 } | merge { b: 2 }           # => { a: 1, b: 2 }
+```
+
+## Strings
+
+```nu
+# Interpolation — use $"..." with () placeholders
+let name = "Alice"
+$"Hello, ($name)!"                  # => Hello, Alice!
+
+# Concatenate
+"Hello " + "World"
+
+# Split
+"a,b,c" | split row ","             # => [a, b, c]
+
+# Join
+[a b c] | str join ","              # => a,b,c
+
+# Replace
+"hello world" | str replace "world" "nushell"
+"hello world" | str replace --all 'l' 'L'
+
+# Contains
+"hello" | str contains "ell"        # => true
+
+# Substring
+"Hello World!" | str substring 4..8 # => o Wo
+
+# Parse into columns
+"Nushell 0.98" | parse "{shell} {version}"
+
+# Uppercase/lowercase
+"hello" | str upcase                # => HELLO
+```
+
+## Lists
+
+```nu
+# Create
+[1, 2, 3]
+1..10                               # Range: 1,2,3,...,10
+
+# Access by index
+let lst = [a b c]
+$lst.0                              # => a
+$lst.-1                             # => c (last element)
+
+# Modify (creates new lists — immutable)
+[1, 2, 3] | insert 1 99             # Insert at index
+[1, 2, 3] | update 1 99            # Replace at index
+[1, 2, 3] | prepend 0              # Add to front
+[1, 2, 3] | append 4               # Add to end
+[1, 2, 3] | drop 1                  # Remove at index
+
+# Iterate
+[1, 2, 3] | each { |n| $n * 2 }    # => [2, 4, 6]
+[1, 2, 3] | each { $in * 2 }       # Same, using $in
+
+# Map with index
+[a b c] | enumerate | each { |it| $"($it.index): ($it.item)" }
+
+# Reduce
+[3, 8, 4] | reduce { |it, acc| $acc + $it }  # => 15
+[3, 8, 4] | reduce --fold 1 { |it, acc| $acc * $it }  # => 96
+
+# Test elements
+[1, 2, 3] | any { $in > 2 }         # => true
+[1, 2, 3] | all { $in > 0 }         # => true
+
+# Length
+[1, 2, 3] | length                  # => 3
+```
+
+## Custom Commands (Functions)
+
+```nu
+# Basic command
+def greet [name: string] {
+    $"hello ($name)"
+}
+
+# With default value
+def greet [name = "nushell"] {
+    $"hello ($name)"
+}
+
+# Typed parameters
+def double [x: int]: int {
+    $x * 2
+}
+
+# Flags
+def greet [
+    name: string
+    --age: int          # Optional flag with value
+    --verbose (-v)      # Shorthand flag (-v)
+] {
+    # body
+}
+greet "Alice" --age 30
+greet "Bob" -v
+
+# Rest parameters (variadic)
+def multi [...names: string] {
+    $names | each { $"Hello ($in)" }
+}
+multi Alice Bob Carol
+
+# Pipeline input in custom commands
+def my_filter [] {
+    let data = $in                   # Capture pipeline input
+    $data | where size > 1mb
+}
+ls | my_filter
+```
+
+## Modules
+
+```nu
+# Define inline
+module greetings {
+    export def hello [] { "hello" }
+}
+use greetings
+greetings hello                     # Subcommand style
+
+# From file
+use path/to/module.nu
+```
+
+## External Commands
+
+```nu
+# Run external commands with ^ prefix
+^git status
+^cargo build --release
+^rg "TODO" src/
+
+# Capture external command output (returns raw string)
+let output = (^git branch | lines)
+let status = (^git status --porcelain)
+
+# Pipe through external commands
+ls | get name | to text | ^grep ".rs"
+
+# Discard output
+^noisy-command | ignore
+```
+
+## Control Flow
+
+```nu
+# If/else — must produce same type from both branches
+if $condition {
+    "yes"
+} else {
+    "no"
+}
+
+# For loops
+for file in (ls) {
+    print $"Processing ($file.name)"
+}
+
+# While
+while $count < 10 {
+    $count += 1
+}
+
+# Try/catch
+try {
+    risky-command
+} catch { |err|
+    print $"Failed: ($err.msg)"
+}
+```
+
+## Common Patterns
+
+```nu
+# Process all files matching a pattern
+ls **/*.rs | each { |file|
+    print $"Linting ($file.name)"
+    ^rustfmt $file.name
+}
+
+# Count lines of code (approximate)
+ls **/*.rs | each { open --raw $in.name | lines | length } | math sum
+
+# Find recently modified files
+ls **/* | where modified > (date now) - 1day
+
+# Convert JSON to CSV
+open data.json | to csv | save data.csv
+
+# Parse log files
+open access.log | lines | parse "{ip} - - [{date}] \"{method} {path}\" {status} {size}"
+```
+
+## Key Gotchas
+
+1. **No `&&` or `||`** — use `;`, `and`, `or`
+2. **No `$VAR` for env vars** — use `$env.VAR`
+3. **No `grep`/`sed`/`awk`** — use `where`, `str replace`, `each`
+4. **`ls` returns a table**, not text — filter with `where`, not `grep`
+5. **`open` is for reading files** — use `open file.txt` not `cat file.txt`
+6. **Closures can't capture `mut` variables** — use immutable `let` inside closures
+7. **External commands need `^` prefix** — `^git` not just `git`
+8. **No `$(cmd)` substitution** — use `(cmd)` directly in expressions
+9. **No backtick command substitution** — use `(cmd)`
+10. **No `fi`/`done`/`esac`** — just `{ }` blocks
+11. **`rm` is safer** — no `rm -rf` needed, just `rm -r`
+12. **`$in` refers to pipeline input** — very useful for chaining

--- a/packages/skills/skills/nushell/SKILL.md
+++ b/packages/skills/skills/nushell/SKILL.md
@@ -36,26 +36,26 @@ ls | $in | where size > 1mb
 
 Nushell has **structured commands**, not text-processing tools:
 
-| Task | Bash | Nushell |
-|------|------|---------|
-| List files | `ls -la` | `ls` (already structured) |
-| Long listing | `ls -la` | `ls -l` or `ls --long` |
-| Find files recursively | `find . -name '*.rs'` | `ls **/*.rs` |
-| Filter by condition | `grep pattern` | `where name =~ "pattern"` or `find "text"` |
-| Sort | `sort` | `sort-by size` |
-| Take first N | `head -5` | `first 5` |
-| Take last N | `tail -3` | `last 3` |
-| Skip N | `tail -n +5` | `skip 4` |
-| Read file | `cat file.txt` | `open file.txt` or `open --raw file.txt` |
-| Write file | `echo "text" > f.txt` | `"text" \| save f.txt` |
-| Append to file | `echo "text" >> f.txt` | `"text" \| save --append f.txt` |
-| Parse CSV | complex | `open data.csv` (auto-detects) |
-| Parse JSON | `jq` | `open data.json` (auto-detects) |
-| Count lines | `wc -l` | `length` |
-| Search in files | `grep -r pattern dir/` | `rg` (via `^rg`) or `ls **/*.rs \| where (open $in.name \| str contains "TODO")` |
-| Replace in strings | `sed 's/a/b/g'` | `str replace --all 'a' 'b'` |
-| Parse date | `date -d "..."` | `"2024-01-01" \| into datetime` |
-| Get help | `man cmd` | `help cmd` or `help commands \| find substring` |
+| Task                   | Bash                   | Nushell                                                                          |
+| ---------------------- | ---------------------- | -------------------------------------------------------------------------------- |
+| List files             | `ls -la`               | `ls` (already structured)                                                        |
+| Long listing           | `ls -la`               | `ls -l` or `ls --long`                                                           |
+| Find files recursively | `find . -name '*.rs'`  | `ls **/*.rs`                                                                     |
+| Filter by condition    | `grep pattern`         | `where name =~ "pattern"` or `find "text"`                                       |
+| Sort                   | `sort`                 | `sort-by size`                                                                   |
+| Take first N           | `head -5`              | `first 5`                                                                        |
+| Take last N            | `tail -3`              | `last 3`                                                                         |
+| Skip N                 | `tail -n +5`           | `skip 4`                                                                         |
+| Read file              | `cat file.txt`         | `open file.txt` or `open --raw file.txt`                                         |
+| Write file             | `echo "text" > f.txt`  | `"text" \| save f.txt`                                                           |
+| Append to file         | `echo "text" >> f.txt` | `"text" \| save --append f.txt`                                                  |
+| Parse CSV              | complex                | `open data.csv` (auto-detects)                                                   |
+| Parse JSON             | `jq`                   | `open data.json` (auto-detects)                                                  |
+| Count lines            | `wc -l`                | `length`                                                                         |
+| Search in files        | `grep -r pattern dir/` | `rg` (via `^rg`) or `ls **/*.rs \| where (open $in.name \| str contains "TODO")` |
+| Replace in strings     | `sed 's/a/b/g'`        | `str replace --all 'a' 'b'`                                                      |
+| Parse date             | `date -d "..."`        | `"2024-01-01" \| into datetime`                                                  |
+| Get help               | `man cmd`              | `help cmd` or `help commands \| find substring`                                  |
 
 ## Pipelines
 

--- a/packages/skills/skills/pwsh/SKILL.md
+++ b/packages/skills/skills/pwsh/SKILL.md
@@ -1,0 +1,232 @@
+# PowerShell Skill
+
+Use this skill whenever the user's shell is PowerShell (pwsh). All commands must use PowerShell syntax — cmdlets, not Bash/POSIX syntax. PowerShell deals in **objects**, not plain text.
+
+## Core Concepts
+
+PowerShell passes objects through pipelines, not text. Every cmdlet outputs structured objects with properties and methods. This is the single biggest difference from Bash.
+
+## Variables
+
+```powershell
+# All variables start with $
+$name = "World"
+$count = 42
+$files = Get-ChildItem
+
+# Environment variables — $env: prefix
+$env:PATH
+$env:HOME
+$env:USERPROFILE
+
+# Automatic variables
+$_                        # Current pipeline object
+$?                        # Success status of last command
+$LASTEXITCODE             # Exit code of last external program
+$args                     # Script arguments
+$PSVersionTable           # PowerShell version info
+```
+
+## Command Equivalents
+
+| Task                   | Bash                   | PowerShell                                              |
+| ---------------------- | ---------------------- | ------------------------------------------------------- |
+| List files             | `ls -la`               | `Get-ChildItem` or `ls` (alias)                         |
+| Find files recursively | `find . -name '*.rs'`  | `Get-ChildItem -Recurse -Filter "*.rs"` or `ls -r *.rs` |
+| Current directory      | `pwd`                  | `Get-Location` or `pwd` (alias)                         |
+| Change directory       | `cd /path`             | `Set-Location /path` or `cd /path` (alias)              |
+| Read file              | `cat file.txt`         | `Get-Content file.txt` or `cat file.txt`                |
+| Write file             | `echo "text" > f.txt`  | `"text" \| Out-File f.txt` or `"text" > f.txt`          |
+| Append to file         | `echo "text" >> f.txt` | `"text" \| Out-File -Append f.txt` or `"text" >> f.txt` |
+| Create directory       | `mkdir -p path`        | `New-Item -ItemType Directory path` or `mkdir path`     |
+| Create file            | `touch file.txt`       | `New-Item -ItemType File file.txt`                      |
+| Copy                   | `cp src dst`           | `Copy-Item src dst` or `cp src dst`                     |
+| Move                   | `mv src dst`           | `Move-Item src dst` or `mv src dst`                     |
+| Remove                 | `rm file`              | `Remove-Item file` or `rm file`                         |
+| Recursive remove       | `rm -rf dir`           | `Remove-Item -Recurse -Force dir` or `rm -r -fo dir`    |
+| Filter text            | `grep pattern`         | `Select-String -Pattern "pattern"` or `sls "pattern"`   |
+| Replace text           | `sed 's/a/b/g'`        | `-replace 'a', 'b'` operator                            |
+| Count lines            | `wc -l`                | `Measure-Object -Line`                                  |
+| Sort                   | `sort`                 | `Sort-Object` or `sort`                                 |
+| Head                   | `head -5`              | `Select-Object -First 5`                                |
+| Tail                   | `tail -5`              | `Select-Object -Last 5`                                 |
+| Tail follow            | `tail -f log`          | `Get-Content -Tail 10 -Wait log`                        |
+| Process list           | `ps aux`               | `Get-Process` or `ps`                                   |
+| Kill process           | `kill PID`             | `Stop-Process -Id PID` or `kill -Id PID`                |
+| Get help               | `man cmd`              | `Get-Help cmd -Full` or `help cmd`                      |
+| Find command           | `man -k keyword`       | `Get-Command *keyword*`                                 |
+| Date                   | `date`                 | `Get-Date` or `date`                                    |
+| Sleep                  | `sleep 1`              | `Start-Sleep -Seconds 1` or `sleep 1`                   |
+| Download file          | `wget url`             | `Invoke-WebRequest url -OutFile file`                   |
+| Environment vars       | `env`                  | `Get-ChildItem env:` or `ls env:`                       |
+| Which/type             | `which cmd`            | `Get-Command cmd` or `gcm cmd`                          |
+| Exit code              | `$?`                   | `$LASTEXITCODE` (external) or `$?` (cmdlet)             |
+| Source file            | `. file.sh`            | `. .\file.ps1`                                          |
+| Background job         | `cmd &`                | `Start-Job { cmd }` or `cmd &`                          |
+
+## Pipelines
+
+```powershell
+# Pipe OBJECTS, not text
+Get-ChildItem | Where-Object { $_.Length -gt 1MB } | Sort-Object Length -Descending
+
+# $_ is the current pipeline object
+Get-Process | Where-Object { $_.WorkingSet -gt 100MB } | Select-Object Name, Id, WorkingSet
+
+# Simplified Where-Object syntax (PS 3.0+)
+Get-Process | Where-Object WorkingSet -gt 100MB
+
+# ForEach-Object for iteration
+1..10 | ForEach-Object { $_ * 2 }
+ls *.txt | ForEach-Object { "Processing $_" }
+
+# Multi-line pipelines use backtick ` (not recommended) or pipe at line end
+Get-ChildItem |
+    Where-Object Length -gt 1MB |
+    Sort-Object Name
+```
+
+## Filtering and Selecting
+
+```powershell
+# Where-Object — filter objects
+Get-Process | Where-Object { $_.CPU -gt 10 }
+Get-ChildItem | Where-Object Name -like "*.txt"
+
+# Select-Object — pick properties or limit rows
+Get-Process | Select-Object Name, Id, CPU
+Get-Process | Select-Object -First 5
+Get-Process | Select-Object -Last 10
+Get-Process | Select-Object -Skip 5 -First 5
+
+# Select-String — grep equivalent for text
+Select-String -Path "*.log" -Pattern "ERROR"
+Get-Content file.txt | Select-String "pattern"
+```
+
+## Common Patterns
+
+```powershell
+# Find files modified in last 7 days
+Get-ChildItem -Recurse | Where-Object { $_.LastWriteTime -gt (Get-Date).AddDays(-7) }
+
+# Count lines of all .rs files
+Get-ChildItem -Recurse -Filter *.rs | Get-Content | Measure-Object -Line
+
+# Find large files
+Get-ChildItem -Recurse | Where-Object Length -gt 10MB | Sort-Object Length -Descending
+
+# Delete all .tmp files recursively
+Get-ChildItem -Recurse -Filter *.tmp | Remove-Item
+
+# Monitor a log file (like tail -f)
+Get-Content -Path "app.log" -Tail 20 -Wait
+
+# Check if command succeeded
+if ($?) { "Success" } else { "Failed (exit code: $LASTEXITCODE)" }
+
+# Loop with index
+$items = @("a", "b", "c")
+for ($i = 0; $i -lt $items.Count; $i++) {
+    "$($i): $($items[$i])"
+}
+
+# Create multiple files
+1..5 | ForEach-Object { New-Item -ItemType File -Name "file$_.txt" }
+
+# Parse JSON
+$data = Get-Content data.json | ConvertFrom-Json
+$data.items[0].name
+
+# Parse CSV
+$rows = Import-Csv data.csv
+$rows | Where-Object { $_.Status -eq "Active" }
+
+# Export to JSON/CSV
+Get-Process | Select-Object Name, Id | ConvertTo-Json | Out-File procs.json
+Get-Process | Select-Object Name, Id | Export-Csv procs.csv
+```
+
+## Scripting
+
+```powershell
+# Parameters
+param(
+    [string]$Name,
+    [int]$Count = 1,
+    [switch]$Force
+)
+
+# Functions
+function Get-Greeting {
+    param([string]$Name = "World")
+    "Hello, $Name!"
+}
+
+# If/else
+if ($value -gt 10) {
+    "Large"
+} elseif ($value -gt 5) {
+    "Medium"
+} else {
+    "Small"
+}
+
+# Switch
+switch ($color) {
+    "red"   { "Stop" }
+    "green" { "Go" }
+    default { "Unknown" }
+}
+
+# ForEach
+foreach ($item in $collection) {
+    "Item: $item"
+}
+
+# While
+while ($count -gt 0) {
+    $count--
+}
+
+# Try/catch
+try {
+    $result = 10 / 0
+} catch {
+    "Error: $_"
+} finally {
+    "Done"
+}
+```
+
+## Comparison Operators
+
+```powershell
+-eq         # Equal
+-ne         # Not equal
+-gt         # Greater than
+-lt         # Less than
+-ge         # Greater or equal
+-le         # Less or equal
+-like       # Wildcard match (*, ?)
+-notlike    # Wildcard non-match
+-match      # Regex match
+-notmatch   # Regex non-match
+-contains   # Collection contains value
+-in         # Value is in collection
+```
+
+## Key Gotchas
+
+1. **No `&&` or `||`** — use `;` or `if ($?) { ... }`
+2. **No `grep`/`sed`/`awk`** — use `Select-String`, `-replace`, `Where-Object`
+3. **`$_` is current pipeline object**, not `$it` or `$in`
+4. **Environment variables need `$env:` prefix** — `$env:PATH`, not `$PATH`
+5. **Comparison uses `-eq`, not `=` or `==`** — `if ($a -eq 5)`
+6. **Strings in double quotes** expand variables (`"Hello $name"`); single quotes don't
+7. **Case-insensitive by default** — `"HELLO" -eq "hello"` is `$true`
+8. **Backtick `` ` `` is escape/continuation**, not backslash
+9. **No `#!/bin/pwsh` shebang needed** for .ps1 files
+10. **`$LASTEXITCODE` for external programs**, `$?` for cmdlets
+11. **`Measure-Object` replaces `wc`** — use `-Line`, `-Word`, `-Character` parameters
+12. **No heredocs** — use here-strings: `@" ... "@` or `@' ... '@`


### PR DESCRIPTION
## Summary

Adds shell-format extension and three companion skills:

### `shell-format` extension
Detects the user's login shell (Nushell, Fish, Zsh, PowerShell, etc.) and injects instructions into the system prompt so the LLM formats all shell commands in the user's **native shell dialect** rather than defaulting to Bash.

### `nushell` skill
Comprehensive Nushell syntax reference covering variables, pipelines, tables, custom commands, control flow, Bash-to-Nu equivalents, and 12 key gotchas.

### `fish` skill
Comprehensive Fish shell syntax reference covering variables, command substitution, string manipulation, control flow, functions, and Bash-to-Fish equivalents.

### `pwsh` skill
Comprehensive PowerShell syntax reference covering cmdlets, objects, pipelines, filtering, comparison operators, and Bash-to-PowerShell command equivalents.

Closes #TBD