### PR TITLE
chore(changeset): remove session resume hint label

### DIFF
--- a/.changeset/remove-session-resume-hint.md
+++ b/.changeset/remove-session-resume-hint.md
@@ -2,8 +2,4 @@
 default: patch
 ---
 
-# Remove session resume hint messages
-
-## Fixed
-
-- Stopped the auto session name extension from emitting `[session-resume-hint]` messages during session switch and shutdown events.
+Removed the auto session name extension's session switch and shutdown hint messages now that pi provides session resume guidance internally.


### PR DESCRIPTION
## Summary
- remove the old custom session resume hint label from the pending changeset text
- cleaned the persisted monopi session file so the old custom message no longer appears in this resumed session

## Validation
- pnpm format:check
- pnpm mdt check