### PR TITLE
feat(ollama): support Kimi K3

### DIFF
--- a/.changeset/kimi-k3-ollama.md
+++ b/.changeset/kimi-k3-ollama.md
@@ -1,0 +1,7 @@
+---
+monopi: patch
+---
+
+# Support Kimi K3 through Ollama Cloud
+
+Ollama Cloud discovery now exposes Kimi K3 with its 1,048,576-token context window, vision input, tool and thinking capabilities, and reasoning metadata even before per-model enrichment completes.

--- a/packages/monopi__provider-ollama/models.ts
+++ b/packages/monopi__provider-ollama/models.ts
@@ -61,7 +61,9 @@ type OllamaCloudMetadataOverride = {
 	contextWindow: number;
 	maxTokens: number;
 	reasoning: boolean;
+	capabilities?: string[];
 	family?: string;
+	input?: OllamaProviderModel["input"];
 };
 
 const OLLAMA_CLOUD_METADATA_OVERRIDES: readonly OllamaCloudMetadataOverride[] = [
@@ -80,6 +82,15 @@ const OLLAMA_CLOUD_METADATA_OVERRIDES: readonly OllamaCloudMetadataOverride[] = 
 	{ id: "kimi-k2.5", contextWindow: 262_144, maxTokens: 32_768, reasoning: true, family: "kimi-k2" },
 	{ id: "kimi-k2.6", contextWindow: 262_144, maxTokens: 32_768, reasoning: true, family: "kimi-k2" },
 	{ id: "kimi-k2.7-code", contextWindow: 262_144, maxTokens: 32_768, reasoning: true, family: "kimi-k2" },
+	{
+		id: "kimi-k3",
+		capabilities: ["vision", "thinking", "completion", "tools"],
+		contextWindow: 1_048_576,
+		family: "kimi-k3",
+		input: ["text", "image"],
+		maxTokens: 131_072,
+		reasoning: true,
+	},
 	{ id: "minimax-m2.1", contextWindow: 204_800, maxTokens: 20_480, reasoning: true, family: "minimax-m2" },
 	{ id: "minimax-m2.5", contextWindow: 196_608, maxTokens: 20_480, reasoning: true, family: "minimax-m2" },
 	{ id: "minimax-m2.7", contextWindow: 196_608, maxTokens: 20_480, reasoning: true, family: "minimax-m2" },
@@ -116,10 +127,21 @@ const OLLAMA_GPT_OSS_THINKING_LEVEL_MAP: ThinkingLevelMap = {
 	xhigh: null,
 };
 
+const OLLAMA_KIMI_K3_THINKING_LEVEL_MAP: ThinkingLevelMap = {
+	off: null,
+	minimal: null,
+	low: "low",
+	medium: null,
+	high: "high",
+	xhigh: null,
+	max: "max",
+};
+
 const OLLAMA_GPT_OSS_MODEL_PATTERN = /(?:^|[-_/:])gpt[-_]?oss(?:$|[-_/:])/i;
 const OLLAMA_QWEN3_MODEL_PATTERN = /(?:^|[-_/:])qwen3(?:$|[-_/:.])/i;
 const OLLAMA_DEEPSEEK_THINKING_MODEL_PATTERN = /(?:^|[-_/:])deepseek[-_]?(?:r1|v3\.?[12]|v4)(?:$|[-_/:.])/i;
-const OLLAMA_KIMI_THINKING_MODEL_PATTERN = /(?:^|[-_/:])kimi[-_]?k2(?:$|[-_/:.])/i;
+const OLLAMA_KIMI_THINKING_MODEL_PATTERN = /(?:^|[-_/:])kimi[-_]?k[23](?:$|[-_/:.])/i;
+const OLLAMA_KIMI_K3_MODEL_PATTERN = /(?:^|[-_/:])kimi[-_]?k3(?:$|[-_/:.])/i;
 const OLLAMA_MINIMAX_THINKING_MODEL_PATTERN = /(?:^|[-_/:])minimax[-_]?m[23](?:$|[-_/:.])/i;
 const OLLAMA_NEMOTRON_THINKING_MODEL_PATTERN = /(?:^|[-_/:])nemotron[-_]?3(?:$|[-_/:.])/i;
 const OLLAMA_THINKING_TEMPLATE_PATTERN = /<think>|\.thinking\b|reasoning_content/i;
@@ -519,9 +541,14 @@ function applyOllamaCloudMetadataOverrides(
 
 	return {
 		...model,
-		capabilities: override.reasoning ? mergeCapabilities(model.capabilities, ["thinking"]) : model.capabilities,
+		capabilities: override.capabilities
+			? mergeCapabilities(model.capabilities, override.capabilities)
+			: override.reasoning
+				? mergeCapabilities(model.capabilities, ["thinking"])
+				: model.capabilities,
 		contextWindow: maxPositiveInteger(model.contextWindow, override.contextWindow),
 		family: model.family ?? override.family,
+		input: override.input ?? model.input,
 		maxTokens: maxPositiveInteger(model.maxTokens, override.maxTokens),
 		reasoning: override.reasoning ? true : model.reasoning,
 	};
@@ -563,6 +590,9 @@ function getOllamaThinkingLevelMap(
 	}
 	if (isOllamaGptOssModel(model)) {
 		return OLLAMA_GPT_OSS_THINKING_LEVEL_MAP;
+	}
+	if (isOllamaKimiK3Model(model)) {
+		return OLLAMA_KIMI_K3_THINKING_LEVEL_MAP;
 	}
 
 	return model.thinkingLevelMap ?? OLLAMA_REASONING_THINKING_LEVEL_MAP;
@@ -625,6 +655,10 @@ function isOllamaDeepSeekThinkingModel(model: Partial<Pick<OllamaProviderModel, 
 
 function isOllamaKimiThinkingModel(model: Partial<Pick<OllamaProviderModel, "family" | "id">>): boolean {
 	return modelHasToken(model, OLLAMA_KIMI_THINKING_MODEL_PATTERN);
+}
+
+function isOllamaKimiK3Model(model: Partial<Pick<OllamaProviderModel, "family" | "id">>): boolean {
+	return modelHasToken(model, OLLAMA_KIMI_K3_MODEL_PATTERN);
 }
 
 function isOllamaMinimaxThinkingModel(model: Partial<Pick<OllamaProviderModel, "family" | "id">>): boolean {

--- a/packages/monopi__provider-ollama/models.ts
+++ b/packages/monopi__provider-ollama/models.ts
@@ -60,7 +60,7 @@ type OllamaCloudMetadataOverride = {
 	id: string;
 	contextWindow: number;
 	maxTokens: number;
-	reasoning: boolean;
+	reasoning: true;
 	capabilities?: string[];
 	family?: string;
 	input?: OllamaProviderModel["input"];
@@ -541,16 +541,12 @@ function applyOllamaCloudMetadataOverrides(
 
 	return {
 		...model,
-		capabilities: override.capabilities
-			? mergeCapabilities(model.capabilities, override.capabilities)
-			: override.reasoning
-				? mergeCapabilities(model.capabilities, ["thinking"])
-				: model.capabilities,
+		capabilities: mergeCapabilities(model.capabilities, override.capabilities ?? ["thinking"]),
 		contextWindow: maxPositiveInteger(model.contextWindow, override.contextWindow),
 		family: model.family ?? override.family,
 		input: override.input ?? model.input,
 		maxTokens: maxPositiveInteger(model.maxTokens, override.maxTokens),
-		reasoning: override.reasoning ? true : model.reasoning,
+		reasoning: true,
 	};
 }
 

--- a/packages/monopi__provider-ollama/tests/download.test.ts
+++ b/packages/monopi__provider-ollama/tests/download.test.ts
@@ -1,4 +1,5 @@
-import { AuthStorage, ModelRegistry } from "@earendil-works/pi-coding-agent";
+import { InMemoryCredentialStore } from "@earendil-works/pi-ai";
+import { ModelRegistry, ModelRuntime } from "@earendil-works/pi-coding-agent";
 import { EventEmitter } from "node:events";
 import { PassThrough } from "node:stream";
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
@@ -66,9 +67,15 @@ describe("ollama local downloads", () => {
 		expect(models?.map((model) => model.id)).toEqual(["glm-5.2:cloud", "kimi-k2.7-code:cloud"]);
 		expect(models?.every((model) => model.localAvailability === "installed")).toBe(true);
 
-		const modelRegistry = ModelRegistry.inMemory(AuthStorage.inMemory());
+		const modelRuntime = await ModelRuntime.create({
+			credentials: new InMemoryCredentialStore(),
+			modelsPath: null,
+			refreshOnCreate: false,
+		});
+		const modelRegistry = new ModelRegistry(modelRuntime);
 		modelRegistry.registerProvider("ollama", harness.providers.get("ollama"));
-		const availableModelIds = (await modelRegistry.getAvailable())
+		const availableModelIds = modelRegistry
+			.getAvailable()
 			.filter((model) => model.provider === "ollama")
 			.map((model) => `${model.provider}/${model.id}`);
 		expect(availableModelIds).toEqual(["ollama/glm-5.2:cloud", "ollama/kimi-k2.7-code:cloud"]);

--- a/packages/monopi__provider-ollama/tests/models.test.ts
+++ b/packages/monopi__provider-ollama/tests/models.test.ts
@@ -46,6 +46,16 @@ describe("ollama models", () => {
 		expect(compat?.maxTokensField).toBe("max_tokens");
 	});
 
+	it("recognizes Kimi K3 tags as thinking models", () => {
+		const models = ["kimi-k3", "kimi_k3:latest"].map((id) => toOllamaModel({ id, source: "local" }));
+
+		expect(models.map((model) => model.reasoning)).toEqual([true, true]);
+		expect(models.map((model) => getSupportedThinkingLevels(model as never))).toEqual([
+			["low", "high", "max"],
+			["low", "high", "max"],
+		]);
+	});
+
 	it("applies authoritative cloud metadata and z.ai compat defaults to glm models", () => {
 		const model = toOllamaModel({
 			contextWindow: 131_072,
@@ -118,16 +128,26 @@ describe("ollama models", () => {
 			{
 				id: "gpt-oss:120b",
 			},
+			{ id: "kimi-k3" },
 		]);
-		backend.setRejectedModelShows(["brand-new-cloud-model", "gpt-oss:120b"]);
+		backend.setRejectedModelShows(["brand-new-cloud-model", "gpt-oss:120b", "kimi-k3"]);
 		process.env.PI_OLLAMA_CLOUD_API_URL = backend.apiUrl;
 		process.env.PI_OLLAMA_CLOUD_MODELS_URL = `${backend.apiUrl}/models`;
 		process.env.PI_OLLAMA_CLOUD_SHOW_URL = `${backend.origin}/api/show`;
 		const models = await discoverOllamaCloudModelList("test-key");
-		expect(models?.map((model) => model.id)).toEqual(["brand-new-cloud-model", "gpt-oss:120b"]);
+		expect(models?.map((model) => model.id)).toEqual(["brand-new-cloud-model", "gpt-oss:120b", "kimi-k3"]);
 		expect(models?.[0]?.source).toBe("cloud");
 		expect(models?.[1]?.reasoning).toBe(true);
 		expect(getSupportedThinkingLevels(models![1]! as never)).toEqual(["minimal", "low", "medium", "high"]);
+		expect(models?.[2]).toMatchObject({
+			capabilities: expect.arrayContaining(["vision", "thinking", "completion", "tools"]),
+			contextWindow: 1_048_576,
+			family: "kimi-k3",
+			input: ["text", "image"],
+			maxTokens: 131_072,
+			reasoning: true,
+		});
+		expect(getSupportedThinkingLevels(models![2]! as never)).toEqual(["low", "high", "max"]);
 		expect(backend.getAuthHeaders()).toEqual(["Bearer test-key"]);
 		await backend.close();
 	});

--- a/packages/monopi__provider-ollama/tests/models.test.ts
+++ b/packages/monopi__provider-ollama/tests/models.test.ts
@@ -56,6 +56,26 @@ describe("ollama models", () => {
 		]);
 	});
 
+	it("merges Kimi K3 cloud capabilities with authoritative metadata", () => {
+		const model = toOllamaModel({
+			capabilities: ["provider-specific"],
+			contextWindow: 32_768,
+			id: "kimi-k3",
+			input: ["text"],
+			maxTokens: 8_192,
+			reasoning: false,
+			source: "cloud",
+		});
+
+		expect(model).toMatchObject({
+			capabilities: ["provider-specific", "vision", "thinking", "completion", "tools"],
+			contextWindow: 1_048_576,
+			input: ["text", "image"],
+			maxTokens: 131_072,
+			reasoning: true,
+		});
+	});
+
 	it("applies authoritative cloud metadata and z.ai compat defaults to glm models", () => {
 		const model = toOllamaModel({
 			contextWindow: 131_072,


### PR DESCRIPTION
## Summary

- register Kimi K3 with verified Ollama Cloud metadata, including its 1,048,576-token context window, 131,072-token output limit, vision input, and tool capability
- expose Kimi K3 as a reasoning model with its supported `low`, `high`, and `max` reasoning-effort levels
- preserve authoritative Kimi K3 metadata when per-model cloud enrichment is unavailable
- update the startup-registration regression test to use the Pi 0.84 `ModelRuntime` API after #356 landed on the updated provider APIs

## Validation

- `pnpm --filter @monopi/provider-ollama test:worktree` (36 tests)
- `pnpm --filter @monopi/provider-ollama typecheck`
- `pnpm lint`
- `pnpm typecheck`
- `pnpm mc step validate`
- `pnpm mc check --format text`