### PR TITLE
ci: pin actions and audit workflows

### DIFF
--- a/.changeset/1783013300-monopi.md
+++ b/.changeset/1783013300-monopi.md
@@ -1,0 +1,7 @@
+---
+monopi: patch
+---
+
+# Harden GitHub Actions workflow checks
+
+GitHub Actions are updated to current pinned commit refs with version comments, and CI now runs local-friendly actionlint and zizmor workflow checks.

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -11,23 +11,30 @@ on:
 concurrency:
   group: ${{ github.workflow }}-${{ github.ref }}
   cancel-in-progress: true
+permissions:
+  contents: read
 jobs:
   commit-lint:
     name: 🧾 conventional commits
     runs-on: ubuntu-latest
     steps:
       - name: 📥 checkout repository
-        uses: actions/checkout@v6.0.2
+        uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
         with:
+          persist-credentials: false
           fetch-depth: 0
       - name: 🧾 validate commit messages
+        env:
+          EVENT_NAME: ${{ github.event_name }}
+          PR_BASE_SHA: ${{ github.event.pull_request.base.sha }}
+          PR_HEAD_SHA: ${{ github.event.pull_request.head.sha }}
         run: |
           # Conventional commit pattern: type(scope)?: description
           PATTERN='^(feat|fix|docs|style|refactor|perf|test|build|ci|chore|revert)(\(.+\))?!?: .+'
 
-          if [ "${{ github.event_name }}" = "pull_request" ]; then
-            BASE_SHA='${{ github.event.pull_request.base.sha }}'
-            HEAD_SHA='${{ github.event.pull_request.head.sha }}'
+          if [ "$EVENT_NAME" = "pull_request" ]; then
+            BASE_SHA="$PR_BASE_SHA"
+            HEAD_SHA="$PR_HEAD_SHA"
             # Validate only real PR commits (exclude synthetic merge commits from refs/pull/*/merge).
             COMMITS=$(git log --format='%s' --no-merges "${BASE_SHA}..${HEAD_SHA}")
           else
@@ -56,7 +63,9 @@ jobs:
     if: "!startsWith(github.event.head_commit.message, 'chore: release')"
     steps:
       - name: 📥 checkout repository
-        uses: actions/checkout@v6.0.2
+        uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
+        with:
+          persist-credentials: false
       - name: 📝 check for changeset
         run: |
           CHANGESETS=$(find .changeset -name '*.md' ! -name 'README.md' 2>/dev/null | wc -l | tr -d ' ')
@@ -146,7 +155,9 @@ jobs:
       contents: read
     steps:
       - name: 📥 checkout repository
-        uses: actions/checkout@v6.0.2
+        uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
+        with:
+          persist-credentials: false
       - name: 🕸️ check dependency graph availability
         id: dependency-graph
         env:
@@ -156,7 +167,7 @@ jobs:
           OWNER="${REPOSITORY%/*}"
           REPO="${REPOSITORY#*/}"
           TOTAL_COUNT="$(gh api graphql \
-            -f query='query($owner: String!, $name: String!) { repository(owner: $owner, name: $name) { dependencyGraphManifests(first: 1) { totalCount } } }' \
+            -f query="query(\$owner: String!, \$name: String!) { repository(owner: \$owner, name: \$name) { dependencyGraphManifests(first: 1) { totalCount } } }" \
             -F owner="$OWNER" \
             -F name="$REPO" \
             --jq '.data.repository.dependencyGraphManifests.totalCount')"
@@ -172,19 +183,55 @@ jobs:
           fi
       - name: 🔍 review dependency changes
         if: steps.dependency-graph.outputs.available == 'true'
-        uses: actions/dependency-review-action@v4.9.0
+        uses: actions/dependency-review-action@a1d282b36b6f3519aa1f3fc636f609c47dddb294 # v5.0.0
         with:
           fail-on-severity: moderate
+  actions-security:
+    name: 🔐 workflow security (actionlint + zizmor)
+    runs-on: ubuntu-latest
+    permissions:
+      actions: read # required for zizmor online audits of workflow metadata
+      contents: read # required for checkout and private-repo workflow reads
+    steps:
+      - name: 📥 checkout repository
+        uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
+        with:
+          persist-credentials: false
+      - name: 📦 setup pnpm
+        uses: pnpm/action-setup@0ebf47130e4866e96fce0953f49152a61190b271 # v6.0.9
+      - name: 🟢 setup node
+        uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e # v6.4.0
+        with:
+          node-version: 22
+          cache: pnpm
+      - name: 🐹 setup go
+        uses: actions/setup-go@924ae3a1cded613372ab5595356fb5720e22ba16 # v6.5.0
+        with:
+          go-version: stable
+      - name: 🧹 lint GitHub Actions workflows
+        run: pnpm actions:lint
+      - name: 🔐 audit GitHub Actions workflows
+        uses: zizmorcore/zizmor-action@192e21d79ab29983730a13d1382995c2307fbcaa # v0.5.7
+        with:
+          advanced-security: false
+          annotations: true
+          inputs: .github/workflows
+          min-severity: low
+          persona: pedantic
+          version: 1.26.1
+
   docs:
     name: 📚 documentation reuse (mdt)
     runs-on: ubuntu-latest
     steps:
       - name: 📥 checkout repository
-        uses: actions/checkout@v6.0.2
+        uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
+        with:
+          persist-credentials: false
       - name: 📦 setup pnpm
-        uses: pnpm/action-setup@v4.4.0
+        uses: pnpm/action-setup@0ebf47130e4866e96fce0953f49152a61190b271 # v6.0.9
       - name: 🟢 setup node
-        uses: actions/setup-node@v6.3.0
+        uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e # v6.4.0
         with:
           node-version: 22
           cache: pnpm
@@ -197,11 +244,13 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: 📥 checkout repository
-        uses: actions/checkout@v6.0.2
+        uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
+        with:
+          persist-credentials: false
       - name: 📦 setup pnpm
-        uses: pnpm/action-setup@v4.4.0
+        uses: pnpm/action-setup@0ebf47130e4866e96fce0953f49152a61190b271 # v6.0.9
       - name: 🟢 setup node
-        uses: actions/setup-node@v6.3.0
+        uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e # v6.4.0
         with:
           node-version: 22
           cache: pnpm
@@ -214,11 +263,13 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: 📥 checkout repository
-        uses: actions/checkout@v6.0.2
+        uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
+        with:
+          persist-credentials: false
       - name: 📦 setup pnpm
-        uses: pnpm/action-setup@v4.4.0
+        uses: pnpm/action-setup@0ebf47130e4866e96fce0953f49152a61190b271 # v6.0.9
       - name: 🟢 setup node
-        uses: actions/setup-node@v6.3.0
+        uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e # v6.4.0
         with:
           node-version: 22
           cache: pnpm
@@ -233,11 +284,13 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: 📥 checkout repository
-        uses: actions/checkout@v6.0.2
+        uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
+        with:
+          persist-credentials: false
       - name: 📦 setup pnpm
-        uses: pnpm/action-setup@v4.4.0
+        uses: pnpm/action-setup@0ebf47130e4866e96fce0953f49152a61190b271 # v6.0.9
       - name: 🟢 setup node
-        uses: actions/setup-node@v6.3.0
+        uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e # v6.4.0
         with:
           node-version: 22
           cache: pnpm
@@ -257,11 +310,13 @@ jobs:
           - 24
     steps:
       - name: 📥 checkout repository
-        uses: actions/checkout@v6.0.2
+        uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
+        with:
+          persist-credentials: false
       - name: 📦 setup pnpm
-        uses: pnpm/action-setup@v4.4.0
+        uses: pnpm/action-setup@0ebf47130e4866e96fce0953f49152a61190b271 # v6.0.9
       - name: 🟢 setup node
-        uses: actions/setup-node@v6.3.0
+        uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e # v6.4.0
         with:
           node-version: ${{ matrix.node }}
           cache: pnpm
@@ -275,17 +330,18 @@ jobs:
     name: 📈 coverage (codecov)
     runs-on: ubuntu-latest
     permissions:
-      contents: read
-      id-token: write
+      contents: read # required for checkout and coverage source paths
+      id-token: write # required for Codecov OIDC upload
     steps:
       - name: 📥 checkout repository
-        uses: actions/checkout@v6.0.2
+        uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
         with:
+          persist-credentials: false
           fetch-depth: 0
       - name: 📦 setup pnpm
-        uses: pnpm/action-setup@v4.4.0
+        uses: pnpm/action-setup@0ebf47130e4866e96fce0953f49152a61190b271 # v6.0.9
       - name: 🟢 setup node
-        uses: actions/setup-node@v6.3.0
+        uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e # v6.4.0
         with:
           node-version: 22
           cache: pnpm
@@ -302,13 +358,13 @@ jobs:
           HEAD_SHA: ${{ github.event.pull_request.head.sha }}
         run: pnpm tsx ./scripts/check-patch-coverage.ts --threshold 95 --lcov coverage/lcov.info
       - name: 📤 upload coverage artifact
-        uses: actions/upload-artifact@v4.6.2
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
         with:
           name: coverage-report
           path: coverage/
           if-no-files-found: error
       - name: 📈 upload coverage to codecov
-        uses: codecov/codecov-action@v5.5.1
+        uses: codecov/codecov-action@fb8b3582c8e4def4969c97caa2f19720cb33a72f # v7.0.0
         with:
           files: coverage/lcov.info
           flags: repo
@@ -326,28 +382,33 @@ jobs:
             version: 0.79.10
     steps:
       - name: 📥 checkout repository
-        uses: actions/checkout@v6.0.2
+        uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
+        with:
+          persist-credentials: false
       - name: 📦 setup pnpm
-        uses: pnpm/action-setup@v4.4.0
+        uses: pnpm/action-setup@0ebf47130e4866e96fce0953f49152a61190b271 # v6.0.9
       - name: 🟢 setup node
-        uses: actions/setup-node@v6.3.0
+        uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e # v6.4.0
         with:
           node-version: 22
           cache: pnpm
       - name: 🤝 verify compatibility smoke suite
-        run: pnpm verify:pi-compat -- --version ${{ matrix.version }}
+        env:
+          PI_COMPAT_VERSION: ${{ matrix.version }}
+        run: pnpm verify:pi-compat -- --version "$PI_COMPAT_VERSION"
   benchmark:
     name: ⏱️ benchmarks (typescript)
     runs-on: ubuntu-latest
     steps:
       - name: 📥 checkout repository
-        uses: actions/checkout@v6.0.2
+        uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
         with:
+          persist-credentials: false
           fetch-depth: 0
       - name: 📦 setup pnpm
-        uses: pnpm/action-setup@v4.4.0
+        uses: pnpm/action-setup@0ebf47130e4866e96fce0953f49152a61190b271 # v6.0.9
       - name: 🟢 setup node
-        uses: actions/setup-node@v6.3.0
+        uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e # v6.4.0
         with:
           node-version: 22
           cache: pnpm
@@ -383,6 +444,7 @@ jobs:
           pnpm bench:live-runtime | tee coverage/benchmarks/live-runtime.txt
       - name: 📝 append benchmark summary
         run: |
+          # shellcheck disable=SC2129
           echo "## Startup benchmark targets" >> "$GITHUB_STEP_SUMMARY"
           echo '```json' >> "$GITHUB_STEP_SUMMARY"
           cat coverage/benchmarks/startup-targets.json >> "$GITHUB_STEP_SUMMARY"
@@ -402,7 +464,7 @@ jobs:
           cat coverage/benchmarks/live-runtime.txt >> "$GITHUB_STEP_SUMMARY"
           echo '```' >> "$GITHUB_STEP_SUMMARY"
       - name: 📤 upload benchmark artifacts
-        uses: actions/upload-artifact@v4.6.2
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
         with:
           name: benchmark-report
           path: coverage/benchmarks/
@@ -420,14 +482,17 @@ jobs:
       - test
       - compat
       - benchmark
+      - actions-security
     if: "!failure() && !cancelled()"
     steps:
       - name: 📥 checkout repository
-        uses: actions/checkout@v6.0.2
+        uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
+        with:
+          persist-credentials: false
       - name: 📦 setup pnpm
-        uses: pnpm/action-setup@v4.4.0
+        uses: pnpm/action-setup@0ebf47130e4866e96fce0953f49152a61190b271 # v6.0.9
       - name: 🟢 setup node
-        uses: actions/setup-node@v6.3.0
+        uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e # v6.4.0
         with:
           node-version: 22
           cache: pnpm

--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -9,8 +9,6 @@ on:
   workflow_dispatch:
 permissions:
   contents: read
-  pages: write
-  id-token: write
 concurrency:
   group: pages
   cancel-in-progress: false
@@ -20,11 +18,13 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: 📥 checkout repository
-        uses: actions/checkout@v4
+        uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
+        with:
+          persist-credentials: false
       - name: 📦 setup pnpm
-        uses: pnpm/action-setup@v4.4.0
+        uses: pnpm/action-setup@0ebf47130e4866e96fce0953f49152a61190b271 # v6.0.9
       - name: 🟢 setup node
-        uses: actions/setup-node@v4
+        uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e # v6.4.0
         with:
           node-version: 22
           cache: pnpm
@@ -33,11 +33,15 @@ jobs:
       - name: 📚 build docs site
         run: pnpm --filter @monopi/docs build
       - name: 📤 upload pages artifact
-        uses: actions/upload-pages-artifact@v3
+        uses: actions/upload-pages-artifact@fc324d3547104276b827a68afc52ff2a11cc49c9 # v5.0.0
         with:
           path: packages/monopi__docs/dist
   deploy:
     name: 🚀 deploy docs
+    permissions:
+      contents: read # required for GitHub Pages deployment metadata
+      pages: write # required to publish the built docs site to GitHub Pages
+      id-token: write # required for GitHub Pages OIDC deployment
     environment:
       name: github-pages
       url: ${{ steps.deployment.outputs.page_url }}
@@ -46,4 +50,4 @@ jobs:
     steps:
       - name: 🚀 deploy to github pages
         id: deployment
-        uses: actions/deploy-pages@v4
+        uses: actions/deploy-pages@cd2ce8fcbc39b97be8ca5fce6e763baed58fa128 # v5.0.0

--- a/package.json
+++ b/package.json
@@ -39,13 +39,16 @@
 		"lint:type-aware": "oxlint --deny-warnings --type-aware .",
 		"format": "oxfmt --write . && oxfmt --write \"**/*.toml\" \"**/*.md\"",
 		"format:check": "oxfmt --check . && oxfmt --check \"**/*.toml\" \"**/*.md\"",
-		"check": "pnpm format:check && pnpm lint",
+		"check": "pnpm format:check && pnpm lint && pnpm actions:check",
 		"change": "mc change",
 		"release": "mc release",
 		"publish": "mc publish",
 		"mc:validate": "mc step:validate",
 		"mc:check": "mc check",
-		"mc:discover": "mc step:discover --format json"
+		"mc:discover": "mc step:discover --format json",
+		"actions:lint": "go run github.com/rhysd/actionlint/cmd/actionlint@v1.7.12",
+		"actions:zizmor": "uvx zizmor@1.26.1 --persona pedantic --min-severity low .github/workflows",
+		"actions:check": "pnpm actions:lint && pnpm actions:zizmor"
 	},
 	"devDependencies": {
 		"@earendil-works/pi-agent-core": "0.78.1",


### PR DESCRIPTION
## Summary\n- update GitHub Actions to current pinned commit refs with version comments\n- add actionlint and zizmor workflow auditing to CI\n- expose local workflow checks via pnpm actions:check and include them in pnpm check\n- tighten workflow permissions and disable checkout credential persistence\n\n## Verification\n- pnpm check\n- pnpm mc:check