### PR TITLE
perf(docs): reduce long-session overhead

### DIFF
--- a/.changeset/improve-docs-runtime-performance.md
+++ b/.changeset/improve-docs-runtime-performance.md
@@ -1,0 +1,5 @@
+---
+monopi: patch
+---
+
+# Improve documentation runtime and loading performance.

--- a/packages/monopi__docs/public/favicon.svg
+++ b/packages/monopi__docs/public/favicon.svg
@@ -1,0 +1,92 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 104 64">
+	<!-- Abdomen — large hexagon, left -->
+	<polygon points="14,32 21,18 35,18 42,32 35,46 21,46" fill="#7c3aed" />
+
+	<!-- Thorax — medium hexagon, center -->
+	<polygon points="44,32 48,24 56,24 60,32 56,40 48,40" fill="#7c3aed" />
+
+	<!-- Head — small hexagon, right -->
+	<polygon points="62,32 66,24 74,24 78,32 74,40 66,40" fill="#00d4aa" />
+
+	<!-- Eyes -->
+	<rect x="68" y="27" width="3" height="3" fill="#fff" />
+	<rect x="68" y="34" width="3" height="3" fill="#fff" />
+
+	<!-- Antennae -->
+	<line
+		x1="78"
+		y1="26"
+		x2="90"
+		y2="16"
+		stroke="#00d4aa"
+		stroke-width="2.5"
+		stroke-linecap="square"
+	/>
+	<line
+		x1="78"
+		y1="38"
+		x2="90"
+		y2="48"
+		stroke="#00d4aa"
+		stroke-width="2.5"
+		stroke-linecap="square"
+	/>
+
+	<!-- Legs — 3 pairs from thorax -->
+	<line
+		x1="48"
+		y1="24"
+		x2="40"
+		y2="10"
+		stroke="#7c3aed"
+		stroke-width="2.5"
+		stroke-linecap="square"
+	/>
+	<line
+		x1="48"
+		y1="40"
+		x2="40"
+		y2="54"
+		stroke="#7c3aed"
+		stroke-width="2.5"
+		stroke-linecap="square"
+	/>
+
+	<line
+		x1="52"
+		y1="24"
+		x2="52"
+		y2="8"
+		stroke="#7c3aed"
+		stroke-width="2.5"
+		stroke-linecap="square"
+	/>
+	<line
+		x1="52"
+		y1="40"
+		x2="52"
+		y2="56"
+		stroke="#7c3aed"
+		stroke-width="2.5"
+		stroke-linecap="square"
+	/>
+
+	<line
+		x1="56"
+		y1="24"
+		x2="64"
+		y2="10"
+		stroke="#7c3aed"
+		stroke-width="2.5"
+		stroke-linecap="square"
+	/>
+	<line
+		x1="56"
+		y1="40"
+		x2="64"
+		y2="54"
+		stroke="#7c3aed"
+		stroke-width="2.5"
+		stroke-linecap="square"
+	/>
+</svg>

--- a/packages/monopi__docs/src/components/Layout.tsx
+++ b/packages/monopi__docs/src/components/Layout.tsx
@@ -1,10 +1,13 @@
 import { Code, ExternalLink, Menu, Search, X } from "lucide-react";
-import { useCallback, useEffect, useState } from "react";
+import { lazy, Suspense, useCallback, useEffect, useState } from "react";
 import { Link, useLocation } from "react-router";
 
 import type { MdxPageData } from "@/hooks/useMdxPages";
 
-import { SearchDialog } from "@/components/SearchDialog";
+const SearchDialog = lazy(async () => {
+	const module = await import("@/components/SearchDialog");
+	return { default: module.SearchDialog };
+});
 
 interface LayoutProps {
 	children: React.ReactNode;
@@ -32,8 +35,12 @@ export function Layout({ children, pages }: LayoutProps) {
 
 	return (
 		<div className="flex h-screen overflow-hidden bg-zinc-950">
-			{/* Search dialog */}
-			<SearchDialog open={searchOpen} onClose={closeSearch} />
+			{/* Search stays out of the initial bundle and unmounts cleanly when closed. */}
+			{searchOpen && (
+				<Suspense fallback={null}>
+					<SearchDialog onClose={closeSearch} />
+				</Suspense>
+			)}
 
 			{/* Mobile overlay */}
 			{sidebarOpen && (
@@ -136,7 +143,7 @@ export function Layout({ children, pages }: LayoutProps) {
 			{/* Main content */}
 			<div className="flex-1 flex flex-col min-w-0">
 				{/* Top bar */}
-				<header className="flex h-14 items-center gap-3 px-4 border-b border-zinc-800 bg-zinc-950/80 backdrop-blur-sm lg:px-6">
+				<header className="flex h-14 items-center gap-3 px-4 border-b border-zinc-800 bg-zinc-950 lg:px-6">
 					<button
 						type="button"
 						className="lg:hidden p-2 text-zinc-400 hover:text-zinc-100"

--- a/packages/monopi__docs/src/components/MdxPage.test.tsx
+++ b/packages/monopi__docs/src/components/MdxPage.test.tsx
@@ -1,11 +1,23 @@
 import { describe, expect, it } from "vitest";
 
-import { getLazyContent } from "./MdxPage";
+import { getInternalDocTarget, getLazyContent } from "./MdxPage";
 
 describe("getLazyContent", () => {
 	it("reuses the lazy component for a page module across renders", () => {
 		const loadPage = async () => ({ default: () => null });
 
 		expect(getLazyContent(loadPage)).toBe(getLazyContent(loadPage));
+	});
+});
+
+describe("getInternalDocTarget", () => {
+	it("converts generated Markdown links into client-side routes", () => {
+		expect(getInternalDocTarget("02-install-and-configure.md")).toBe("/02-install-and-configure");
+		expect(getInternalDocTarget("./03-included-workflows.md#worktrees")).toBe("/03-included-workflows#worktrees");
+	});
+
+	it("leaves external and non-document links alone", () => {
+		expect(getInternalDocTarget("https://example.com/docs.md")).toBeNull();
+		expect(getInternalDocTarget("#requirements")).toBeNull();
 	});
 });

--- a/packages/monopi__docs/src/components/MdxPage.tsx
+++ b/packages/monopi__docs/src/components/MdxPage.tsx
@@ -1,4 +1,4 @@
-import { lazy, Suspense, type ComponentType, type LazyExoticComponent } from "react";
+import { lazy, Suspense, type ComponentPropsWithoutRef, type ComponentType, type LazyExoticComponent } from "react";
 import { Link, useParams } from "react-router";
 
 import type { MdxPageData } from "@/hooks/useMdxPages";
@@ -8,15 +8,35 @@ interface MdxPageProps {
 }
 
 type MdxModuleLoader = MdxPageData["module"];
+type MdxAnchorProps = ComponentPropsWithoutRef<"a">;
+interface MdxContentProps {
+	components?: { a?: ComponentType<MdxAnchorProps> };
+}
+type LazyMdxContent = LazyExoticComponent<ComponentType<MdxContentProps>>;
+
+const INTERNAL_DOC_LINK_REGEX = /^(?:\.\/)?(\d{2}-[a-z0-9-]+)\.md(#[a-z0-9-]+)?$/i;
+const MDX_COMPONENTS = { a: MdxAnchor };
 
 // The loaders come from a static import.meta.glob catalog, so this cache has a finite domain.
-const lazyContentByModule = new Map<MdxModuleLoader, LazyExoticComponent<ComponentType>>();
+const lazyContentByModule = new Map<MdxModuleLoader, LazyMdxContent>();
 
-export function getLazyContent(module: MdxModuleLoader): LazyExoticComponent<ComponentType> {
+export function getInternalDocTarget(href: string | undefined): string | null {
+	const internalMatch = href?.match(INTERNAL_DOC_LINK_REGEX);
+	if (!internalMatch) return null;
+	return `/${internalMatch[1]}${internalMatch[2] ?? ""}`;
+}
+
+function MdxAnchor({ href, ...props }: MdxAnchorProps) {
+	const internalTarget = getInternalDocTarget(href);
+	if (internalTarget) return <Link {...props} to={internalTarget} />;
+	return <a {...props} href={href} />;
+}
+
+export function getLazyContent(module: MdxModuleLoader): LazyMdxContent {
 	const cachedContent = lazyContentByModule.get(module);
 	if (cachedContent) return cachedContent;
 
-	const content = lazy(module);
+	const content = lazy(module) as LazyMdxContent;
 	lazyContentByModule.set(module, content);
 	return content;
 }
@@ -37,7 +57,7 @@ export function MdxPage({ page }: MdxPageProps) {
 					</div>
 				}
 			>
-				<Content />
+				<Content components={MDX_COMPONENTS} />
 			</Suspense>
 		</article>
 	);

--- a/packages/monopi__docs/src/components/SearchDialog.tsx
+++ b/packages/monopi__docs/src/components/SearchDialog.tsx
@@ -5,37 +5,32 @@ import { Link } from "react-router";
 import { useSearch } from "@/hooks/useSearch";
 
 interface SearchDialogProps {
-	open: boolean;
 	onClose: () => void;
 }
 
-export function SearchDialog({ open, onClose }: SearchDialogProps) {
+export function SearchDialog({ onClose }: SearchDialogProps) {
 	const { query, results, loading, search } = useSearch();
 	const inputRef = useRef<HTMLInputElement>(null);
 
 	useEffect(() => {
-		if (open) {
-			// Delay focus to ensure the dialog is rendered
-			const timer = setTimeout(() => inputRef.current?.focus(), 50);
-			return () => clearTimeout(timer);
-		}
-	}, [open]);
+		// Delay focus until the lazily loaded dialog is rendered.
+		const timer = setTimeout(() => inputRef.current?.focus(), 50);
+		return () => clearTimeout(timer);
+	}, []);
 
 	useEffect(() => {
 		const handleKeyDown = (e: KeyboardEvent) => {
-			if (e.key === "Escape" && open) onClose();
+			if (e.key === "Escape") onClose();
 		};
 		document.addEventListener("keydown", handleKeyDown);
 		return () => document.removeEventListener("keydown", handleKeyDown);
-	}, [open, onClose]);
-
-	if (!open) return null;
+	}, [onClose]);
 
 	return (
 		<div className="fixed inset-0 z-50 flex items-start justify-center pt-[15vh]">
 			{/* Backdrop */}
 			<div
-				className="absolute inset-0 bg-black/60 backdrop-blur-sm"
+				className="absolute inset-0 bg-black/70"
 				onClick={onClose}
 				onKeyDown={(e) => e.key === "Enter" && onClose()}
 				role="button"

--- a/packages/monopi__docs/src/hooks/useSearch.ts
+++ b/packages/monopi__docs/src/hooks/useSearch.ts
@@ -13,6 +13,9 @@ interface SearchIndexEntry {
 	text: string;
 }
 
+const SEARCH_INDEX_URL = new URL("../content/search-index.json", import.meta.url);
+const SEARCH_RESULT_LIMIT = 10;
+
 let searchIndex: MiniSearch | null = null;
 let indexPromise: Promise<MiniSearch> | null = null;
 
@@ -24,9 +27,13 @@ async function getSearchIndex(): Promise<MiniSearch> {
 		return indexPromise;
 	}
 
-	indexPromise = (async () => {
-		const { default: entries } = await import("../content/search-index.json");
-		const ms = new MiniSearch<SearchIndexEntry>({
+	const loadPromise = (async () => {
+		const response = await fetch(SEARCH_INDEX_URL);
+		if (!response.ok) {
+			throw new Error(`Failed to load search index: ${response.status}`);
+		}
+		const entries = (await response.json()) as SearchIndexEntry[];
+		const index = new MiniSearch<SearchIndexEntry>({
 			fields: ["title", "text"],
 			searchOptions: {
 				boost: { title: 3 },
@@ -35,12 +42,17 @@ async function getSearchIndex(): Promise<MiniSearch> {
 			},
 			storeFields: ["title"],
 		});
-		ms.addAll(entries);
-		searchIndex = ms;
-		return ms;
+		index.addAll(entries);
+		searchIndex = index;
+		return index;
 	})();
+	indexPromise = loadPromise;
 
-	return indexPromise;
+	try {
+		return await loadPromise;
+	} finally {
+		if (indexPromise === loadPromise) indexPromise = null;
+	}
 }
 
 export function useSearch() {
@@ -49,8 +61,10 @@ export function useSearch() {
 	const [loading, setLoading] = useState(false);
 
 	useEffect(() => {
-		if (!query.trim()) {
+		const normalizedQuery = query.trim();
+		if (!normalizedQuery) {
 			setResults([]);
+			setLoading(false);
 			return;
 		}
 
@@ -62,15 +76,20 @@ export function useSearch() {
 				if (cancelled) {
 					return;
 				}
-				const hits = index.search(query) as unknown as {
+				const hits = index.search(normalizedQuery) as unknown as {
 					id: string;
 					title: string;
 				}[];
-				const searchResults: SearchResult[] = hits.map((hit) => ({
-					id: hit.id,
-					text: "",
-					title: hit.title ?? hit.id,
-				}));
+				const resultCount = Math.min(hits.length, SEARCH_RESULT_LIMIT);
+				const searchResults: SearchResult[] = [];
+				for (let index = 0; index < resultCount; index++) {
+					const hit = hits[index];
+					searchResults.push({
+						id: hit.id,
+						text: "",
+						title: hit.title ?? hit.id,
+					});
+				}
 				setResults(searchResults);
 			})
 			.catch(() => {


### PR DESCRIPTION
## Summary

- lazy-load and mount documentation search only while it is open, keeping MiniSearch and the search index off the initial path
- fetch/cache the finite search index on demand, cap rendered results, and cleanly ignore stale async updates
- convert generated Markdown document links into React Router links to avoid full-page requests
- remove persistent backdrop blur effects and add the missing favicon asset
- add focused coverage for Markdown-to-SPA route conversion

## Audit results

A Playwright/CDP stress run found no reproducible listener, document, frame, or detached-DOM leak: listener and DOM counts stayed stable across 600 route transitions and 600 search open/type/close cycles after forced garbage collection. The bounded MDX lazy-component cache is retained intentionally because its key space is the static seven-page catalog.

The concrete overhead reductions are:

- initial JS: 268.8 kB -> 248.0 kB (85.0 kB -> 78.8 kB gzip)
- deferred search: 21.2 kB JS plus 22.3 kB search data, loaded only on first use
- 600-cycle search stress test: cumulative script time 0.584s -> 0.429s and task time 1.757s -> 1.257s
- internal generated-doc navigation now performs zero document requests

## Validation

- `pnpm format:check`
- `pnpm lint`
- `pnpm typecheck`
- `pnpm --filter @monopi/docs typecheck`
- `pnpm test`
- `pnpm build`
- `pnpm mdt check`
- `pnpm mc check`
- `pnpm security:check`
- `git diff --check`
- production-build Playwright validation for deferred loading, search lifecycle, internal SPA links, and favicon response
- Playwright/CDP route and search stress tests with forced GC
