### PR TITLE
fix(subagents): wrap artifact paths instead of truncating in TUI

### DIFF
--- a/packages/subagents/render.ts
+++ b/packages/subagents/render.ts
@@ -278,9 +278,10 @@ export function renderSubagentResult(
 
 		if (r.artifactPaths) {
 			c.addChild(new Spacer(1));
-			c.addChild(
-				new Text(truncLine(theme.fg("dim", `Artifacts: ${shortenPath(r.artifactPaths.outputPath)}`), w), 0, 0),
-			);
+			const artifactLabel = theme.fg("dim", `Artifacts: ${shortenPath(r.artifactPaths.outputPath)}`);
+			// Wrap instead of truncate so the full path is always visible
+			const wrapped = wrapTextWithAnsi(artifactLabel, w);
+			c.addChild(new Text(wrapped.join("\n"), 0, 0));
 		}
 		return c;
 	}
@@ -469,7 +470,10 @@ export function renderSubagentResult(
 
 	if (d.artifacts) {
 		c.addChild(new Spacer(1));
-		c.addChild(new Text(truncLine(theme.fg("dim", `Artifacts dir: ${shortenPath(d.artifacts.dir)}`), w), 0, 0));
+		const artifactLabel = theme.fg("dim", `Artifacts dir: ${shortenPath(d.artifacts.dir)}`);
+		// Wrap instead of truncate so the full path is always visible
+		const wrapped = wrapTextWithAnsi(artifactLabel, w);
+		c.addChild(new Text(wrapped.join("\n"), 0, 0));
 	}
 	return c;
 }


### PR DESCRIPTION
## Problem

Subagent artifact paths are hard-truncated in the TUI result view by `truncLine()`. When the path is long (e.g. iCloud Drive, Dropbox, or other nested directories), the ellipsis cuts off the actual path, making it impossible to navigate to the artifacts directory.

```
Artifacts: ~/.pi/agent/sessions/--Users-ironin-Library-CloudStorage-Dropbox-Didi…
```

## Fix

Replace `truncLine()` with `wrapTextWithAnsi()` (already imported from `@earendil-works/pi-tui`) for both artifact path lines in `renderSubagentResult()`:

- Single-result: `Artifacts: <path>`
- Multi-step/chain: `Artifacts dir: <dir>`

Short paths render identically (single line). Long paths wrap to the next line instead of being cut off.

## Diff

```diff
--- a/packages/subagents/render.ts
+++ b/packages/subagents/render.ts
@@ -309,9 +309,10 @@ export function renderSubagentResult(
 \t\tif (r.artifactPaths) {
 \t\t\tc.addChild(new Spacer(1));
-\t\t\tc.addChild(
-\t\t\t\tnew Text(truncLine(theme.fg("dim", `Artifacts: ${shortenPath(r.artifactPaths.outputPath)}`), w), 0, 0),
-\t\t\t);
+\t\t\tconst artifactLabel = theme.fg("dim", `Artifacts: ${shortenPath(r.artifactPaths.outputPath)}`);
+\t\t\tconst wrapped = wrapTextWithAnsi(artifactLabel, w);
+\t\t\tc.addChild(new Text(wrapped.join("\n"), 0, 0));
 \t\t}
 \t\treturn c;
 \t}
@@ -511,7 +512,10 @@ export function renderSubagentResult(
 \tif (d.artifacts) {
 \t\tc.addChild(new Spacer(1));
-\t\tc.addChild(new Text(truncLine(theme.fg("dim", `Artifacts dir: ${shortenPath(d.artifacts.dir)}`), w), 0, 0));
+\t\tconst artifactLabel = theme.fg("dim", `Artifacts dir: ${shortenPath(d.artifacts.dir)}`);
+\t\tconst wrapped = wrapTextWithAnsi(artifactLabel, w);
+\t\tc.addChild(new Text(wrapped.join("\n"), 0, 0));
 \t}
 \treturn c;
 }
```

Closes #318