### PR TITLE
fix(ollama): prefix OLLAMA_API_KEY with $ in registerProvider apiKey

### DIFF
--- a/.changeset/ollama-cloud-api-key-dollar-prefix.md
+++ b/.changeset/ollama-cloud-api-key-dollar-prefix.md
@@ -1,0 +1,9 @@
+---
+default: patch
+---
+
+Fix `registerProvider("ollama-cloud")` legacy env var deprecation warning
+
+Pass `$OLLAMA_API_KEY` (with `$` prefix) instead of bare `OLLAMA_API_KEY`
+as the apiKey value to `registerProvider`, matching Pi's new config value
+syntax for environment variable references.

--- a/packages/ollama/index.ts
+++ b/packages/ollama/index.ts
@@ -127,7 +127,7 @@ function registerOllamaLocalProvider(pi: ExtensionAPI): void {
 function registerOllamaCloudProvider(pi: ExtensionAPI): void {
 	pi.registerProvider(OLLAMA_CLOUD_PROVIDER, {
 		api: OLLAMA_API,
-		apiKey: OLLAMA_CLOUD_API_KEY_ENV,
+		apiKey: `$${OLLAMA_CLOUD_API_KEY_ENV}`,
 		baseUrl: getOllamaCloudRuntimeConfig().apiUrl,
 		oauth: createOllamaCloudOAuthProvider(() => cloudEnvDiscoveryState.models),
 		models: toProviderModels(cloudEnvDiscoveryState.models),


### PR DESCRIPTION
## Problem

Pi emits a deprecation warning for `registerProvider("ollama-cloud")`:

```
Deprecation warning: registerProvider("ollama-cloud") apiKey value "OLLAMA_API_KEY" 
is treated as a legacy environment variable reference. Pass "$OLLAMA_API_KEY" instead.
```

This is the same class of issue as #321 (fixed for the provider-catalog package), but the `ollama` extension has its own `registerProvider` call that passes the bare env var name `"OLLAMA_API_KEY"` without the `$` prefix.

## Fix

In `packages/ollama/index.ts`, line 130, change:

```ts
apiKey: OLLAMA_CLOUD_API_KEY_ENV,  // was "OLLAMA_API_KEY"
```

to:

```ts
apiKey: `$${OLLAMA_CLOUD_API_KEY_ENV}`,  // now "$OLLAMA_API_KEY"
```

The `OLLAMA_CLOUD_API_KEY_ENV` constant is still used bare for `process.env[]` lookups elsewhere (correct), but when passed as an `apiKey` to `registerProvider` it now uses the `$` prefix convention.

Also includes the `@vitest/browser` 4.1.8 bump from #322 to fix GHSA-2h32-95rg-cppp.