### PR TITLE
ci: disable setup-go cache for workflow lint

### DIFF
--- a/.changeset/1783014200-monopi.md
+++ b/.changeset/1783014200-monopi.md
@@ -1,0 +1,7 @@
+---
+monopi: patch
+---
+
+# Remove setup-go cache warning
+
+The workflow security job disables `actions/setup-go` caching because the repository does not contain a `go.mod` file for cache dependency discovery.

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -207,6 +207,7 @@ jobs:
       - name: 🐹 setup go
         uses: actions/setup-go@924ae3a1cded613372ab5595356fb5720e22ba16 # v6.5.0
         with:
+          cache: false
           go-version: stable
       - name: 🧹 lint GitHub Actions workflows
         run: pnpm actions:lint


### PR DESCRIPTION
## Summary\n- disable actions/setup-go cache in the workflow security job\n- avoid setup-go warnings because this repo has no go.mod cache dependency file\n\n## Verification\n- pnpm actions:check\n- pnpm format:check\n- pnpm mc:check