### PR TITLE
fix(docs): restore GitHub Pages site

### DIFF
--- a/.changeset/fix-docs-site-base-path.md
+++ b/.changeset/fix-docs-site-base-path.md
@@ -1,0 +1,7 @@
+---
+monopi: patch
+---
+
+# Fix the documentation site base path
+
+Serve documentation assets and client-side routes from the renamed `monopi` GitHub Pages path.

--- a/packages/monopi__docs/index.html
+++ b/packages/monopi__docs/index.html
@@ -2,7 +2,7 @@
 <html lang="en" class="dark">
 	<head>
 		<meta charset="UTF-8" />
-		<link rel="icon" type="image/svg+xml" href="/oh-pi/favicon.svg" />
+		<link rel="icon" type="image/svg+xml" href="%BASE_URL%favicon.svg" />
 		<meta name="viewport" content="width=device-width, initial-scale=1.0" />
 		<title>monopi docs</title>
 	</head>

--- a/packages/monopi__docs/src/components/Layout.tsx
+++ b/packages/monopi__docs/src/components/Layout.tsx
@@ -87,7 +87,7 @@ export function Layout({ children, pages }: LayoutProps) {
 								className={`
 									block rounded-lg px-3 py-2 text-sm font-medium transition-colors
 									${
-										location.pathname === "/oh-pi/" || location.pathname === "/oh-pi"
+										location.pathname === "/"
 											? "bg-pi-emerald/10 text-pi-emerald"
 											: "text-zinc-400 hover:bg-zinc-800/60 hover:text-zinc-200"
 									}
@@ -104,7 +104,7 @@ export function Layout({ children, pages }: LayoutProps) {
 									className={`
 										block rounded-lg px-3 py-2 text-sm font-medium transition-colors
 										${
-											location.pathname === `/oh-pi/${page.slug}`
+											location.pathname === `/${page.slug}`
 												? "bg-pi-emerald/10 text-pi-emerald"
 												: "text-zinc-400 hover:bg-zinc-800/60 hover:text-zinc-200"
 										}

--- a/packages/monopi__docs/src/components/MdxPage.tsx
+++ b/packages/monopi__docs/src/components/MdxPage.tsx
@@ -1,5 +1,5 @@
 import { lazy, Suspense } from "react";
-import { useParams } from "react-router";
+import { Link, useParams } from "react-router";
 
 import type { MdxPageData } from "@/hooks/useMdxPages";
 
@@ -38,9 +38,9 @@ export function NotFoundPage() {
 			<p className="text-zinc-400">
 				Page not found: <code className="text-pi-emerald">/{params["*"]}</code>
 			</p>
-			<a href="/oh-pi/" className="text-pi-emerald hover:underline">
+			<Link to="/" className="text-pi-emerald hover:underline">
 				← Back to docs
-			</a>
+			</Link>
 		</div>
 	);
 }

--- a/packages/monopi__docs/src/main.tsx
+++ b/packages/monopi__docs/src/main.tsx
@@ -10,7 +10,7 @@ if (!root) throw new Error("Root element not found");
 
 createRoot(root).render(
 	<StrictMode>
-		<BrowserRouter basename="/monopi">
+		<BrowserRouter basename={import.meta.env.BASE_URL}>
 			<App />
 		</BrowserRouter>
 	</StrictMode>,

--- a/packages/monopi__docs/vite.config.ts
+++ b/packages/monopi__docs/vite.config.ts
@@ -26,7 +26,7 @@ function ghPages404(): Plugin {
 }
 
 export default defineConfig({
-	base: "/oh-pi/",
+	base: "/monopi/",
 	build: {
 		emptyOutDir: true,
 		outDir: "dist",


### PR DESCRIPTION
## Summary

- update Vite asset paths for the renamed `monopi` GitHub Pages project
- derive React Router navigation from Vite's base URL
- remove stale `/oh-pi/` links from the docs shell

## Root cause

GitHub Pages serves the repository at `/monopi/`, but the generated HTML still requested JavaScript and CSS from the removed `/oh-pi/` path. The HTML returned 200 while every application asset returned 404, leaving a blank page.

## Validation

- `pnpm --filter @monopi/docs build`
- `pnpm mc check`
- `pnpm lint`
- preview smoke test: home, JS, CSS, favicon, and deep route all returned HTTP 200
