### PR TITLE
feat: support subagents.excludeBuiltins

### DIFF
--- a/.changeset/subagents-exclude-builtins.md
+++ b/.changeset/subagents-exclude-builtins.md
@@ -1,0 +1,8 @@
+---
+default: minor
+---
+
+# Allow projects to hide built-in subagents
+
+- Added `.pi/settings.json` support for `subagents.excludeBuiltins: true`.
+- When enabled, subagent discovery skips built-in and user-level agents so project agent lists stay focused.

--- a/packages/monopi__subagents/agents.ts
+++ b/packages/monopi__subagents/agents.ts
@@ -3,9 +3,7 @@
  */
 
 import * as fs from "node:fs";
-import * as os from "node:os";
 import * as path from "node:path";
-import { fileURLToPath } from "node:url";
 
 import { mergeAgentsForScope } from "./agent-selection.js";
 import { KNOWN_FIELDS } from "./agent-serializer.js";
@@ -244,6 +242,30 @@ function loadChainsFromDir(dir: string, source: AgentSource): ChainConfig[] {
 
 const BUILTIN_AGENTS_DIR = path.join(import.meta.dirname, "agents");
 
+/** Read the nearest project `subagents.excludeBuiltins` setting. */
+function readExcludeBuiltinsFlag(cwd: string): boolean {
+	let current = path.resolve(cwd);
+	while (true) {
+		const settingsPath = path.join(current, ".pi", "settings.json");
+		if (fs.existsSync(settingsPath)) {
+			try {
+				const settings = JSON.parse(fs.readFileSync(settingsPath, "utf8")) as {
+					subagents?: { excludeBuiltins?: unknown };
+				};
+				return settings.subagents?.excludeBuiltins === true;
+			} catch {
+				return false;
+			}
+		}
+
+		const parent = path.dirname(current);
+		if (parent === current) {
+			return false;
+		}
+		current = parent;
+	}
+}
+
 function mergeNamedConfigs<T extends { name: string }>(groups: T[][]): T[] {
 	const merged = new Map<string, T>();
 	for (const group of groups) {
@@ -276,9 +298,10 @@ export function discoverAgents(cwd: string, scope: AgentScope): AgentDiscoveryRe
 	const userDir = getUserAgentsDir();
 	const projectAgentsDir = findNearestProjectAgentsDir(cwd);
 	const projectAgentDirs = findProjectAgentsDirs(cwd);
+	const excludeBuiltins = readExcludeBuiltinsFlag(cwd);
 
-	const builtinAgents = loadAgentsFromDir(BUILTIN_AGENTS_DIR, "builtin");
-	const userAgents = scope === "project" ? [] : loadAgentsFromDir(userDir, "user");
+	const builtinAgents = excludeBuiltins ? [] : loadAgentsFromDir(BUILTIN_AGENTS_DIR, "builtin");
+	const userAgents = scope === "project" || excludeBuiltins ? [] : loadAgentsFromDir(userDir, "user");
 	const projectAgents = scope === "user" ? [] : loadAgentsFromDirs(projectAgentDirs, "project");
 	const agents = mergeAgentsForScope(scope, userAgents, projectAgents, builtinAgents);
 
@@ -296,9 +319,10 @@ export function discoverAgentsAll(cwd: string): {
 	const userDir = getUserAgentsDir();
 	const projectDir = findNearestProjectAgentsDir(cwd);
 	const projectDirs = findProjectAgentsDirs(cwd);
+	const excludeBuiltins = readExcludeBuiltinsFlag(cwd);
 
-	const builtin = loadAgentsFromDir(BUILTIN_AGENTS_DIR, "builtin");
-	const user = loadAgentsFromDir(userDir, "user");
+	const builtin = excludeBuiltins ? [] : loadAgentsFromDir(BUILTIN_AGENTS_DIR, "builtin");
+	const user = excludeBuiltins ? [] : loadAgentsFromDir(userDir, "user");
 	const project = loadAgentsFromDirs(projectDirs, "project");
 	const chains = mergeNamedConfigs([loadChainsFromDir(userDir, "user"), loadChainsFromDirs(projectDirs, "project")]);
 

--- a/packages/monopi__subagents/tests/agents.test.ts
+++ b/packages/monopi__subagents/tests/agents.test.ts
@@ -27,6 +27,12 @@ function writeAgentFile(rootDir: string, relativePath: string, content: string):
 	fs.writeFileSync(filePath, content, "utf-8");
 }
 
+function writeProjectSettings(rootDir: string, settings: unknown): void {
+	const settingsPath = path.join(rootDir, ".pi", "settings.json");
+	fs.mkdirSync(path.dirname(settingsPath), { recursive: true });
+	fs.writeFileSync(settingsPath, JSON.stringify(settings), "utf-8");
+}
+
 beforeEach(() => {
 	savedHome = process.env.HOME;
 	savedUserProfile = process.env.USERPROFILE;
@@ -79,6 +85,36 @@ describe("discoverAgents", () => {
 		expect(byName.get("frontend-designer")?.extraFields?.category).toBe("visual-engineering");
 		expect(byName.get("multimodal-summariser")?.extraFields?.category).toBe("multimodal-default");
 		expect(result.projectAgentsDir).toBe(getSharedProjectAgentsDir(cwd));
+	});
+
+	it("excludes builtin and user agents when project settings request project-only discovery", () => {
+		const homeDir = createTempDir("subagents-exclude-home-");
+		const projectDir = createTempDir("subagents-exclude-project-");
+		const nestedDir = path.join(projectDir, "packages", "legal");
+		process.env.HOME = homeDir;
+		process.env.USERPROFILE = homeDir;
+		process.env.PI_SUBAGENT_PROJECT_AGENTS_MODE = "shared";
+		fs.mkdirSync(nestedDir, { recursive: true });
+		writeProjectSettings(projectDir, { subagents: { excludeBuiltins: true } });
+
+		writeAgentFile(
+			homeDir,
+			".pi/agent/agents/custom-user.md",
+			"---\nname: custom-user\ndescription: User agent\n---\n\nUser prompt\n",
+		);
+		writeAgentFile(
+			getSharedProjectAgentsDir(projectDir),
+			"custom-project.md",
+			"---\nname: custom-project\ndescription: Project agent\n---\n\nProject prompt\n",
+		);
+
+		const result = discoverAgents(nestedDir, "both");
+		const byName = new Map(result.agents.map((agent) => [agent.name, agent]));
+		expect(byName.get("custom-project")?.source).toBe("project");
+		expect(byName.has("custom-user")).toBe(false);
+		expect(byName.has("scout")).toBe(false);
+		expect(byName.has("planner")).toBe(false);
+		expect(result.projectAgentsDir).toBe(getSharedProjectAgentsDir(projectDir));
 	});
 
 	it("prefers shared project agents over user and builtin agents by default", () => {
@@ -219,6 +255,34 @@ describe("discoverAgentsAll", () => {
 		expect(result.project.map((agent) => agent.name)).toContain("custom-project");
 		expect(result.chains.map((chain) => chain.name)).toContain("review-pipeline");
 		expect(result.userDir).toBe(path.join(homeDir, ".pi", "agent", "agents"));
+		expect(result.projectDir).toBe(getSharedProjectAgentsDir(projectDir));
+	});
+
+	it("excludes builtin and user agent groups from discoverAgentsAll when configured", () => {
+		const homeDir = createTempDir("subagents-all-exclude-home-");
+		const projectDir = createTempDir("subagents-all-exclude-project-");
+		const nestedDir = path.join(projectDir, "apps", "legal");
+		process.env.HOME = homeDir;
+		process.env.USERPROFILE = homeDir;
+		process.env.PI_SUBAGENT_PROJECT_AGENTS_MODE = "shared";
+		fs.mkdirSync(nestedDir, { recursive: true });
+		writeProjectSettings(projectDir, { subagents: { excludeBuiltins: true } });
+
+		writeAgentFile(
+			homeDir,
+			".pi/agent/agents/custom-user.md",
+			"---\nname: custom-user\ndescription: User agent\n---\n\nUser prompt\n",
+		);
+		writeAgentFile(
+			getSharedProjectAgentsDir(projectDir),
+			"custom-project.md",
+			"---\nname: custom-project\ndescription: Project agent\n---\n\nProject prompt\n",
+		);
+
+		const result = discoverAgentsAll(nestedDir);
+		expect(result.builtin).toEqual([]);
+		expect(result.user).toEqual([]);
+		expect(result.project.map((agent) => agent.name)).toContain("custom-project");
 		expect(result.projectDir).toBe(getSharedProjectAgentsDir(projectDir));
 	});
 


### PR DESCRIPTION
## Summary
- Add nearest-project `.pi/settings.json` support for `subagents.excludeBuiltins: true`.
- Skip built-in and user-level agents from `discoverAgents()` and `discoverAgentsAll()` when enabled.
- Add regression coverage for nested workspaces using shared project agent storage.

Closes #267.

## Validation
- `pnpm exec vitest run packages/monopi__subagents/tests/agents.test.ts`
- `pnpm format:check`
- `pnpm lint`
- `pnpm mc:check`
- `pnpm typecheck`
- `pnpm test`
- `pnpm build`
