### PR TITLE
fix(extensions): increase MAX_DETAIL_DEPTH to 6 to preserve todo task objects

### DIFF
--- a/packages/extensions/extensions/tool-metadata.test.ts
+++ b/packages/extensions/extensions/tool-metadata.test.ts
@@ -77,6 +77,51 @@ describe("tool-metadata extension", () => {
 		expect(patch.details.outputGuard).toEqual(expect.objectContaining({ detailsSanitized: true }));
 	});
 
+	it("preserves todo tool phase/task structure through details sanitization (depth regression)", async () => {
+		// Regression: MAX_DETAIL_DEPTH was 4, which truncated task objects at depth 4:
+		//   details(0) → phases(1) → phase(2) → tasks(3) → task(4) ← "[depth-truncated]"
+		// After sanitization the AgentSession would call setTodoPhases with tasks that are
+		// strings, causing task.content === undefined on every subsequent call.
+		const harness = createExtensionHarness();
+		toolMetadataExtension(harness.pi as never);
+
+		const todoDetails = {
+			phases: [
+				{
+					name: "Tasks",
+					tasks: [
+						{ content: "Task one", status: "in_progress" },
+						{ content: "Task two", status: "pending" },
+					],
+				},
+			],
+			storage: "memory",
+		};
+
+		const [patch] = await harness.emitAsync(
+			"tool_result",
+			{
+				toolCallId: "todo-1",
+				toolName: "todo",
+				input: { ops: [{ op: "init" }] },
+				content: [{ type: "text", text: "2 tasks" }],
+				details: todoDetails,
+			},
+			harness.ctx,
+		);
+
+		const phases = (patch.details as typeof todoDetails).phases;
+		expect(phases).toHaveLength(1);
+		// Tasks must be objects, not the "[depth-truncated]" string.
+		const tasks = phases[0].tasks;
+		expect(tasks).toHaveLength(2);
+		expect(typeof tasks[0]).toBe("object");
+		expect(tasks[0].content).toBe("Task one");
+		expect(tasks[0].status).toBe("in_progress");
+		expect(tasks[1].content).toBe("Task two");
+		expect(tasks[1].status).toBe("pending");
+	});
+
 	it("builds visible completion metadata for tool results", async () => {
 		const harness = createExtensionHarness();
 		harness.ctx.getContextUsage = vi

--- a/packages/extensions/extensions/tool-metadata.ts
+++ b/packages/extensions/extensions/tool-metadata.ts
@@ -31,7 +31,7 @@ const MAX_TEXT_LINE_CHARS = 2000;
 const MAX_TEXT_LINES = 2000;
 const OUTPUT_GUARD_NOTE = "\n[tool output truncated for UI safety]";
 const MAX_DETAIL_FIELDS = 256;
-const MAX_DETAIL_DEPTH = 4;
+const MAX_DETAIL_DEPTH = 6;
 
 function pad(value: number): string {
 	return `${value}`.padStart(2, "0");


### PR DESCRIPTION
Fixes #332.

## What changed

Raised `MAX_DETAIL_DEPTH` from `4` to `6` in `packages/extensions/extensions/tool-metadata.ts`.

Strings bypass the depth check via the early `typeof === 'string'` branch, so no string field is ever truncated regardless of depth.

## Before / After

```
// Before
tasks: ["[depth-truncated]", "[depth-truncated]"]
task.content → undefined
task.status  → undefined

// After
tasks: [{ content: "Task one", status: "in_progress" }, ...]
task.content → "Task one"
task.status  → "in_progress"
```

## Testing

Added a regression test that constructs a todo-shaped `details` payload (phases → phase → tasks → task) and asserts both `content` and `status` survive sanitization as typed values, not the truncation sentinel.