### PR TITLE
chore: ignore Playwright CLI artifacts

### DIFF
--- a/.changeset/ignore-playwright-cli-artifacts.md
+++ b/.changeset/ignore-playwright-cli-artifacts.md
@@ -1,0 +1,7 @@
+---
+monopi: patch
+---
+
+# Ignore generated Playwright CLI artifacts
+
+Generated Playwright CLI snapshots and console logs no longer appear as untracked repository files.

--- a/.gitignore
+++ b/.gitignore
@@ -8,6 +8,7 @@ coverage/
 *.tsbuildinfo
 .ace-tool/
 .mdt/
+.playwright-cli/
 
 # npm lockfile (migrated to pnpm)
 package-lock.json


### PR DESCRIPTION
## Summary

- ignore generated `.playwright-cli/` snapshots and logs
- add the required patch changeset

## Validation

- `pnpm mc step validate`
- `pnpm mc check`
- `git diff --check`
- verified `git check-ignore` matches the requested snapshot and other Playwright CLI artifacts
