### PR TITLE
fix(ollama): infer thinking metadata dynamically

### DIFF
--- a/.changeset/1782990116-default.md
+++ b/.changeset/1782990116-default.md
@@ -1,0 +1,7 @@
+---
+default: patch
+---
+
+# Detect Ollama thinking metadata dynamically
+
+Ollama model discovery now infers thinking-capable families, records supported thinking levels, and preserves token/compatibility metadata when models are cached or written to models.json.

--- a/packages/monopi__cli/src/utils/writers.test.ts
+++ b/packages/monopi__cli/src/utils/writers.test.ts
@@ -204,6 +204,40 @@ describe("provider keep strategy", () => {
 		expect(models.providers.openai.api).toBe("openai-responses");
 	});
 
+	it("writeModelConfig persists discovered thinking metadata", () => {
+		const dir = makeTempDir();
+		writeModelConfig(
+			dir,
+			makeConfig({
+				providerStrategy: "replace",
+				providers: [
+					{
+						name: "custom-ollama",
+						apiKey: "none",
+						baseUrl: "http://localhost:11434/v1",
+						api: "openai-completions",
+						discoveredModels: [
+							{
+								contextWindow: 131072,
+								id: "gpt-oss:120b",
+								input: ["text"],
+								maxTokens: 32768,
+								reasoning: true,
+								thinkingLevelMap: { off: null, low: "low", medium: "medium", high: "high", xhigh: null },
+								compat: { maxTokensField: "max_tokens", supportsDeveloperRole: false },
+							},
+						],
+					},
+				],
+			}),
+		);
+
+		const models = JSON.parse(readFileSync(join(dir, "models.json"), "utf8"));
+		const [model] = models.providers["custom-ollama"].models;
+		expect(model.thinkingLevelMap).toEqual({ off: null, low: "low", medium: "medium", high: "high", xhigh: null });
+		expect(model.compat).toEqual({ maxTokensField: "max_tokens", supportsDeveloperRole: false });
+	});
+
 	it("writeProviderEnv merges auth/settings when strategy is add", () => {
 		const dir = makeTempDir();
 		const settingsPath = join(dir, "settings.json");

--- a/packages/monopi__cli/src/utils/writers.ts
+++ b/packages/monopi__cli/src/utils/writers.ts
@@ -161,15 +161,24 @@ export function writeModelConfig(agentDir: string, config: OhPConfigWithRouting)
 			}
 
 			if (cp.discoveredModels?.length) {
-				entry.models = cp.discoveredModels.map((m) => ({
-					contextWindow: m.contextWindow,
-					cost: { cacheRead: 0, cacheWrite: 0, input: 0, output: 0 },
-					id: m.id,
-					input: m.input,
-					maxTokens: m.maxTokens,
-					name: m.id,
-					reasoning: m.reasoning,
-				}));
+				entry.models = cp.discoveredModels.map((m) => {
+					const modelEntry: Record<string, unknown> = {
+						contextWindow: m.contextWindow,
+						cost: { cacheRead: 0, cacheWrite: 0, input: 0, output: 0 },
+						id: m.id,
+						input: m.input,
+						maxTokens: m.maxTokens,
+						name: m.id,
+						reasoning: m.reasoning,
+					};
+					if (m.thinkingLevelMap) {
+						modelEntry.thinkingLevelMap = m.thinkingLevelMap;
+					}
+					if (m.compat) {
+						modelEntry.compat = m.compat;
+					}
+					return modelEntry;
+				});
 			} else if (cp.defaultModel) {
 				const caps = MODEL_CAPABILITIES[cp.defaultModel];
 				entry.models = [

--- a/packages/monopi__core/src/types.ts
+++ b/packages/monopi__core/src/types.ts
@@ -9,6 +9,10 @@ export interface DiscoveredModel {
 	input: ("text" | "image")[];
 	contextWindow: number;
 	maxTokens: number;
+	/** Maps pi thinking levels to provider values; null marks unsupported levels. */
+	thinkingLevelMap?: Partial<Record<"off" | "minimal" | "low" | "medium" | "high" | "xhigh", string | null>>;
+	/** Provider-specific compatibility overrides for generated models.json entries. */
+	compat?: Record<string, unknown>;
 }
 
 /** Configuration for a single LLM provider (API key, endpoint, model selection). */

--- a/packages/monopi__provider-ollama/index.ts
+++ b/packages/monopi__provider-ollama/index.ts
@@ -6,6 +6,7 @@ import {
 	type Context,
 	type Model,
 	type SimpleStreamOptions,
+	getSupportedThinkingLevels,
 	streamSimpleOpenAICompletions,
 } from "@earendil-works/pi-ai";
 
@@ -711,6 +712,7 @@ function renderModelInfo(model: CollectedOllamaModel): string {
 		`Source: ${model.provider === OLLAMA_LOCAL_PROVIDER ? "Local Ollama daemon" : "Ollama Cloud"}`,
 		`Inputs: ${model.input.join(", ")}`,
 		`Reasoning: ${model.reasoning ? "yes" : "no"}`,
+		`Thinking levels: ${getSupportedThinkingLevels(model as Model<Api>).join(", ")}`,
 		`Context window: ${model.contextWindow.toLocaleString()}`,
 		`Max tokens: ${model.maxTokens.toLocaleString()}`,
 		`Base URL: ${model.baseUrl}`,

--- a/packages/monopi__provider-ollama/models.ts
+++ b/packages/monopi__provider-ollama/models.ts
@@ -46,6 +46,8 @@ interface OllamaShowResponse {
 	capabilities?: unknown;
 	model_info?: Record<string, unknown>;
 	details?: Record<string, unknown>;
+	parameters?: unknown;
+	template?: unknown;
 }
 
 const DEFAULT_CONTEXT_WINDOW = 128_000;
@@ -61,12 +63,27 @@ const OLLAMA_OPENAI_COMPAT: NonNullable<OllamaProviderModel["compat"]> = {
 };
 
 const OLLAMA_REASONING_THINKING_LEVEL_MAP: ThinkingLevelMap = {
+	off: "none",
 	minimal: "low",
 	low: "low",
 	medium: "medium",
 	high: "high",
-	xhigh: "high",
+	xhigh: "max",
 };
+
+const OLLAMA_GPT_OSS_THINKING_LEVEL_MAP: ThinkingLevelMap = {
+	off: null,
+	minimal: "low",
+	low: "low",
+	medium: "medium",
+	high: "high",
+	xhigh: null,
+};
+
+const OLLAMA_GPT_OSS_MODEL_PATTERN = /(?:^|[-_/:])gpt[-_]?oss(?:$|[-_/:])/i;
+const OLLAMA_QWEN3_MODEL_PATTERN = /(?:^|[-_/:])qwen3(?:$|[-_/:.])/i;
+const OLLAMA_DEEPSEEK_THINKING_MODEL_PATTERN = /(?:^|[-_/:])deepseek[-_]?(?:r1|v3\.?1)(?:$|[-_/:.])/i;
+const OLLAMA_THINKING_TEMPLATE_PATTERN = /<think>|\.thinking\b|reasoning_content/i;
 
 const OLLAMA_CLOUD_ZAI_COMPAT: Partial<NonNullable<OllamaProviderModel["compat"]>> = {
 	supportsReasoningEffort: false,
@@ -217,6 +234,7 @@ export function toOllamaModel(
 	const contextWindow = normalizePositiveInteger(model.contextWindow, DEFAULT_CONTEXT_WINDOW);
 	const maxTokens = normalizeModelMaxTokens(model, contextWindow);
 	const compatDefaults = getOllamaCompatDefaults(model);
+	const reasoning = normalizeModelReasoning(model);
 	return {
 		capabilities: sanitizeCapabilities(model.capabilities),
 		compat: {
@@ -234,11 +252,9 @@ export function toOllamaModel(
 		name: applySourceSuffix(model.name?.trim() || formatDisplayName(model.id), model.source),
 		parameterSize: sanitizeOptionalString(model.parameterSize),
 		quantization: sanitizeOptionalString(model.quantization),
-		reasoning: model.reasoning ?? false,
+		reasoning,
 		source: model.source,
-		thinkingLevelMap: model.reasoning
-			? (model.thinkingLevelMap ?? OLLAMA_REASONING_THINKING_LEVEL_MAP)
-			: model.thinkingLevelMap,
+		thinkingLevelMap: getOllamaThinkingLevelMap(model, reasoning),
 	};
 }
 
@@ -301,6 +317,7 @@ function cloneModel(model: OllamaProviderModel): OllamaProviderModel {
 		cost: { ...model.cost },
 		input: [...model.input],
 		localAvailability: model.localAvailability,
+		thinkingLevelMap: model.thinkingLevelMap ? { ...model.thinkingLevelMap } : undefined,
 	};
 }
 
@@ -328,25 +345,31 @@ function normalizeDiscoveredModel(
 		? payload.capabilities.filter((capability): capability is string => typeof capability === "string")
 		: [];
 	const capabilitySet = new Set(capabilities.map((capability) => capability.toLowerCase()));
-	const rawContext = extractContextWindow(payload.model_info);
-	const contextWindow = rawContext ?? fallback?.contextWindow ?? cached?.contextWindow ?? DEFAULT_CONTEXT_WINDOW;
+	const parameters = parseOllamaParameters(payload.parameters);
+	const rawContext = extractContextWindow(payload.model_info) ?? extractParameterInteger(parameters, "num_ctx");
+	const family = extractDetailField(payload.details, "family") ?? cached?.family ?? fallback?.family;
+	const contextWindow = rawContext ?? cached?.contextWindow ?? fallback?.contextWindow ?? DEFAULT_CONTEXT_WINDOW;
+	const rawMaxTokens =
+		extractOutputTokenLimit(payload.model_info) ?? extractParameterInteger(parameters, "num_predict");
 	const maxTokens =
-		fallback?.maxTokens ??
-		cached?.maxTokens ??
-		(rawContext ? inferMaxTokens(rawContext) : inferMaxTokens(contextWindow));
+		rawMaxTokens ?? cached?.maxTokens ?? fallback?.maxTokens ?? inferMaxTokens(contextWindow, { id, source });
+	const reasoning =
+		capabilitySet.has("thinking") ||
+		modelMatchesOllamaThinkingCatalog({ family, id, source, template: payload.template }) ||
+		Boolean(cached?.reasoning ?? fallback?.reasoning);
 	return toOllamaModel({
 		capabilities,
 		contextWindow,
-		family: extractDetailField(payload.details, "family") ?? fallback?.family ?? cached?.family,
+		family,
 		id,
-		input: capabilitySet.has("vision") ? ["text", "image"] : (fallback?.input ?? cached?.input ?? ["text"]),
+		input: capabilitySet.has("vision") ? ["text", "image"] : (cached?.input ?? fallback?.input ?? ["text"]),
 		localAvailability: source === "local" ? "installed" : undefined,
 		maxTokens,
 		parameterSize:
-			extractDetailField(payload.details, "parameter_size") ?? fallback?.parameterSize ?? cached?.parameterSize,
+			extractDetailField(payload.details, "parameter_size") ?? cached?.parameterSize ?? fallback?.parameterSize,
 		quantization:
-			extractDetailField(payload.details, "quantization_level") ?? fallback?.quantization ?? cached?.quantization,
-		reasoning: capabilitySet.has("thinking") || fallback?.reasoning || cached?.reasoning,
+			extractDetailField(payload.details, "quantization_level") ?? cached?.quantization ?? fallback?.quantization,
+		reasoning,
 		source,
 	});
 }
@@ -359,12 +382,51 @@ function extractContextWindow(modelInfo: Record<string, unknown> | undefined): n
 		if (!key.endsWith(".context_length")) {
 			continue;
 		}
-		const parsed = typeof value === "number" ? value : Number(value);
-		if (Number.isFinite(parsed) && parsed > 0) {
-			return Math.floor(parsed);
+		const parsed = normalizeUnknownPositiveInteger(value);
+		if (parsed) {
+			return parsed;
 		}
 	}
 	return null;
+}
+
+function extractOutputTokenLimit(modelInfo: Record<string, unknown> | undefined): number | null {
+	if (!modelInfo) {
+		return null;
+	}
+	for (const [key, value] of Object.entries(modelInfo)) {
+		if (!key.endsWith(".max_output_tokens")) {
+			continue;
+		}
+		const parsed = normalizeUnknownPositiveInteger(value);
+		if (parsed) {
+			return parsed;
+		}
+	}
+	return null;
+}
+
+function parseOllamaParameters(parameters: unknown): ReadonlyMap<string, number> {
+	if (typeof parameters !== "string" || parameters.trim().length === 0) {
+		return new Map();
+	}
+
+	const values = new Map<string, number>();
+	for (const line of parameters.split(/\r?\n/)) {
+		const [key, rawValue] = line.trim().split(/\s+/, 2);
+		if (!key || !rawValue) {
+			continue;
+		}
+		const parsed = normalizeUnknownPositiveInteger(rawValue);
+		if (parsed) {
+			values.set(key, parsed);
+		}
+	}
+	return values;
+}
+
+function extractParameterInteger(parameters: ReadonlyMap<string, number>, key: string): number | null {
+	return parameters.get(key) ?? null;
 }
 
 function sanitizeInput(input: OllamaProviderModel["input"] | undefined): ("text" | "image")[] {
@@ -392,6 +454,26 @@ function inferMaxTokens(
 	return DEFAULT_MAX_TOKENS;
 }
 
+function normalizeModelReasoning(
+	model: Partial<Pick<OllamaProviderModel, "family" | "id" | "reasoning" | "source">>,
+): boolean {
+	return model.reasoning ?? modelMatchesOllamaThinkingCatalog(model);
+}
+
+function getOllamaThinkingLevelMap(
+	model: Partial<Pick<OllamaProviderModel, "family" | "id" | "source" | "thinkingLevelMap">>,
+	reasoning: boolean,
+): ThinkingLevelMap | undefined {
+	if (!reasoning) {
+		return model.thinkingLevelMap;
+	}
+	if (isOllamaGptOssModel(model)) {
+		return OLLAMA_GPT_OSS_THINKING_LEVEL_MAP;
+	}
+
+	return model.thinkingLevelMap ?? OLLAMA_REASONING_THINKING_LEVEL_MAP;
+}
+
 function normalizeModelMaxTokens(
 	model: Partial<OllamaProviderModel> & Pick<OllamaProviderModel, "id">,
 	contextWindow: number,
@@ -416,12 +498,45 @@ function getOllamaCompatDefaults(
 	return {};
 }
 
+function modelMatchesOllamaThinkingCatalog(
+	model: Partial<Pick<OllamaProviderModel, "family" | "id" | "source">> & { template?: unknown },
+): boolean {
+	if (isOllamaGptOssModel(model) || isOllamaQwen3Model(model) || isOllamaDeepSeekThinkingModel(model)) {
+		return true;
+	}
+	if (isOllamaCloudZaiModel(model)) {
+		return true;
+	}
+	return typeof model.template === "string" && OLLAMA_THINKING_TEMPLATE_PATTERN.test(model.template);
+}
+
+function isOllamaGptOssModel(model: Partial<Pick<OllamaProviderModel, "family" | "id">>): boolean {
+	return modelHasToken(model, OLLAMA_GPT_OSS_MODEL_PATTERN);
+}
+
+function isOllamaQwen3Model(model: Partial<Pick<OllamaProviderModel, "family" | "id">>): boolean {
+	return modelHasToken(model, OLLAMA_QWEN3_MODEL_PATTERN);
+}
+
+function isOllamaDeepSeekThinkingModel(model: Partial<Pick<OllamaProviderModel, "family" | "id">>): boolean {
+	return modelHasToken(model, OLLAMA_DEEPSEEK_THINKING_MODEL_PATTERN);
+}
+
+function modelHasToken(model: Partial<Pick<OllamaProviderModel, "family" | "id">>, pattern: RegExp): boolean {
+	return pattern.test(model.id ?? "") || pattern.test(model.family ?? "");
+}
+
 function isOllamaCloudZaiModel(model: Partial<Pick<OllamaProviderModel, "id" | "source">>): boolean {
 	return model.source === "cloud" && typeof model.id === "string" && model.id.trim().toLowerCase().startsWith("glm-");
 }
 
 function normalizePositiveInteger(value: number | undefined, fallback: number): number {
 	return typeof value === "number" && Number.isFinite(value) && value > 0 ? Math.floor(value) : fallback;
+}
+
+function normalizeUnknownPositiveInteger(value: unknown): number | null {
+	const parsed = typeof value === "number" ? value : Number(value);
+	return Number.isFinite(parsed) && parsed > 0 ? Math.floor(parsed) : null;
 }
 
 function formatDisplayName(id: string): string {

--- a/packages/monopi__provider-ollama/tests/models.test.ts
+++ b/packages/monopi__provider-ollama/tests/models.test.ts
@@ -1,3 +1,4 @@
+import { getSupportedThinkingLevels } from "@earendil-works/pi-ai";
 import { mkdtemp, rm } from "node:fs/promises";
 import { tmpdir } from "node:os";
 import { join } from "node:path";
@@ -80,6 +81,8 @@ describe("ollama models", () => {
 		const models = await discoverOllamaCloudModelList("test-key");
 		expect(models?.map((model) => model.id)).toEqual(["brand-new-cloud-model", "gpt-oss:120b"]);
 		expect(models?.[0]?.source).toBe("cloud");
+		expect(models?.[1]?.reasoning).toBe(true);
+		expect(getSupportedThinkingLevels(models![1]! as never)).toEqual(["minimal", "low", "medium", "high"]);
 		expect(backend.getAuthHeaders()).toEqual(["Bearer test-key"]);
 		await backend.close();
 	});
@@ -246,6 +249,34 @@ describe("ollama models", () => {
 		await backend.close();
 	});
 
+	it("uses Ollama show metadata and catalog heuristics for thinking and token limits", async () => {
+		const backend = await createTestOllamaBackend();
+		backend.setModels([
+			{
+				id: "qwen3:32b",
+				capabilities: ["completion", "tools"],
+				contextWindow: 32768,
+				family: "qwen3",
+				maxTokens: 8192,
+				parameters: "temperature 0.7\nnum_ctx 65536\nnum_predict 12288",
+			},
+		]);
+		process.env.OLLAMA_HOST = backend.origin;
+		const models = await discoverOllamaLocalModels();
+		expect(models?.[0]?.reasoning).toBe(true);
+		expect(models?.[0]?.contextWindow).toBe(32768);
+		expect(models?.[0]?.maxTokens).toBe(8192);
+		expect(getSupportedThinkingLevels(models![0]! as never)).toEqual([
+			"off",
+			"minimal",
+			"low",
+			"medium",
+			"high",
+			"xhigh",
+		]);
+		await backend.close();
+	});
+
 	it("uses default metadata when show discovery fails", async () => {
 		const backend = await createTestOllamaBackend();
 		backend.setModels([
@@ -267,7 +298,7 @@ describe("ollama models", () => {
 		const models = await discoverOllamaCloudModels("test-key");
 		expect(models?.map((model) => model.id)).toEqual(["gpt-oss:120b", "qwen3-vl:235b"]);
 		expect(models?.[1]?.input).toEqual(["text"]);
-		expect(models?.[1]?.reasoning).toBe(false);
+		expect(models?.[1]?.reasoning).toBe(true);
 		await backend.close();
 	});
 

--- a/packages/monopi__provider-ollama/tests/test-backend.ts
+++ b/packages/monopi__provider-ollama/tests/test-backend.ts
@@ -7,7 +7,9 @@ interface BackendModel {
 	capabilities?: string[];
 	contextWindow?: number;
 	family?: string;
+	maxTokens?: number;
 	parameterSize?: string;
+	parameters?: string;
 	quantization?: string;
 }
 
@@ -92,7 +94,9 @@ export async function createTestOllamaBackend(): Promise<TestOllamaBackend> {
 						},
 						model_info: {
 							[`${family}.context_length`]: match.contextWindow ?? 131072,
+							[`${family}.max_output_tokens`]: match.maxTokens ?? undefined,
 						},
+						parameters: match.parameters,
 					}),
 				);
 			});


### PR DESCRIPTION
## Summary
- infer Ollama thinking support from show capabilities, known thinking model families, and chat templates
- expose correct supported thinking levels for generic Ollama reasoning models and GPT-OSS
- preserve discovered thinking/compat metadata when writing generated models.json entries

## Verification
- pnpm format:check
- pnpm --filter @monopi/provider-ollama typecheck
- pnpm --filter @monopi/provider-ollama test:worktree
- pnpm typecheck
- pnpm lint
- pnpm mc check