### PR TITLE
fix(ollama): prime local models before startup filtering

### DIFF
--- a/.changeset/1783869517-monopi.md
+++ b/.changeset/1783869517-monopi.md
@@ -1,0 +1,7 @@
+---
+monopi: patch
+---
+
+# register local Ollama models during startup
+
+Prime the local Ollama model ID list before provider registration so installed cloud proxy models are available when pi resolves enabledModels, with a bounded discovery timeout and deferred CLI detection.

--- a/packages/monopi__provider-ollama/index.ts
+++ b/packages/monopi__provider-ollama/index.ts
@@ -31,6 +31,7 @@ import { clearOllamaCliStatusCache, getOllamaCliStatus, type OllamaCliStatus, pu
 import {
 	discoverOllamaCloudModelList,
 	discoverOllamaCloudModels,
+	discoverOllamaLocalModelList,
 	discoverOllamaLocalModels,
 	getCredentialModels,
 	getFallbackOllamaCloudModels,
@@ -111,6 +112,7 @@ const PULL_STATUS_KEY = "ollama.pull";
 const OLLAMA_STARTUP_CLI_REFRESH_DELAY_MS = 250;
 const OLLAMA_STARTUP_CLOUD_REFRESH_DELAY_MS = 250;
 const OLLAMA_STARTUP_CLOUD_DISCOVERY_TIMEOUT_MS = 5_000;
+const OLLAMA_STARTUP_LOCAL_DISCOVERY_TIMEOUT_MS = 1_000;
 
 let ollamaCliStatus: OllamaCliStatus | null = null;
 let missingCliWarningShown = false;
@@ -808,7 +810,11 @@ function summarizeCapabilities(model: OllamaProviderModel): string | null {
 }
 
 function getRegisteredLocalModels(): OllamaProviderModel[] {
-	if (!ollamaCliStatus?.available) {
+	if (ollamaCliStatus === null) {
+		// Initial model matching runs before the deferred CLI probe, but installed models only need the local API.
+		return localDiscoveryState.models;
+	}
+	if (!ollamaCliStatus.available) {
 		return [];
 	}
 	const cloudCatalog =
@@ -932,6 +938,21 @@ function createOllamaProcessEnv(): NodeJS.ProcessEnv {
 	return env;
 }
 
+async function primeOllamaLocalModelsBeforeRegistration(): Promise<void> {
+	const abortController = new AbortController();
+	const timeout = setTimeout(() => abortController.abort(), OLLAMA_STARTUP_LOCAL_DISCOVERY_TIMEOUT_MS);
+	timeout.unref?.();
+	try {
+		localDiscoveryState.models = (await discoverOllamaLocalModelList({ signal: abortController.signal })) ?? [];
+		localDiscoveryState.lastError = null;
+		localDiscoveryState.lastRefresh = Date.now();
+	} catch (error) {
+		localDiscoveryState.lastError = error instanceof Error ? error.message : String(error);
+	} finally {
+		clearTimeout(timeout);
+	}
+}
+
 async function primeOllamaCloudModelsBeforeRegistration(): Promise<void> {
 	const abortController = new AbortController();
 	const timeout = setTimeout(() => abortController.abort(), OLLAMA_STARTUP_CLOUD_DISCOVERY_TIMEOUT_MS);
@@ -971,6 +992,7 @@ export {
 	createOllamaCloudOAuthProvider,
 	discoverOllamaCloudModelList,
 	discoverOllamaCloudModels,
+	discoverOllamaLocalModelList,
 	discoverOllamaLocalModels,
 	getCredentialModels,
 	getFallbackOllamaCloudModels,
@@ -980,7 +1002,7 @@ export {
 export { type OllamaCloudCredentials, type OllamaProviderModel, toOllamaCloudModel, toOllamaModel } from "./models.js";
 
 export default async function ollamaProviderExtension(pi: ExtensionAPI): Promise<void> {
-	await primeOllamaCloudModelsBeforeRegistration();
+	await Promise.all([primeOllamaCloudModelsBeforeRegistration(), primeOllamaLocalModelsBeforeRegistration()]);
 	const registerLifecycle = registerOllamaLifecycle(pi);
 	bootstrapOllamaProviders(pi, registerLifecycle);
 	registerOllamaCommands(pi);

--- a/packages/monopi__provider-ollama/models.ts
+++ b/packages/monopi__provider-ollama/models.ts
@@ -145,6 +145,18 @@ export function getCredentialModels(credentials: OllamaCloudCredentials): Ollama
 	return models.length > 0 ? sanitizeStoredModels(models) : getFallbackOllamaCloudModels();
 }
 
+export async function discoverOllamaLocalModelList(
+	options: { signal?: AbortSignal } = {},
+): Promise<OllamaProviderModel[] | null> {
+	const config = getOllamaLocalRuntimeConfig();
+	const modelIds = await discoverOllamaModelIds(config, { signal: options.signal });
+	if (modelIds.length === 0) return null;
+	const cachedModels = new Map<string, OllamaProviderModel>();
+	return modelIds
+		.map((id) => normalizeDiscoveredModel(id, null, "local", [], cachedModels))
+		.filter((model) => model !== null);
+}
+
 export async function discoverOllamaLocalModels(
 	options: { signal?: AbortSignal } = {},
 ): Promise<OllamaProviderModel[] | null> {

--- a/packages/monopi__provider-ollama/tests/download.test.ts
+++ b/packages/monopi__provider-ollama/tests/download.test.ts
@@ -1,3 +1,4 @@
+import { AuthStorage, ModelRegistry } from "@earendil-works/pi-coding-agent";
 import { EventEmitter } from "node:events";
 import { PassThrough } from "node:stream";
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
@@ -41,6 +42,79 @@ afterEach(async () => {
 });
 
 describe("ollama local downloads", () => {
+	it("registers installed cloud proxy models before initial enabled-model matching", async () => {
+		const cloudBackend = await createTestOllamaBackend();
+		backends.push(cloudBackend);
+		cloudBackend.setModels([]);
+
+		const localBackend = await createTestOllamaBackend();
+		backends.push(localBackend);
+		localBackend.setModels([{ id: "glm-5.2:cloud" }, { id: "kimi-k2.7-code:cloud" }]);
+
+		process.env.PI_OLLAMA_CLOUD_API_URL = cloudBackend.apiUrl;
+		process.env.PI_OLLAMA_CLOUD_MODELS_URL = `${cloudBackend.apiUrl}/models`;
+		process.env.PI_OLLAMA_CLOUD_SHOW_URL = `${cloudBackend.origin}/api/show`;
+		process.env.OLLAMA_HOST = localBackend.origin;
+
+		const { default: ollamaProviderExtension } = await import("../index.js");
+		const harness = createExtensionHarness();
+		await ollamaProviderExtension(harness.pi as never);
+
+		const models = harness.providers.get("ollama")?.models as
+			| Array<{ id: string; localAvailability?: string }>
+			| undefined;
+		expect(models?.map((model) => model.id)).toEqual(["glm-5.2:cloud", "kimi-k2.7-code:cloud"]);
+		expect(models?.every((model) => model.localAvailability === "installed")).toBe(true);
+
+		const modelRegistry = ModelRegistry.inMemory(AuthStorage.inMemory());
+		modelRegistry.registerProvider("ollama", harness.providers.get("ollama"));
+		const availableModelIds = (await modelRegistry.getAvailable())
+			.filter((model) => model.provider === "ollama")
+			.map((model) => `${model.provider}/${model.id}`);
+		expect(availableModelIds).toEqual(["ollama/glm-5.2:cloud", "ollama/kimi-k2.7-code:cloud"]);
+		expect(execFileMock).not.toHaveBeenCalled();
+
+		await harness.emitAsync("session_shutdown", { type: "session_shutdown" }, harness.ctx as never);
+	});
+
+	it("bounds initial local model discovery when the daemon does not respond", async () => {
+		vi.useFakeTimers();
+		const modelsModule = await import("../models.js");
+		const cloudDiscovery = vi.spyOn(modelsModule, "discoverOllamaCloudModelList").mockResolvedValue(null);
+		let localDiscoveryAborted = false;
+		const localDiscovery = vi.spyOn(modelsModule, "discoverOllamaLocalModelList").mockImplementation(
+			(options: { signal?: AbortSignal } = {}) =>
+				new Promise((resolve) => {
+					options.signal?.addEventListener(
+						"abort",
+						() => {
+							localDiscoveryAborted = true;
+							resolve(null);
+						},
+						{ once: true },
+					);
+				}),
+		);
+
+		try {
+			const { default: ollamaProviderExtension } = await import("../index.js");
+			const harness = createExtensionHarness();
+			const registration = ollamaProviderExtension(harness.pi as never);
+
+			await vi.advanceTimersByTimeAsync(1_000);
+			await expect(registration).resolves.toBeUndefined();
+			expect(localDiscoveryAborted).toBe(true);
+			expect(harness.providers.has("ollama")).toBe(true);
+			expect(execFileMock).not.toHaveBeenCalled();
+
+			await harness.emitAsync("session_shutdown", { type: "session_shutdown" }, harness.ctx as never);
+		} finally {
+			cloudDiscovery.mockRestore();
+			localDiscovery.mockRestore();
+			vi.useRealTimers();
+		}
+	});
+
 	it("registers downloadable local models with cloud context metadata when the CLI is available", async () => {
 		execFileMock.mockImplementation((_command, _args, _options, callback) => {
 			queueMicrotask(() => {

--- a/packages/monopi__provider-ollama/tests/models.test.ts
+++ b/packages/monopi__provider-ollama/tests/models.test.ts
@@ -8,6 +8,7 @@ import { loadCachedOllamaCloudModels, saveCachedOllamaCloudModels } from "../cac
 import {
 	discoverOllamaCloudModelList,
 	discoverOllamaCloudModels,
+	discoverOllamaLocalModelList,
 	discoverOllamaLocalModels,
 	getCredentialModels,
 	toOllamaModel,
@@ -262,6 +263,20 @@ describe("ollama models", () => {
 		expect(glmCompat?.zaiToolStream).toBe(true);
 		expect(models?.[1]?.input).toEqual(["text", "image"]);
 		expect(backend.getAuthHeaders()).toEqual(["", "", ""]);
+		await backend.close();
+	});
+
+	it("discovers local model ids without waiting for metadata enrichment", async () => {
+		const backend = await createTestOllamaBackend();
+		backend.setModels([{ id: "glm-5.2:cloud" }, { id: "kimi-k2.7-code:cloud" }]);
+		backend.setRejectedModelShows(["glm-5.2:cloud", "kimi-k2.7-code:cloud"]);
+		process.env.OLLAMA_HOST = backend.origin;
+
+		const models = await discoverOllamaLocalModelList();
+
+		expect(models?.map((model) => model.id)).toEqual(["glm-5.2:cloud", "kimi-k2.7-code:cloud"]);
+		expect(models?.every((model) => model.localAvailability === "installed")).toBe(true);
+		expect(backend.getAuthHeaders()).toEqual([""]);
 		await backend.close();
 	});
 


### PR DESCRIPTION
Prime local Ollama model IDs before provider registration with a one-second bound, so installed cloud proxy IDs are available when Pi resolves enabledModels. Includes regression tests and a monopi patch changeset.