### PR TITLE
feat(btw): support multiple scrollable conversations

### DIFF
--- a/.changeset/1783757622-monopi-extension-btw.md
+++ b/.changeset/1783757622-monopi-extension-btw.md
@@ -1,0 +1,7 @@
+---
+monopi: minor
+---
+
+# add multiple BTW conversations and transcript scrollback
+
+Adds a fixed-height, scrollable conversation picker and PageUp/PageDown transcript navigation while preserving legacy side-thread entries.

--- a/packages/monopi__extension-btw/README.md
+++ b/packages/monopi__extension-btw/README.md
@@ -8,10 +8,18 @@ pi install npm:@monopi/extension-btw
 
 ## Commands
 
-- `/btw` — open the side-chat overlay.
-- `/btw <question>` — ask a side question without interrupting the main thread.
+- `/btw` — open the side chat. When saved conversations exist, this opens a conversation picker.
+- `/btw <question>` — start a new side conversation and ask immediately without interrupting the main thread.
 
-The side thread is persisted as custom session entries so it can be restored as the session tree changes.
+Questions entered inside an open overlay continue that conversation. Conversations are persisted independently as custom session
+entries, so you can switch between previous threads and restore them as the session tree changes.
+
+## Navigation
+
+- Conversation picker: `↑` / `↓` moves one item, `PageUp` / `PageDown` moves one page, `Enter` selects, and `Esc`
+  cancels. The picker uses a fixed percentage of the terminal height and scrolls when conversations overflow it.
+- Conversation overlay: `PageUp` / `PageDown` scrolls through long responses, `Enter` submits, and `Esc` closes. The
+  position indicator shows the visible transcript range.
 
 ## Attribution
 

--- a/packages/monopi__extension-btw/index.ts
+++ b/packages/monopi__extension-btw/index.ts
@@ -34,6 +34,9 @@ import {
 
 const BTW_ENTRY_TYPE = "btw-thread-entry";
 const BTW_RESET_TYPE = "btw-thread-reset";
+const BTW_START_TYPE = "btw-thread-start";
+const CONVERSATION_PICKER_HEIGHT_RATIO = 0.55;
+const LEGACY_CONVERSATION_ID = "legacy";
 
 const BTW_SYSTEM_PROMPT = [
 	"You are BTW, a side-channel assistant embedded in the user's coding agent.",
@@ -54,11 +57,26 @@ type BtwDetails = {
 	provider: string;
 	model: string;
 	thinkingLevel: SessionThinkingLevel;
+	conversationId?: string;
 	usage?: AssistantMessage["usage"];
+};
+
+type BtwConversation = {
+	id: string;
+	createdAt: number;
+	updatedAt: number;
+	thread: BtwDetails[];
+	persisted: boolean;
+};
+
+type BtwStartDetails = {
+	conversationId: string;
+	timestamp: number;
 };
 
 type BtwResetDetails = {
 	timestamp: number;
+	conversationId?: string;
 };
 
 type OverlayRuntime = {
@@ -67,7 +85,14 @@ type OverlayRuntime = {
 	close?: () => void;
 	finish?: () => void;
 	setDraft?: (value: string) => void;
+	scrollToBottom?: () => void;
 	closed?: boolean;
+};
+
+export type ConversationPickerItem = {
+	id: string | null;
+	label: string;
+	description: string;
 };
 
 type SideSessionRuntime = {
@@ -205,7 +230,160 @@ function notify(
 	}
 }
 
-class BtwOverlay extends Container implements Focusable {
+function getConversationTitle(conversation: BtwConversation): string {
+	const firstQuestion = conversation.thread[0]?.question.replace(/\s+/gu, " ").trim();
+	return firstQuestion || "Untitled conversation";
+}
+
+export function getPickerHeight(terminalRows: number): number {
+	return Math.max(1, Math.floor(Math.max(1, terminalRows) * CONVERSATION_PICKER_HEIGHT_RATIO));
+}
+
+export class BtwConversationPicker extends Container {
+	private readonly items: ConversationPickerItem[];
+	private readonly tui: TUI;
+	private readonly theme: ExtensionContext["ui"]["theme"];
+	private readonly keybindings: KeybindingsManager;
+	private readonly onSelectCallback: (id: string | null) => void;
+	private readonly onCancelCallback: () => void;
+	private selectedIndex = 0;
+	private scrollOffset = 0;
+	private viewportHeight = 3;
+
+	constructor(
+		tui: TUI,
+		theme: ExtensionContext["ui"]["theme"],
+		keybindings: KeybindingsManager,
+		items: ConversationPickerItem[],
+		onSelect: (id: string | null) => void,
+		onCancel: () => void,
+	) {
+		super();
+		this.tui = tui;
+		this.theme = theme;
+		this.keybindings = keybindings;
+		this.items = items;
+		this.onSelectCallback = onSelect;
+		this.onCancelCallback = onCancel;
+	}
+
+	handleInput(data: string): void {
+		if (this.keybindings.matches(data, "tui.select.cancel")) {
+			this.onCancelCallback();
+			return;
+		}
+		if (this.keybindings.matches(data, "tui.select.confirm")) {
+			const selected = this.items[this.selectedIndex];
+			if (selected) {
+				this.onSelectCallback(selected.id);
+			}
+			return;
+		}
+
+		let nextIndex = this.selectedIndex;
+		if (this.keybindings.matches(data, "tui.select.up")) {
+			nextIndex--;
+		} else if (this.keybindings.matches(data, "tui.select.down")) {
+			nextIndex++;
+		} else if (this.keybindings.matches(data, "tui.select.pageUp")) {
+			nextIndex -= this.viewportHeight;
+		} else if (this.keybindings.matches(data, "tui.select.pageDown")) {
+			nextIndex += this.viewportHeight;
+		} else {
+			return;
+		}
+
+		this.selectedIndex = Math.max(0, Math.min(nextIndex, this.items.length - 1));
+		this.ensureSelectionVisible();
+		this.tui.requestRender();
+	}
+
+	private ensureSelectionVisible(): void {
+		const maxOffset = Math.max(0, this.items.length - this.viewportHeight);
+		if (this.selectedIndex < this.scrollOffset) {
+			this.scrollOffset = this.selectedIndex;
+		} else if (this.selectedIndex >= this.scrollOffset + this.viewportHeight) {
+			this.scrollOffset = this.selectedIndex - this.viewportHeight + 1;
+		}
+		this.scrollOffset = Math.max(0, Math.min(this.scrollOffset, maxOffset));
+	}
+
+	private borderLine(width: number, edge: "top" | "middle" | "bottom"): string {
+		const [left, right] = edge === "top" ? ["┌", "┐"] : edge === "middle" ? ["├", "┤"] : ["└", "┘"];
+		return this.theme.fg("borderMuted", `${left}${"─".repeat(Math.max(0, width - 2))}${right}`);
+	}
+
+	private frameLine(content: string, width: number): string {
+		const innerWidth = Math.max(1, width - 2);
+		const truncated = truncateToWidth(content, innerWidth, "");
+		return `${this.theme.fg("borderMuted", "│")}${truncated}${" ".repeat(Math.max(0, innerWidth - visibleWidth(truncated)))}${this.theme.fg("borderMuted", "│")}`;
+	}
+
+	override render(width: number): string[] {
+		const pickerWidth = Math.max(2, width);
+		const pickerHeight = getPickerHeight(this.tui.terminal.rows);
+		if (pickerHeight < 8) {
+			this.viewportHeight = 1;
+			this.ensureSelectionVisible();
+			const item = this.items[this.selectedIndex];
+			const itemLabel = item ? this.theme.fg("accent", `→ ${item.label}`) : this.theme.fg("dim", "No conversations");
+			const compactLines: string[] = [];
+			if (pickerHeight >= 3) {
+				compactLines.push(this.frameLine(this.theme.fg("accent", this.theme.bold(" BTW conversations ")), pickerWidth));
+			}
+			compactLines.push(this.frameLine(itemLabel, pickerWidth));
+			while (compactLines.length < pickerHeight - 1) {
+				compactLines.push(this.frameLine("", pickerWidth));
+			}
+			if (pickerHeight >= 2) {
+				compactLines.push(
+					this.frameLine(
+						this.theme.fg("dim", `↑↓ · Enter · ${this.selectedIndex + 1}/${this.items.length}`),
+						pickerWidth,
+					),
+				);
+			}
+			return compactLines;
+		}
+
+		this.viewportHeight = pickerHeight - 5;
+		this.ensureSelectionVisible();
+
+		const endIndex = Math.min(this.items.length, this.scrollOffset + this.viewportHeight);
+		const lines = [
+			this.borderLine(pickerWidth, "top"),
+			this.frameLine(this.theme.fg("accent", this.theme.bold(" BTW conversations ")), pickerWidth),
+			this.borderLine(pickerWidth, "middle"),
+		];
+
+		for (let index = this.scrollOffset; index < endIndex; index++) {
+			const item = this.items[index];
+			if (!item) continue;
+			const prefix = index === this.selectedIndex ? "→ " : "  ";
+			const label = `${prefix}${item.label}`;
+			const availableDescriptionWidth = Math.max(0, pickerWidth - visibleWidth(label) - 5);
+			const description =
+				availableDescriptionWidth >= 12 ? `  ${truncateToWidth(item.description, availableDescriptionWidth, "…")}` : "";
+			const content = index === this.selectedIndex ? this.theme.fg("accent", label + description) : label + description;
+			lines.push(this.frameLine(content, pickerWidth));
+		}
+		while (lines.length < this.viewportHeight + 3) {
+			lines.push(this.frameLine("", pickerWidth));
+		}
+
+		const position = this.items.length > this.viewportHeight ? ` · ${this.selectedIndex + 1}/${this.items.length}` : "";
+		lines.push(
+			this.frameLine(
+				this.theme.fg("dim", `↑↓ navigate · PgUp/PgDn page · Enter select · Esc cancel${position}`),
+				pickerWidth,
+			),
+		);
+		lines.push(this.borderLine(pickerWidth, "bottom"));
+		return lines;
+	}
+}
+
+export class BtwOverlay extends Container implements Focusable {
 	private readonly input: Input;
 	private readonly tui: TUI;
 	private readonly theme: ExtensionContext["ui"]["theme"];
@@ -214,7 +392,11 @@ class BtwOverlay extends Container implements Focusable {
 	private readonly getStatus: () => string;
 	private readonly onSubmitCallback: (value: string) => void;
 	private readonly onDismissCallback: () => void;
+	private readonly onInvalidateCallback: () => void;
 	private isFocused = false;
+	private scrollOffset = 0;
+	private transcriptHeight = 6;
+	private previousTranscriptLength = 0;
 
 	get focused(): boolean {
 		return this.isFocused;
@@ -233,6 +415,7 @@ class BtwOverlay extends Container implements Focusable {
 		getStatus: () => string,
 		onSubmit: (value: string) => void,
 		onDismiss: () => void,
+		onInvalidate: () => void,
 	) {
 		super();
 		this.tui = tui;
@@ -242,6 +425,7 @@ class BtwOverlay extends Container implements Focusable {
 		this.getStatus = getStatus;
 		this.onSubmitCallback = onSubmit;
 		this.onDismissCallback = onDismiss;
+		this.onInvalidateCallback = onInvalidate;
 
 		this.input = new Input();
 		this.input.onSubmit = (value) => {
@@ -257,8 +441,23 @@ class BtwOverlay extends Container implements Focusable {
 			this.onDismissCallback();
 			return;
 		}
+		if (this.keybindings.matches(data, "tui.select.pageUp")) {
+			this.scrollOffset += this.transcriptHeight;
+			this.tui.requestRender();
+			return;
+		}
+		if (this.keybindings.matches(data, "tui.select.pageDown")) {
+			this.scrollOffset = Math.max(0, this.scrollOffset - this.transcriptHeight);
+			this.tui.requestRender();
+			return;
+		}
 
 		this.input.handleInput(data);
+	}
+
+	scrollToBottom(): void {
+		this.scrollOffset = 0;
+		this.tui.requestRender();
 	}
 
 	setDraft(value: string): void {
@@ -283,17 +482,26 @@ class BtwOverlay extends Container implements Focusable {
 	}
 
 	override render(width: number): string[] {
-		const dialogWidth = Math.max(56, Math.min(width, Math.floor(width * 0.9)));
-		const innerWidth = Math.max(40, dialogWidth - 2);
-		const terminalRows = process.stdout.rows ?? 30;
-		const dialogHeight = Math.max(16, Math.min(30, Math.floor(terminalRows * 0.75)));
-		const chromeHeight = 7;
-		const transcriptHeight = Math.max(6, dialogHeight - chromeHeight);
+		const dialogWidth = Math.max(2, Math.min(width, Math.floor(width * 0.9)));
+		const innerWidth = Math.max(1, dialogWidth - 2);
+		const terminalRows = this.tui.terminal.rows;
+		const dialogHeight = Math.max(1, Math.min(30, Math.floor(Math.max(1, terminalRows) * 0.75)));
+		const compact = dialogHeight < 10;
+		const chromeHeight = compact ? Math.min(3, Math.max(1, dialogHeight - 1)) : 9;
+		this.transcriptHeight = Math.max(1, dialogHeight - chromeHeight);
 
-		// Markdown renders to innerWidth already — no manual wrapping needed
+		// Markdown renders to innerWidth already — no manual wrapping needed.
 		const transcript = this.getTranscript(innerWidth, this.theme);
-		const visibleTranscript = transcript.slice(-transcriptHeight);
-		const transcriptPadding = Math.max(0, transcriptHeight - visibleTranscript.length);
+		if (this.scrollOffset > 0 && transcript.length > this.previousTranscriptLength) {
+			this.scrollOffset += transcript.length - this.previousTranscriptLength;
+		}
+		this.previousTranscriptLength = transcript.length;
+		const maxScrollOffset = Math.max(0, transcript.length - this.transcriptHeight);
+		this.scrollOffset = Math.max(0, Math.min(this.scrollOffset, maxScrollOffset));
+		const transcriptEnd = Math.max(0, transcript.length - this.scrollOffset);
+		const transcriptStart = Math.max(0, transcriptEnd - this.transcriptHeight);
+		const visibleTranscript = transcript.slice(transcriptStart, transcriptEnd);
+		const transcriptPadding = Math.max(0, this.transcriptHeight - visibleTranscript.length);
 
 		const status = this.getStatus();
 
@@ -301,6 +509,24 @@ class BtwOverlay extends Container implements Focusable {
 		this.input.focused = false;
 		const inputLine = this.input.render(innerWidth)[0] ?? "";
 		this.input.focused = previousFocused;
+
+		if (compact) {
+			if (dialogHeight === 1) {
+				return [truncateToWidth(inputLine, dialogWidth, "")];
+			}
+			const compactLines: string[] = [];
+			if (dialogHeight >= 4) {
+				compactLines.push(this.frameLine(this.theme.fg("accent", this.theme.bold(" BTW side chat ")), innerWidth));
+			}
+			for (const line of visibleTranscript) {
+				compactLines.push(this.frameLine(line, innerWidth));
+			}
+			if (dialogHeight >= 3) {
+				compactLines.push(this.frameLine(this.theme.fg("warning", status), innerWidth));
+			}
+			compactLines.push(`${this.theme.fg("borderMuted", "│")}${inputLine}${this.theme.fg("borderMuted", "│")}`);
+			return compactLines.slice(0, dialogHeight);
+		}
 
 		const lines = [
 			this.borderLine(innerWidth, "top"),
@@ -317,22 +543,35 @@ class BtwOverlay extends Container implements Focusable {
 		}
 
 		lines.push(this.theme.fg("borderMuted", `├${"─".repeat(innerWidth)}┤`));
-		lines.push(this.frameLine(this.theme.fg("warning", status), innerWidth));
+		const scrollPosition =
+			transcript.length > this.transcriptHeight
+				? ` · ${transcriptStart + 1}-${transcriptEnd}/${transcript.length}`
+				: "";
+		lines.push(this.frameLine(this.theme.fg("warning", status) + this.theme.fg("dim", scrollPosition), innerWidth));
 		lines.push(`${this.theme.fg("borderMuted", "│")}${inputLine}${this.theme.fg("borderMuted", "│")}`);
-		lines.push(this.frameLine(this.theme.fg("dim", "Enter submit · Esc close"), innerWidth));
+		lines.push(this.frameLine(this.theme.fg("dim", "Enter submit · PgUp/PgDn scroll · Esc close"), innerWidth));
 		lines.push(this.borderLine(innerWidth, "bottom"));
 
 		return lines;
 	}
+
+	override invalidate(): void {
+		super.invalidate();
+		this.onInvalidateCallback();
+	}
 }
 
 export default function (pi: ExtensionAPI) {
+	const conversations = new Map<string, BtwConversation>();
+	let activeConversationId: string | null = null;
 	let thread: BtwDetails[] = [];
+	let conversationSequence = 0;
 	let pendingQuestion: string | null = null;
 	let pendingAnswer = "";
 	let pendingError: string | null = null;
 	let pendingToolCalls: ToolCallInfo[] = [];
 	let sideBusy = false;
+	let sideRequestGeneration = 0;
 	let overlayStatus = "Ready";
 	let overlayDraft = "";
 	let overlayRuntime: OverlayRuntime | null = null;
@@ -340,6 +579,35 @@ export default function (pi: ExtensionAPI) {
 	let overlayRefreshTimer: ReturnType<typeof setTimeout> | null = null;
 
 	const mdTheme = getMarkdownTheme();
+	let renderedAnswerCache = new WeakMap<BtwDetails, { width: number; answer: string; lines: string[] }>();
+
+	function createConversationId(): string {
+		conversationSequence++;
+		return `${Date.now().toString(36)}-${conversationSequence.toString(36)}`;
+	}
+
+	function setActiveConversation(id: string | null): void {
+		activeConversationId = id;
+		thread = id ? (conversations.get(id)?.thread ?? []) : [];
+	}
+
+	function createConversation(): BtwConversation {
+		const timestamp = Date.now();
+		const conversation: BtwConversation = {
+			id: createConversationId(),
+			createdAt: timestamp,
+			updatedAt: timestamp,
+			thread: [],
+			persisted: false,
+		};
+		conversations.set(conversation.id, conversation);
+		setActiveConversation(conversation.id);
+		return conversation;
+	}
+
+	function getSortedConversations(): BtwConversation[] {
+		return Array.from(conversations.values()).sort((a, b) => b.updatedAt - a.updatedAt);
+	}
 
 	function getModelKey(ctx: ExtensionContext): string {
 		const model = ctx.model;
@@ -352,16 +620,29 @@ export default function (pi: ExtensionAPI) {
 			const md = new Markdown(text, 0, 0, mdTheme);
 			return md.render(width);
 		} catch {
-			// Fall back to plain text wrapping if Markdown rendering fails
-			return text.split("\n").flatMap((line) => {
-				if (!line) return [""];
-				const wrapped: string[] = [];
-				for (let i = 0; i < line.length; i += width) {
-					wrapped.push(line.slice(i, i + width));
+			// Fall back to plain text wrapping if Markdown rendering fails.
+			const lines: string[] = [];
+			for (const line of text.split("\n")) {
+				if (!line) {
+					lines.push("");
+					continue;
 				}
-				return wrapped.length > 0 ? wrapped : [""];
-			});
+				for (let index = 0; index < line.length; index += width) {
+					lines.push(line.slice(index, index + width));
+				}
+			}
+			return lines;
 		}
+	}
+
+	function renderCompletedAnswer(item: BtwDetails, width: number): string[] {
+		const cached = renderedAnswerCache.get(item);
+		if (cached && cached.width === width && cached.answer === item.answer) {
+			return cached.lines;
+		}
+		const lines = renderMarkdownLines(item.answer, width);
+		renderedAnswerCache.set(item, { width, answer: item.answer, lines });
+		return lines;
 	}
 
 	function formatToolArgs(toolName: string, args: unknown): string {
@@ -411,14 +692,14 @@ export default function (pi: ExtensionAPI) {
 		}
 
 		const lines: string[] = [];
-		for (const item of thread.slice(-6)) {
+		for (const item of thread) {
 			// User message
 			const userText = item.question.trim().split("\n")[0];
 			lines.push(theme.fg("accent", theme.bold("You: ")) + truncateToWidth(userText, width - 5, "…"));
 			lines.push("");
 
 			// Assistant message rendered as markdown
-			const mdLines = renderMarkdownLines(item.answer, width);
+			const mdLines = renderCompletedAnswer(item, width);
 			lines.push(...mdLines);
 			lines.push("");
 		}
@@ -514,53 +795,91 @@ export default function (pi: ExtensionAPI) {
 		}
 	}
 
-	async function resetThread(ctx: ExtensionContext | ExtensionCommandContext, persist = true): Promise<void> {
-		thread = [];
+	function clearTransientState(): void {
 		pendingQuestion = null;
 		pendingAnswer = "";
 		pendingError = null;
 		pendingToolCalls = [];
 		sideBusy = false;
+		overlayDraft = "";
+		overlayStatus = "Ready";
+	}
+
+	async function resetThread(_ctx: ExtensionContext | ExtensionCommandContext, persist = true): Promise<void> {
+		const conversationId = activeConversationId;
+		clearTransientState();
 		setOverlayDraft("");
-		setOverlayStatus("Ready");
-		await disposeSideSession();
-		if (persist) {
-			const details: BtwResetDetails = { timestamp: Date.now() };
-			pi.appendEntry(BTW_RESET_TYPE, details);
+		if (conversationId) {
+			const conversation = conversations.get(conversationId);
+			conversations.delete(conversationId);
+			if (persist && conversation?.persisted) {
+				const details: BtwResetDetails = { conversationId, timestamp: Date.now() };
+				pi.appendEntry(BTW_RESET_TYPE, details);
+			}
 		}
+		setActiveConversation(null);
+		await disposeSideSession();
+		setOverlayStatus("Ready");
 		syncOverlay();
 	}
 
 	async function restoreThread(ctx: ExtensionContext): Promise<void> {
 		await disposeSideSession();
-		thread = [];
-		pendingQuestion = null;
-		pendingAnswer = "";
-		pendingError = null;
-		pendingToolCalls = [];
-		sideBusy = false;
-		overlayStatus = "Ready";
-		overlayDraft = "";
-		const branch = ctx.sessionManager.getBranch();
-		let lastResetIndex = -1;
-		for (let i = 0; i < branch.length; i++) {
-			const entry = branch[i];
-			if (entry.type === "custom" && entry.customType === BTW_RESET_TYPE) {
-				lastResetIndex = i;
-			}
-		}
+		conversations.clear();
+		setActiveConversation(null);
+		clearTransientState();
+		renderedAnswerCache = new WeakMap();
 
-		for (const entry of branch.slice(lastResetIndex + 1)) {
-			if (entry.type !== "custom" || entry.customType !== BTW_ENTRY_TYPE) {
+		for (const entry of ctx.sessionManager.getBranch()) {
+			if (entry.type !== "custom") {
+				continue;
+			}
+
+			if (entry.customType === BTW_START_TYPE) {
+				const details = entry.data as BtwStartDetails | undefined;
+				if (!details?.conversationId || !Number.isFinite(details.timestamp)) {
+					continue;
+				}
+				conversations.set(details.conversationId, {
+					id: details.conversationId,
+					createdAt: details.timestamp,
+					updatedAt: details.timestamp,
+					thread: [],
+					persisted: true,
+				});
+				continue;
+			}
+
+			if (entry.customType === BTW_RESET_TYPE) {
+				const details = entry.data as BtwResetDetails | undefined;
+				conversations.delete(details?.conversationId || LEGACY_CONVERSATION_ID);
+				continue;
+			}
+
+			if (entry.customType !== BTW_ENTRY_TYPE) {
 				continue;
 			}
 			const details = entry.data as BtwDetails | undefined;
-			if (!details?.question || !details.answer) {
+			if (!details?.question || !details.answer || !Number.isFinite(details.timestamp)) {
 				continue;
 			}
-			thread.push(details);
+			const conversationId = details.conversationId || LEGACY_CONVERSATION_ID;
+			let conversation = conversations.get(conversationId);
+			if (!conversation) {
+				conversation = {
+					id: conversationId,
+					createdAt: details.timestamp,
+					updatedAt: details.timestamp,
+					thread: [],
+					persisted: true,
+				};
+				conversations.set(conversationId, conversation);
+			}
+			conversation.thread.push(details);
+			conversation.updatedAt = Math.max(conversation.updatedAt, details.timestamp);
 		}
 
+		setActiveConversation(getSortedConversations()[0]?.id ?? null);
 		syncOverlay();
 	}
 
@@ -658,8 +977,64 @@ export default function (pi: ExtensionAPI) {
 		return activeSideSession;
 	}
 
-	async function ensureOverlay(ctx: ExtensionCommandContext | ExtensionContext): Promise<void> {
-		if (!ctx.hasUI) {
+	async function activateConversation(id: string): Promise<boolean> {
+		const activationGeneration = sideRequestGeneration;
+		if (!conversations.has(id)) {
+			return false;
+		}
+		await disposeSideSession();
+		if (activationGeneration !== sideRequestGeneration || !conversations.has(id)) {
+			return false;
+		}
+		clearTransientState();
+		setActiveConversation(id);
+		setOverlayStatus("Conversation ready.");
+		return true;
+	}
+
+	async function showConversationPicker(ctx: ExtensionCommandContext): Promise<string | null | undefined> {
+		const items: ConversationPickerItem[] = [
+			{
+				id: null,
+				label: "Start a new conversation",
+				description: "Open an empty side thread",
+			},
+		];
+		for (const conversation of getSortedConversations()) {
+			const exchangeCount = conversation.thread.length;
+			const updated = new Date(conversation.updatedAt).toLocaleString();
+			items.push({
+				id: conversation.id,
+				label: getConversationTitle(conversation),
+				description: `${exchangeCount} ${exchangeCount === 1 ? "exchange" : "exchanges"} · ${updated}`,
+			});
+		}
+
+		return ctx.ui.custom<string | null | undefined>(
+			(tui, theme, keybindings, done) =>
+				new BtwConversationPicker(
+					tui,
+					theme,
+					keybindings,
+					items,
+					(id) => done(id),
+					() => done(undefined),
+				),
+			{
+				overlay: true,
+				overlayOptions: {
+					width: "72%",
+					minWidth: 64,
+					maxHeight: "60%",
+					anchor: "top-center",
+					margin: { top: 1, left: 2, right: 2 },
+				},
+			},
+		);
+	}
+
+	async function ensureOverlay(ctx: ExtensionCommandContext): Promise<void> {
+		if (ctx.mode !== "tui") {
 			return;
 		}
 
@@ -702,11 +1077,15 @@ export default function (pi: ExtensionAPI) {
 						() => {
 							void closeOverlayFlow(ctx);
 						},
+						() => {
+							renderedAnswerCache = new WeakMap();
+						},
 					);
 
 					overlay.focused = true;
 					overlay.setDraft(overlayDraft);
 					runtime.setDraft = (value) => overlay.setDraft(value);
+					runtime.scrollToBottom = () => overlay.scrollToBottom();
 					runtime.refresh = () => {
 						overlay.focused = runtime.handle?.isFocused() ?? false;
 						tui.requestRender();
@@ -793,14 +1172,20 @@ export default function (pi: ExtensionAPI) {
 	}
 
 	async function injectSummaryIntoMain(ctx: ExtensionContext | ExtensionCommandContext): Promise<void> {
-		if (thread.length === 0) {
+		const conversationId = activeConversationId;
+		const items = thread;
+		if (!conversationId || items.length === 0) {
 			notify(ctx, "No BTW thread to summarize.", "warning");
 			return;
 		}
 
+		const operationGeneration = sideRequestGeneration;
 		setOverlayStatus("Summarizing BTW thread for injection...");
 		try {
-			const summary = await summarizeThread(ctx, thread);
+			const summary = await summarizeThread(ctx, items);
+			if (operationGeneration !== sideRequestGeneration || activeConversationId !== conversationId) {
+				return;
+			}
 			const message = `Summary of my BTW side conversation:\n\n${summary}`;
 			if (ctx.isIdle()) {
 				pi.sendUserMessage(message);
@@ -811,63 +1196,87 @@ export default function (pi: ExtensionAPI) {
 			await resetThread(ctx);
 			notify(ctx, "Injected BTW summary into main chat.", "info");
 		} catch (error) {
-			notify(ctx, error instanceof Error ? error.message : String(error), "error");
+			if (operationGeneration === sideRequestGeneration && activeConversationId === conversationId) {
+				notify(ctx, error instanceof Error ? error.message : String(error), "error");
+			}
 		}
 	}
 
 	async function closeOverlayFlow(ctx: ExtensionContext | ExtensionCommandContext): Promise<void> {
+		const conversationId = activeConversationId;
 		dismissOverlay();
 		if (!ctx.hasUI) {
 			return;
 		}
 
-		if (thread.length === 0) {
+		if (!conversationId || thread.length === 0) {
 			return;
 		}
 
 		const choice = await ctx.ui.select("Close BTW:", ["Keep side thread", "Inject summary into main chat"]);
-		if (choice === "Inject summary into main chat") {
+		if (choice === "Inject summary into main chat" && activeConversationId === conversationId) {
 			await injectSummaryIntoMain(ctx);
 		}
 	}
 
-	async function runBtwPrompt(ctx: ExtensionCommandContext, question: string): Promise<void> {
+	async function runBtwPrompt(
+		ctx: ExtensionCommandContext,
+		question: string,
+		conversationId: string | null,
+	): Promise<void> {
 		const model = ctx.model;
 		if (!model) {
 			setOverlayStatus("No active model selected.");
 			notify(ctx, "No active model selected.", "error");
 			return;
 		}
-
-		const auth = await ctx.modelRegistry.getApiKeyAndHeaders(model);
-		if (auth.ok === false) {
-			const message = auth.error;
-			setOverlayStatus(message);
-			notify(ctx, message, "error");
-			return;
-		}
-
 		if (sideBusy) {
 			notify(ctx, "BTW is still processing the previous message.", "warning");
 			return;
 		}
-
-		const side = await ensureSideSession(ctx);
-		if (!side) {
-			notify(ctx, "Unable to create BTW side session.", "error");
+		const conversation = conversationId ? conversations.get(conversationId) : undefined;
+		if (!conversation || activeConversationId !== conversationId) {
 			return;
 		}
 
+		const requestGeneration = ++sideRequestGeneration;
+		const isRequestCurrent = () =>
+			requestGeneration === sideRequestGeneration && activeConversationId === conversationId;
 		sideBusy = true;
-		pendingQuestion = question;
-		pendingAnswer = "";
-		pendingError = null;
-		pendingToolCalls = [];
-		setOverlayStatus("Streaming side response...");
-		syncOverlay();
 
 		try {
+			const auth = await ctx.modelRegistry.getApiKeyAndHeaders(model);
+			if (!isRequestCurrent()) {
+				return;
+			}
+			if (auth.ok === false) {
+				const message = auth.error;
+				setOverlayStatus(message);
+				notify(ctx, message, "error");
+				return;
+			}
+
+			const side = await ensureSideSession(ctx);
+			if (!isRequestCurrent()) {
+				return;
+			}
+			if (!side) {
+				notify(ctx, "Unable to create BTW side session.", "error");
+				return;
+			}
+
+			overlayRuntime?.scrollToBottom?.();
+			pendingQuestion = question;
+			pendingAnswer = "";
+			pendingError = null;
+			pendingToolCalls = [];
+			setOverlayStatus("Streaming side response...");
+			syncOverlay();
+
 			await side.session.prompt(question, { source: "extension" });
+			if (!isRequestCurrent()) {
+				return;
+			}
 			const response = getLastAssistantMessage(side.session);
 			if (!response) {
 				throw new Error("BTW request finished without a response.");
@@ -881,16 +1290,27 @@ export default function (pi: ExtensionAPI) {
 
 			const answer = extractText(response.content) || "(No text response)";
 			pendingAnswer = answer;
+			const timestamp = Date.now();
 			const details: BtwDetails = {
 				question,
 				answer,
-				timestamp: Date.now(),
+				timestamp,
 				provider: model.provider,
 				model: model.id,
 				thinkingLevel: pi.getThinkingLevel() as SessionThinkingLevel,
+				conversationId: conversation.id,
 				usage: response.usage,
 			};
-			thread.push(details);
+			conversation.thread.push(details);
+			conversation.updatedAt = timestamp;
+			if (!conversation.persisted) {
+				const startDetails: BtwStartDetails = {
+					conversationId: conversation.id,
+					timestamp: conversation.createdAt,
+				};
+				pi.appendEntry(BTW_START_TYPE, startDetails);
+				conversation.persisted = true;
+			}
 			pi.appendEntry(BTW_ENTRY_TYPE, details);
 
 			pendingQuestion = null;
@@ -898,17 +1318,22 @@ export default function (pi: ExtensionAPI) {
 			pendingToolCalls = [];
 			setOverlayStatus("Ready for the next side question.");
 		} catch (error) {
+			if (!isRequestCurrent()) {
+				return;
+			}
 			const message = error instanceof Error ? error.message : String(error);
 			pendingError = message;
 			setOverlayStatus("BTW request failed.");
 			notify(ctx, message, "error");
 		} finally {
-			sideBusy = false;
-			syncOverlay();
+			if (isRequestCurrent()) {
+				sideBusy = false;
+				syncOverlay();
+			}
 		}
 	}
 
-	async function submitFromOverlay(ctx: ExtensionContext | ExtensionCommandContext, rawValue: string): Promise<void> {
+	async function submitFromOverlay(ctx: ExtensionCommandContext, rawValue: string): Promise<void> {
 		const question = rawValue.trim();
 		if (!question) {
 			setOverlayStatus("Enter a question first.");
@@ -916,43 +1341,64 @@ export default function (pi: ExtensionAPI) {
 		}
 
 		setOverlayDraft("");
-		if (!("waitForIdle" in ctx)) {
-			setOverlayStatus("BTW submit requires command context. Re-open with /btw.");
-			return;
-		}
-
-		await runBtwPrompt(ctx, question);
+		await runBtwPrompt(ctx, question, activeConversationId);
 	}
 
 	pi.registerCommand("btw", {
-		description: "Open a simple BTW side-chat popover. `/btw <text>` asks immediately, `/btw` opens the side thread.",
+		description: "Open or select a BTW side conversation. `/btw <text>` starts a new conversation immediately.",
 		handler: async (args, ctx) => {
+			if (ctx.mode !== "tui") {
+				notify(ctx, "BTW conversations are available in TUI mode only.", "warning");
+				return;
+			}
 			const question = args.trim();
 
 			if (!question) {
-				if (thread.length > 0 && ctx.hasUI) {
-					const choice = await ctx.ui.select("BTW side chat:", ["Continue previous conversation", "Start fresh"]);
-					if (choice === "Continue previous conversation") {
-						// Dispose session so it's recreated with fresh main context on next submit
-						await disposeSideSession();
-						setOverlayStatus("Continuing BTW thread.");
-						await ensureOverlay(ctx);
-					} else if (choice === "Start fresh") {
-						await resetThread(ctx, true);
-						setOverlayStatus("Ready");
-						await ensureOverlay(ctx);
-					}
-					// null = user cancelled (Esc), do nothing
-				} else {
-					await resetThread(ctx, true);
+				if (!ctx.hasUI) {
+					return;
+				}
+
+				if (conversations.size === 0) {
+					createConversation();
 					setOverlayStatus("Ready");
 					await ensureOverlay(ctx);
+					return;
 				}
+
+				dismissOverlay();
+				const pickerGeneration = sideRequestGeneration;
+				const selectedId = await showConversationPicker(ctx);
+				if (selectedId === undefined || pickerGeneration !== sideRequestGeneration) {
+					return;
+				}
+				if (selectedId === null) {
+					await disposeSideSession();
+					if (pickerGeneration !== sideRequestGeneration) {
+						return;
+					}
+					clearTransientState();
+					createConversation();
+				} else if (!(await activateConversation(selectedId))) {
+					notify(ctx, "That BTW conversation is no longer available.", "warning");
+					return;
+				}
+				await ensureOverlay(ctx);
 				return;
 			}
 
+			if (sideBusy) {
+				notify(ctx, "BTW is still processing the previous message.", "warning");
+				return;
+			}
+			const commandGeneration = sideRequestGeneration;
+			await disposeSideSession();
+			if (commandGeneration !== sideRequestGeneration) {
+				return;
+			}
+			clearTransientState();
+			const conversation = createConversation();
 			await ensureOverlay(ctx);
-			await runBtwPrompt(ctx, question);
+			await runBtwPrompt(ctx, question, conversation.id);
 		},
 	});
 
@@ -961,6 +1407,7 @@ export default function (pi: ExtensionAPI) {
 	});
 
 	pi.on("session_tree", async (_event, ctx) => {
+		sideRequestGeneration++;
 		await restoreThread(ctx);
 	});
 

--- a/packages/monopi__extension-btw/tests/btw.test.ts
+++ b/packages/monopi__extension-btw/tests/btw.test.ts
@@ -10,6 +10,7 @@ vi.mock("@earendil-works/pi-tui", () => ({
 		addChild(child: any) {
 			this.children.push(child);
 		}
+		invalidate() {}
 	},
 	Input: class Input {
 		focused = false;
@@ -35,6 +36,9 @@ vi.mock("@earendil-works/pi-tui", () => ({
 			public theme?: unknown,
 		) {}
 		render(_width: number) {
+			if (this.text.startsWith("throw:")) {
+				throw new Error("Markdown render failed");
+			}
 			return [this.text];
 		}
 	},
@@ -75,8 +79,10 @@ vi.mock("@earendil-works/pi-coding-agent", () => ({
 	},
 }));
 
+import { createAgentSession } from "@earendil-works/pi-coding-agent";
+
 import { createExtensionHarness } from "../../../test-utils/extension-runtime-harness.js";
-import btwExtension from "../index.js";
+import btwExtension, { BtwConversationPicker, BtwOverlay, getPickerHeight } from "../index.js";
 
 const model = {
 	provider: "anthropic",
@@ -112,6 +118,23 @@ function configureModel(harness: ReturnType<typeof createExtensionHarness>) {
 	} as never;
 }
 
+const testTheme = {
+	bold: (text: string) => text,
+	fg: (_color: string, text: string) => text,
+};
+
+function createTuiTestKit() {
+	return {
+		keybindings: {
+			matches: (data: string, binding: string) => data === binding,
+		},
+		tui: {
+			requestRender: vi.fn(),
+			terminal: { rows: 30 },
+		},
+	};
+}
+
 describe("btw command", () => {
 	beforeEach(() => {
 		vi.clearAllMocks();
@@ -143,14 +166,64 @@ describe("btw command", () => {
 		expect(customSpy).toHaveBeenCalled();
 	});
 
-	it("shows an error when no model is active", async () => {
+	it("shows an error without persisting an empty conversation when no model is active", async () => {
 		const harness = createExtensionHarness();
+		const appendEntry = vi.fn();
+		harness.pi.appendEntry = appendEntry;
 		btwExtension(harness.pi as never);
 
 		await harness.commands.get("btw").handler("What changed?", harness.ctx);
 
 		expect(harness.notifications).toContainEqual({
 			msg: "No active model selected.",
+			type: "error",
+		});
+		expect(appendEntry).not.toHaveBeenCalled();
+	});
+
+	it("rejects the custom conversation UI outside TUI mode", async () => {
+		const harness = createExtensionHarness();
+		harness.ctx.mode = "rpc";
+		const customSpy = vi.fn();
+		harness.ctx.ui.custom = customSpy;
+		btwExtension(harness.pi as never);
+
+		await harness.commands.get("btw").handler("Question", harness.ctx);
+
+		expect(customSpy).not.toHaveBeenCalled();
+		expect(harness.notifications).toContainEqual({
+			msg: "BTW conversations are available in TUI mode only.",
+			type: "warning",
+		});
+	});
+
+	it("does not persist a conversation when model authentication fails", async () => {
+		const harness = createExtensionHarness();
+		configureModel(harness);
+		const appendEntry = vi.fn();
+		harness.pi.appendEntry = appendEntry;
+		harness.ctx.modelRegistry.getApiKeyAndHeaders = vi.fn().mockResolvedValue({ ok: false, error: "Auth failed" });
+		btwExtension(harness.pi as never);
+
+		await harness.commands.get("btw").handler("Question", harness.ctx);
+
+		expect(harness.notifications).toContainEqual({ msg: "Auth failed", type: "error" });
+		expect(appendEntry).not.toHaveBeenCalled();
+	});
+
+	it("handles a model disappearing before side-session creation", async () => {
+		const harness = createExtensionHarness();
+		configureModel(harness);
+		harness.ctx.modelRegistry.getApiKeyAndHeaders = vi.fn().mockImplementation(async () => {
+			harness.ctx.model = undefined;
+			return { ok: true, apiKey: "key", headers: {} };
+		});
+		btwExtension(harness.pi as never);
+
+		await harness.commands.get("btw").handler("Question", harness.ctx);
+
+		expect(harness.notifications).toContainEqual({
+			msg: "Unable to create BTW side session.",
 			type: "error",
 		});
 	});
@@ -170,8 +243,168 @@ describe("btw command", () => {
 			expect.objectContaining({
 				question: "What changed?",
 				answer: "Test answer",
+				conversationId: expect.any(String),
 			}),
 		);
+	});
+
+	it("keeps independently addressable conversations for repeated invocations", async () => {
+		const harness = createExtensionHarness();
+		configureModel(harness);
+		const appendEntry = vi.fn();
+		harness.pi.appendEntry = appendEntry;
+		harness.ctx.ui.custom = vi.fn().mockResolvedValue(null);
+
+		btwExtension(harness.pi as never);
+		await harness.commands.get("btw").handler("First topic", harness.ctx);
+		await harness.commands.get("btw").handler("Second topic", harness.ctx);
+
+		const persistedEntries = appendEntry.mock.calls
+			.filter(([type]) => type === "btw-thread-entry")
+			.map(([, details]) => details);
+		expect(persistedEntries).toHaveLength(2);
+		expect(persistedEntries[0].conversationId).not.toBe(persistedEntries[1].conversationId);
+
+		const pickerLines: string[] = [];
+		const { keybindings, tui } = createTuiTestKit();
+		harness.ctx.ui.custom = vi.fn().mockImplementation(async (factory: any) => {
+			const picker = await factory(tui, testTheme, keybindings, () => {});
+			pickerLines.push(...picker.render(90));
+			picker.handleInput("tui.select.cancel");
+			return undefined;
+		});
+		await harness.commands.get("btw").handler("", harness.ctx);
+
+		expect(pickerLines.join("\n")).toContain("First topic");
+		expect(pickerLines.join("\n")).toContain("Second topic");
+	});
+
+	it("starts an unpersisted empty conversation from the picker", async () => {
+		const harness = createExtensionHarness();
+		configureModel(harness);
+		const appendEntry = vi.fn();
+		harness.pi.appendEntry = appendEntry;
+		harness.ctx.ui.custom = vi.fn().mockResolvedValue(null);
+		btwExtension(harness.pi as never);
+		await harness.commands.get("btw").handler("Saved topic", harness.ctx);
+		appendEntry.mockClear();
+
+		const { keybindings, tui } = createTuiTestKit();
+		let openedOverlay: BtwOverlay | undefined;
+		harness.ctx.ui.custom = vi.fn().mockImplementation(async (factory: any) => {
+			let selectedValue: unknown;
+			const component = await factory(tui, testTheme, keybindings, (value: unknown) => {
+				selectedValue = value;
+			});
+			if (component instanceof BtwConversationPicker) {
+				component.render(90);
+				component.handleInput("tui.select.confirm");
+				return selectedValue;
+			}
+			openedOverlay = component;
+			return null;
+		});
+
+		await harness.commands.get("btw").handler("", harness.ctx);
+		expect(openedOverlay?.render(90).join("\n")).toContain("No BTW messages yet");
+		expect(appendEntry).not.toHaveBeenCalled();
+	});
+
+	it("handles a stale conversation picker selection", async () => {
+		const harness = createExtensionHarness();
+		configureModel(harness);
+		harness.ctx.ui.custom = vi.fn().mockResolvedValue(null);
+		btwExtension(harness.pi as never);
+		await harness.commands.get("btw").handler("Saved topic", harness.ctx);
+
+		harness.ctx.ui.custom = vi.fn().mockResolvedValue("missing-conversation");
+		await harness.commands.get("btw").handler("", harness.ctx);
+
+		expect(harness.notifications).toContainEqual({
+			msg: "That BTW conversation is no longer available.",
+			type: "warning",
+		});
+	});
+
+	it.each([
+		{ label: "a new conversation", selectionMoves: 0 },
+		{ label: "an existing conversation", selectionMoves: 1 },
+	])("cancels selecting $label when the session branch changes", async ({ selectionMoves }) => {
+		const harness = createExtensionHarness();
+		configureModel(harness);
+		const appendEntry = vi.fn();
+		harness.pi.appendEntry = appendEntry;
+		harness.ctx.ui.custom = vi.fn().mockResolvedValue(null);
+		btwExtension(harness.pi as never);
+		await harness.commands.get("btw").handler("Saved topic", harness.ctx);
+		appendEntry.mockClear();
+
+		let resolveAbort: (() => void) | undefined;
+		mockSession.abort.mockImplementationOnce(
+			() =>
+				new Promise<void>((resolve) => {
+					resolveAbort = resolve;
+				}),
+		);
+		const { keybindings, tui } = createTuiTestKit();
+		harness.ctx.ui.custom = vi.fn().mockImplementation(async (factory: any) => {
+			let selectedValue: unknown;
+			const picker = await factory(tui, testTheme, keybindings, (value: unknown) => {
+				selectedValue = value;
+			});
+			picker.render(90);
+			for (let index = 0; index < selectionMoves; index++) {
+				picker.handleInput("tui.select.down");
+			}
+			picker.handleInput("tui.select.confirm");
+			return selectedValue;
+		});
+
+		const selectionPromise = harness.commands.get("btw").handler("", harness.ctx);
+		await new Promise((resolve) => setTimeout(resolve, 0));
+		await harness.emitAsync("session_tree", { type: "session_tree" }, harness.ctx);
+		resolveAbort?.();
+		await selectionPromise;
+
+		expect(appendEntry).not.toHaveBeenCalled();
+	});
+
+	it("does not open terminal UI when TUI dialogs are unavailable", async () => {
+		const harness = createExtensionHarness();
+		harness.ctx.hasUI = false;
+		const customSpy = vi.fn();
+		harness.ctx.ui.custom = customSpy;
+		btwExtension(harness.pi as never);
+
+		await harness.commands.get("btw").handler("", harness.ctx);
+
+		expect(customSpy).not.toHaveBeenCalled();
+	});
+
+	it("cancels a new direct question when the branch changes during session disposal", async () => {
+		const harness = createExtensionHarness();
+		configureModel(harness);
+		const appendEntry = vi.fn();
+		harness.pi.appendEntry = appendEntry;
+		harness.ctx.ui.custom = vi.fn().mockResolvedValue(null);
+		btwExtension(harness.pi as never);
+		await harness.commands.get("btw").handler("Saved topic", harness.ctx);
+		appendEntry.mockClear();
+
+		let resolveAbort: (() => void) | undefined;
+		mockSession.abort.mockImplementationOnce(
+			() =>
+				new Promise<void>((resolve) => {
+					resolveAbort = resolve;
+				}),
+		);
+		const questionPromise = harness.commands.get("btw").handler("Stale direct question", harness.ctx);
+		await new Promise((resolve) => setTimeout(resolve, 0));
+		await harness.emitAsync("session_tree", { type: "session_tree" }, harness.ctx);
+		resolveAbort?.();
+		await questionPromise;
+
+		expect(appendEntry).not.toHaveBeenCalled();
 	});
 
 	it("restores thread entries on session_start", async () => {
@@ -198,9 +431,281 @@ describe("btw command", () => {
 		expect(getBranch).toHaveBeenCalled();
 	});
 
-	it("does not reset the thread on session_tree while a side prompt is busy", async () => {
+	it("restores multiple conversations and applies resets to only their target", async () => {
+		const harness = createExtensionHarness();
+		harness.ctx.sessionManager.getBranch = vi.fn(() => [
+			{ type: "message", role: "user" },
+			{ type: "custom", customType: "btw-thread-start", data: { timestamp: 0 } },
+			{
+				type: "custom",
+				customType: "btw-thread-start",
+				data: { timestamp: 1, conversationId: "empty-conversation" },
+			},
+			{
+				type: "custom",
+				customType: "btw-thread-reset",
+				data: { timestamp: 2, conversationId: "empty-conversation" },
+			},
+			{
+				type: "custom",
+				customType: "btw-thread-entry",
+				data: {
+					question: "Removed topic",
+					answer: "Old answer",
+					provider: "anthropic",
+					model: "claude-sonnet-4",
+					thinkingLevel: "off",
+					timestamp: 1,
+					conversationId: "conversation-1",
+				},
+			},
+			{
+				type: "custom",
+				customType: "btw-thread-entry",
+				data: {
+					question: "Kept topic",
+					answer: "Current answer",
+					provider: "anthropic",
+					model: "claude-sonnet-4",
+					thinkingLevel: "off",
+					timestamp: 2,
+					conversationId: "conversation-2",
+				},
+			},
+			{
+				type: "custom",
+				customType: "btw-thread-reset",
+				data: { timestamp: 3, conversationId: "conversation-1" },
+			},
+		]);
+
+		btwExtension(harness.pi as never);
+		await harness.emitAsync("session_start", { type: "session_start" }, harness.ctx);
+
+		const pickerLines: string[] = [];
+		const { keybindings, tui } = createTuiTestKit();
+		harness.ctx.ui.custom = vi.fn().mockImplementation(async (factory: any) => {
+			const picker = await factory(tui, testTheme, keybindings, () => {});
+			pickerLines.push(...picker.render(90));
+			return undefined;
+		});
+		await harness.commands.get("btw").handler("", harness.ctx);
+
+		expect(pickerLines.join("\n")).toContain("Kept topic");
+		expect(pickerLines.join("\n")).not.toContain("Removed topic");
+	});
+
+	it("continues the selected previous conversation with its persisted id", async () => {
 		const harness = createExtensionHarness();
 		configureModel(harness);
+		harness.ctx.sessionManager.getBranch = vi.fn(() => [
+			{
+				type: "custom",
+				customType: "btw-thread-entry",
+				data: {
+					question: "Older topic",
+					answer: "throw:\n\nOlder answer",
+					provider: "anthropic",
+					model: "claude-sonnet-4",
+					thinkingLevel: "off",
+					timestamp: 1,
+					conversationId: "conversation-1",
+				},
+			},
+			{
+				type: "custom",
+				customType: "btw-thread-entry",
+				data: {
+					question: "Newer topic",
+					answer: "Newer answer",
+					provider: "anthropic",
+					model: "claude-sonnet-4",
+					thinkingLevel: "off",
+					timestamp: 2,
+					conversationId: "conversation-2",
+				},
+			},
+		]);
+		const appendEntry = vi.fn();
+		harness.pi.appendEntry = appendEntry;
+		btwExtension(harness.pi as never);
+		await harness.emitAsync("session_start", { type: "session_start" }, harness.ctx);
+
+		const { keybindings, tui } = createTuiTestKit();
+		let conversationOverlay: BtwOverlay | undefined;
+		harness.ctx.ui.custom = vi.fn().mockImplementation(async (factory: any) => {
+			let selectedValue: unknown;
+			const component = await factory(tui, testTheme, keybindings, (value: unknown) => {
+				selectedValue = value;
+			});
+			if (component instanceof BtwConversationPicker) {
+				component.render(90);
+				component.handleInput("tui.select.down");
+				component.handleInput("tui.select.down");
+				component.handleInput("tui.select.confirm");
+				return selectedValue;
+			}
+			conversationOverlay = component;
+			return null;
+		});
+
+		await harness.commands.get("btw").handler("", harness.ctx);
+		expect(conversationOverlay?.render(90).join("\n")).toContain("Older topic");
+		expect(conversationOverlay?.render(90).join("\n")).toContain("Older answer");
+		conversationOverlay?.invalidate();
+
+		(conversationOverlay as any).input.onSubmit("");
+		(conversationOverlay as any).input.onSubmit("Follow-up");
+		await vi.waitFor(() => {
+			expect(appendEntry).toHaveBeenCalledWith(
+				"btw-thread-entry",
+				expect.objectContaining({
+					question: "Follow-up",
+					conversationId: "conversation-1",
+				}),
+			);
+		});
+	});
+
+	it("removes only the active persisted conversation after summary injection", async () => {
+		const harness = createExtensionHarness();
+		configureModel(harness);
+		const appendEntry = vi.fn();
+		harness.pi.appendEntry = appendEntry;
+		harness.ctx.ui.custom = vi.fn().mockResolvedValue(null);
+		btwExtension(harness.pi as never);
+		await harness.commands.get("btw").handler("Topic to summarize", harness.ctx);
+		const conversationId = appendEntry.mock.calls.find(([type]) => type === "btw-thread-entry")?.[1].conversationId;
+		appendEntry.mockClear();
+
+		const { keybindings, tui } = createTuiTestKit();
+		let conversationOverlay: BtwOverlay | undefined;
+		harness.ctx.ui.custom = vi.fn().mockImplementation(async (factory: any) => {
+			let selectedValue: unknown;
+			const component = await factory(tui, testTheme, keybindings, (value: unknown) => {
+				selectedValue = value;
+			});
+			if (component instanceof BtwConversationPicker) {
+				component.render(90);
+				component.handleInput("tui.select.down");
+				component.handleInput("tui.select.confirm");
+				return selectedValue;
+			}
+			conversationOverlay = component;
+			return null;
+		});
+		harness.ctx.ui.select = vi.fn().mockResolvedValue("Inject summary into main chat");
+
+		await harness.commands.get("btw").handler("", harness.ctx);
+		(conversationOverlay as any).input.onEscape();
+
+		await vi.waitFor(() => {
+			expect(appendEntry).toHaveBeenCalledWith("btw-thread-reset", expect.objectContaining({ conversationId }));
+		});
+	});
+
+	it("keeps the active conversation when summary generation fails", async () => {
+		const harness = createExtensionHarness();
+		configureModel(harness);
+		harness.ctx.ui.custom = vi.fn().mockResolvedValue(null);
+		btwExtension(harness.pi as never);
+		await harness.commands.get("btw").handler("Topic to summarize", harness.ctx);
+
+		const { keybindings, tui } = createTuiTestKit();
+		let conversationOverlay: BtwOverlay | undefined;
+		harness.ctx.ui.custom = vi.fn().mockImplementation(async (factory: any) => {
+			let selectedValue: unknown;
+			const component = await factory(tui, testTheme, keybindings, (value: unknown) => {
+				selectedValue = value;
+			});
+			if (component instanceof BtwConversationPicker) {
+				component.render(90);
+				component.handleInput("tui.select.down");
+				component.handleInput("tui.select.confirm");
+				return selectedValue;
+			}
+			conversationOverlay = component;
+			return null;
+		});
+		harness.ctx.ui.select = vi.fn().mockResolvedValue("Inject summary into main chat");
+		await harness.commands.get("btw").handler("", harness.ctx);
+		mockSession.prompt.mockRejectedValueOnce(new Error("Summary failed"));
+
+		(conversationOverlay as any).input.onEscape();
+
+		await vi.waitFor(() => {
+			expect(harness.notifications).toContainEqual({ msg: "Summary failed", type: "error" });
+		});
+		expect(harness.userMessages).toHaveLength(0);
+	});
+
+	it("does not inject or reset a summary after branch navigation", async () => {
+		const harness = createExtensionHarness();
+		configureModel(harness);
+		const appendEntry = vi.fn();
+		harness.pi.appendEntry = appendEntry;
+		harness.ctx.ui.custom = vi.fn().mockResolvedValue(null);
+		btwExtension(harness.pi as never);
+		await harness.commands.get("btw").handler("Topic to summarize", harness.ctx);
+		appendEntry.mockClear();
+
+		const { keybindings, tui } = createTuiTestKit();
+		let conversationOverlay: BtwOverlay | undefined;
+		harness.ctx.ui.custom = vi.fn().mockImplementation(async (factory: any) => {
+			let selectedValue: unknown;
+			const component = await factory(tui, testTheme, keybindings, (value: unknown) => {
+				selectedValue = value;
+			});
+			if (component instanceof BtwConversationPicker) {
+				component.render(90);
+				component.handleInput("tui.select.down");
+				component.handleInput("tui.select.confirm");
+				return selectedValue;
+			}
+			conversationOverlay = component;
+			return null;
+		});
+		harness.ctx.ui.select = vi.fn().mockResolvedValue("Inject summary into main chat");
+		await harness.commands.get("btw").handler("", harness.ctx);
+
+		let resolveSummary: (() => void) | undefined;
+		mockSession.prompt.mockImplementation(
+			() =>
+				new Promise<void>((resolve) => {
+					resolveSummary = resolve;
+				}),
+		);
+		(conversationOverlay as any).input.onEscape();
+		await new Promise((resolve) => setTimeout(resolve, 0));
+
+		harness.ctx.sessionManager.getBranch = vi.fn(() => [
+			{
+				type: "custom",
+				customType: "btw-thread-entry",
+				data: {
+					question: "Destination topic",
+					answer: "Destination answer",
+					provider: "anthropic",
+					model: "claude-sonnet-4",
+					thinkingLevel: "off",
+					timestamp: 2,
+					conversationId: "destination",
+				},
+			},
+		]);
+		await harness.emitAsync("session_tree", { type: "session_tree" }, harness.ctx);
+		resolveSummary?.();
+		await new Promise((resolve) => setTimeout(resolve, 0));
+
+		expect(harness.userMessages).toHaveLength(0);
+		expect(appendEntry).not.toHaveBeenCalledWith("btw-thread-reset", expect.anything());
+	});
+
+	it("aborts a busy side prompt before restoring a different session branch", async () => {
+		const harness = createExtensionHarness();
+		configureModel(harness);
+		const appendEntry = vi.fn();
+		harness.pi.appendEntry = appendEntry;
 
 		let resolvePrompt: (() => void) | undefined;
 		mockSession.prompt.mockImplementation(
@@ -213,15 +718,213 @@ describe("btw command", () => {
 		btwExtension(harness.pi as never);
 		const runPromise = harness.commands.get("btw").handler("Question?", harness.ctx);
 		await new Promise((resolve) => setTimeout(resolve, 0));
+		await harness.commands.get("btw").handler("Another question?", harness.ctx);
+		expect(harness.notifications).toContainEqual({
+			msg: "BTW is still processing the previous message.",
+			type: "warning",
+		});
 
 		const getBranch = vi.fn(() => []);
 		harness.ctx.sessionManager.getBranch = getBranch;
-		harness.emit("session_tree", { type: "session_tree" }, harness.ctx);
+		await harness.emitAsync("session_tree", { type: "session_tree" }, harness.ctx);
 
-		expect(getBranch).not.toHaveBeenCalled();
+		expect(mockSession.abort).toHaveBeenCalled();
+		expect(getBranch).toHaveBeenCalled();
 
 		resolvePrompt?.();
 		await runPromise;
+		expect(appendEntry).not.toHaveBeenCalled();
+	});
+
+	it("does not start a prompt on a new branch when navigation happens during authentication", async () => {
+		const harness = createExtensionHarness();
+		configureModel(harness);
+		const appendEntry = vi.fn();
+		harness.pi.appendEntry = appendEntry;
+		let resolveAuth: ((value: { ok: true; apiKey: string; headers: object }) => void) | undefined;
+		harness.ctx.modelRegistry.getApiKeyAndHeaders = vi.fn(
+			() =>
+				new Promise((resolve) => {
+					resolveAuth = resolve;
+				}),
+		);
+		btwExtension(harness.pi as never);
+
+		const runPromise = harness.commands.get("btw").handler("Old branch question", harness.ctx);
+		await new Promise((resolve) => setTimeout(resolve, 0));
+		harness.ctx.sessionManager.getBranch = vi.fn(() => [
+			{
+				type: "custom",
+				customType: "btw-thread-entry",
+				data: {
+					question: "Destination topic",
+					answer: "Destination answer",
+					provider: "anthropic",
+					model: "claude-sonnet-4",
+					thinkingLevel: "off",
+					timestamp: 2,
+					conversationId: "destination",
+				},
+			},
+		]);
+		await harness.emitAsync("session_tree", { type: "session_tree" }, harness.ctx);
+		resolveAuth?.({ ok: true, apiKey: "key", headers: {} });
+		await runPromise;
+
+		expect(mockSession.prompt).not.toHaveBeenCalled();
+		expect(appendEntry).not.toHaveBeenCalled();
+	});
+
+	it("does not prompt when navigation happens during side-session creation", async () => {
+		const harness = createExtensionHarness();
+		configureModel(harness);
+		const appendEntry = vi.fn();
+		harness.pi.appendEntry = appendEntry;
+		let resolveSession: ((value: unknown) => void) | undefined;
+		vi.mocked(createAgentSession).mockImplementationOnce(
+			() =>
+				new Promise((resolve) => {
+					resolveSession = resolve;
+				}) as never,
+		);
+		btwExtension(harness.pi as never);
+
+		const runPromise = harness.commands.get("btw").handler("Old branch question", harness.ctx);
+		await new Promise((resolve) => setTimeout(resolve, 0));
+		await harness.emitAsync("session_tree", { type: "session_tree" }, harness.ctx);
+		resolveSession?.({ session: mockSession, extensionsResult: { extensions: [], errors: [], runtime: {} } });
+		await runPromise;
+
+		expect(mockSession.prompt).not.toHaveBeenCalled();
+		expect(appendEntry).not.toHaveBeenCalled();
+	});
+
+	it("suppresses stale errors after branch navigation", async () => {
+		const harness = createExtensionHarness();
+		configureModel(harness);
+		let rejectPrompt: ((error: Error) => void) | undefined;
+		mockSession.prompt.mockImplementation(
+			() =>
+				new Promise<void>((_resolve, reject) => {
+					rejectPrompt = reject;
+				}),
+		);
+		btwExtension(harness.pi as never);
+
+		const runPromise = harness.commands.get("btw").handler("Question?", harness.ctx);
+		await new Promise((resolve) => setTimeout(resolve, 0));
+		await harness.emitAsync("session_tree", { type: "session_tree" }, harness.ctx);
+		rejectPrompt?.(new Error("stale failure"));
+		await runPromise;
+
+		expect(harness.notifications).not.toContainEqual({ msg: "stale failure", type: "error" });
+	});
+});
+
+describe("btw transcript overlay", () => {
+	it("scrolls long transcripts by page and follows the tail again", () => {
+		const { keybindings, tui } = createTuiTestKit();
+		const transcript = Array.from({ length: 50 }, (_, index) => `line-${index}`);
+		const onInvalidate = vi.fn();
+		const overlay = new BtwOverlay(
+			tui as never,
+			testTheme as never,
+			keybindings as never,
+			() => transcript,
+			() => "Ready",
+			() => {},
+			() => {},
+			onInvalidate,
+		);
+
+		const tail = overlay.render(80).join("\n");
+		expect(tail).toContain("line-49");
+		expect(tail).not.toContain("line-0");
+
+		overlay.handleInput("tui.select.pageUp");
+		const olderPage = overlay.render(80).join("\n");
+		expect(olderPage).toContain("line-36");
+		expect(olderPage).not.toContain("line-49");
+
+		transcript.push("line-50", "line-51");
+		expect(overlay.render(80).join("\n")).toContain("line-36");
+
+		overlay.handleInput("tui.select.pageDown");
+		overlay.handleInput("tui.select.pageDown");
+		expect(overlay.render(80).join("\n")).toContain("line-51");
+		overlay.invalidate();
+		expect(onInvalidate).toHaveBeenCalledOnce();
+
+		tui.terminal.rows = 1;
+		expect(overlay.render(80)).toHaveLength(1);
+		tui.terminal.rows = 6;
+		const compact = overlay.render(80);
+		expect(compact).toHaveLength(4);
+		expect(compact.join("\n")).toContain("BTW side chat");
+		expect(tui.requestRender).toHaveBeenCalled();
+	});
+});
+
+describe("btw conversation picker", () => {
+	it("uses a fixed percentage height and scrolls overflowing options", () => {
+		const { keybindings, tui } = createTuiTestKit();
+		const onSelect = vi.fn();
+		const onCancel = vi.fn();
+		const items = Array.from({ length: 30 }, (_, index) => ({
+			id: `conversation-${index}`,
+			label: `Conversation ${index}`,
+			description: `${index + 1} exchanges`,
+		}));
+		const picker = new BtwConversationPicker(
+			tui as never,
+			testTheme as never,
+			keybindings as never,
+			items,
+			onSelect,
+			onCancel,
+		);
+
+		const expectedHeight = getPickerHeight(tui.terminal.rows);
+		const firstPage = picker.render(90);
+		expect(firstPage).toHaveLength(expectedHeight);
+		expect(firstPage.join("\n")).toContain("Conversation 0");
+		expect(firstPage.join("\n")).not.toContain("Conversation 29");
+		expect(getPickerHeight(40)).toBe(22);
+
+		picker.handleInput("tui.select.pageDown");
+		const nextPage = picker.render(90).join("\n");
+		expect(nextPage).not.toContain("Conversation 0");
+		picker.handleInput("tui.select.pageUp");
+		picker.handleInput("tui.select.up");
+		picker.handleInput("unbound-key");
+		picker.handleInput("tui.select.cancel");
+		picker.handleInput("tui.select.confirm");
+		expect(onCancel).toHaveBeenCalledOnce();
+		expect(onSelect).toHaveBeenCalledWith(expect.any(String));
+	});
+
+	it("keeps the selected option visible on short terminals", () => {
+		const { keybindings, tui } = createTuiTestKit();
+		tui.terminal.rows = 8;
+		const items = Array.from({ length: 10 }, (_, index) => ({
+			id: `conversation-${index}`,
+			label: `Conversation ${index}`,
+			description: "Saved thread",
+		}));
+		const picker = new BtwConversationPicker(
+			tui as never,
+			testTheme as never,
+			keybindings as never,
+			items,
+			() => {},
+			() => {},
+		);
+
+		expect(picker.render(60)).toHaveLength(getPickerHeight(8));
+		picker.handleInput("tui.select.pageDown");
+		const lines = picker.render(60);
+		expect(lines).toHaveLength(getPickerHeight(8));
+		expect(lines.join("\n")).toContain("Conversation 1");
 	});
 });
 
@@ -256,6 +959,17 @@ describe("btw startup restore", () => {
 		btwExtension(harness.pi as never);
 		await harness.emitAsync("session_start", { type: "session_start" }, harness.ctx);
 
+		const { keybindings, tui } = createTuiTestKit();
+		let component: unknown;
+		harness.ctx.ui.custom = vi.fn().mockImplementation(async (factory: any) => {
+			component = await factory(tui, testTheme, keybindings, () => {});
+			return null;
+		});
+		await harness.commands.get("btw").handler("", harness.ctx);
+		await Promise.resolve();
+
 		expect(getBranch).toHaveBeenCalled();
+		expect(component).toBeInstanceOf(BtwOverlay);
+		expect((component as BtwOverlay).render(90).join("\n")).not.toContain("Old question");
 	});
 });

--- a/test-utils/extension-runtime-harness.js
+++ b/test-utils/extension-runtime-harness.js
@@ -99,6 +99,7 @@ export function createExtensionHarness() {
 		hasPendingMessages: () => false,
 		hasUI: true,
 		isIdle: () => true,
+		mode: "tui",
 		model: undefined,
 		modelRegistry: {
 			getAvailable: () => [],

--- a/test-utils/extension-runtime-harness.ts
+++ b/test-utils/extension-runtime-harness.ts
@@ -109,6 +109,7 @@ export function createExtensionHarness() {
 		hasPendingMessages: () => false,
 		hasUI: true,
 		isIdle: () => true,
+		mode: "tui",
 		model: undefined as unknown,
 		modelRegistry: {
 			getAvailable: () => [],


### PR DESCRIPTION
## Summary

- add PageUp/PageDown scrollback and visible-range feedback for long BTW transcripts
- persist and restore multiple independent BTW conversations with a fixed-height scrollable picker
- guard prompts and summary injection against session-branch navigation races
- preserve compatibility with legacy BTW entries and document the new controls

## Validation

- `pnpm test` (1401 passed, 8 skipped)
- `pnpm lint`
- `pnpm typecheck`
- `pnpm mdt check`
- `pnpm mc check`
- patch coverage: 100% (310/310 changed executable lines)