### PR TITLE
fix(security): bump nanoid override to 3.3.18

### DIFF
--- a/.changeset/fix-nanoid-security-override.md
+++ b/.changeset/fix-nanoid-security-override.md
@@ -1,0 +1,5 @@
+---
+monopi: patch
+---
+
+Bump the `nanoid` override to `3.3.18` to resolve the high-severity advisory GHSA-2v37-7h3g-55p8 (custom generators can loop indefinitely when size is zero) reached via `postcss` in the analytics dashboard dev dependency tree.

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -25,7 +25,7 @@ overrides:
   basic-ftp@<=5.3.0: '>=5.3.1'
   protobufjs: 7.6.5
   postcss: 8.5.23
-  nanoid: 3.3.17
+  nanoid: 3.3.18
   esbuild@<=0.24.2: '>=0.25.0'
   drizzle-orm@<0.45.2: '>=0.45.2'
   shell-quote: 1.9.0
@@ -4281,8 +4281,8 @@ packages:
   ms@2.1.3:
     resolution: {integrity: sha512-6FlzubTLZG3J2a/NVCAleEhjzq5oxgHyaCU9yYXvcLsvoVaHJq/s5xXI6/XXP6tz7R9xAOtHnSO/tXtF3WRTlA==}
 
-  nanoid@3.3.17:
-    resolution: {integrity: sha512-xQLf0A3HOMlgHq0n247/LRuAOYmB7dXJ/DvAxGvsSBij45XtBSmQycu+F8ODbHwns/XyFZagyL1+J0Offw1E0g==}
+  nanoid@3.3.18:
+    resolution: {integrity: sha512-DTg4MJbGMWkfi6VZFdNt2/caMbQy4Ou+Op/hJQvGEWcnVfoA1QA+xzRKAzw9jD6+GVOOeYr/mIcuDSdug6F6+w==}
     engines: {node: ^10 || ^12 || ^13.7 || ^14 || >=15.0.1}
     hasBin: true
 
@@ -8360,7 +8360,7 @@ snapshots:
 
   ms@2.1.3: {}
 
-  nanoid@3.3.17: {}
+  nanoid@3.3.18: {}
 
   napi-build-utils@2.0.0: {}
 
@@ -8521,7 +8521,7 @@ snapshots:
 
   postcss@8.5.23:
     dependencies:
-      nanoid: 3.3.17
+      nanoid: 3.3.18
       picocolors: 1.1.1
       source-map-js: 1.2.1
 

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -29,7 +29,7 @@ overrides:
   "basic-ftp@<=5.3.0": ">=5.3.1"
   protobufjs: 7.6.5
   postcss: 8.5.23
-  nanoid: 3.3.17
+  nanoid: 3.3.18
   "esbuild@<=0.24.2": ">=0.25.0"
   "drizzle-orm@<0.45.2": ">=0.45.2"
   shell-quote: 1.9.0


### PR DESCRIPTION
## Summary

- Bump the `nanoid` override in `pnpm-workspace.yaml` from `3.3.17` to `3.3.18`
- Resolves high-severity advisory **GHSA-2v37-7h3g-55p8** (custom generators can loop indefinitely when size is zero), reached via `postcss` in the `@monopi/analytics-dashboard` dev dependency tree
- Regenerate `pnpm-lock.yaml` and reinstall so `node_modules` picks up the patched version

## Validation

- `pnpm security:check` — all three stages pass (allowlist, prod audit, dev audit)
- `pnpm install --frozen-lockfile` — clean
