### PR TITLE
fix: preserve Cursor provider blobs across checkpoints

### DIFF
--- a/.changeset/cursor-provider-blob-store.md
+++ b/.changeset/cursor-provider-blob-store.md
@@ -1,0 +1,5 @@
+---
+default: patch
+---
+
+Fix Cursor provider conversation checkpoint persistence so saved sessions keep newly registered blobs for follow-up messages.

--- a/packages/monopi__provider-cursor/provider.ts
+++ b/packages/monopi__provider-cursor/provider.ts
@@ -407,12 +407,18 @@ function handleServerMessage(options: {
 			options.state.totalTokens = serverMessage.message.value.tokenDetails.usedTokens;
 		}
 		const checkpoint = toBinary(ConversationStateStructureSchema, serverMessage.message.value);
-		upsertConversationState(options.runtime.conversationKey, (current) => ({
-			conversationId: current?.conversationId ?? deterministicConversationId(options.runtime.conversationKey),
-			checkpoint,
-			blobStore: current?.blobStore ?? new Map(options.run.blobStore),
-			lastAccessMs: Date.now(),
-		}));
+		upsertConversationState(options.runtime.conversationKey, (current) => {
+			const blobStore = new Map(current?.blobStore ?? []);
+			for (const [blobId, blobData] of options.run.blobStore) {
+				blobStore.set(blobId, blobData);
+			}
+			return {
+				conversationId: current?.conversationId ?? deterministicConversationId(options.runtime.conversationKey),
+				checkpoint,
+				blobStore,
+				lastAccessMs: Date.now(),
+			};
+		});
 	}
 }
 

--- a/packages/monopi__provider-cursor/tests/provider-stream.test.ts
+++ b/packages/monopi__provider-cursor/tests/provider-stream.test.ts
@@ -518,6 +518,20 @@ describe("streamSimpleCursor", () => {
 		expect(providerMocks.sendRequestContextResult).toHaveBeenCalledTimes(1);
 		expect(providerMocks.sendExecResult).toHaveBeenCalledTimes(9);
 		expect(providerMocks.upsertConversationState).toHaveBeenCalledTimes(1);
+
+		const upsertCheckpoint = providerMocks.upsertConversationState.mock.calls[0]?.[1] as (current: {
+			conversationId: string;
+			blobStore: Map<string, Uint8Array>;
+			lastAccessMs: number;
+		}) => { conversationId: string; blobStore: Map<string, Uint8Array> };
+		const persisted = upsertCheckpoint({
+			conversationId: "saved-conv",
+			blobStore: new Map([["existing", new Uint8Array([9])]]),
+			lastAccessMs: 0,
+		});
+		expect(persisted.conversationId).toBe("saved-conv");
+		expect(Array.from(persisted.blobStore.keys()).sort()).toEqual(["blob", "existing"]);
+
 		expect(providerMocks.setActiveRun).toHaveBeenCalledWith(
 			"session:session-1:composer-2",
 			expect.objectContaining({


### PR DESCRIPTION
## Summary
- merge Cursor provider run blob stores into persisted conversation state on every checkpoint update
- keep existing conversation IDs/blob entries while preserving newly registered blobs for follow-up messages
- add regression coverage for saved checkpoint blob merging

Fixes #317.

## Validation
- pnpm exec vitest run packages/monopi__provider-cursor/tests/provider-stream.test.ts packages/monopi__provider-cursor/tests/provider.test.ts
- pnpm format:check
- pnpm lint
- pnpm mc:check
- pnpm typecheck
- pnpm test
- pnpm build