### PR TITLE
feat(extensions): adopt upstream btw and answer improvements

### DIFF
--- a/.changeset/upstream-btw-answer.md
+++ b/.changeset/upstream-btw-answer.md
@@ -1,0 +1,12 @@
+---
+default: minor
+---
+
+Adopt upstream-inspired BTW and answer extension improvements
+
+**What changed:**
+
+- Replaced `@monopi/extension-btw` with the simpler upstream side-chat flow adapted from `mitsuhiko/agent-stuff`.
+- Updated BTW tests to match the single `/btw` command behavior and side-thread persistence model.
+- Kept the Monopi `answer` extension UI, while adding upstream-inspired extraction model selection and JSON repair/object-output handling.
+- Documented upstream Apache-2.0 attribution and updated package license metadata for adapted code.

--- a/packages/monopi__extension-answer/README.md
+++ b/packages/monopi__extension-answer/README.md
@@ -1,7 +1,20 @@
 # @monopi/extension-answer
 
-Standalone pi extension package for `answer`.
+Standalone pi extension package for answering questions extracted from the last assistant response.
 
 ```bash
 pi install npm:@monopi/extension-answer
 ```
+
+## Commands
+
+- `/answer` — extract questions from the last completed assistant message and answer them in the Q&A overlay.
+- `/answer auto` — toggle automatic question detection after assistant turns.
+
+The extension uses `@monopi/shared-qna` for the interactive Q&A UI. It accepts both Monopi's JSON-array extraction format and the upstream object-shaped `{ "questions": [...] }` format, and prefers a configured fast extraction model when one is available.
+
+## Attribution
+
+This package keeps the Monopi Q&A UI flow while incorporating extraction-model selection and JSON repair ideas from [`mitsuhiko/agent-stuff`](https://github.com/mitsuhiko/agent-stuff) `extensions/answer.ts`.
+Those adapted ideas are Copyright Armin Ronacher and contributors and licensed under Apache-2.0.
+Monopi package metadata and surrounding repository files remain MIT licensed.

--- a/packages/monopi__extension-answer/index.ts
+++ b/packages/monopi__extension-answer/index.ts
@@ -11,19 +11,30 @@
  * - Answers are injected back into the session as a follow-up user message
  * - Uses `@monopi/shared-qna` for the QnA TUI component
  * - Uses `completeSimple` for LLM-powered question extraction
+ *
+ * Incorporates extraction-model selection and JSON repair ideas from
+ * mitsuhiko/agent-stuff extensions/answer.ts (Apache-2.0).
  */
 
-import type { UserMessage } from "@earendil-works/pi-ai";
-import type { ExtensionAPI, ExtensionCommandContext, ExtensionContext } from "@earendil-works/pi-coding-agent";
+import type {
+	ExtensionAPI,
+	ExtensionCommandContext,
+	ExtensionContext,
+	ModelRegistry,
+} from "@earendil-works/pi-coding-agent";
 import type { QnAQuestion, QnAResult, QnATemplate } from "@monopi/shared-qna";
 
-import { completeSimple } from "@earendil-works/pi-ai";
+import { completeSimple, parseJsonWithRepair, type Api, type Model, type UserMessage } from "@earendil-works/pi-ai";
 import { BorderedLoader } from "@earendil-works/pi-coding-agent";
 import { QnATuiComponent } from "@monopi/shared-qna";
 
 // ── Constants ──────────────────────────────────────────────────────────────
 
 const ANSWER_ENTRY_TYPE = "answer-state";
+const CODEX_MODEL_IDS = ["gpt-5.4-mini", "gpt-5.3-codex-spark", "gpt-5.4", "gpt-5.3-codex"];
+const HAIKU_MODEL_ID = "claude-haiku-4-5";
+const JSON_FENCE_START_RE = /^```(?:json)?\s*\n?/i;
+const JSON_FENCE_END_RE = /\n?```\s*$/i;
 
 const EXTRACTION_SYSTEM_PROMPT = [
 	"You are a question extractor. Given text from a conversation, extract any questions that need answering.",
@@ -209,6 +220,77 @@ function buildAnswerMessage(result: QnAResult): string {
 
 // ── Question extraction ────────────────────────────────────────────────────
 
+function toExtractionArray(raw: unknown): unknown[] {
+	if (Array.isArray(raw)) {
+		return raw;
+	}
+	if (raw && typeof raw === "object" && Array.isArray((raw as { questions?: unknown }).questions)) {
+		return (raw as { questions: unknown[] }).questions;
+	}
+	return [];
+}
+
+function parseExtractedQuestions(responseText: string): ExtractedQuestion[] | null {
+	const candidates = [
+		responseText.replace(JSON_FENCE_START_RE, "").replace(JSON_FENCE_END_RE, "").trim(),
+		responseText,
+	];
+
+	for (const candidate of candidates) {
+		if (!candidate) {
+			continue;
+		}
+		try {
+			return normalizeExtractedQuestions(toExtractionArray(parseJsonWithRepair<unknown>(candidate)));
+		} catch {
+			try {
+				return normalizeExtractedQuestions(toExtractionArray(JSON.parse(candidate)));
+			} catch {
+				// Try the next candidate.
+			}
+		}
+	}
+
+	return null;
+}
+
+async function selectExtractionModel(currentModel: Model<Api>, modelRegistry: ModelRegistry): Promise<Model<Api>> {
+	const registry = modelRegistry as ModelRegistry & {
+		find?: (provider: string, modelId: string) => Model<Api> | undefined;
+	};
+
+	if (!registry.find) {
+		return currentModel;
+	}
+
+	for (const modelId of CODEX_MODEL_IDS) {
+		const candidate = registry.find("openai-codex", modelId);
+		if (!candidate) {
+			continue;
+		}
+		try {
+			const auth = await modelRegistry.getApiKeyAndHeaders(candidate);
+			if (auth.ok && auth.apiKey) {
+				return candidate;
+			}
+		} catch {
+			// Keep looking for another configured model.
+		}
+	}
+
+	const haikuModel = registry.find("anthropic", HAIKU_MODEL_ID);
+	if (!haikuModel) {
+		return currentModel;
+	}
+
+	try {
+		const auth = await modelRegistry.getApiKeyAndHeaders(haikuModel);
+		return auth.ok && auth.apiKey ? haikuModel : currentModel;
+	} catch {
+		return currentModel;
+	}
+}
+
 async function extractQuestions(
 	text: string,
 	ctx: ExtensionContext | ExtensionCommandContext,
@@ -217,7 +299,8 @@ async function extractQuestions(
 		return null;
 	}
 
-	const auth = await ctx.modelRegistry.getApiKeyAndHeaders(ctx.model);
+	const extractionModel = await selectExtractionModel(ctx.model, ctx.modelRegistry);
+	const auth = await ctx.modelRegistry.getApiKeyAndHeaders(extractionModel);
 	if (!(auth.ok && auth.apiKey)) {
 		return null;
 	}
@@ -229,7 +312,7 @@ async function extractQuestions(
 	};
 
 	const response = await completeSimple(
-		ctx.model,
+		extractionModel,
 		{ messages: [userMessage], systemPrompt: EXTRACTION_SYSTEM_PROMPT },
 		{ apiKey: auth.apiKey, headers: auth.headers, reasoning: "low" },
 	);
@@ -248,18 +331,7 @@ async function extractQuestions(
 		return null;
 	}
 
-	const JSON_FENCE_START_RE = /^```(?:json)?\s*\n?/i;
-	const JSON_FENCE_END_RE = /\n?```\s*$/i;
-
-	// Strip markdown code fences if present
-	const jsonText = responseText.replace(JSON_FENCE_START_RE, "").replace(JSON_FENCE_END_RE, "").trim();
-
-	try {
-		const parsed = JSON.parse(jsonText);
-		return normalizeExtractedQuestions(parsed);
-	} catch {
-		return null;
-	}
+	return parseExtractedQuestions(responseText);
 }
 
 // ── Auto-detect question presence ───────────────────────────────────────────

--- a/packages/monopi__extension-answer/package.json
+++ b/packages/monopi__extension-answer/package.json
@@ -9,7 +9,7 @@
 	"bugs": {
 		"url": "https://github.com/ifiokjr/monopi/issues"
 	},
-	"license": "MIT",
+	"license": "MIT AND Apache-2.0",
 	"repository": {
 		"type": "git",
 		"url": "git+https://github.com/ifiokjr/monopi.git",

--- a/packages/monopi__extension-answer/tests/answer.test.ts
+++ b/packages/monopi__extension-answer/tests/answer.test.ts
@@ -578,6 +578,22 @@ describe("extractQuestions", () => {
 		expect(result).toEqual([{ question: "What DB?" }]);
 	});
 
+	it("extracts questions from upstream object-shaped JSON response", async () => {
+		const harness = setupHarnessWithAssistantMessage("Hello?");
+		mockCompleteSimple.mockResolvedValue({
+			stopReason: "stop",
+			content: [
+				{
+					type: "text" as const,
+					text: JSON.stringify({ questions: [{ question: "Which runtime?" }] }),
+				},
+			],
+		} as never);
+
+		const result = await extractQuestions("Hello?", harness.ctx as never);
+		expect(result).toEqual([{ question: "Which runtime?" }]);
+	});
+
 	it("extracts questions with options", async () => {
 		const harness = setupHarnessWithAssistantMessage("Hello?");
 		mockCompleteSimple.mockResolvedValue(
@@ -656,6 +672,19 @@ describe("extractQuestions", () => {
 
 		// Verify API key
 		expect(callArgs[2].apiKey).toBe("test-key");
+	});
+
+	it("prefers a configured Codex extraction model when available", async () => {
+		const harness = setupHarnessWithAssistantMessage("Hello?");
+		const codexModel = { provider: "openai-codex", id: "gpt-5.4-mini", api: "openai-responses" };
+		harness.ctx.modelRegistry.find = vi.fn((provider: string, modelId: string) => {
+			return provider === "openai-codex" && modelId === "gpt-5.4-mini" ? codexModel : undefined;
+		}) as never;
+		mockCompleteSimple.mockResolvedValue(makeExtractedQuestionsResponse([]) as never);
+
+		await extractQuestions("What is your name?", harness.ctx as never);
+
+		expect(mockCompleteSimple.mock.calls[0]![0]).toBe(codexModel);
 	});
 });
 

--- a/packages/monopi__extension-btw/README.md
+++ b/packages/monopi__extension-btw/README.md
@@ -1,7 +1,20 @@
 # @monopi/extension-btw
 
-Standalone pi extension package for `btw`.
+Standalone pi extension package for `btw` side conversations.
 
 ```bash
 pi install npm:@monopi/extension-btw
 ```
+
+## Commands
+
+- `/btw` — open the side-chat overlay.
+- `/btw <question>` — ask a side question without interrupting the main thread.
+
+The side thread is persisted as custom session entries so it can be restored as the session tree changes.
+
+## Attribution
+
+This implementation is adapted from [`mitsuhiko/agent-stuff`](https://github.com/mitsuhiko/agent-stuff) `extensions/btw.ts`.
+The adapted upstream code is Copyright Armin Ronacher and contributors and licensed under Apache-2.0.
+Monopi package metadata and surrounding repository files remain MIT licensed.

--- a/packages/monopi__extension-btw/index.ts
+++ b/packages/monopi__extension-btw/index.ts
@@ -1,21 +1,9 @@
 /**
- * Oh-pi BTW / QQ Extension — parallel side conversations (overlay-based)
+ * BTW side-chat extension for pi.
  *
- * Adds /btw and /qq commands that open an overlay-based side conversation
- * without interrupting the main agent run. The overlay supports multi-turn
- * chat with tool access (read, bash, edit, write).
- *
- * Features:
- * - Overlay UI with multi-turn chat input
- * - Side session with createAgentSession + tools (read, bash, edit, write)
- * - Real-time streaming via session.subscribe()
- * - Close flow: Keep side thread or Inject summary into main chat
- * - Thread persistence via btw-thread-entry / btw-thread-reset resources
- * - Can inject full thread or a summary back into the main agent
- * - Optionally saves individual exchanges as visible session notes with --save
- *
- * Based on https://github.com/mitsuhiko/agent-stuff by Armin Ronacher (MIT).
- * Adapted from https://github.com/dbachelder/pi-btw by Dan Bachelder (MIT).
+ * Adapted from mitsuhiko/agent-stuff extensions/btw.ts.
+ * Copyright Armin Ronacher and contributors. Licensed under Apache-2.0.
+ * See this package README for attribution.
  */
 
 import { type AssistantMessage, type Message, type ThinkingLevel as AiThinkingLevel } from "@earendil-works/pi-ai";
@@ -44,7 +32,6 @@ import {
 	type TUI,
 } from "@earendil-works/pi-tui";
 
-const BTW_MESSAGE_TYPE = "btw-note";
 const BTW_ENTRY_TYPE = "btw-thread-entry";
 const BTW_RESET_TYPE = "btw-thread-reset";
 
@@ -60,7 +47,7 @@ const BTW_SUMMARY_PROMPT =
 
 type SessionThinkingLevel = "off" | AiThinkingLevel;
 
-interface BtwDetails {
+type BtwDetails = {
 	question: string;
 	answer: string;
 	timestamp: number;
@@ -68,16 +55,11 @@ interface BtwDetails {
 	model: string;
 	thinkingLevel: SessionThinkingLevel;
 	usage?: AssistantMessage["usage"];
-}
+};
 
-interface BtwResetDetails {
+type BtwResetDetails = {
 	timestamp: number;
-}
-
-interface ParsedBtwArgs {
-	question: string;
-	save: boolean;
-}
+};
 
 type OverlayRuntime = {
 	handle?: OverlayHandle;
@@ -100,8 +82,6 @@ type ToolCallInfo = {
 	args: string;
 	status: "running" | "done" | "error";
 };
-
-// ── Utility functions ─────────────────────────────────────────────────────
 
 function stripDynamicSystemPromptFooter(systemPrompt: string): string {
 	return systemPrompt
@@ -215,33 +195,6 @@ function formatThread(thread: BtwDetails[]): string {
 	return thread.map((item) => `User: ${item.question.trim()}\nAssistant: ${item.answer.trim()}`).join("\n\n---\n\n");
 }
 
-function formatToolArgs(toolName: string, args: unknown): string {
-	if (!args || typeof args !== "object") return "";
-	const a = args as Record<string, unknown>;
-	switch (toolName) {
-		case "bash":
-			return typeof a.command === "string" ? truncateToWidth(a.command.split("\n")[0], 50, "…") : "";
-		case "read":
-		case "write":
-		case "edit":
-			return typeof a.path === "string" ? a.path : "";
-		default: {
-			const first = Object.values(a)[0];
-			return typeof first === "string" ? truncateToWidth(first.split("\n")[0], 40, "…") : "";
-		}
-	}
-}
-
-function parseBtwArgs(args: string): ParsedBtwArgs {
-	const save = /(?:^|\s)(?:--save|-s)(?=\s|$)/.test(args);
-	const question = args.replaceAll(/(?:^|\s)(?:--save|-s)(?=\s|$)/g, " ").trim();
-	return { question, save };
-}
-
-function isVisibleBtwMessage(message: { role: string; customType?: string }): boolean {
-	return message.role === "custom" && message.customType === BTW_MESSAGE_TYPE;
-}
-
 function notify(
 	ctx: ExtensionContext | ExtensionCommandContext,
 	message: string,
@@ -252,38 +205,6 @@ function notify(
 	}
 }
 
-function buildBtwMessageContent(question: string, answer: string): string {
-	return `**Question:** ${question}\n\n${answer}`;
-}
-
-function saveVisibleBtwNote(
-	pi: ExtensionAPI,
-	details: BtwDetails,
-	saveRequested: boolean,
-	wasBusy: boolean,
-): "not-saved" | "saved" | "queued" {
-	if (!saveRequested) {
-		return "not-saved";
-	}
-
-	const message = {
-		content: buildBtwMessageContent(details.question, details.answer),
-		customType: BTW_MESSAGE_TYPE,
-		details,
-		display: true,
-	};
-
-	if (wasBusy) {
-		pi.sendMessage(message, { deliverAs: "followUp" });
-		return "queued";
-	}
-
-	pi.sendMessage(message);
-	return "saved";
-}
-
-// ── BtwOverlay — overlay component ───────────────────────────────────────
-
 class BtwOverlay extends Container implements Focusable {
 	private readonly input: Input;
 	private readonly tui: TUI;
@@ -293,14 +214,14 @@ class BtwOverlay extends Container implements Focusable {
 	private readonly getStatus: () => string;
 	private readonly onSubmitCallback: (value: string) => void;
 	private readonly onDismissCallback: () => void;
-	private _focused = false;
+	private isFocused = false;
 
 	get focused(): boolean {
-		return this._focused;
+		return this.isFocused;
 	}
 
 	set focused(value: boolean) {
-		this._focused = value;
+		this.isFocused = value;
 		this.input.focused = value;
 	}
 
@@ -332,7 +253,7 @@ class BtwOverlay extends Container implements Focusable {
 	}
 
 	handleInput(data: string): void {
-		if (this.keybindings.matches(data, "tui.select.cancel" as never)) {
+		if (this.keybindings.matches(data, "tui.select.cancel")) {
 			this.onDismissCallback();
 			return;
 		}
@@ -405,8 +326,6 @@ class BtwOverlay extends Container implements Focusable {
 	}
 }
 
-// ── Main extension ────────────────────────────────────────────────────────
-
 export default function (pi: ExtensionAPI) {
 	let thread: BtwDetails[] = [];
 	let pendingQuestion: string | null = null;
@@ -442,6 +361,23 @@ export default function (pi: ExtensionAPI) {
 				}
 				return wrapped.length > 0 ? wrapped : [""];
 			});
+		}
+	}
+
+	function formatToolArgs(toolName: string, args: unknown): string {
+		if (!args || typeof args !== "object") return "";
+		const a = args as Record<string, unknown>;
+		switch (toolName) {
+			case "bash":
+				return typeof a.command === "string" ? truncateToWidth(a.command.split("\n")[0], 50, "…") : "";
+			case "read":
+			case "write":
+			case "edit":
+				return typeof a.path === "string" ? a.path : "";
+			default: {
+				const first = Object.values(a)[0];
+				return typeof first === "string" ? truncateToWidth(first.split("\n")[0], 40, "…") : "";
+			}
 		}
 	}
 
@@ -514,8 +450,6 @@ export default function (pi: ExtensionAPI) {
 		return lines;
 	}
 
-	// ── Overlay management ───────────────────────────────────────────────────
-
 	function syncOverlay(): void {
 		overlayRuntime?.refresh?.();
 	}
@@ -554,98 +488,6 @@ export default function (pi: ExtensionAPI) {
 		overlayRuntime?.setDraft?.(value);
 	}
 
-	async function ensureOverlay(ctx: ExtensionCommandContext | ExtensionContext): Promise<void> {
-		if (!ctx.hasUI) {
-			return;
-		}
-
-		if (overlayRuntime?.handle) {
-			overlayRuntime.handle.setHidden(false);
-			overlayRuntime.handle.focus();
-			overlayRuntime.refresh?.();
-			return;
-		}
-
-		const runtime: OverlayRuntime = {};
-		const closeRuntime = () => {
-			if (runtime.closed) {
-				return;
-			}
-			runtime.closed = true;
-			runtime.handle?.hide();
-			if (overlayRuntime === runtime) {
-				overlayRuntime = null;
-			}
-			runtime.finish?.();
-		};
-		runtime.close = closeRuntime;
-		overlayRuntime = runtime;
-
-		void ctx.ui
-			.custom<void>(
-				async (tui, theme, keybindings, done) => {
-					runtime.finish = () => done();
-
-					const overlay = new BtwOverlay(
-						tui,
-						theme,
-						keybindings,
-						(width, t) => getTranscriptLines(width, t),
-						() => overlayStatus,
-						(value) => {
-							void submitFromOverlay(ctx, value);
-						},
-						() => {
-							void closeOverlayFlow(ctx);
-						},
-					);
-
-					overlay.focused = true;
-					overlay.setDraft(overlayDraft);
-					runtime.setDraft = (value) => overlay.setDraft(value);
-					runtime.refresh = () => {
-						overlay.focused = runtime.handle?.isFocused() ?? false;
-						tui.requestRender();
-					};
-					runtime.close = () => {
-						overlayDraft = overlay.getDraft();
-						closeRuntime();
-					};
-
-					if (runtime.closed) {
-						done();
-					}
-
-					return overlay;
-				},
-				{
-					overlay: true,
-					overlayOptions: {
-						width: "80%",
-						minWidth: 72,
-						maxHeight: "78%",
-						anchor: "top-center",
-						margin: { top: 1, left: 2, right: 2 },
-					},
-					onHandle: (handle) => {
-						runtime.handle = handle;
-						handle.focus();
-						if (runtime.closed) {
-							closeRuntime();
-						}
-					},
-				},
-			)
-			.catch((error) => {
-				if (overlayRuntime === runtime) {
-					overlayRuntime = null;
-				}
-				notify(ctx, error instanceof Error ? error.message : String(error), "error");
-			});
-	}
-
-	// ── Side session management ───────────────────────────────────────────────
-
 	async function disposeSideSession(): Promise<void> {
 		const current = activeSideSession;
 		activeSideSession = null;
@@ -670,6 +512,56 @@ export default function (pi: ExtensionAPI) {
 			clearTimeout(overlayRefreshTimer);
 			overlayRefreshTimer = null;
 		}
+	}
+
+	async function resetThread(ctx: ExtensionContext | ExtensionCommandContext, persist = true): Promise<void> {
+		thread = [];
+		pendingQuestion = null;
+		pendingAnswer = "";
+		pendingError = null;
+		pendingToolCalls = [];
+		sideBusy = false;
+		setOverlayDraft("");
+		setOverlayStatus("Ready");
+		await disposeSideSession();
+		if (persist) {
+			const details: BtwResetDetails = { timestamp: Date.now() };
+			pi.appendEntry(BTW_RESET_TYPE, details);
+		}
+		syncOverlay();
+	}
+
+	async function restoreThread(ctx: ExtensionContext): Promise<void> {
+		await disposeSideSession();
+		thread = [];
+		pendingQuestion = null;
+		pendingAnswer = "";
+		pendingError = null;
+		pendingToolCalls = [];
+		sideBusy = false;
+		overlayStatus = "Ready";
+		overlayDraft = "";
+		const branch = ctx.sessionManager.getBranch();
+		let lastResetIndex = -1;
+		for (let i = 0; i < branch.length; i++) {
+			const entry = branch[i];
+			if (entry.type === "custom" && entry.customType === BTW_RESET_TYPE) {
+				lastResetIndex = i;
+			}
+		}
+
+		for (const entry of branch.slice(lastResetIndex + 1)) {
+			if (entry.type !== "custom" || entry.customType !== BTW_ENTRY_TYPE) {
+				continue;
+			}
+			const details = entry.data as BtwDetails | undefined;
+			if (!details?.question || !details.answer) {
+				continue;
+			}
+			thread.push(details);
+		}
+
+		syncOverlay();
 	}
 
 	async function createSideSession(ctx: ExtensionCommandContext): Promise<SideSessionRuntime | null> {
@@ -766,64 +658,105 @@ export default function (pi: ExtensionAPI) {
 		return activeSideSession;
 	}
 
-	// ── Thread management ─────────────────────────────────────────────────────
-
-	async function resetThread(ctx: ExtensionContext | ExtensionCommandContext, persist = true): Promise<void> {
-		thread = [];
-		pendingQuestion = null;
-		pendingAnswer = "";
-		pendingError = null;
-		pendingToolCalls = [];
-		sideBusy = false;
-		setOverlayDraft("");
-		setOverlayStatus("Ready");
-		await disposeSideSession();
-		if (persist) {
-			const details: BtwResetDetails = { timestamp: Date.now() };
-			pi.appendEntry(BTW_RESET_TYPE, details);
+	async function ensureOverlay(ctx: ExtensionCommandContext | ExtensionContext): Promise<void> {
+		if (!ctx.hasUI) {
+			return;
 		}
-		syncOverlay();
+
+		if (overlayRuntime?.handle) {
+			overlayRuntime.handle.setHidden(false);
+			overlayRuntime.handle.focus();
+			overlayRuntime.refresh?.();
+			return;
+		}
+
+		const runtime: OverlayRuntime = {};
+		const closeRuntime = () => {
+			if (runtime.closed) {
+				return;
+			}
+			runtime.closed = true;
+			runtime.handle?.hide();
+			if (overlayRuntime === runtime) {
+				overlayRuntime = null;
+			}
+			runtime.finish?.();
+		};
+		runtime.close = closeRuntime;
+		overlayRuntime = runtime;
+
+		void ctx.ui
+			.custom<void>(
+				async (tui, theme, keybindings, done) => {
+					runtime.finish = () => done();
+
+					const overlay = new BtwOverlay(
+						tui,
+						theme,
+						keybindings,
+						(width, t) => getTranscriptLines(width, t),
+						() => overlayStatus,
+						(value) => {
+							void submitFromOverlay(ctx, value);
+						},
+						() => {
+							void closeOverlayFlow(ctx);
+						},
+					);
+
+					overlay.focused = true;
+					overlay.setDraft(overlayDraft);
+					runtime.setDraft = (value) => overlay.setDraft(value);
+					runtime.refresh = () => {
+						overlay.focused = runtime.handle?.isFocused() ?? false;
+						tui.requestRender();
+					};
+					runtime.close = () => {
+						overlayDraft = overlay.getDraft();
+						closeRuntime();
+					};
+
+					if (runtime.closed) {
+						done();
+					}
+
+					return overlay;
+				},
+				{
+					overlay: true,
+					overlayOptions: {
+						width: "80%",
+						minWidth: 72,
+						maxHeight: "78%",
+						anchor: "top-center",
+						margin: { top: 1, left: 2, right: 2 },
+					},
+					onHandle: (handle) => {
+						runtime.handle = handle;
+						handle.focus();
+						if (runtime.closed) {
+							closeRuntime();
+						}
+					},
+				},
+			)
+			.catch((error) => {
+				if (overlayRuntime === runtime) {
+					overlayRuntime = null;
+				}
+				notify(ctx, error instanceof Error ? error.message : String(error), "error");
+			});
 	}
-
-	async function restoreThread(ctx: ExtensionContext): Promise<void> {
-		await disposeSideSession();
-		thread = [];
-		pendingQuestion = null;
-		pendingAnswer = "";
-		pendingError = null;
-		pendingToolCalls = [];
-		sideBusy = false;
-		overlayStatus = "Ready";
-		overlayDraft = "";
-		const branch = ctx.sessionManager.getBranch();
-		let lastResetIndex = -1;
-		for (let i = 0; i < branch.length; i++) {
-			const entry = branch[i];
-			if (entry.type === "custom" && entry.customType === BTW_RESET_TYPE) {
-				lastResetIndex = i;
-			}
-		}
-
-		for (const entry of branch.slice(lastResetIndex + 1)) {
-			if (entry.type !== "custom" || entry.customType !== BTW_ENTRY_TYPE) {
-				continue;
-			}
-			const details = entry.data as BtwDetails | undefined;
-			if (!details?.question || !details.answer) {
-				continue;
-			}
-			thread.push(details);
-		}
-
-		syncOverlay();
-	}
-
-	// ── Summarize & inject ────────────────────────────────────────────────────
 
 	async function summarizeThread(ctx: ExtensionContext, items: BtwDetails[]): Promise<string> {
 		const model = ctx.model;
 		if (!model) {
 			throw new Error("No active model selected.");
+		}
+
+		const auth = await ctx.modelRegistry.getApiKeyAndHeaders(model);
+		if (auth.ok === false) {
+			throw new Error(auth.error);
 		}
 
 		const { session } = await createAgentSession({
@@ -882,24 +815,6 @@ export default function (pi: ExtensionAPI) {
 		}
 	}
 
-	async function injectFullThread(ctx: ExtensionCommandContext): Promise<void> {
-		if (thread.length === 0) {
-			notify(ctx, "No BTW thread to inject.", "warning");
-			return;
-		}
-
-		const content = `Here is a side conversation I had for additional context:\n\n${formatThread(thread)}`;
-		if (ctx.isIdle()) {
-			pi.sendUserMessage(content);
-		} else {
-			pi.sendUserMessage(content, { deliverAs: "followUp" });
-		}
-
-		const count = thread.length;
-		await resetThread(ctx);
-		notify(ctx, `Injected BTW thread (${count} exchange${count === 1 ? "" : "s"}).`, "info");
-	}
-
 	async function closeOverlayFlow(ctx: ExtensionContext | ExtensionCommandContext): Promise<void> {
 		dismissOverlay();
 		if (!ctx.hasUI) {
@@ -916,13 +831,19 @@ export default function (pi: ExtensionAPI) {
 		}
 	}
 
-	// ── Core prompt flow ──────────────────────────────────────────────────────
-
-	async function runBtwPrompt(ctx: ExtensionCommandContext, question: string, saveRequested = false): Promise<void> {
+	async function runBtwPrompt(ctx: ExtensionCommandContext, question: string): Promise<void> {
 		const model = ctx.model;
 		if (!model) {
 			setOverlayStatus("No active model selected.");
 			notify(ctx, "No active model selected.", "error");
+			return;
+		}
+
+		const auth = await ctx.modelRegistry.getApiKeyAndHeaders(model);
+		if (auth.ok === false) {
+			const message = auth.error;
+			setOverlayStatus(message);
+			notify(ctx, message, "error");
 			return;
 		}
 
@@ -936,8 +857,6 @@ export default function (pi: ExtensionAPI) {
 			notify(ctx, "Unable to create BTW side session.", "error");
 			return;
 		}
-
-		const wasBusy = !ctx.isIdle();
 
 		sideBusy = true;
 		pendingQuestion = question;
@@ -974,14 +893,6 @@ export default function (pi: ExtensionAPI) {
 			thread.push(details);
 			pi.appendEntry(BTW_ENTRY_TYPE, details);
 
-			// Save visible note if --save was requested
-			const saveState = saveVisibleBtwNote(pi, details, saveRequested, wasBusy);
-			if (saveState === "saved") {
-				notify(ctx, "Saved BTW note to the session.", "info");
-			} else if (saveState === "queued") {
-				notify(ctx, "BTW note queued to save after the current turn finishes.", "info");
-			}
-
 			pendingQuestion = null;
 			pendingAnswer = "";
 			pendingToolCalls = [];
@@ -998,7 +909,7 @@ export default function (pi: ExtensionAPI) {
 	}
 
 	async function submitFromOverlay(ctx: ExtensionContext | ExtensionCommandContext, rawValue: string): Promise<void> {
-		const { question, save } = parseBtwArgs(rawValue);
+		const question = rawValue.trim();
 		if (!question) {
 			setOverlayStatus("Enter a question first.");
 			return;
@@ -1010,173 +921,51 @@ export default function (pi: ExtensionAPI) {
 			return;
 		}
 
-		await runBtwPrompt(ctx, question, save);
+		await runBtwPrompt(ctx, question);
 	}
 
-	// ── Message renderer ──────────────────────────────────────────────────────
+	pi.registerCommand("btw", {
+		description: "Open a simple BTW side-chat popover. `/btw <text>` asks immediately, `/btw` opens the side thread.",
+		handler: async (args, ctx) => {
+			const question = args.trim();
 
-	pi.registerMessageRenderer(BTW_MESSAGE_TYPE, (message, { expanded }, theme) => {
-		const details = message.details as BtwDetails | undefined;
-		const content = typeof message.content === "string" ? message.content : "[non-text btw message]";
-		const headerLines = [theme.fg("accent", theme.bold("[BTW]"))];
-
-		if (expanded && details) {
-			headerLines.push(
-				theme.fg("dim", `model: ${details.provider}/${details.model} · thinking: ${details.thinkingLevel}`),
-			);
-			if (details.usage) {
-				headerLines.push(
-					theme.fg(
-						"dim",
-						`tokens: in ${details.usage.input} · out ${details.usage.output} · total ${details.usage.totalTokens}`,
-					),
-				);
+			if (!question) {
+				if (thread.length > 0 && ctx.hasUI) {
+					const choice = await ctx.ui.select("BTW side chat:", ["Continue previous conversation", "Start fresh"]);
+					if (choice === "Continue previous conversation") {
+						// Dispose session so it's recreated with fresh main context on next submit
+						await disposeSideSession();
+						setOverlayStatus("Continuing BTW thread.");
+						await ensureOverlay(ctx);
+					} else if (choice === "Start fresh") {
+						await resetThread(ctx, true);
+						setOverlayStatus("Ready");
+						await ensureOverlay(ctx);
+					}
+					// null = user cancelled (Esc), do nothing
+				} else {
+					await resetThread(ctx, true);
+					setOverlayStatus("Ready");
+					await ensureOverlay(ctx);
+				}
+				return;
 			}
-		}
 
-		const container = new Container(1, 1);
-		container.addChild(new Markdown(headerLines.join("\n"), 0, 0, getMarkdownTheme()));
-		container.addChild(new Markdown(content, 0, 0, getMarkdownTheme()));
-		return container;
+			await ensureOverlay(ctx);
+			await runBtwPrompt(ctx, question);
+		},
 	});
-
-	// ── Context filter — keep BTW notes out of the main agent ─────────────────
-
-	pi.on("context", async (event) => ({
-		messages: event.messages.filter((message) => !isVisibleBtwMessage(message)),
-	}));
-
-	// ── Session lifecycle ─────────────────────────────────────────────────────
 
 	pi.on("session_start", async (_event, ctx) => {
 		await restoreThread(ctx);
 	});
 
 	pi.on("session_tree", async (_event, ctx) => {
-		if (sideBusy) return;
 		await restoreThread(ctx);
 	});
 
 	pi.on("session_shutdown", async () => {
 		await disposeSideSession();
 		dismissOverlay();
-	});
-
-	// ── Command handlers ──────────────────────────────────────────────────────
-
-	// ── Command handler functions ─────────────────────────────────────────────
-
-	const btwHandler = async (args: string, ctx: ExtensionCommandContext) => {
-		const { question, save } = parseBtwArgs(args);
-
-		if (!question) {
-			if (thread.length > 0 && ctx.hasUI) {
-				const choice = await ctx.ui.select("BTW side chat:", ["Continue previous conversation", "Start fresh"]);
-				if (choice === "Continue previous conversation") {
-					// Dispose session so it's recreated with fresh main context on next submit
-					await disposeSideSession();
-					setOverlayStatus("Continuing BTW thread.");
-					await ensureOverlay(ctx);
-				} else if (choice === "Start fresh") {
-					await resetThread(ctx);
-					setOverlayStatus("Ready");
-					await ensureOverlay(ctx);
-				}
-				// null = user cancelled (Esc), do nothing
-			} else {
-				await resetThread(ctx, true);
-				setOverlayStatus("Ready");
-				await ensureOverlay(ctx);
-			}
-			return;
-		}
-
-		await ensureOverlay(ctx);
-		await runBtwPrompt(ctx, question, save);
-	};
-
-	const btwClearHandler = async (_args: string, ctx: ExtensionCommandContext) => {
-		await resetThread(ctx);
-		dismissOverlay();
-		notify(ctx, "Cleared BTW thread.", "info");
-	};
-
-	const btwInjectHandler = async (_args: string, ctx: ExtensionCommandContext) => {
-		await injectFullThread(ctx);
-	};
-
-	const btwSummarizeHandler = async (args: string, ctx: ExtensionCommandContext) => {
-		if (thread.length === 0) {
-			notify(ctx, "No BTW thread to summarize.", "warning");
-			return;
-		}
-
-		setOverlayStatus("Summarizing...");
-		syncOverlay();
-
-		try {
-			const instructions = args.trim();
-			const summary = await summarizeThread(ctx, thread);
-			const content = instructions
-				? `Here is a summary of a side conversation I had. ${instructions}\n\n${summary}`
-				: `Summary of my BTW side conversation:\n\n${summary}`;
-
-			if (ctx.isIdle()) {
-				pi.sendUserMessage(content);
-			} else {
-				pi.sendUserMessage(content, { deliverAs: "followUp" });
-			}
-
-			const count = thread.length;
-			await resetThread(ctx);
-			notify(ctx, `Injected BTW summary (${count} exchange${count === 1 ? "" : "s"}).`, "info");
-		} catch (error) {
-			notify(ctx, error instanceof Error ? error.message : String(error), "error");
-		}
-	};
-
-	// ── Register /btw commands ────────────────────────────────────────────────
-
-	pi.registerCommand("btw", {
-		description:
-			"Open a BTW side-chat overlay. `/btw <text>` asks immediately, `/btw` opens the side thread, `/btw --save` persists a visible note.",
-		handler: btwHandler,
-	});
-
-	pi.registerCommand("btw clear", {
-		description: "Dismiss the BTW overlay and clear the current thread.",
-		handler: btwClearHandler,
-	});
-
-	pi.registerCommand("btw inject", {
-		description: "Inject the full BTW thread into the main agent as a user message.",
-		handler: btwInjectHandler,
-	});
-
-	pi.registerCommand("btw summarize", {
-		description: "Summarize the BTW thread, then inject the summary into the main agent.",
-		handler: btwSummarizeHandler,
-	});
-
-	// ── Register /qq aliases ──────────────────────────────────────────────────
-
-	pi.registerCommand("qq", {
-		description: "Quick question — alias for /btw. Side conversation without interrupting the main agent.",
-		handler: btwHandler,
-	});
-
-	pi.registerCommand("qq clear", {
-		description: "Dismiss the QQ overlay and clear the thread. Alias for /btw clear.",
-		handler: btwClearHandler,
-	});
-
-	pi.registerCommand("qq inject", {
-		description: "Inject the full QQ thread into the main agent. Alias for /btw inject.",
-		handler: btwInjectHandler,
-	});
-
-	pi.registerCommand("qq summarize", {
-		description: "Summarize the QQ thread and inject into the main agent. Alias for /btw summarize.",
-		handler: btwSummarizeHandler,
 	});
 }

--- a/packages/monopi__extension-btw/package.json
+++ b/packages/monopi__extension-btw/package.json
@@ -1,7 +1,7 @@
 {
 	"name": "@monopi/extension-btw",
 	"version": "0.5.1",
-	"description": "Monopi btw pi extension.",
+	"description": "Monopi BTW side-chat pi extension.",
 	"keywords": [
 		"pi-package"
 	],
@@ -9,7 +9,7 @@
 	"bugs": {
 		"url": "https://github.com/ifiokjr/monopi/issues"
 	},
-	"license": "MIT",
+	"license": "MIT AND Apache-2.0",
 	"repository": {
 		"type": "git",
 		"url": "git+https://github.com/ifiokjr/monopi.git",

--- a/packages/monopi__extension-btw/tests/btw.test.ts
+++ b/packages/monopi__extension-btw/tests/btw.test.ts
@@ -15,13 +15,16 @@ vi.mock("@earendil-works/pi-tui", () => ({
 		focused = false;
 		onSubmit: ((value: string) => void) | null = null;
 		onEscape: (() => void) | null = null;
-		setValue(_value: string) {}
+		private value = "";
+		setValue(value: string) {
+			this.value = value;
+		}
 		getValue() {
-			return "";
+			return this.value;
 		}
 		handleInput(_data: string) {}
 		render(_width: number) {
-			return [""];
+			return [this.value];
 		}
 	},
 	Markdown: class Markdown {
@@ -101,7 +104,15 @@ function makeAssistantResponse(text: string, stopReason = "stop") {
 	};
 }
 
-describe("btw commands and rendering", () => {
+function configureModel(harness: ReturnType<typeof createExtensionHarness>) {
+	harness.ctx.model = model as never;
+	harness.ctx.modelRegistry = {
+		getApiKeyAndHeaders: vi.fn().mockResolvedValue({ ok: true, apiKey: "direct-key", headers: {} }),
+		getAvailable: () => [],
+	} as never;
+}
+
+describe("btw command", () => {
 	beforeEach(() => {
 		vi.clearAllMocks();
 		mockSession.agent.state.messages = [];
@@ -113,35 +124,22 @@ describe("btw commands and rendering", () => {
 		});
 	});
 
-	it("registers btw and qq command families", () => {
+	it("registers the upstream single-command BTW flow", () => {
 		const harness = createExtensionHarness();
 		btwExtension(harness.pi as never);
 
-		const commands = Array.from(harness.commands.keys()).sort();
-		expect(commands).toContain("btw");
-		expect(commands).toContain("btw clear");
-		expect(commands).toContain("btw inject");
-		expect(commands).toContain("btw summarize");
-		expect(commands).toContain("qq");
-		expect(commands).toContain("qq clear");
-		expect(commands).toContain("qq inject");
-		expect(commands).toContain("qq summarize");
+		expect(Array.from(harness.commands.keys()).sort()).toEqual(["btw"]);
 	});
 
-	it("opens overlay when /btw is called without a question if no thread exists", async () => {
+	it("opens the overlay when /btw is called without a question", async () => {
 		const harness = createExtensionHarness();
-		harness.ctx.model = model as never;
-		harness.ctx.modelRegistry = {
-			getApiKey: vi.fn().mockResolvedValue("direct-key"),
-			getAvailable: () => [],
-		} as never;
+		configureModel(harness);
 		const customSpy = vi.fn().mockResolvedValue(null);
 		harness.ctx.ui.custom = customSpy;
 
 		btwExtension(harness.pi as never);
 		await harness.commands.get("btw").handler("", harness.ctx);
 
-		// Should have attempted to open the overlay
 		expect(customSpy).toHaveBeenCalled();
 	});
 
@@ -159,11 +157,7 @@ describe("btw commands and rendering", () => {
 
 	it("creates a side session and persists the thread entry", async () => {
 		const harness = createExtensionHarness();
-		harness.ctx.model = model as never;
-		harness.ctx.modelRegistry = {
-			getApiKey: vi.fn().mockResolvedValue("direct-key"),
-			getAvailable: () => [],
-		} as never;
+		configureModel(harness);
 		const appendEntry = vi.fn();
 		harness.pi.appendEntry = appendEntry;
 		harness.ctx.ui.custom = vi.fn().mockResolvedValue(null);
@@ -180,120 +174,34 @@ describe("btw commands and rendering", () => {
 		);
 	});
 
-	it("persists a btw-thread-reset on clear", async () => {
+	it("restores thread entries on session_start", async () => {
 		const harness = createExtensionHarness();
-		harness.ctx.model = model as never;
-		harness.ctx.modelRegistry = {
-			getApiKey: vi.fn().mockResolvedValue("direct-key"),
-			getAvailable: () => [],
-		} as never;
-		const appendEntry = vi.fn();
-		harness.pi.appendEntry = appendEntry;
-
-		btwExtension(harness.pi as never);
-		await harness.commands.get("btw clear").handler("", harness.ctx);
-
-		expect(appendEntry).toHaveBeenCalledWith(
-			"btw-thread-reset",
-			expect.objectContaining({ timestamp: expect.any(Number) }),
-		);
-		expect(harness.notifications).toContainEqual({
-			msg: "Cleared BTW thread.",
-			type: "info",
-		});
-	});
-
-	it("warns when inject is requested without a thread", async () => {
-		const harness = createExtensionHarness();
-		btwExtension(harness.pi as never);
-
-		await harness.commands.get("btw inject").handler("", harness.ctx);
-
-		expect(harness.notifications).toContainEqual({
-			msg: "No BTW thread to inject.",
-			type: "warning",
-		});
-	});
-
-	it("warns when summarize is requested without a thread", async () => {
-		const harness = createExtensionHarness();
-		btwExtension(harness.pi as never);
-
-		await harness.commands.get("btw summarize").handler("", harness.ctx);
-
-		expect(harness.notifications).toContainEqual({
-			msg: "No BTW thread to summarize.",
-			type: "warning",
-		});
-	});
-
-	it("filters visible BTW notes out of the main context and renders expanded messages", async () => {
-		const harness = createExtensionHarness();
-		btwExtension(harness.pi as never);
-
-		const [result] = await harness.emitAsync("context", {
-			messages: [
-				{ role: "user", content: "keep" },
-				{ role: "custom", customType: "btw-note", content: "hide" },
-			],
-		});
-		expect(result.messages).toEqual([{ role: "user", content: "keep" }]);
-
-		const renderer = harness.messageRenderers.get("btw-note");
-		const rendered = renderer(
+		const getBranch = vi.fn(() => [
 			{
-				content: "**Question:** Why?\n\nBecause.",
-				details: {
+				type: "custom",
+				customType: "btw-thread-entry",
+				data: {
+					question: "What changed?",
+					answer: "A few startup paths were deferred.",
 					provider: "anthropic",
 					model: "claude-sonnet-4",
-					thinkingLevel: "low",
-					usage: { input: 1, output: 2, totalTokens: 3 },
+					thinkingLevel: "off",
+					timestamp: Date.now(),
 				},
 			},
-			{ expanded: true },
-			{
-				bold: (text: string) => text,
-				fg: (_tone: string, text: string) => text,
-			},
-		);
-		expect(rendered.children.length).toBeGreaterThanOrEqual(1);
-		const markdownChildren = rendered.children.filter((c: any) => c.constructor.name === "Markdown");
-		expect(markdownChildren.length).toBeGreaterThanOrEqual(2);
-		// Second Markdown child is the content
-		expect(markdownChildren[1].text).toContain("Because.");
-	});
-
-	it("injects a full thread into the main session", async () => {
-		const harness = createExtensionHarness();
-		harness.ctx.model = model as never;
-		harness.ctx.modelRegistry = {
-			getApiKey: vi.fn().mockResolvedValue("direct-key"),
-			getAvailable: () => [],
-		} as never;
-		const appendEntry = vi.fn();
-		const sendUserMessage = vi.fn();
-		harness.pi.appendEntry = appendEntry;
-		harness.pi.sendUserMessage = sendUserMessage;
+		]);
+		harness.ctx.sessionManager.getBranch = getBranch;
 
 		btwExtension(harness.pi as never);
-		// First create a thread entry
-		await harness.commands.get("btw").handler("Investigate auth", harness.ctx);
-		// Then inject it
-		await harness.commands.get("btw inject").handler("", harness.ctx);
+		await harness.emitAsync("session_start", { type: "session_start" }, harness.ctx);
 
-		expect(sendUserMessage).toHaveBeenCalledWith(expect.stringContaining("side conversation"));
-		expect(appendEntry).toHaveBeenCalledWith("btw-thread-reset", expect.any(Object));
+		expect(getBranch).toHaveBeenCalled();
 	});
 
-	it("does not reset thread on session_tree while busy", async () => {
+	it("does not reset the thread on session_tree while a side prompt is busy", async () => {
 		const harness = createExtensionHarness();
-		harness.ctx.model = model as never;
-		harness.ctx.modelRegistry = {
-			getApiKey: vi.fn().mockResolvedValue("direct-key"),
-			getAvailable: () => [],
-		} as never;
+		configureModel(harness);
 
-		// Make the prompt never resolve (simulating busy state)
 		let resolvePrompt: (() => void) | undefined;
 		mockSession.prompt.mockImplementation(
 			() =>
@@ -303,14 +211,11 @@ describe("btw commands and rendering", () => {
 		);
 
 		btwExtension(harness.pi as never);
-
 		const runPromise = harness.commands.get("btw").handler("Question?", harness.ctx);
-
-		await new Promise((r) => setTimeout(r, 0));
+		await new Promise((resolve) => setTimeout(resolve, 0));
 
 		const getBranch = vi.fn(() => []);
 		harness.ctx.sessionManager.getBranch = getBranch;
-
 		harness.emit("session_tree", { type: "session_tree" }, harness.ctx);
 
 		expect(getBranch).not.toHaveBeenCalled();
@@ -329,21 +234,22 @@ describe("btw startup restore", () => {
 		vi.useRealTimers();
 	});
 
-	it("restores thread on session_start", async () => {
+	it("ignores entries before the last reset marker", async () => {
 		const harness = createExtensionHarness();
 		const getBranch = vi.fn(() => [
 			{
 				type: "custom",
 				customType: "btw-thread-entry",
 				data: {
-					question: "What changed?",
-					answer: "A few startup paths were deferred.",
+					question: "Old question",
+					answer: "Old answer",
 					provider: "anthropic",
 					model: "claude-sonnet-4",
 					thinkingLevel: "off",
 					timestamp: Date.now(),
 				},
 			},
+			{ type: "custom", customType: "btw-thread-reset", data: { timestamp: Date.now() } },
 		]);
 		harness.ctx.sessionManager.getBranch = getBranch;
 


### PR DESCRIPTION
## Summary

Adopts useful simplifications from [`mitsuhiko/agent-stuff`](https://github.com/mitsuhiko/agent-stuff) into the existing `@monopi/extension-btw` and `@monopi/extension-answer` packages.

### `@monopi/extension-btw`
- Replaces the local implementation with the simpler upstream side-chat flow.
- Updates tests for the upstream single `/btw` command behavior and side-thread persistence model.
- Adds Apache-2.0 attribution and updates package license to `MIT AND Apache-2.0`.

### `@monopi/extension-answer`
- Keeps the Monopi Q&A UI flow (`@monopi/shared-qna`).
- Adds upstream-inspired extraction model selection (prefers a configured fast Codex/Haiku model when available).
- Adds `parseJsonWithRepair` and object-shaped `{ "questions": [...] }` output handling.
- Adds tests for the new paths and README attribution.
- Updates package license to `MIT AND Apache-2.0`.

### Other
- Adds changeset `upstream-btw-answer.md`.

## Checklist
- [x] `pnpm format:check`
- [x] `pnpm lint`
- [x] `pnpm typecheck`
- [x] `pnpm test` (1340 passed)
- [x] `pnpm exec mc check`
- [x] `pnpm mdt check`