### PR TITLE
fix(docs): update content after navigation

### DIFF
--- a/.changeset/fix-docs-page-navigation.md
+++ b/.changeset/fix-docs-page-navigation.md
@@ -1,0 +1,5 @@
+---
+monopi: patch
+---
+
+# Fix documentation links to update page content.

--- a/packages/monopi__docs/src/components/MdxPage.test.tsx
+++ b/packages/monopi__docs/src/components/MdxPage.test.tsx
@@ -1,0 +1,11 @@
+import { describe, expect, it } from "vitest";
+
+import { getLazyContent } from "./MdxPage";
+
+describe("getLazyContent", () => {
+	it("reuses the lazy component for a page module across renders", () => {
+		const loadPage = async () => ({ default: () => null });
+
+		expect(getLazyContent(loadPage)).toBe(getLazyContent(loadPage));
+	});
+});

--- a/packages/monopi__docs/src/components/MdxPage.tsx
+++ b/packages/monopi__docs/src/components/MdxPage.tsx
@@ -1,4 +1,4 @@
-import { lazy, Suspense } from "react";
+import { lazy, Suspense, type ComponentType, type LazyExoticComponent } from "react";
 import { Link, useParams } from "react-router";
 
 import type { MdxPageData } from "@/hooks/useMdxPages";
@@ -7,8 +7,22 @@ interface MdxPageProps {
 	page: MdxPageData;
 }
 
+type MdxModuleLoader = MdxPageData["module"];
+
+// The loaders come from a static import.meta.glob catalog, so this cache has a finite domain.
+const lazyContentByModule = new Map<MdxModuleLoader, LazyExoticComponent<ComponentType>>();
+
+export function getLazyContent(module: MdxModuleLoader): LazyExoticComponent<ComponentType> {
+	const cachedContent = lazyContentByModule.get(module);
+	if (cachedContent) return cachedContent;
+
+	const content = lazy(module);
+	lazyContentByModule.set(module, content);
+	return content;
+}
+
 export function MdxPage({ page }: MdxPageProps) {
-	const Content = lazy(page.module);
+	const Content = getLazyContent(page.module);
 
 	return (
 		<article className="prose-doc">

--- a/vitest.config.ts
+++ b/vitest.config.ts
@@ -29,7 +29,7 @@ const coverageExclude = [
 	"packages/monopi__analytics-db/src/index.ts",
 	"packages/monopi__analytics-db/src/migrations.ts",
 	"packages/monopi__analytics-extension/index.ts",
-	// Docs site — no tests needed for a static documentation site
+	// Docs site — validated through builds and focused tests rather than unit coverage thresholds
 	"packages/monopi__docs/vite.config.ts",
 	"packages/monopi__docs/src/**/*.tsx",
 	"packages/monopi__docs/src/**/*.ts",
@@ -58,6 +58,7 @@ export default defineConfig({
 			"benchmarks/**/*.test.ts",
 			"scripts/**/*.test.ts",
 			"packages/monopi__core/src/**/*.test.ts",
+			"packages/monopi__docs/src/**/*.test.tsx",
 			"packages/monopi__adaptive-routing/**/*.test.ts",
 			"packages/monopi__background-tasks/tests/**/*.test.ts",
 			"packages/monopi__cli/src/**/*.test.ts",


### PR DESCRIPTION
## Summary

- cache each MDX module's React lazy component instead of recreating it during every render
- add a regression test that requires lazy component identity to remain stable across renders
- include focused documentation component tests in the root Vitest suite

## Root cause

`MdxPage` called `lazy(page.module)` inside the component body. During client-side navigation, the new lazy component suspended, then retries created another new lazy component and suspended again. React Router updated the browser URL, but React kept showing the previous page content.

## Validation

- `pnpm format:check`
- `pnpm lint`
- `pnpm --filter @monopi/docs typecheck`
- `pnpm test`
- `pnpm build`
- `pnpm mdt check`
- `pnpm mc check`
- `pnpm security:check`
- `git diff --check`
- Playwright clicked all seven documentation links sequentially, returned Home, and navigated Back; every URL, active sidebar link, title, and page body updated with no console errors
