### PR TITLE
fix: resolve obvious issue triage bugs

### DIFF
--- a/.changeset/triage-obvious-issues.md
+++ b/.changeset/triage-obvious-issues.md
@@ -1,0 +1,5 @@
+---
+default: patch
+---
+
+Fix several triaged issues: preserve nested todo tool task fields in metadata sanitization, include labels in worktree completions, wrap subagent artifact paths instead of truncating them, keep watchdog loading safe when event-loop histograms are unavailable, avoid compact-header stale render reads, and clean up analytics dashboard config imports.

--- a/packages/monopi__analytics-dashboard/vite.config.ts
+++ b/packages/monopi__analytics-dashboard/vite.config.ts
@@ -1,8 +1,7 @@
 /* C8 ignore file */
 import tailwindcss from "@tailwindcss/vite";
 import react from "@vitejs/plugin-react";
-import { dirname, resolve } from "node:path";
-import { fileURLToPath } from "node:url";
+import { resolve } from "node:path";
 import { defineConfig } from "vite";
 
 const __dirname = import.meta.dirname;

--- a/packages/monopi__analytics-dashboard/vitest.config.ts
+++ b/packages/monopi__analytics-dashboard/vitest.config.ts
@@ -1,7 +1,6 @@
 import tailwindcss from "@tailwindcss/vite";
 import react from "@vitejs/plugin-react";
-import { dirname, resolve } from "node:path";
-import { fileURLToPath } from "node:url";
+import { resolve } from "node:path";
 import { defineConfig } from "vitest/config";
 
 const __dirname = import.meta.dirname;

--- a/packages/monopi__extension-compact-header/index.ts
+++ b/packages/monopi__extension-compact-header/index.ts
@@ -98,6 +98,22 @@ export default function (pi: ExtensionAPI) {
 		ctx.ui.setHeader((tui, theme) => {
 			const unsubSafeMode = subscribeSafeMode(() => tui.requestRender());
 			const commandCatalog = buildCommandCatalog(pi.getCommands());
+			let model = "no model";
+			let provider = "";
+			let thinking = "default";
+			try {
+				const m = ctx.model;
+				model = m ? `${m.id}` : "no model";
+				provider = m?.provider ?? "";
+			} catch {
+				model = "no model";
+				provider = "";
+			}
+			try {
+				thinking = pi.getThinkingLevel();
+			} catch {
+				thinking = "default";
+			}
 			return {
 				dispose() {
 					unsubSafeMode();
@@ -109,18 +125,7 @@ export default function (pi: ExtensionAPI) {
 					const d = (s: string) => theme.fg("dim", s);
 					const a = (s: string) => theme.fg("accent", s);
 
-					let model: string;
-					let provider: string;
-					try {
-						const m = ctx.model;
-						model = m ? `${m.id}` : "no model";
-						provider = m?.provider ?? "";
-					} catch {
-						model = "no model";
-						provider = "";
-					}
 					const { prompts, skills } = commandCatalog;
-					const thinking = pi.getThinkingLevel();
 
 					const pad = (s: string, w: number) => s + " ".repeat(Math.max(0, w - visibleWidth(s)));
 					const t = (s: string) => truncateToWidth(s, width);

--- a/packages/monopi__extension-compact-header/tests/compact-header.test.ts
+++ b/packages/monopi__extension-compact-header/tests/compact-header.test.ts
@@ -101,6 +101,7 @@ describe("compact-header plain-icons bootstrap", () => {
 		const harness = createExtensionHarness();
 		const setHeader = vi.fn();
 		(harness.ctx.ui as { setHeader: typeof setHeader }).setHeader = setHeader;
+		harness.pi.getThinkingLevel = vi.fn(() => "default") as never;
 		harness.pi.getCommands = vi.fn(() => [
 			{ name: "optimize", source: "prompt" },
 			{ name: "review", source: "prompt" },
@@ -124,9 +125,14 @@ describe("compact-header plain-icons bootstrap", () => {
 				fg: (_color: string, text: string) => text,
 			},
 		);
+		expect(harness.pi.getThinkingLevel).toHaveBeenCalledTimes(1);
+		harness.pi.getThinkingLevel = vi.fn(() => {
+			throw new Error("This extension instance is stale after session replacement or reload");
+		}) as never;
 		component?.render(120);
 		component?.render(120);
 
 		expect(harness.pi.getCommands).toHaveBeenCalledTimes(1);
+		expect(harness.pi.getThinkingLevel).not.toHaveBeenCalled();
 	});
 });

--- a/packages/monopi__extension-tool-metadata/index.ts
+++ b/packages/monopi__extension-tool-metadata/index.ts
@@ -31,7 +31,7 @@ const MAX_TEXT_LINE_CHARS = 2000;
 const MAX_TEXT_LINES = 2000;
 const OUTPUT_GUARD_NOTE = "\n[tool output truncated for UI safety]";
 const MAX_DETAIL_FIELDS = 256;
-const MAX_DETAIL_DEPTH = 4;
+const MAX_DETAIL_DEPTH = 6;
 
 function pad(value: number): string {
 	return `${value}`.padStart(2, "0");

--- a/packages/monopi__extension-tool-metadata/tests/tool-metadata.test.ts
+++ b/packages/monopi__extension-tool-metadata/tests/tool-metadata.test.ts
@@ -54,6 +54,36 @@ describe("tool-metadata extension", () => {
 		expect(patch.content[0].text).not.toContain("\u0000");
 	});
 
+	it("preserves todo task fields nested in tool details", async () => {
+		const harness = createExtensionHarness();
+		toolMetadataExtension(harness.pi as never);
+
+		const [patch] = await harness.emitAsync(
+			"tool_result",
+			{
+				toolCallId: "tool-todo",
+				toolName: "todo",
+				input: {},
+				content: [{ type: "text", text: "updated todos" }],
+				details: {
+					phases: [
+						{
+							tasks: [
+								{ content: "Task one", status: "in_progress" },
+								{ content: "Task two", status: "pending" },
+							],
+						},
+					],
+				},
+			},
+			harness.ctx,
+		);
+
+		const phases = patch.details.phases as { tasks: { content: string; status: string }[] }[];
+		expect(phases[0].tasks[0]).toMatchObject({ content: "Task one", status: "in_progress" });
+		expect(phases[0].tasks[1]).toMatchObject({ content: "Task two", status: "pending" });
+	});
+
 	it("sanitizes oversized details payloads used by fallback renderers", async () => {
 		const harness = createExtensionHarness();
 		toolMetadataExtension(harness.pi as never);

--- a/packages/monopi__extension-watchdog/index.ts
+++ b/packages/monopi__extension-watchdog/index.ts
@@ -46,6 +46,36 @@ const STARTUP_CONFIG_LOAD_DELAY_MS = 250;
 const STARTUP_WARMUP_SAMPLE_COUNT = 1;
 const STALE_SAMPLE_MIN_ELAPSED_MS = 60_000;
 const STALE_SAMPLE_MIN_LAG_MS = 30_000;
+
+interface EventLoopHistogram {
+	readonly max: number;
+	readonly mean: number;
+	disable(): void;
+	enable(): void;
+	percentile(percentile: number): number;
+	reset(): void;
+}
+
+function createNoopEventLoopHistogram(): EventLoopHistogram {
+	return {
+		disable() {},
+		enable() {},
+		max: 0,
+		mean: 0,
+		percentile() {
+			return 0;
+		},
+		reset() {},
+	};
+}
+
+function createEventLoopHistogram(): EventLoopHistogram {
+	try {
+		return monitorEventLoopDelay({ resolution: HISTOGRAM_RESOLUTION_MS });
+	} catch {
+		return createNoopEventLoopHistogram();
+	}
+}
 /**
 <!-- {=extensionsWatchdogConfigPathDocs} -->
 
@@ -419,9 +449,7 @@ export default function watchdogExtension(pi: ExtensionAPI) {
 	installRuntimeDiagnostics(pi);
 	let thresholds = DEFAULT_WATCHDOG_THRESHOLDS;
 	let sampleIntervalMs = DEFAULT_SAMPLE_INTERVAL_MS;
-	const histogram = monitorEventLoopDelay({
-		resolution: HISTOGRAM_RESOLUTION_MS,
-	});
+	const histogram = createEventLoopHistogram();
 
 	const coreCount = Math.max(1, cpus().length || 1);
 	const sampleHistory: WatchdogSample[] = [];

--- a/packages/monopi__extension-watchdog/tests/watchdog.test.ts
+++ b/packages/monopi__extension-watchdog/tests/watchdog.test.ts
@@ -1,18 +1,21 @@
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 
-const { mockExistsSync, mockReadFileSync } = vi.hoisted(() => ({
-	mockExistsSync: vi.fn(() => false),
-	mockReadFileSync: vi.fn(),
-}));
-
-const histogram = {
-	enable: vi.fn(),
-	disable: vi.fn(),
-	reset: vi.fn(),
-	percentile: vi.fn(() => 0),
-	mean: 0,
-	max: 0,
-};
+const { histogram, mockExistsSync, mockMonitorEventLoopDelay, mockReadFileSync } = vi.hoisted(() => {
+	const histogram = {
+		enable: vi.fn(),
+		disable: vi.fn(),
+		reset: vi.fn(),
+		percentile: vi.fn(() => 0),
+		mean: 0,
+		max: 0,
+	};
+	return {
+		histogram,
+		mockExistsSync: vi.fn(() => false),
+		mockMonitorEventLoopDelay: vi.fn(() => histogram),
+		mockReadFileSync: vi.fn(),
+	};
+});
 
 vi.mock("node:fs", () => ({
 	existsSync: mockExistsSync,
@@ -20,7 +23,7 @@ vi.mock("node:fs", () => ({
 }));
 
 vi.mock("node:perf_hooks", () => ({
-	monitorEventLoopDelay: vi.fn(() => histogram),
+	monitorEventLoopDelay: mockMonitorEventLoopDelay,
 }));
 
 vi.mock("node:os", async (importOriginal) => {
@@ -140,6 +143,8 @@ beforeEach(() => {
 	histogram.mean = 0;
 	histogram.max = 0;
 	histogram.percentile.mockReturnValue(0);
+	mockMonitorEventLoopDelay.mockReset();
+	mockMonitorEventLoopDelay.mockReturnValue(histogram);
 	mockExistsSync.mockReset();
 	mockExistsSync.mockReturnValue(false);
 	mockReadFileSync.mockReset();
@@ -241,6 +246,26 @@ describe("watchdog helpers", () => {
 });
 
 describe("watchdog extension", () => {
+	it("falls back when event-loop histograms are unavailable", async () => {
+		mockMonitorEventLoopDelay.mockImplementation(() => {
+			throw new Error("Not implemented");
+		});
+		const pi = createMockPi();
+		const ctx = createMockCtx();
+
+		expect(() => watchdogExtension(pi as any)).not.toThrow();
+		mockCpuUsageSequence([
+			{ user: 0, system: 0 },
+			{ user: 0, system: 0 },
+		]);
+		mockMemoryUsage();
+
+		await pi._emit("session_start", {}, ctx);
+		await pi._commands.get("watchdog").handler("sample", ctx);
+
+		expect(ctx._statuses.get("watchdog")).toBeUndefined();
+	});
+
 	it("does not load watchdog config during extension registration", () => {
 		const pi = createMockPi();
 		watchdogExtension(pi as any);

--- a/packages/monopi__extension-worktree/index.ts
+++ b/packages/monopi__extension-worktree/index.ts
@@ -491,7 +491,9 @@ function buildCommandSpec(pi: ExtensionAPI) {
 			"Inspect or manage git worktrees: /worktree [status|list|open [target]|create <branch> [purpose]|cleanup <target|all>]",
 		getArgumentCompletions(prefix: string) {
 			const options = ["status", "list", "open", "create", "cleanup"];
-			return options.filter((value) => value.startsWith(prefix.trim().toLowerCase())).map((value) => ({ value }));
+			return options
+				.filter((value) => value.startsWith(prefix.trim().toLowerCase()))
+				.map((value) => ({ label: value, value }));
 		},
 		handler: async (args: string, ctx: ExtensionContext) => {
 			const trimmed = args.trim();

--- a/packages/monopi__extension-worktree/tests/worktree.test.ts
+++ b/packages/monopi__extension-worktree/tests/worktree.test.ts
@@ -65,6 +65,9 @@ describe("worktree extension", () => {
 		expect(harness.commands.has("worktree")).toBe(true);
 		expect(harness.commands.has("Worktree")).toBe(true);
 		expect(harness.commands.has("wt")).toBe(true);
+		expect(harness.commands.get("worktree")?.getArgumentCompletions?.("cl")).toEqual([
+			{ label: "cleanup", value: "cleanup" },
+		]);
 	});
 
 	it("does not probe or write worktree status on session start", () => {

--- a/packages/monopi__subagents/render.ts
+++ b/packages/monopi__subagents/render.ts
@@ -29,6 +29,12 @@ function getTermWidth(): number {
 	return process.stdout.columns || 120;
 }
 
+function addWrappedText(container: Container, text: string, width: number): void {
+	for (const line of wrapTextWithAnsi(text, width)) {
+		container.addChild(new Text(line, 0, 0));
+	}
+}
+
 // Grapheme segmenter for proper Unicode handling (shared instance)
 const segmenter = new Intl.Segmenter(undefined, { granularity: "grapheme" });
 
@@ -278,9 +284,7 @@ export function renderSubagentResult(
 
 		if (r.artifactPaths) {
 			c.addChild(new Spacer(1));
-			c.addChild(
-				new Text(truncLine(theme.fg("dim", `Artifacts: ${shortenPath(r.artifactPaths.outputPath)}`), w), 0, 0),
-			);
+			addWrappedText(c, theme.fg("dim", `Artifacts: ${shortenPath(r.artifactPaths.outputPath)}`), w);
 		}
 		return c;
 	}
@@ -469,7 +473,7 @@ export function renderSubagentResult(
 
 	if (d.artifacts) {
 		c.addChild(new Spacer(1));
-		c.addChild(new Text(truncLine(theme.fg("dim", `Artifacts dir: ${shortenPath(d.artifacts.dir)}`), w), 0, 0));
+		addWrappedText(c, theme.fg("dim", `Artifacts dir: ${shortenPath(d.artifacts.dir)}`), w);
 	}
 	return c;
 }

--- a/packages/monopi__subagents/tests/render.test.ts
+++ b/packages/monopi__subagents/tests/render.test.ts
@@ -279,6 +279,47 @@ describe("renderSubagentResult", () => {
 		expect(widget.children.some((child: any) => child.constructor.name === "Markdown")).toBe(true);
 	});
 
+	it("wraps single-result artifact paths without truncating them", () => {
+		const originalColumns = process.stdout.columns;
+		process.stdout.columns = 30;
+		const artifactPath = "/tmp/artifacts/super-long-output-path-that-must-remain-readable.md";
+
+		try {
+			const widget: any = renderSubagentResult(
+				{
+					content: [{ type: "text", text: "ok" }],
+					details: {
+						mode: "single",
+						results: [
+							{
+								agent: "scout",
+								task: "Inspect",
+								exitCode: 0,
+								messages: [],
+								artifactPaths: {
+									inputPath: "/tmp/input.md",
+									outputPath: artifactPath,
+									metadataPath: "/tmp/meta.json",
+									jsonlPath: "/tmp/run.jsonl",
+								},
+							},
+						],
+					},
+				} as never,
+				{ expanded: true },
+				createTheme() as never,
+			);
+			const textChildren = widget.children.map((child: any) => child.text).filter(Boolean);
+			const artifactIndex = textChildren.findIndex((text: string) => text.startsWith("Artifacts:"));
+			const artifactLines = textChildren.slice(artifactIndex);
+
+			expect(artifactLines.join("")).toBe(`Artifacts: ${artifactPath}`);
+			expect(artifactLines.join("\n")).not.toContain("…");
+		} finally {
+			process.stdout.columns = originalColumns;
+		}
+	});
+
 	it("renders chain results with chain visualization, pending steps, running details, and artifact dirs", () => {
 		const widget: any = renderSubagentResult(
 			{


### PR DESCRIPTION
## Summary
- preserve nested todo tool task details during tool metadata sanitization
- add labels to worktree completions
- wrap subagent artifact paths instead of truncating them
- fall back when watchdog event-loop histograms are unavailable
- avoid compact-header stale render reads
- clean up analytics dashboard config imports

## Validation
- pnpm exec vitest run packages/monopi__extension-tool-metadata/tests/tool-metadata.test.ts packages/monopi__extension-worktree/tests/worktree.test.ts packages/monopi__subagents/tests/render.test.ts packages/monopi__extension-watchdog/tests/watchdog.test.ts packages/monopi__extension-compact-header/tests/compact-header.test.ts
- pnpm format:check
- pnpm lint
- pnpm mc:check
- pnpm test
- pnpm typecheck

Closes #310
Closes #318
Closes #332