### PR TITLE
chore(format): run oxfmt across TOML and Markdown

### DIFF
--- a/.changeset/1782996033-default.md
+++ b/.changeset/1782996033-default.md
@@ -1,0 +1,7 @@
+---
+default: patch
+---
+
+# Format TOML and Markdown project files
+
+Project formatting now uses a single lint:fix command that runs oxfmt before oxlint, and monochange.toml is kept in oxfmt-compatible TOML formatting.

--- a/monochange.toml
+++ b/monochange.toml
@@ -1,525 +1,63 @@
 #:schema https://monochange.github.io/monochange/schemas/monochange.schema.json
-# =============================================================================
-# monochange.toml - repository configuration for monochange
-# =============================================================================
-#
-# This file is the single source of truth for release planning, CLI commands,
-# changelog generation, and automation flows in this monorepo.
-#
-# Run `monochange step validate` to check this file against the workspace.
-# Run `monochange init` to generate a starter config from detected packages.
-
-# =============================================================================
-# [defaults] - repository-wide defaults applied to every package unless
-# overridden at the package or group level.
-# =============================================================================
 
 [defaults]
-# Bump severity applied to transitive dependents when a dependency changes.
-# When package A depends on package B, and B gets a minor bump, A receives
-# whichever bump is configured here.
-#
-# Options: "none", "patch", "minor", "major"
-# Default: "patch"
 parent_bump = "patch"
-
-# Whether to include private packages (publish = false) in discovery and
-# release planning. When false, private packages are discovered but excluded
-# from release plans and version bumps.
-#
-# Default: false
 include_private = false
-
-# Emit a warning when version-group members have mismatched current versions.
-# Helps catch accidental version drift in grouped packages.
-#
-# Default: true
 warn_on_group_mismatch = true
-
-# Default package type for all packages that don't declare their own `type`.
-# Setting this avoids repeating `type = "cargo"` on every [package.*] entry.
-#
-# Options: "cargo", "npm", "deno", "dart", "flutter", "python"
-# Default: none (each package must declare its own type)
-# package_type = "cargo"
-
-# Default changelog configuration applied to every package that doesn't
-# declare its own `changelog` field.
-#
-# Accepts three forms:
-#   true                           → use "{{ path }}/CHANGELOG.md" for every package
-#   false                          → disable changelogs by default
-#   "{{ path }}/changelog.md"      → pattern where {{ path }} is replaced with each package path
-#
-# As a table, you can set path, format, and the initial header used when
-# monochange creates a changelog from empty content:
-#   [defaults.changelog]
-#   path = "{{ path }}/changelog.md"
-#   format = "keep_a_changelog"
-#   initial_header = """
-#   # Changelog
-#
-#   All notable changes to this project will be documented in this file.
-#   """
-#
-# Supported formats: "monochange" (default), "keep_a_changelog"
-# Default: none (changelogs are disabled unless configured)
-# [defaults.changelog]
-# path = "{{ path }}/changelog.md"
-# format = "keep_a_changelog"
-# initial_header = """
-# # Changelog
-#
-# All notable changes to this project will be documented in this file.
-#
-# This changelog is managed by [monochange](https://github.com/monochange/monochange).
-# """
-
-# Default changelog configuration. When [changelog] is not specified,
-# built-in defaults provide standard sections (Major, Breaking Change, Added,
-# Minor, Changed, Fixed, Patch, Testing, Refactor, Documentation, Security,
-# Performance, None) and corresponding types. See [changelog] section below
-# for customization.
-# [changelog] - workspace-wide changelog configuration
-#
-# Controls templates, sections, and types for changelog rendering.
-# When omitted, built-in defaults provide standard sections and types.
-#
-# [changelog]
-# templates - Templates that control how individual change entries render.
-# Each template is tried in order; the first one whose required variables are
-# all present wins. If none match, falls back to "- ".
-#
-# sections - Named changelog sections with heading and priority (lower = first).
-# The built-in defaults provide standard sections matching the commented example.
-#
-# section_thresholds - Optional rendering cutoffs based on section priority.
-# Use these to collapse lower-priority sections into markdown <details> blocks
-# or omit them entirely.
-#
-# types - Change type definitions mapping changeset types to section and bump severity.
-# Each type key references a section key and declares a default bump severity.
-# The built-in defaults provide standard types matching the commented example.
-
-# [changelog.templates]
-# Add custom templates if the defaults don't match your style.
-
-# [changelog.sections]
-# major = { heading = "Major", description = "Major version bumps", priority = 5 }
-# breaking = { heading = "Breaking Change", description = "API changes requiring migration", priority = 10 }
-# minor = { heading = "Minor", description = "Minor version bumps", priority = 15 }
-# feat = { heading = "Added", description = "New features added", priority = 20 }
-# change = { heading = "Changed", description = "Changes to existing functionality", priority = 25 }
-# fix = { heading = "Fixed", description = "Bug fixes", priority = 30 }
-# patch = { heading = "Patch", description = "Patch version bumps", priority = 35 }
-# test = { heading = "Testing", description = "Changes that only modify tests", priority = 40 }
-# refactor = { heading = "Refactor", description = "Code refactoring without functional changes", priority = 40 }
-# docs = { heading = "Documentation", description = "Changes that only modify documentation", priority = 40 }
-# security = { heading = "Security", description = "Security-related changes", priority = 40 }
-# perf = { heading = "Performance", description = "Performance improvements", priority = 40 }
-# none = { heading = "None", description = "No version bump", priority = 50 }
-
-# [changelog.section_thresholds]
-# collapse = 127
-# ignored = 127
-
-# [changelog.types]
-# breaking = { section = "breaking", bump = "major" }
-# major = { section = "major", bump = "major" }
-# feat = { section = "feat", bump = "minor" }
-# minor = { section = "minor", bump = "minor" }
-# change = { section = "change", bump = "minor" }
-# fix = { section = "fix", bump = "patch" }
-# patch = { section = "patch", bump = "patch" }
-# test = { section = "test" }
-# none = { section = "none" }
-# docs = { section = "docs" }
-# security = { section = "security" }
-# refactor = { section = "refactor", bump = "patch" }
-# perf = { heading = "perf" }
-
-
-# Default empty_update_message applied when a package is bumped but has no
-# direct changeset entries (e.g. transitive dependency bumps or group
-# synchronization). Template placeholders are interpolated at render time
-# using minijinja syntax.
-#
-# Available placeholders:
-#   {{ package }}, {{ package_name }}, {{ package_id }}
-#   {{ group }}, {{ group_name }}, {{ group_id }}
-#   {{ version }}, {{ new_version }}, {{ current_version }}, {{ previous_version }}
-#   {{ bump }}, {{ trigger }}, {{ ecosystem }}
-#   {{ release_owner }}, {{ release_owner_kind }}
-#   {{ members }}, {{ member_count }}  (group changelogs only)
-#   {{ reasons }}
-#
-# Precedence: package → group → defaults → built-in message
-# Default: built-in message varies by grouped/ungrouped context
-#
-# empty_update_message = "No direct changes; {{ package }} updated to {{ version }}."
-
-
-# Default release_title applied when creating provider releases.
-# This is a plain-text title used for GitHub, GitLab, and Gitea releases.
-#
-# Available placeholders:
-#   {{ version }}, {{ id }}, {{ date }}, {{ time }}, {{ datetime }}
-#   {{ changes_count }}, {{ tag_url }}, {{ compare_url }}
-#
-# Defaults:
-#   Primary versioning:    " ()"
-#   Namespaced versioning: "  ()"
-#
-# release_title = "{{ version }} ({{ date }})"
-
-
-# Default changelog_version_title controls how changelog version headings render.
-# This is markdown-capable and supports links.
-#
-# Available placeholders: same as release_title above.
-#
-# Defaults:
-#   Primary:    "[]() ()" (linked when source configured)
-#   Namespaced: " []() ()"
-#
-# To restore headings without dates (the previous default), set:
-#   changelog_version_title = "{{ version }}"
-#
-# changelog_version_title = "[{{ version }}]({{ tag_url }}) ({{ date }})"
-
-
-# =============================================================================
-# [changelog] - workspace-wide changelog configuration
-# =============================================================================
-
-# [changelog]
-# Templates that control how individual change entries render in changelogs.
-# Each template is tried in order; the first one whose required variables are
-# all present wins (uses minijinja strict mode - all referenced variables must
-# be defined). If none match, falls back to "- {{ summary }}".
-#
-# Available variables:
-#   {{ summary }}       - the change summary from the changeset
-#   {{ details }}       - optional multi-line details block
-#   {{ package }}       - package name
-#   {{ version }}       - planned version
-#   {{ target_id }}     - release owner id (package or group)
-#   {{ bump }}          - bump severity (none, patch, minor, major)
-#   {{ type }}          - optional change type (e.g. "security", "note")
-#   {{ context }}       - rendered context context block
-#   {{ context }}    - alias for {{ context }}
-#   {{ changeset_path }} - path to the changeset file
-#   {{ change_owner }}, {{ change_owner_link }}
-#   {{ review_request }}, {{ review_request_link }}
-#   {{ introduced_commit }}, {{ introduced_commit_link }}
-#   {{ last_updated_commit }}, {{ last_updated_commit_link }}
-#   {{ related_issues }}, {{ related_issue_links }}
-#   {{ closed_issues }}, {{ closed_issue_links }}
-#
-# Default: ["#### {{ summary }}\n\n{{ details }}", "- {{ summary }}"]
-# templates = [
-#   "#### {{ summary }}\n\n{{ details }}\n\n{{ context }}",
-#   "#### {{ summary }}\n\n{{ context }}",
-#   "#### {{ summary }}\n\n{{ details }}",
-#   "- {{ summary }}",
-# ]
-
-
-# =============================================================================
-# [package.*] - declare each release-managed package explicitly
-# =============================================================================
-#
-# Required fields:
-#   path  - relative path from repo root to the package directory
-#
-# Optional fields:
-#   type                    - "cargo", "npm", "deno", "dart", "flutter", "python"
-#                             (not needed when defaults.package_type is set)
-#   changelog               - true, false, "path/to/changelog.md", or a table
-#                             with { path, format, initial_header }; overrides
-#                             [defaults.changelog]
-#   excluded_changelog_types - list of changelog type keys to exclude from this target
-#   empty_update_message    - per-package fallback text for transitive bumps
-#   versioned_files         - additional files to update with the new version
-#                             package-scoped string entries infer the package ecosystem,
-#                             e.g. ["Cargo.toml"] or ["**/crates/*/Cargo.toml"]
-#                             explicit typed entries remain supported, e.g.
-#                             [{ path = "group.toml", type = "cargo" }]
-#                             typed manifest entries can update dependency
-#                             sections and arbitrary string fields inside TOML
-#                             or JSON manifests, e.g.
-#                             [{ path = "Cargo.toml", type = "cargo", fields = ["workspace.metadata.bin.monochange.version"], prefix = "" }]
-#                             regex entries update plain-text files and must include a
-#                             named `version` capture group, e.g.
-#                             [{ path = "README.md", regex = 'v(?<version>\d+\.\d+\.\d+)' }]
-#                             regex entries cannot set `type`, `prefix`, `fields`, or `name`
-#                             lockfiles can still be listed explicitly, but
-#                             ecosystem-level lockfile refresh now prefers
-#                             [ecosystems.<name>].lockfile_commands
-#   ignore_ecosystem_versioned_files - opt out of inherited [ecosystems.<name>].versioned_files
-#                             defaults for this package (default: false)
-#   ignored_paths           - glob patterns for paths within this package to
-#                             exclude from changeset verification
-#   additional_paths        - glob patterns for paths outside the package
-#                             directory that should trigger changeset verification
-#   publish                 - package publishing settings; package values
-#                             override inherited [ecosystems.<name>].publish
-#                             defaults
-#     enabled               - include this package in managed publishing
-#                             flows (default: true)
-#     mode                  - "builtin" for monochange-managed publishing to
-#                             the default public registry for the ecosystem, or
-#                             "external" when your CI or scripts handle
-#                             publishing themselves (default: "builtin").
-#                             npm-family workspaces use the detected workspace
-#                             manager for built-in publish commands, so pnpm
-#                             workspaces publish via `pnpm publish`.
-#     registry              - registry override. Built-in publishing only
-#                             supports the default public registry for each
-#                             ecosystem: "crates_io", "npm", "jsr", or
-#                             "pub_dev". Custom/private registries must use
-#                             mode = "external".
-#     trusted_publishing    - whether this package is expected to use registry
-#                             trusted/OIDC publishing flows when available.
-#                             Set `trusted_publishing = true` for defaults, or
-#                             use a table to override GitHub trust metadata:
-#                             enabled, repository, workflow, environment
-#                             (default: enabled)
-#     rate_limits.enforce   - block built-in publish runs when the selected
-#                             package set requires more than one known registry
-#                             rate-limit window. Use `monochange publish-plan` to inspect
-#                             batches first. (default: false)
-#     placeholder.readme    - inline README text to use when publishing a
-#                             placeholder package for the first bootstrap
-#                             release
-#     placeholder.readme_file - workspace-relative path to a README file used
-#                             for placeholder publishing. Set either
-#                             placeholder.readme or placeholder.readme_file.
-#   tag                     - whether to create a git tag for this package (default: false)
-#   release                 - whether to create a provider release (default: false)
-#   version_format          - "namespaced" (default: "pkg/v1.0.0") or
-#                             "primary" (just "v1.0.0"); only one package/group
-#                             may use "primary"
-
+type = "npm"
 
 [package."@monopi/adaptive-routing"]
 path = "packages/monopi__adaptive-routing"
 type = "npm"
-
-# [package."@monopi/adaptive-routing.publish"]
-# enabled = true
-# mode = "builtin"
-# trusted_publishing = true
-# [package."@monopi/adaptive-routing.publish.trusted_publishing"]
-# enabled = true
-# repository = "owner/repo"
-# workflow = "publish.yml"
-# environment = "release"
-# registry = "npm"
-
-# [package."@monopi/adaptive-routing.publish.placeholder"]
-# readme = "This package is a placeholder published by monochange until the first real release."
-# readme_file = "docs/@monopi/adaptive-routing-placeholder.md"
 
 
 [package."@monopi/agents"]
 path = "packages/monopi__agents"
 type = "npm"
 
-# [package."@monopi/agents.publish"]
-# enabled = true
-# mode = "builtin"
-# trusted_publishing = true
-# [package."@monopi/agents.publish.trusted_publishing"]
-# enabled = true
-# repository = "owner/repo"
-# workflow = "publish.yml"
-# environment = "release"
-# registry = "npm"
-
-# [package."@monopi/agents.publish.placeholder"]
-# readme = "This package is a placeholder published by monochange until the first real release."
-# readme_file = "docs/@monopi/agents-placeholder.md"
-
-
 [package."@monopi/analytics-dashboard"]
 path = "packages/monopi__analytics-dashboard"
 type = "npm"
-
-# [package."@monopi/analytics-dashboard.publish"]
-# enabled = true
-# mode = "builtin"
-# trusted_publishing = true
-# [package."@monopi/analytics-dashboard.publish.trusted_publishing"]
-# enabled = true
-# repository = "owner/repo"
-# workflow = "publish.yml"
-# environment = "release"
-# registry = "npm"
-
-# [package."@monopi/analytics-dashboard.publish.placeholder"]
-# readme = "This package is a placeholder published by monochange until the first real release."
-# readme_file = "docs/@monopi/analytics-dashboard-placeholder.md"
 
 
 [package."@monopi/analytics-db"]
 path = "packages/monopi__analytics-db"
 type = "npm"
 
-# [package."@monopi/analytics-db.publish"]
-# enabled = true
-# mode = "builtin"
-# trusted_publishing = true
-# [package."@monopi/analytics-db.publish.trusted_publishing"]
-# enabled = true
-# repository = "owner/repo"
-# workflow = "publish.yml"
-# environment = "release"
-# registry = "npm"
-
-# [package."@monopi/analytics-db.publish.placeholder"]
-# readme = "This package is a placeholder published by monochange until the first real release."
-# readme_file = "docs/@monopi/analytics-db-placeholder.md"
-
 
 [package."@monopi/analytics-extension"]
 path = "packages/monopi__analytics-extension"
 type = "npm"
-
-# [package."@monopi/analytics-extension.publish"]
-# enabled = true
-# mode = "builtin"
-# trusted_publishing = true
-# [package."@monopi/analytics-extension.publish.trusted_publishing"]
-# enabled = true
-# repository = "owner/repo"
-# workflow = "publish.yml"
-# environment = "release"
-# registry = "npm"
-
-# [package."@monopi/analytics-extension.publish.placeholder"]
-# readme = "This package is a placeholder published by monochange until the first real release."
-# readme_file = "docs/@monopi/analytics-extension-placeholder.md"
 
 
 [package."@monopi/background-tasks"]
 path = "packages/monopi__background-tasks"
 type = "npm"
 
-# [package."@monopi/background-tasks.publish"]
-# enabled = true
-# mode = "builtin"
-# trusted_publishing = true
-# [package."@monopi/background-tasks.publish.trusted_publishing"]
-# enabled = true
-# repository = "owner/repo"
-# workflow = "publish.yml"
-# environment = "release"
-# registry = "npm"
-
-# [package."@monopi/background-tasks.publish.placeholder"]
-# readme = "This package is a placeholder published by monochange until the first real release."
-# readme_file = "docs/@monopi/background-tasks-placeholder.md"
-
 
 [package."@monopi/cli"]
 path = "packages/monopi__cli"
 type = "npm"
-
-# [package."@monopi/cli.publish"]
-# enabled = true
-# mode = "builtin"
-# trusted_publishing = true
-# [package."@monopi/cli.publish.trusted_publishing"]
-# enabled = true
-# repository = "owner/repo"
-# workflow = "publish.yml"
-# environment = "release"
-# registry = "npm"
-
-# [package."@monopi/cli.publish.placeholder"]
-# readme = "This package is a placeholder published by monochange until the first real release."
-# readme_file = "docs/@monopi/cli-placeholder.md"
 
 
 [package."@monopi/core"]
 path = "packages/monopi__core"
 type = "npm"
 
-# [package."@monopi/core.publish"]
-# enabled = true
-# mode = "builtin"
-# trusted_publishing = true
-# [package."@monopi/core.publish.trusted_publishing"]
-# enabled = true
-# repository = "owner/repo"
-# workflow = "publish.yml"
-# environment = "release"
-# registry = "npm"
-
-# [package."@monopi/core.publish.placeholder"]
-# readme = "This package is a placeholder published by monochange until the first real release."
-# readme_file = "docs/@monopi/core-placeholder.md"
-
 
 [package."@monopi/provider-cursor"]
 path = "packages/monopi__provider-cursor"
 type = "npm"
-
-# [package."@monopi/provider-cursor.publish"]
-# enabled = true
-# mode = "builtin"
-# trusted_publishing = true
-# [package."@monopi/provider-cursor.publish.trusted_publishing"]
-# enabled = true
-# repository = "owner/repo"
-# workflow = "publish.yml"
-# environment = "release"
-# registry = "npm"
-
-# [package."@monopi/provider-cursor.publish.placeholder"]
-# readme = "This package is a placeholder published by monochange until the first real release."
-# readme_file = "docs/@monopi/provider-cursor-placeholder.md"
 
 
 [package."@monopi/diagnostics"]
 path = "packages/monopi__diagnostics"
 type = "npm"
 
-# [package."@monopi/diagnostics.publish"]
-# enabled = true
-# mode = "builtin"
-# trusted_publishing = true
-# [package."@monopi/diagnostics.publish.trusted_publishing"]
-# enabled = true
-# repository = "owner/repo"
-# workflow = "publish.yml"
-# environment = "release"
-# registry = "npm"
-
-# [package."@monopi/diagnostics.publish.placeholder"]
-# readme = "This package is a placeholder published by monochange until the first real release."
-# readme_file = "docs/@monopi/diagnostics-placeholder.md"
-
 
 [package."@monopi/docs"]
 path = "packages/monopi__docs"
 type = "npm"
-
-# [package."@monopi/docs.publish"]
-# enabled = true
-# mode = "builtin"
-# trusted_publishing = true
-# [package."@monopi/docs.publish.trusted_publishing"]
-# enabled = true
-# repository = "owner/repo"
-# workflow = "publish.yml"
-# environment = "release"
-# registry = "npm"
-
-# [package."@monopi/docs.publish.placeholder"]
-# readme = "This package is a placeholder published by monochange until the first real release."
-# readme_file = "docs/@monopi/docs-placeholder.md"
 
 
 [package."@monopi/extension-answer"]
@@ -602,307 +140,70 @@ type = "npm"
 path = "packages/monopi__context"
 type = "npm"
 
-# [package."@monopi/context.publish"]
-# enabled = true
-# mode = "builtin"
-# trusted_publishing = true
-# [package."@monopi/context.publish.trusted_publishing"]
-# enabled = true
-# repository = "owner/repo"
-# workflow = "publish.yml"
-# environment = "release"
-# registry = "npm"
-
-# [package."@monopi/context.publish.placeholder"]
-# readme = "This package is a placeholder published by monochange until the first real release."
-# readme_file = "docs/@monopi/context-placeholder.md"
-
 
 [package."@monopi/monopi"]
 path = "packages/monopi__monopi"
 type = "npm"
-
-# [package."@monopi/monopi.publish"]
-# enabled = true
-# mode = "builtin"
-# trusted_publishing = true
-# [package."@monopi/monopi.publish.trusted_publishing"]
-# enabled = true
-# repository = "owner/repo"
-# workflow = "publish.yml"
-# environment = "release"
-# registry = "npm"
-
-# [package."@monopi/monopi.publish.placeholder"]
-# readme = "This package is a placeholder published by monochange until the first real release."
-# readme_file = "docs/@monopi/monopi-placeholder.md"
 
 
 [package."@monopi/provider-ollama"]
 path = "packages/monopi__provider-ollama"
 type = "npm"
 
-# [package."@monopi/provider-ollama.publish"]
-# enabled = true
-# mode = "builtin"
-# trusted_publishing = true
-# [package."@monopi/provider-ollama.publish.trusted_publishing"]
-# enabled = true
-# repository = "owner/repo"
-# workflow = "publish.yml"
-# environment = "release"
-# registry = "npm"
-
-# [package."@monopi/provider-ollama.publish.placeholder"]
-# readme = "This package is a placeholder published by monochange until the first real release."
-# readme_file = "docs/@monopi/provider-ollama-placeholder.md"
-
 
 [package."@monopi/bash-live-view"]
 path = "packages/monopi__bash-live-view"
 type = "npm"
-
-# [package."@monopi/bash-live-view.publish"]
-# enabled = true
-# mode = "builtin"
-# trusted_publishing = true
-# [package."@monopi/bash-live-view.publish.trusted_publishing"]
-# enabled = true
-# repository = "owner/repo"
-# workflow = "publish.yml"
-# environment = "release"
-# registry = "npm"
-
-# [package."@monopi/bash-live-view.publish.placeholder"]
-# readme = "This package is a placeholder published by monochange until the first real release."
-# readme_file = "docs/@monopi/bash-live-view-placeholder.md"
 
 
 [package."@monopi/pretty"]
 path = "packages/monopi__pretty"
 type = "npm"
 
-# [package."@monopi/pretty.publish"]
-# enabled = true
-# mode = "builtin"
-# trusted_publishing = true
-# [package."@monopi/pretty.publish.trusted_publishing"]
-# enabled = true
-# repository = "owner/repo"
-# workflow = "publish.yml"
-# environment = "release"
-# registry = "npm"
-
-# [package."@monopi/pretty.publish.placeholder"]
-# readme = "This package is a placeholder published by monochange until the first real release."
-# readme_file = "docs/@monopi/pretty-placeholder.md"
-
 
 [package."@monopi/remote-tailscale"]
 path = "packages/monopi__remote-tailscale"
 type = "npm"
-
-# [package."@monopi/remote-tailscale.publish"]
-# enabled = true
-# mode = "builtin"
-# trusted_publishing = true
-# [package."@monopi/remote-tailscale.publish.trusted_publishing"]
-# enabled = true
-# repository = "owner/repo"
-# workflow = "publish.yml"
-# environment = "release"
-# registry = "npm"
-
-# [package."@monopi/remote-tailscale.publish.placeholder"]
-# readme = "This package is a placeholder published by monochange until the first real release."
-# readme_file = "docs/@monopi/remote-tailscale-placeholder.md"
 
 
 [package."@monopi/provider-catalog"]
 path = "packages/monopi__provider-catalog"
 type = "npm"
 
-# [package."@monopi/provider-catalog.publish"]
-# enabled = true
-# mode = "builtin"
-# trusted_publishing = true
-# [package."@monopi/provider-catalog.publish.trusted_publishing"]
-# enabled = true
-# repository = "owner/repo"
-# workflow = "publish.yml"
-# environment = "release"
-# registry = "npm"
-
-# [package."@monopi/provider-catalog.publish.placeholder"]
-# readme = "This package is a placeholder published by monochange until the first real release."
-# readme_file = "docs/@monopi/provider-catalog-placeholder.md"
-
 
 [package."@monopi/shared-qna"]
 path = "packages/monopi__shared-qna"
 type = "npm"
-
-# [package."@monopi/shared-qna.publish"]
-# enabled = true
-# mode = "builtin"
-# trusted_publishing = true
-# [package."@monopi/shared-qna.publish.trusted_publishing"]
-# enabled = true
-# repository = "owner/repo"
-# workflow = "publish.yml"
-# environment = "release"
-# registry = "npm"
-
-# [package."@monopi/shared-qna.publish.placeholder"]
-# readme = "This package is a placeholder published by monochange until the first real release."
-# readme_file = "docs/@monopi/shared-qna-placeholder.md"
 
 
 [package."@monopi/skills"]
 path = "packages/monopi__skills"
 type = "npm"
 
-# [package."@monopi/skills.publish"]
-# enabled = true
-# mode = "builtin"
-# trusted_publishing = true
-# [package."@monopi/skills.publish.trusted_publishing"]
-# enabled = true
-# repository = "owner/repo"
-# workflow = "publish.yml"
-# environment = "release"
-# registry = "npm"
-
-# [package."@monopi/skills.publish.placeholder"]
-# readme = "This package is a placeholder published by monochange until the first real release."
-# readme_file = "docs/@monopi/skills-placeholder.md"
-
 
 [package."@monopi/subagents"]
 path = "packages/monopi__subagents"
 type = "npm"
-
-# [package."@monopi/subagents.publish"]
-# enabled = true
-# mode = "builtin"
-# trusted_publishing = true
-# [package."@monopi/subagents.publish.trusted_publishing"]
-# enabled = true
-# repository = "owner/repo"
-# workflow = "publish.yml"
-# environment = "release"
-# registry = "npm"
-
-# [package."@monopi/subagents.publish.placeholder"]
-# readme = "This package is a placeholder published by monochange until the first real release."
-# readme_file = "docs/@monopi/subagents-placeholder.md"
 
 
 [package."@monopi/web-client"]
 path = "packages/monopi__web-client"
 type = "npm"
 
-# [package."@monopi/web-client.publish"]
-# enabled = true
-# mode = "builtin"
-# trusted_publishing = true
-# [package."@monopi/web-client.publish.trusted_publishing"]
-# enabled = true
-# repository = "owner/repo"
-# workflow = "publish.yml"
-# environment = "release"
-# registry = "npm"
-
-# [package."@monopi/web-client.publish.placeholder"]
-# readme = "This package is a placeholder published by monochange until the first real release."
-# readme_file = "docs/@monopi/web-client-placeholder.md"
-
 
 [package."@monopi/web-remote"]
 path = "packages/monopi__web-remote"
 type = "npm"
-
-# [package."@monopi/web-remote.publish"]
-# enabled = true
-# mode = "builtin"
-# trusted_publishing = true
-# [package."@monopi/web-remote.publish.trusted_publishing"]
-# enabled = true
-# repository = "owner/repo"
-# workflow = "publish.yml"
-# environment = "release"
-# registry = "npm"
-
-# [package."@monopi/web-remote.publish.placeholder"]
-# readme = "This package is a placeholder published by monochange until the first real release."
-# readme_file = "docs/@monopi/web-remote-placeholder.md"
 
 
 [package."@monopi/web-server"]
 path = "packages/monopi__web-server"
 type = "npm"
 
-# [package."@monopi/web-server.publish"]
-# enabled = true
-# mode = "builtin"
-# trusted_publishing = true
-# [package."@monopi/web-server.publish.trusted_publishing"]
-# enabled = true
-# repository = "owner/repo"
-# workflow = "publish.yml"
-# environment = "release"
-# registry = "npm"
-
-# [package."@monopi/web-server.publish.placeholder"]
-# readme = "This package is a placeholder published by monochange until the first real release."
-# readme_file = "docs/@monopi/web-server-placeholder.md"
-
-
-# =============================================================================
 
 [package."@monopi/db"]
 path = "packages/monopi__db"
 type = "npm"
-
-# [group.*] - version groups that share a single release identity
-# =============================================================================
-#
-# When packages belong to a group, they share a synchronized version and a
-# single release tag/identity. If any member bumps, all members bump to the
-# group's highest severity.
-#
-# Required fields:
-#   packages - list of [package.*] ids that belong to this group
-#
-# Optional fields:
-#   changelog               - path or table for the group-level changelog;
-#                             tables may also set `include = "all"`,
-#                             `include = "group-only"`, or
-#                             `include = ["package-id"]` to control which
-#                             member-targeted changesets appear in the group
-#                             changelog (direct group-targeted changesets are
-#                             always included; default: "all")
-#   excluded_changelog_types - list of changelog type keys to exclude from this target
-#   empty_update_message    - fallback text when the group bumps but a
-#                             specific member has no direct changeset entries
-#   versioned_files         - additional files to version-bump with the group
-#                             groups must use explicit typed entries because the
-#                             ecosystem cannot be inferred from a bare string;
-#                             regex entries are also supported, e.g.
-#                             [{ path = "**/install.sh", regex = 'SDK_VERSION="(?<version>\d+\.\d+\.\d+)"' }]
-#   tag                     - create a git tag for the group release (default: false)
-#   release                 - create a provider release for the group (default: false)
-#   version_format          - "namespaced" (default) or "primary"
-#
-# Rules:
-#   - group members must be declared under [package.*]
-#   - package and group ids share one namespace (no collisions)
-#   - a package may belong to only one group
-#   - only one package or group may use version_format = "primary"
-#   - group tag/release/version_format override member package settings
-#   - prefer package ids in authored changesets when possible; dependents and
-#     grouped members propagate automatically, so group ids are best for
-#     intentionally group-owned releases
 
 
 [group.default]
@@ -955,337 +256,33 @@ packages = [
 tag = true
 release = true
 version_format = "primary"
-# [group.main.changelog]
-# path = "changelog.md"
-# include = ["package-id"]
 
 
-# =============================================================================
-# [[deployments]] - deployment intent definitions
-# =============================================================================
-#
-# Deployments are structured intents emitted in the release manifest so
-# downstream CI can decide when and how to execute them. monochange does not
-# run deployments directly - it declares them.
-#
-# Fields:
-#   name            - unique deployment name
-#   trigger         - when to deploy: "workflow" (manual), "release_pr_merge",
-#                     or "release_published"
-#   workflow        - CI workflow to trigger
-#   environment     - target environment name (optional)
-#   release_targets - which release targets activate this deployment (default: all)
-#   requires        - dependencies that must be met before deploying
-#   metadata        - arbitrary key-value pairs passed to the workflow
-#
-# Example:
-# [[deployments]]
-# name = "docs"
-# trigger = "release_published"
-# workflow = "docs-release"
-# environment = "github-pages"
-# release_targets = ["main"]
-# requires = ["main"]
-# metadata = { site = "github-pages" }
-
-# =============================================================================
-# [ecosystems.*] - per-ecosystem discovery and publishing settings
-# =============================================================================
-#
-# Each supported ecosystem can be configured independently.
-#
-# Fields:
-#   enabled  - opt-in/opt-out of discovery for this ecosystem (default: none,
-#              meaning discovery runs when manifests are found)
-#   roots    - restrict discovery to specific directories (default: scan entire repo)
-#   exclude  - glob patterns to exclude from discovery
-#   dependency_version_prefix - default dependency prefix for typed versioned_files
-#   versioned_files - ecosystem-wide default versioned_files inherited by matching packages;
-#                     entries may be typed manifest updates (including
-#                     arbitrary TOML/JSON field paths) or plain-text regex
-#                     replacements with a named `version` capture, e.g.
-#                     [{ path = "src/lib.rs", regex = 'VERSION: &str = "(?<version>\d+\.\d+\.\d+)"' }]
-#   lockfile_commands — optional escape-hatch commands that refresh ecosystem
-#                       lockfiles after a release updates manifest versions.
-#                       By default monochange rewrites supported lockfiles
-#                       directly from the release plan so `monochange release` stays on
-#                       the fast path. Cargo is not re-run automatically anymore,
-#                       so incomplete Cargo.lock files should be refreshed with
-#                       explicit commands here or manually afterwards. When set,
-#                       these commands fully own lockfile refresh for that ecosystem.
-#   publish          — ecosystem-wide publishing defaults inherited by matching
-#                      packages unless the package overrides them
-#     enabled        — enable managed publishing for the ecosystem (default: true)
-#     mode           — "builtin" or "external" (default: "builtin")
-#     registry       — default public registry for this ecosystem. Built-in
-#                      publishing only supports the ecosystem's canonical public
-#                      registry.
-#     trusted_publishing — whether packages in this ecosystem should default to
-#                      trusted/OIDC publishing flows when available. Set
-#                      `trusted_publishing = true` for defaults, or use a table
-#                      with enabled/repository/workflow/environment to inherit
-#                      trust metadata into matching packages (default: enabled)
-#     rate_limits.enforce — block built-in publish runs for matching packages
-#                      when the selected package set exceeds a known single
-#                      registry window. (default: false)
-#     placeholder.readme / placeholder.readme_file — default placeholder README
-#                      source inherited by packages during bootstrap publishing
-#   auto_discover    — automatically discover packages by walking the workspace
-#                      for ecosystem manifests (Cargo.toml, package.json, etc.)
-#                      instead of declaring each one in a [package.*] section.
-#
-#     auto_discover.include — glob patterns for directories to scan (required)
-#     auto_discover.exclude — glob patterns to skip within included paths (optional)
-#     auto_discover.id — package id template (default: "")
-#                        variables: name, path, sanitized_path, manifest, ecosystem
-#     auto_discover.defaults — package-level defaults for all discovered packages
-#                           tag — override the default tag setting (optional)
-#                           release — override the default release setting (optional)
-#                           version_format — override the default version format (optional)
-#
-#   When auto_discover is enabled, packages found by scanning the workspace
-#   inherit defaults from [ecosystems.*].auto_discover.defaults, then from
-#   [defaults]. Explicit [package.*] entries always override auto-discovered
-#   packages, so you only need to declare packages that deviate from defaults.
-
-# =============================================================================
-# [lints] - manifest lint configuration
-# =============================================================================
-#
-# Configure lint presets, global rules, and scoped overrides for package
-# manifests. Lint suites live in ecosystem crates, but configuration lives in
-# this top-level section.
-#
 [lints]
-# Start with baseline presets so existing repositories can adopt `mc check`
-# without turning formatting preferences into blocking errors. Upgrade to
-# `*/recommended` or `*/strict` when the workspace is ready to enforce policy.
 use = ["cargo/baseline", "npm/baseline", "dart/baseline"]
-# include = ["crates/**", "packages/**"]
-# exclude = ["examples/**"]
-# disable_gitignore = false
-#
-# Fields:
-#   use               - preset ids enabled globally
-#   include           - optional glob patterns that opt specific manifest paths
-#                       into linting; when omitted, every non-gitignored
-#                       manifest is considered
-#   exclude           - glob patterns removed from linting after include/default
-#                       selection
-#   disable_gitignore - set true to lint gitignored manifests too; this is not
-#                       recommended for normal repositories
-#
-# [lints.rules]
-# "cargo/internal-dependency-workspace" = "error"
-# "npm/workspace-protocol" = "error"
-#
-# [[lints.scopes]]
-# name = "published cargo packages"
-# match = { ecosystems = ["cargo"], managed = true, publishable = true }
-# use = ["cargo/recommended"]
-# rules = { "cargo/required-package-fields" = "error" }
-#
-# Scope selector fields inside `match`:
-#   ecosystems  - ecosystem ids like cargo, npm, or dart
-#   paths       - glob patterns against manifest paths relative to the workspace root
-#   package_ids - configured package ids to target directly
-#   group_ids   - configured group ids to target via group membership
-#   managed     - include only managed/unmanaged packages when set
-#   private     - include only private/public packages when set
-#   publishable - include only publishable/non-publishable packages when set
 
 
 [ecosystems.cargo]
 enabled = true
 
-# [ecosystems.cargo.publish]
-# enabled = true
-# mode = "builtin"
-# trusted_publishing = true
-# [ecosystems.cargo.publish.trusted_publishing]
-# enabled = true
-# workflow = "publish.yml"
-# registry = "crates_io"
-
 
 [ecosystems.npm]
 enabled = true
 
-# [ecosystems.npm.publish]
-# enabled = true
-# mode = "builtin"
-# trusted_publishing = true
-# [ecosystems.npm.publish.trusted_publishing]
-# enabled = true
-# workflow = "publish.yml"
-# registry = "npm"
-
-
-# [ecosystems.deno]
-# enabled = true
-
-# [ecosystems.deno.publish]
-# enabled = true
-# mode = "builtin"
-# trusted_publishing = true
-# [ecosystems.deno.publish.trusted_publishing]
-# enabled = true
-# workflow = "publish.yml"
-# registry = "jsr"
-
-
-# [ecosystems.dart]
-# enabled = true
-
-# [ecosystems.dart.publish]
-# enabled = true
-# mode = "builtin"
-# trusted_publishing = true
-# [ecosystems.dart.publish.trusted_publishing]
-# enabled = true
-# workflow = "publish.yml"
-# registry = "pub_dev"
-
-
-# [ecosystems.python]
-# enabled = true
-
-
-# =============================================================================
-# [source] - source-control provider configuration
-# =============================================================================
-#
-# Configures the repository host for release automation: creating releases,
-# opening release pull requests, and evaluating changeset policy.
-#
-# Required fields:
-#   provider - "github", "gitlab", or "gitea"
-#   owner    - repository owner or organization
-#   repo     - repository name
-#
-# Optional fields:
-#   host    - custom host URL for self-hosted instances
-#   api_url - custom API URL (e.g. for GitHub Enterprise)
-
-#
-# [source]
-# provider = "github"
-# owner = "your-org"
-# repo = "your-repo"
-
-# [source.releases] - provider release settings and release branch policy
-#
-# Controls whether and how releases are created on the provider when the
-# PublishRelease CLI step runs. Release refs are verified by commit reachability.
-# Tags and publish steps are enforced by default; commit-release stays flexible
-# unless you opt in.
-#
-# Fields:
-#   enabled             - enable/disable release creation (default: true)
-#   draft               - create releases as drafts (default: false)
-#   prerelease          - mark releases as pre-releases (default: false)
-#   generate_notes      - ask the provider to auto-generate release notes (default: false)
-#   source              - release notes source: "monochange" (use monochange-rendered
-#                         notes) or "github_generated" (use provider-generated notes)
-#                         Default: "monochange"
-#   branches            - release branch names or globs, e.g. ["main", "release/*"]
-#   enforce_for_tags    - reject unsafe tag-release refs (default: true)
-#   enforce_for_publish - reject unsafe publish refs (default: true)
-#   enforce_for_commit  - reject unsafe commit-release refs (default: false)
-#   changeset_context_timeout_seconds - hosted-source enrichment timeout (default: 120)
-#
-# [source.releases]
-# enabled = true
-# draft = false
-# prerelease = false
-# source = "monochange"
-# branches = ["main"]
-# enforce_for_tags = true
-# enforce_for_publish = true
-# enforce_for_commit = false
-# changeset_context_timeout_seconds = 120
-
-# [source.pull_requests] - release pull request settings
-#
-# Controls the OpenReleaseRequest CLI step which creates or updates a release
-# PR with version bumps, changelog updates, and changeset cleanup.
-#
-# Fields:
-#   enabled       - enable/disable release PR creation (default: true)
-#   branch_prefix - branch name prefix for release PRs (default: "monochange/release")
-#   base          - target branch for the release PR (default: "main")
-#   title         - PR title template (default: "chore(release): prepare release")
-#   labels        - labels applied to the release PR (default: ["release", "automated"]
-#   auto_merge    - enable auto-merge on the PR when supported (default: false)
-#
-# [source.pull_requests]
-# enabled = true
-# branch_prefix = "monochange/release"
-# base = "main"
-# title = "chore(release): prepare release"
-# labels = ["release", "automated"]
-# auto_merge = false
-
-
-# =============================================================================
-# [changesets.affected] - changeset verification settings
-# =============================================================================
-#
-# Controls the `AffectedPackages` CLI step which checks whether pull requests
-# include changeset files that cover all changed packages.
-#
-# This section works independently of any source provider.
 
 [changesets.affected]
-# Whether changeset verification is enabled. When false, the AffectedPackages
-# step will refuse to run.
-# Default: true
 enabled = true
 
-# Whether a missing changeset is treated as a failure (true) or just a
-# warning (false).
-# Default: true
 required = true
 
-# Pull-request labels that skip verification entirely. When any label on the
-# PR matches an entry here, the verify step returns "skipped" instead of
-# evaluating coverage.
-# Default: []
 skip_labels = []
 
-# Whether to render a failure comment body in the evaluation output for
-# CI integrations to post back to the pull request.
-# Default: true
 comment_on_failure = true
 
-# Additional non-package root-level paths that should also trigger changeset
-# requirements when changed. Package directories are included automatically.
-# Default: []
 changed_paths = []
 
-# Files that should not trigger changeset requirements.
-# Default: []
 ignored_paths = []
 
-# =============================================================================
-# [cli.*] - optional user-defined CLI commands
-# =============================================================================
-#
-# `monochange init` intentionally leaves the starter config without [cli.*] command
-# tables. Most built-in operations are available directly as immutable
-# `monochange step *` commands, so new projects do not need generated workflow aliases
-# just to validate, discover, release, publish, or inspect diagnostics.
-#
-# Add [cli.<name>] tables only for project-specific workflows that combine
-# multiple steps, add custom shell commands, or provide organization-specific
-# command names. Each table becomes a top-level `monochange <name>` command.
-#
-# See the configuration guide for the full [cli.*] schema, input types, and
-# step definition examples.
-
-# =============================================================================
-# [cli.*] - repository-specific CLI commands
-# =============================================================================
 
 [cli.change]
 help_text = "Create a new changeset file for the next release"

--- a/package.json
+++ b/package.json
@@ -35,7 +35,7 @@
 		"docs:update": "pnpm mdt update",
 		"docs:check": "pnpm mdt check",
 		"lint": "oxlint --deny-warnings .",
-		"lint:fix": "oxlint --fix .",
+		"lint:fix": "oxfmt --write . && oxlint --fix .",
 		"lint:type-aware": "oxlint --deny-warnings --type-aware .",
 		"format": "oxfmt --write .",
 		"format:check": "oxfmt --check .",


### PR DESCRIPTION
## Summary
- update pnpm lint:fix to run oxfmt before oxlint, providing one command to format and lint the repo
- keep monochange.toml comment-free and formatted by oxfmt
- verify TOML and Markdown files are covered by oxfmt checks

## Verification
- pnpm lint:fix
- pnpm check
- pnpm mc check
- pnpm docs:check
- pnpm exec oxfmt --check "**/*.toml" "**/*.md"
- pnpm typecheck