### PR TITLE
feat: watch external agent configs

### DIFF
--- a/.changeset/external-agent-watchers.md
+++ b/.changeset/external-agent-watchers.md
@@ -1,0 +1,8 @@
+---
+default: minor
+---
+
+# Watch external agent config directories
+
+- Added debounced watchers for existing `.vscode`, `.claude/agents`, `.opencode/agents`, and `.pi/agents` directories during external subagent resolution.
+- Scoped cache invalidation to entries backed by changed directories and close watchers on session reset/shutdown.

--- a/packages/monopi__subagents/external-agents.ts
+++ b/packages/monopi__subagents/external-agents.ts
@@ -30,8 +30,24 @@ interface CacheEntry {
 }
 
 const MAX_CACHE_SIZE = 100;
+const MAX_WATCHED_DIRS = 128;
+const WATCH_DEBOUNCE_MS = 1_000;
 const resolutionCache = new Map<string, CacheEntry>();
 const autoSavedAgents = new Set<string>(); // key: name:cwd
+
+interface WatchEntry {
+	watcher: fs.FSWatcher;
+	timer: ReturnType<typeof setTimeout> | null;
+}
+
+type WatchFactory = (dirPath: string, listener: fs.WatchListener<string>) => fs.FSWatcher;
+
+function defaultWatchFactory(dirPath: string, listener: fs.WatchListener<string>): fs.FSWatcher {
+	return fs.watch(dirPath, { persistent: false }, listener);
+}
+
+let watchFactory: WatchFactory = defaultWatchFactory;
+const externalAgentWatchers = new Map<string, WatchEntry>();
 
 function cacheKey(name: string, cwd: string): string {
 	return `${name}:${path.resolve(cwd)}`;
@@ -80,6 +96,91 @@ function setCachedResult(name: string, cwd: string, result: ExternalAgentResult 
 export function clearExternalAgentCache(): void {
 	resolutionCache.clear();
 	autoSavedAgents.clear();
+}
+
+/** Inspect cache size in tests without exposing mutable cache internals. */
+export function getExternalAgentCacheSizeForTests(): number {
+	return resolutionCache.size;
+}
+
+function isPathWithinDir(filePath: string, dirPath: string): boolean {
+	const resolvedFile = path.resolve(filePath);
+	const resolvedDir = path.resolve(dirPath);
+	return resolvedFile === resolvedDir || resolvedFile.startsWith(`${resolvedDir}${path.sep}`);
+}
+
+function invalidateExternalAgentCacheForDir(dirPath: string): void {
+	const deleteKeys: string[] = [];
+	for (const [key, entry] of resolutionCache) {
+		if (entry.filePath && isPathWithinDir(entry.filePath, dirPath)) {
+			deleteKeys.push(key);
+		}
+	}
+	for (const key of deleteKeys) resolutionCache.delete(key);
+	if (deleteKeys.length > 0) autoSavedAgents.clear();
+}
+
+function closeExternalAgentWatcher(dirPath: string, entry: WatchEntry): void {
+	if (entry.timer) clearTimeout(entry.timer);
+	try {
+		entry.watcher.close();
+	} catch {}
+	externalAgentWatchers.delete(dirPath);
+}
+
+/** Close all external-agent config directory watchers. */
+export function closeExternalAgentWatchers(): void {
+	const entries = Array.from(externalAgentWatchers.entries());
+	for (const [dirPath, entry] of entries) closeExternalAgentWatcher(dirPath, entry);
+}
+
+/** Override watcher construction in tests. */
+export function setExternalAgentWatchFactoryForTests(factory: WatchFactory | null): void {
+	closeExternalAgentWatchers();
+	watchFactory = factory ?? defaultWatchFactory;
+}
+
+function scheduleExternalAgentCacheInvalidation(dirPath: string): void {
+	const entry = externalAgentWatchers.get(dirPath);
+	if (!entry) return;
+	if (entry.timer) clearTimeout(entry.timer);
+	entry.timer = setTimeout(() => {
+		entry.timer = null;
+		invalidateExternalAgentCacheForDir(dirPath);
+	}, WATCH_DEBOUNCE_MS);
+	entry.timer.unref?.();
+}
+
+function isDirectoryPath(dirPath: string): boolean {
+	try {
+		return fs.statSync(dirPath).isDirectory();
+	} catch {
+		return false;
+	}
+}
+
+function discoverExternalAgentWatchDirs(cwd: string): string[] {
+	const dirs: string[] = [];
+	for (const dir of searchUp(cwd, ".vscode")) dirs.push(path.join(dir, ".vscode"));
+	for (const dir of searchUp(cwd, ".claude")) dirs.push(path.join(dir, ".claude", "agents"));
+	for (const dir of searchUp(cwd, ".opencode")) dirs.push(path.join(dir, ".opencode", "agents"));
+	for (const dir of searchUp(cwd, ".pi")) dirs.push(path.join(dir, ".pi", "agents"));
+	return dirs;
+}
+
+/** Watch existing external-agent config directories and debounce cache invalidation. */
+export function watchExternalAgentConfigDirs(cwd: string): void {
+	for (const dirPath of discoverExternalAgentWatchDirs(cwd)) {
+		const resolvedDir = path.resolve(dirPath);
+		if (externalAgentWatchers.has(resolvedDir) || !isDirectoryPath(resolvedDir)) continue;
+		if (externalAgentWatchers.size >= MAX_WATCHED_DIRS) return;
+		try {
+			const watcher = watchFactory(resolvedDir, () => scheduleExternalAgentCacheInvalidation(resolvedDir));
+			externalAgentWatchers.set(resolvedDir, { watcher, timer: null });
+		} catch {
+			// Best-effort watcher registration; cache mtime checks still protect reads.
+		}
+	}
 }
 
 // ---------------------------------------------------------------------------
@@ -336,6 +437,8 @@ export function resolveExternalAgent(name: string, cwd: string): ExternalAgentRe
 		if (cached) maybeAutoSaveAgent(name, cwd, cached);
 		return cached ?? undefined;
 	}
+
+	watchExternalAgentConfigDirs(cwd);
 
 	let filePathForCache = "";
 

--- a/packages/monopi__subagents/index.ts
+++ b/packages/monopi__subagents/index.ts
@@ -45,7 +45,7 @@ import { executeChain } from "./chain-execution.js";
 import { registerSubagentCommands } from "./command-registration.js";
 import { createDynamicAgent } from "./dynamic-agent.js";
 import { runSync } from "./execution.js";
-import { parseStringList, resolveExternalAgent } from "./external-agents.js";
+import { closeExternalAgentWatchers, parseStringList, resolveExternalAgent } from "./external-agents.js";
 import { resolveSubagentLimits } from "./limits.js";
 import { resolveSubagentModelResolution, toAvailableModelRefs } from "./model-routing.js";
 import { renderSubagentResult, renderWidget } from "./render.js";
@@ -1453,6 +1453,7 @@ MANAGEMENT (use action field — omit agent/task/chain/tasks):
 		}
 		cleanupTimers.clear();
 		asyncJobs.clear();
+		closeExternalAgentWatchers();
 		runtimeMonitor.clearResults();
 		if (ctx.hasUI) {
 			lastUiContext = ctx;
@@ -1478,6 +1479,7 @@ MANAGEMENT (use action field — omit agent/task/chain/tasks):
 		}
 		cleanupTimers.clear();
 		asyncJobs.clear();
+		closeExternalAgentWatchers();
 		runtimeMonitor.clearResults();
 		if (lastUiContext?.hasUI) {
 			lastUiContext.ui.setWidget(WIDGET_KEY, undefined);

--- a/packages/monopi__subagents/tests/external-agents.test.ts
+++ b/packages/monopi__subagents/tests/external-agents.test.ts
@@ -5,9 +5,15 @@
 import * as fs from "node:fs";
 import * as os from "node:os";
 import * as path from "node:path";
-import { afterEach, beforeEach, describe, expect, it } from "vitest";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 
-import { clearExternalAgentCache, resolveExternalAgent } from "../external-agents.js";
+import {
+	clearExternalAgentCache,
+	closeExternalAgentWatchers,
+	getExternalAgentCacheSizeForTests,
+	resolveExternalAgent,
+	setExternalAgentWatchFactoryForTests,
+} from "../external-agents.js";
 
 describe("resolveExternalAgent", () => {
 	let tmpDir: string;
@@ -21,6 +27,11 @@ describe("resolveExternalAgent", () => {
 	});
 
 	afterEach(() => {
+		setExternalAgentWatchFactoryForTests(null);
+		closeExternalAgentWatchers();
+		clearExternalAgentCache();
+		vi.useRealTimers();
+		vi.restoreAllMocks();
 		process.chdir(originalCwd);
 		fs.rmSync(tmpDir, { recursive: true, force: true });
 	});
@@ -236,6 +247,36 @@ describe("resolveExternalAgent", () => {
 	// -------------------------------------------------------------------
 
 	describe("caching", () => {
+		it("debounces watched config directory changes and invalidates cached results", async () => {
+			vi.useFakeTimers();
+
+			const agentsDir = path.join(tmpDir, ".pi", "agents");
+			const agentPath = path.join(agentsDir, "watched.md");
+			fs.mkdirSync(agentsDir, { recursive: true });
+			fs.writeFileSync(agentPath, "old prompt");
+
+			let emitChange: (() => void) | undefined;
+			const watcherClose = vi.fn();
+			const watchFactory = vi.fn((_: string, listener: fs.WatchListener<string>) => {
+				emitChange = () => listener("change", "watched.md");
+				return { close: watcherClose } as unknown as fs.FSWatcher;
+			});
+			setExternalAgentWatchFactoryForTests(watchFactory);
+
+			const first = resolveExternalAgent("watched", tmpDir);
+			expect(first?.config.systemPrompt).toBe("old prompt");
+			expect(watchFactory).toHaveBeenCalledOnce();
+
+			expect(getExternalAgentCacheSizeForTests()).toBe(1);
+
+			emitChange?.();
+			await vi.advanceTimersByTimeAsync(999);
+			expect(getExternalAgentCacheSizeForTests()).toBe(1);
+
+			await vi.advanceTimersByTimeAsync(1);
+			expect(getExternalAgentCacheSizeForTests()).toBe(0);
+		});
+
 		it("caches resolved agents", () => {
 			const agentsDir = path.join(tmpDir, ".pi", "agents");
 			fs.mkdirSync(agentsDir, { recursive: true });


### PR DESCRIPTION
## Summary
- Add debounced `fs.watch` invalidation for existing external agent config directories.
- Scope invalidation to cached results backed by the changed directory.
- Close external-agent watchers on session reset/shutdown.
- Add deterministic coverage for debounce timing and cache invalidation.

Closes #301.

## Validation
- `pnpm exec vitest run packages/monopi__subagents/tests/external-agents.test.ts packages/monopi__subagents/tests/index-entrypoint.test.ts packages/monopi__subagents/tests/session-churn.test.ts`
- `pnpm format:check`
- `pnpm lint`
- `pnpm mc:check`
- `pnpm typecheck`
- `pnpm test`
- `pnpm build`
