### PR TITLE
fix(usage-tracker): make dashboard overlay closable with Escape and toggle

### DIFF
--- a/.changeset/fix-usage-overlay-escape-and-toggle.md
+++ b/.changeset/fix-usage-overlay-escape-and-toggle.md
@@ -1,0 +1,16 @@
+---
+default: patch
+---
+
+Fix usage dashboard overlay not closable with Escape key
+
+The usage dashboard overlay (`/usage` and `Ctrl+Shift+U`) was impossible
+to close because `handleInput` matched raw `\x1B` which is also the start
+of multi-byte terminal sequences (arrow keys, etc.).
+
+Changes:
+- Use `keybindings.matches(data, "tui.select.cancel")` instead of raw
+  `\x1B` comparison for Escape detection (matching btw overlay pattern)
+- Support toggle: pressing `Ctrl+Shift+U` (or `/usage`) while the overlay
+  is open now closes it instead of opening a second overlay
+- Track overlay handle via `onHandle` callback for visibility control

--- a/packages/extensions/extensions/usage-tracker.test.ts
+++ b/packages/extensions/extensions/usage-tracker.test.ts
@@ -1750,10 +1750,7 @@ describe("usage-tracker extension", () => {
 			);
 
 			await runWithTimers(() => pi._commands.get("usage").handler("", ctx));
-			expect(ctx.ui.custom).toHaveBeenCalledWith(
-				expect.any(Function),
-				expect.objectContaining({ overlay: true }),
-			);
+			expect(ctx.ui.custom).toHaveBeenCalledWith(expect.any(Function), expect.objectContaining({ overlay: true }));
 
 			const rendererFactory = (ctx.ui.custom as ReturnType<typeof vi.fn>).mock.calls[0][0] as (...args: unknown[]) => {
 				render: (width: number) => string[];
@@ -1827,10 +1824,7 @@ describe("usage-tracker extension", () => {
 					expect.stringContaining("OpenAI"),
 				]),
 			);
-			expect(ctx.ui.custom).toHaveBeenCalledWith(
-				expect.any(Function),
-				expect.objectContaining({ overlay: true }),
-			);
+			expect(ctx.ui.custom).toHaveBeenCalledWith(expect.any(Function), expect.objectContaining({ overlay: true }));
 
 			const rendererFactory = (ctx.ui.custom as ReturnType<typeof vi.fn>).mock.calls[0][0] as (...args: unknown[]) => {
 				render: (width: number) => string[];
@@ -1858,10 +1852,7 @@ describe("usage-tracker extension", () => {
 			await runWithTimers(() => pi._commands.get("usage").handler("claude", ctx));
 
 			expect(ctx.ui.select).not.toHaveBeenCalled();
-			expect(ctx.ui.custom).toHaveBeenCalledWith(
-				expect.any(Function),
-				expect.objectContaining({ overlay: true }),
-			);
+			expect(ctx.ui.custom).toHaveBeenCalledWith(expect.any(Function), expect.objectContaining({ overlay: true }));
 		});
 
 		it("surfaces recently viewed providers in the picker", async () => {

--- a/packages/extensions/extensions/usage-tracker.test.ts
+++ b/packages/extensions/extensions/usage-tracker.test.ts
@@ -370,7 +370,7 @@ describe("usage-tracker extension", () => {
 		it("registers ctrl+shift+u shortcut (overrides built-in deleteToLineStart)", () => {
 			usageTracker(pi as any);
 			expect(pi._shortcuts.has("ctrl+shift+u")).toBe(true);
-			expect(pi._shortcuts.get("ctrl+shift+u").description).toContain("rate limits");
+			expect(pi._shortcuts.get("ctrl+shift+u").description).toContain("Toggle usage dashboard");
 		});
 
 		it("does not load persisted history or rate-limit cache during registration", () => {
@@ -1750,9 +1750,10 @@ describe("usage-tracker extension", () => {
 			);
 
 			await runWithTimers(() => pi._commands.get("usage").handler("", ctx));
-			expect(ctx.ui.custom).toHaveBeenCalledWith(expect.any(Function), {
-				overlay: true,
-			});
+			expect(ctx.ui.custom).toHaveBeenCalledWith(
+				expect.any(Function),
+				expect.objectContaining({ overlay: true }),
+			);
 
 			const rendererFactory = (ctx.ui.custom as ReturnType<typeof vi.fn>).mock.calls[0][0] as (...args: unknown[]) => {
 				render: (width: number) => string[];
@@ -1826,9 +1827,10 @@ describe("usage-tracker extension", () => {
 					expect.stringContaining("OpenAI"),
 				]),
 			);
-			expect(ctx.ui.custom).toHaveBeenCalledWith(expect.any(Function), {
-				overlay: true,
-			});
+			expect(ctx.ui.custom).toHaveBeenCalledWith(
+				expect.any(Function),
+				expect.objectContaining({ overlay: true }),
+			);
 
 			const rendererFactory = (ctx.ui.custom as ReturnType<typeof vi.fn>).mock.calls[0][0] as (...args: unknown[]) => {
 				render: (width: number) => string[];
@@ -1856,9 +1858,10 @@ describe("usage-tracker extension", () => {
 			await runWithTimers(() => pi._commands.get("usage").handler("claude", ctx));
 
 			expect(ctx.ui.select).not.toHaveBeenCalled();
-			expect(ctx.ui.custom).toHaveBeenCalledWith(expect.any(Function), {
-				overlay: true,
-			});
+			expect(ctx.ui.custom).toHaveBeenCalledWith(
+				expect.any(Function),
+				expect.objectContaining({ overlay: true }),
+			);
 		});
 
 		it("surfaces recently viewed providers in the picker", async () => {
@@ -1902,6 +1905,56 @@ describe("usage-tracker extension", () => {
 
 			const pickerOptions = (ctx.ui.select as ReturnType<typeof vi.fn>).mock.calls[0]?.[1] as string[];
 			expect(pickerOptions).toEqual(expect.arrayContaining([expect.stringContaining("OpenAI — recently viewed")]));
+		});
+
+		it("closes overlay with Escape via keybindings (tui.select.cancel)", async () => {
+			mockFetch.mockResolvedValue(
+				makeFetchResponse({
+					body: {
+						five_hour: {
+							utilization: 58,
+							resets_at: new Date(Date.now() + 45_000).toISOString(),
+						},
+						seven_day: {
+							utilization: 21,
+							resets_at: new Date(Date.now() + 100_000).toISOString(),
+						},
+					},
+				}),
+			);
+
+			usageTracker(pi as any);
+			pi._emit("session_start", { type: "session_start" }, ctx);
+			vi.advanceTimersByTime(15_000);
+			pi._emit(
+				"turn_end",
+				{
+					type: "turn_end",
+					turnIndex: 1,
+					message: makeAssistantMessage({ costTotal: 0.015 }),
+					toolResults: [],
+				},
+				ctx,
+			);
+
+			await runWithTimers(() => pi._commands.get("usage").handler("openai", ctx));
+
+			const factory = (ctx.ui.custom as ReturnType<typeof vi.fn>).mock.calls[0][0] as (
+				...args: unknown[]
+			) => Component & { handleInput: (data: string) => void };
+			const mockKeybindings = {
+				matches: vi.fn((_data: string, _action: string) => false),
+			};
+			const component = factory(
+				{ requestRender: vi.fn() },
+				{ fg: (_color: string, text: string) => text },
+				mockKeybindings,
+				vi.fn(),
+			);
+
+			// Escape key should be delegated to keybindings.matches
+			component.handleInput("\x1b");
+			expect(mockKeybindings.matches).toHaveBeenCalledWith("\x1b", "tui.select.cancel");
 		});
 	});
 

--- a/packages/extensions/extensions/usage-tracker.ts
+++ b/packages/extensions/extensions/usage-tracker.ts
@@ -27,9 +27,9 @@ Key usage-tracker surfaces:
 <!-- {/extensionsUsageTrackerCommandsDocs} -->
 */
 
+import type { OverlayHandle } from "@earendil-works/pi-tui";
 import type { AssistantMessage } from "@mariozechner/pi-ai";
 import type { ExtensionAPI, ExtensionContext } from "@mariozechner/pi-coding-agent";
-import type { OverlayHandle } from "@earendil-works/pi-tui";
 
 import { getAgentDir } from "@mariozechner/pi-coding-agent";
 import { Type } from "@sinclair/typebox";
@@ -814,11 +814,11 @@ export default function usageTracker(pi: ExtensionAPI) {
 				},
 			)
 			.then(() => {
-					usageOverlayHandle = null;
-				})
-				.catch(() => {
-						usageOverlayHandle = null;
-					});
+				usageOverlayHandle = null;
+			})
+			.catch(() => {
+				usageOverlayHandle = null;
+			});
 	}
 
 	function recordUsageSample(sample: UsageSample, options: { persist?: boolean } = {}): void {

--- a/packages/extensions/extensions/usage-tracker.ts
+++ b/packages/extensions/extensions/usage-tracker.ts
@@ -29,6 +29,7 @@ Key usage-tracker surfaces:
 
 import type { AssistantMessage } from "@mariozechner/pi-ai";
 import type { ExtensionAPI, ExtensionContext } from "@mariozechner/pi-coding-agent";
+import type { OverlayHandle } from "@earendil-works/pi-tui";
 
 import { getAgentDir } from "@mariozechner/pi-coding-agent";
 import { Type } from "@sinclair/typebox";
@@ -232,6 +233,7 @@ export default function usageTracker(pi: ExtensionAPI) {
 	let widgetVisible = true;
 	/** Last provider explicitly opened in the usage dashboard. */
 	let lastSelectedUsageProvider: ProviderKey | null = null;
+	let usageOverlayHandle: OverlayHandle | null = null;
 	/** Cached rate limit probes. */
 	const rateLimits = new Map<string, ProviderRateLimits>();
 	/** Last probe timestamp per provider (for cooldown). */
@@ -773,26 +775,50 @@ export default function usageTracker(pi: ExtensionAPI) {
 	}
 
 	async function openUsageOverlay(ctx: ExtensionContext, provider: ProviderKey | null): Promise<void> {
+		// If overlay is already open, close it (toggle behavior)
+		if (usageOverlayHandle) {
+			usageOverlayHandle.hide();
+			usageOverlayHandle = null;
+			return;
+		}
+
 		lastSelectedUsageProvider = provider;
 
-		await ctx.ui.custom(
-			(_tui, theme, _keybindings, done) => {
-				const lines = generateRichReport(ctx, theme, provider);
-				return {
-					render(width: number) {
-						return lines.map((line) => truncateAnsi(line, width));
+		void ctx.ui
+			.custom<void>(
+				(_tui, theme, keybindings, done) => {
+					const lines = generateRichReport(ctx, theme, provider);
+					return {
+						render(width: number) {
+							return lines.map((line) => truncateAnsi(line, width));
+						},
+						handleInput(data: string) {
+							if (
+								data === "q" ||
+								data === " " ||
+								data === "\r" ||
+								keybindings.matches(data, "tui.select.cancel" as never)
+							) {
+								done();
+							}
+						},
+						// Biome-ignore lint/suspicious/noEmptyBlockStatements: required by Component interface
+						dispose() {},
+					};
+				},
+				{
+					overlay: true,
+					onHandle: (handle) => {
+						usageOverlayHandle = handle;
 					},
-					handleInput(data: string) {
-						if (data === "q" || data === "\x1B" || data === "\r" || data === " ") {
-							done();
-						}
-					},
-					// Biome-ignore lint/suspicious/noEmptyBlockStatements: required by Component interface
-					dispose() {},
-				};
-			},
-			{ overlay: true },
-		);
+				},
+			)
+			.then(() => {
+					usageOverlayHandle = null;
+				})
+				.catch(() => {
+						usageOverlayHandle = null;
+					});
 	}
 
 	function recordUsageSample(sample: UsageSample, options: { persist?: boolean } = {}): void {
@@ -1891,7 +1917,7 @@ export default function usageTracker(pi: ExtensionAPI) {
 	// ─── Keyboard shortcut ────────────────────────────────────────────────
 
 	pi.registerShortcut("ctrl+shift+u", {
-		description: "Show usage dashboard with current-provider rate limits and costs",
+		description: "Toggle usage dashboard overlay",
 		async handler(ctx) {
 			await loadPersistedState();
 			triggerProbeAll(true);


### PR DESCRIPTION
## Problem

The usage dashboard overlay (opened via `/usage` or `Ctrl+Shift+U`) could not be closed with the Escape key. Once opened, the overlay was stuck — no way to dismiss it.

## Root Cause

The `handleInput` method compared raw `data === "\x1B"` for Escape. In terminal protocols, `\x1B` is also the start byte of multi-character sequences (arrow keys, Page Up, etc.), so this raw comparison would either:
- Never match (if the terminal sent `\x1B` as part of a longer sequence)
- Or incorrectly close the overlay on arrow key presses

## Fix

1. **Escape key**: Replaced raw `\x1B` check with `keybindings.matches(data, "tui.select.cancel")` — the same pattern used by the `btw` overlay. This properly handles Escape vs. other escape sequences.

2. **Toggle behavior**: Added `onHandle` callback to track the overlay handle. When `/usage` or `Ctrl+Shift+U` is triggered while the overlay is already open, it now closes (toggles off) instead of opening a duplicate.

3. **Updated shortcut description**: Changed from "Show usage dashboard with current-provider rate limits and costs" to "Toggle usage dashboard overlay".