### PR TITLE
feat: configure subagent fan-out limits

### DIFF
--- a/.changeset/subagent-configurable-limits.md
+++ b/.changeset/subagent-configurable-limits.md
@@ -1,0 +1,9 @@
+---
+default: minor
+---
+
+# Make subagent fan-out limits configurable
+
+- Added configurable subagent `maxParallel` and `maxConcurrency` limits.
+- Environment variables (`PI_SUBAGENT_MAX_PARALLEL`, `PI_SUBAGENT_MAX_CONCURRENCY`) take precedence and can raise or lower limits.
+- User settings can raise or lower limits, while project `.pi/settings.json` values can only lower the built-in defaults.

--- a/packages/monopi__subagents/index.ts
+++ b/packages/monopi__subagents/index.ts
@@ -46,6 +46,7 @@ import { registerSubagentCommands } from "./command-registration.js";
 import { createDynamicAgent } from "./dynamic-agent.js";
 import { runSync } from "./execution.js";
 import { parseStringList, resolveExternalAgent } from "./external-agents.js";
+import { resolveSubagentLimits } from "./limits.js";
 import { resolveSubagentModelResolution, toAvailableModelRefs } from "./model-routing.js";
 import { renderSubagentResult, renderWidget } from "./render.js";
 import { recordRun } from "./run-history.js";
@@ -59,8 +60,6 @@ import {
 	checkSubagentDepth,
 	DEFAULT_ARTIFACT_CONFIG,
 	DEFAULT_MAX_OUTPUT,
-	MAX_CONCURRENCY,
-	MAX_PARALLEL,
 	RESULTS_DIR,
 	WIDGET_KEY,
 } from "./types.js";
@@ -296,6 +295,7 @@ MANAGEMENT (use action field — omit agent/task/chain/tasks):
 			const hasChain = (params.chain?.length ?? 0) > 0;
 			const hasTasks = (params.tasks?.length ?? 0) > 0;
 			const hasSingle = Boolean(params.agent && params.task);
+			const limits = await resolveSubagentLimits({ cwd: ctx.cwd });
 
 			const requestedAsync = params.async ?? asyncByDefault;
 			const parallelDowngraded = hasTasks && requestedAsync;
@@ -592,10 +592,10 @@ MANAGEMENT (use action field — omit agent/task/chain/tasks):
 			}
 
 			if (hasTasks && params.tasks) {
-				// MAX_PARALLEL check first (fail fast before TUI)
-				if (params.tasks.length > MAX_PARALLEL) {
+				// Limit check first (fail fast before TUI)
+				if (params.tasks.length > limits.maxParallel) {
 					return {
-						content: [{ type: "text", text: `Max ${MAX_PARALLEL} tasks` }],
+						content: [{ type: "text", text: `Max ${limits.maxParallel} tasks` }],
 						isError: true,
 						details: { mode: "parallel" as const, results: [] },
 					};
@@ -747,7 +747,7 @@ MANAGEMENT (use action field — omit agent/task/chain/tasks):
 				const behaviors = agentConfigs.map((c) => resolveStepBehavior(c, {}));
 				const liveResults: (SingleResult | undefined)[] = new Array(params.tasks.length).fill(undefined);
 				const liveProgress: (AgentProgress | undefined)[] = new Array(params.tasks.length).fill(undefined);
-				const results = await mapConcurrent(params.tasks, MAX_CONCURRENCY, async (t, i) => {
+				const results = await mapConcurrent(params.tasks, limits.maxConcurrency, async (t, i) => {
 					const overrideSkills = skillOverrides[i];
 					const effectiveSkills = overrideSkills === undefined ? behaviors[i]?.skills : overrideSkills;
 					return runSync(ctx.cwd, agents, t.agent, tasks[i]!, {

--- a/packages/monopi__subagents/limits.ts
+++ b/packages/monopi__subagents/limits.ts
@@ -1,0 +1,99 @@
+import fs from "node:fs/promises";
+import path from "node:path";
+
+import { resolveAgentDir } from "./paths.js";
+import { MAX_CONCURRENCY, MAX_PARALLEL } from "./types.js";
+
+export interface SubagentLimitSettings {
+	maxConcurrency?: number;
+	maxParallel?: number;
+}
+
+export interface SubagentLimits {
+	maxConcurrency: number;
+	maxParallel: number;
+}
+
+interface ResolveSubagentLimitsOptions {
+	agentDir?: string;
+	cwd: string;
+	env?: NodeJS.ProcessEnv;
+}
+
+const ENV_MAX_PARALLEL = "PI_SUBAGENT_MAX_PARALLEL";
+const ENV_MAX_CONCURRENCY = "PI_SUBAGENT_MAX_CONCURRENCY";
+
+function parsePositiveInteger(value: unknown): number | undefined {
+	const parsed = typeof value === "number" ? value : typeof value === "string" && value.trim() ? Number(value) : NaN;
+	if (!Number.isSafeInteger(parsed) || parsed < 1) {
+		return undefined;
+	}
+	return parsed;
+}
+
+async function readSubagentSettings(settingsPath: string): Promise<SubagentLimitSettings> {
+	try {
+		const settings = JSON.parse(await fs.readFile(settingsPath, "utf8")) as {
+			subagent?: SubagentLimitSettings;
+		};
+		return settings.subagent ?? {};
+	} catch {
+		return {};
+	}
+}
+
+function resolveLimit(options: {
+	defaultValue: number;
+	envValue: unknown;
+	projectValue: unknown;
+	userValue: unknown;
+}): number {
+	const envLimit = parsePositiveInteger(options.envValue);
+	if (envLimit !== undefined) {
+		return envLimit;
+	}
+
+	const userLimit = parsePositiveInteger(options.userValue);
+	if (userLimit !== undefined) {
+		return userLimit;
+	}
+
+	const projectLimit = parsePositiveInteger(options.projectValue);
+	if (projectLimit !== undefined) {
+		return Math.min(projectLimit, options.defaultValue);
+	}
+
+	return options.defaultValue;
+}
+
+/** Resolve subagent fan-out limits with project-safe caps.
+ *
+ * Precedence per limit:
+ * 1. Environment variables can raise or lower.
+ * 2. User settings (`~/.pi/agent/settings.json`) can raise or lower.
+ * 3. Project settings (`.pi/settings.json`) can only lower defaults.
+ * 4. Built-in defaults apply otherwise.
+ */
+export async function resolveSubagentLimits(options: ResolveSubagentLimitsOptions): Promise<SubagentLimits> {
+	const env = options.env ?? process.env;
+	const agentDir = options.agentDir ?? resolveAgentDir();
+	const [userSettings, projectSettings] = await Promise.all([
+		readSubagentSettings(path.join(agentDir, "settings.json")),
+		readSubagentSettings(path.join(options.cwd, ".pi", "settings.json")),
+	]);
+
+	return {
+		maxConcurrency: resolveLimit({
+			defaultValue: MAX_CONCURRENCY,
+			envValue: env[ENV_MAX_CONCURRENCY],
+			projectValue: projectSettings.maxConcurrency,
+			userValue: userSettings.maxConcurrency,
+		}),
+		maxParallel: resolveLimit({
+			defaultValue: MAX_PARALLEL,
+			envValue: env[ENV_MAX_PARALLEL],
+			projectValue: projectSettings.maxParallel,
+			userValue: userSettings.maxParallel,
+		}),
+	};
+}

--- a/packages/monopi__subagents/tests/index-entrypoint.test.ts
+++ b/packages/monopi__subagents/tests/index-entrypoint.test.ts
@@ -55,6 +55,7 @@ const mocks = vi.hoisted(() => ({
 	expandTildePath: vi.fn((value: string) => value),
 	getSubagentSessionRoot: vi.fn(() => "/tmp/subagent-session-root"),
 	loadSubagentConfig: vi.fn(() => ({})),
+	resolveSubagentLimits: vi.fn(() => ({ maxConcurrency: 4, maxParallel: 3 })),
 	resolveSubagentModelResolution: vi.fn(() => ({
 		model: undefined,
 		source: "agent-default",
@@ -113,10 +114,11 @@ vi.mock("../types.js", () => ({
 	RESULTS_DIR: "/tmp/pi-async-subagent-results",
 	DEFAULT_ARTIFACT_CONFIG: { cleanupDays: 7 },
 	DEFAULT_MAX_OUTPUT: { bytes: 200 * 1024, lines: 5000 },
-	MAX_CONCURRENCY: 4,
-	MAX_PARALLEL: 3,
 	WIDGET_KEY: "subagent-async",
 	checkSubagentDepth: mocks.checkSubagentDepth,
+}));
+vi.mock("../limits.js", () => ({
+	resolveSubagentLimits: mocks.resolveSubagentLimits,
 }));
 vi.mock("../utils.js", () => ({
 	readStatus: mocks.readStatus,
@@ -336,6 +338,7 @@ beforeEach(() => {
 	mocks.findByPrefix.mockReturnValue(null);
 	mocks.readStatus.mockReturnValue(null);
 	mocks.loadSubagentConfig.mockReturnValue({});
+	mocks.resolveSubagentLimits.mockReturnValue({ maxConcurrency: 4, maxParallel: 3 });
 });
 
 afterEach(() => {

--- a/packages/monopi__subagents/tests/limits.test.ts
+++ b/packages/monopi__subagents/tests/limits.test.ts
@@ -1,0 +1,107 @@
+import fs from "node:fs";
+import os from "node:os";
+import path from "node:path";
+import { afterEach, describe, expect, it } from "vitest";
+
+import { resolveSubagentLimits } from "../limits.js";
+
+const tempDirs: string[] = [];
+
+function createTempDir(prefix: string): string {
+	const dir = fs.mkdtempSync(path.join(os.tmpdir(), prefix));
+	tempDirs.push(dir);
+	return dir;
+}
+
+function writeSettings(baseDir: string, settings: unknown): void {
+	fs.mkdirSync(baseDir, { recursive: true });
+	fs.writeFileSync(path.join(baseDir, "settings.json"), JSON.stringify(settings));
+}
+
+afterEach(() => {
+	for (const dir of tempDirs.splice(0)) {
+		fs.rmSync(dir, { force: true, recursive: true });
+	}
+});
+
+describe("resolveSubagentLimits", () => {
+	it("uses defaults when no overrides are present", async () => {
+		const cwd = createTempDir("subagent-limits-project-");
+		const agentDir = createTempDir("subagent-limits-agent-");
+
+		expect(await resolveSubagentLimits({ agentDir, cwd, env: {} })).toEqual({
+			maxConcurrency: 4,
+			maxParallel: 8,
+		});
+	});
+
+	it("allows user settings to raise or lower limits", async () => {
+		const cwd = createTempDir("subagent-limits-project-");
+		const agentDir = createTempDir("subagent-limits-agent-");
+		writeSettings(agentDir, { subagent: { maxConcurrency: 8, maxParallel: 16 } });
+
+		expect(await resolveSubagentLimits({ agentDir, cwd, env: {} })).toEqual({
+			maxConcurrency: 8,
+			maxParallel: 16,
+		});
+
+		writeSettings(agentDir, { subagent: { maxConcurrency: 2, maxParallel: 3 } });
+		expect(await resolveSubagentLimits({ agentDir, cwd, env: {} })).toEqual({
+			maxConcurrency: 2,
+			maxParallel: 3,
+		});
+	});
+
+	it("lets project settings lower defaults but not raise them", async () => {
+		const cwd = createTempDir("subagent-limits-project-");
+		const agentDir = createTempDir("subagent-limits-agent-");
+		writeSettings(path.join(cwd, ".pi"), { subagent: { maxConcurrency: 2, maxParallel: 4 } });
+
+		expect(await resolveSubagentLimits({ agentDir, cwd, env: {} })).toEqual({
+			maxConcurrency: 2,
+			maxParallel: 4,
+		});
+
+		writeSettings(path.join(cwd, ".pi"), { subagent: { maxConcurrency: 9, maxParallel: 99 } });
+		expect(await resolveSubagentLimits({ agentDir, cwd, env: {} })).toEqual({
+			maxConcurrency: 4,
+			maxParallel: 8,
+		});
+	});
+
+	it("prefers env vars over user and project settings per limit", async () => {
+		const cwd = createTempDir("subagent-limits-project-");
+		const agentDir = createTempDir("subagent-limits-agent-");
+		writeSettings(agentDir, { subagent: { maxConcurrency: 6, maxParallel: 12 } });
+		writeSettings(path.join(cwd, ".pi"), { subagent: { maxConcurrency: 2, maxParallel: 4 } });
+
+		expect(
+			await resolveSubagentLimits({
+				agentDir,
+				cwd,
+				env: { PI_SUBAGENT_MAX_PARALLEL: "20" },
+			}),
+		).toEqual({
+			maxConcurrency: 6,
+			maxParallel: 20,
+		});
+	});
+
+	it("ignores invalid values and falls through to lower-precedence sources", async () => {
+		const cwd = createTempDir("subagent-limits-project-");
+		const agentDir = createTempDir("subagent-limits-agent-");
+		writeSettings(agentDir, { subagent: { maxConcurrency: 0, maxParallel: -1 } });
+		writeSettings(path.join(cwd, ".pi"), { subagent: { maxConcurrency: 2, maxParallel: 4 } });
+
+		expect(
+			await resolveSubagentLimits({
+				agentDir,
+				cwd,
+				env: { PI_SUBAGENT_MAX_CONCURRENCY: "nope" },
+			}),
+		).toEqual({
+			maxConcurrency: 2,
+			maxParallel: 4,
+		});
+	});
+});

--- a/packages/monopi__subagents/tests/session-churn.test.ts
+++ b/packages/monopi__subagents/tests/session-churn.test.ts
@@ -78,11 +78,21 @@ vi.mock("../types.js", () => ({
 	WIDGET_KEY: "subagent-async",
 	checkSubagentDepth: () => ({ blocked: false, depth: 0, maxDepth: 2 }),
 }));
+vi.mock("../limits.js", () => ({
+	resolveSubagentLimits: () => ({ maxConcurrency: 4, maxParallel: 8 }),
+}));
 vi.mock("../utils.js", () => ({
 	readStatus: mockReadStatus,
 	findByPrefix: vi.fn(),
 	getFinalOutput: vi.fn(() => ""),
-	mapConcurrent: async <T, R>(items: T[], fn: (item: T) => Promise<R>) => Promise.all(items.map((item) => fn(item))),
+	mapConcurrent: async <T, R>(
+		items: T[],
+		concurrencyOrFn: number | ((item: T) => Promise<R>),
+		maybeFn?: (item: T) => Promise<R>,
+	) => {
+		const mapper = typeof concurrencyOrFn === "function" ? concurrencyOrFn : maybeFn;
+		return Promise.all(items.map((item) => mapper?.(item)));
+	},
 }));
 vi.mock("../completion-dedupe.js", () => ({
 	buildCompletionKey: vi.fn(() => "key"),


### PR DESCRIPTION
## Summary
- Add configurable subagent maxParallel and maxConcurrency resolution with env > user settings > project settings > defaults precedence.
- Keep project .pi/settings.json safe by capping project-provided limits at built-in defaults.
- Wire resolved limits into parallel task validation and concurrent execution.

Closes #269.

## Validation
- pnpm format:check
- pnpm exec vitest run packages/monopi__subagents/tests/limits.test.ts packages/monopi__subagents/tests/index-entrypoint.test.ts packages/monopi__subagents/tests/session-churn.test.ts
- pnpm lint
- pnpm mc:check
- pnpm typecheck
- pnpm test
- pnpm build