### PR TITLE
fix(shell): respect execution tool dialects

### DIFF
--- a/.changeset/fix-shell-dialect-execution.md
+++ b/.changeset/fix-shell-dialect-execution.md
@@ -1,0 +1,7 @@
+---
+monopi: patch
+---
+
+# Fix shell dialect execution
+
+Separate user-facing shell formatting from execution-tool dialects, add guarded native-shell execution, and recognize native-shell command failures.

--- a/packages/monopi__extension-git-guard/index.ts
+++ b/packages/monopi__extension-git-guard/index.ts
@@ -13,6 +13,8 @@ import type { ExtensionAPI, ExtensionContext } from "@earendil-works/pi-coding-a
 
 export const INTERACTIVE_GIT_WARNING_PREFIX = "Interactive git command blocked";
 const DIRTY_REPO_CHECK_DELAY_MS = 250;
+const GUARDED_COMMAND_TOOLS = new Set(["bash", "native_shell"]);
+const NUSHELL_EXTERNAL_COMMAND_PREFIX_REGEX = /^\^\s*/;
 
 interface InteractiveGitDetection {
 	reason: string;
@@ -47,7 +49,7 @@ function stripLeadingEnvAssignments(segment: string): string {
 	while (true) {
 		const next = stripped.replace(/^(?:[A-Za-z_][A-Za-z0-9_]*=(?:"[^"]*"|'[^']*'|\S+)\s+)*/, "");
 		if (next === stripped) {
-			return stripped;
+			return stripped.replace(NUSHELL_EXTERNAL_COMMAND_PREFIX_REGEX, "");
 		}
 		stripped = next.trimStart();
 	}
@@ -153,7 +155,7 @@ export default function (pi: ExtensionAPI) {
 	};
 
 	pi.on("tool_call", async (event) => {
-		if (event.toolName !== "bash") {
+		if (!GUARDED_COMMAND_TOOLS.has(event.toolName)) {
 			return;
 		}
 		const command = (event.input as { command?: string }).command ?? "";

--- a/packages/monopi__extension-git-guard/tests/git-guard.test.ts
+++ b/packages/monopi__extension-git-guard/tests/git-guard.test.ts
@@ -16,6 +16,7 @@ describe("detectInteractiveGitCommand", () => {
 		expect(result).not.toBeNull();
 		expect(result?.reason).toContain("git commit");
 		expect(result?.suggestion).toContain("git commit -m");
+		expect(detectInteractiveGitCommand("^git commit")?.reason).toContain("git commit");
 	});
 
 	it("ignores non-git shell text that merely mentions git", () => {
@@ -48,12 +49,36 @@ describe("INTERACTIVE_GIT_WARNING_PREFIX", () => {
 });
 
 describe("git-guard extension", () => {
+	it("guards interactive commands from Bash and native shell tools", async () => {
+		const harness = createExtensionHarness();
+		gitGuardExtension(harness.pi as never);
+
+		for (const toolName of ["bash", "native_shell"]) {
+			const results = await harness.emitAsync(
+				"tool_call",
+				{ input: { command: toolName === "native_shell" ? "^git commit" : "git commit" }, toolName },
+				harness.ctx,
+			);
+			const blocked = results.find((result) => result !== undefined) as { block: boolean; reason: string };
+			expect(blocked.block).toBe(true);
+			expect(blocked.reason).toContain(INTERACTIVE_GIT_WARNING_PREFIX);
+		}
+
+		const unguarded = await harness.emitAsync(
+			"tool_call",
+			{ input: { command: "git commit" }, toolName: "unrelated_tool" },
+			harness.ctx,
+		);
+		expect(unguarded.every((result) => result === undefined)).toBe(true);
+	});
+
 	it("defers dirty-repo startup checks until after the initial startup window", async () => {
 		vi.useFakeTimers();
 		try {
 			const harness = createExtensionHarness();
 			harness.pi.exec = vi.fn(async () => ({
 				stdout: " M README.md\n?? notes.txt\n",
+				stderr: "",
 				exitCode: 0,
 			}));
 

--- a/packages/monopi__extension-shell-format/README.md
+++ b/packages/monopi__extension-shell-format/README.md
@@ -1,7 +1,23 @@
 # @monopi/extension-shell-format
 
-Standalone pi extension package for `shell-format`.
+A pi extension that detects the user's login shell and keeps user-facing command examples in that shell's syntax without sending incompatible syntax to execution tools.
 
-```bash
-pi install npm:@monopi/extension-shell-format
+```nu
+^pi install npm:@monopi/extension-shell-format
 ```
+
+## Execution behavior
+
+The extension keeps two concerns separate:
+
+- Commands intended for the user to copy use the login shell's dialect.
+- Tool calls use the dialect declared by each tool. In particular, the `bash` tool always receives Bash syntax.
+
+For a supported non-Bash login shell with a matching `$SHELL` executable, the extension also registers `native_shell`. This tool invokes the login shell directly, so Nushell, Fish, Zsh, or PowerShell-specific syntax can be executed without a Bash quoting layer.
+
+For example, with Nushell as the login shell:
+
+- use `git status` in a `bash` tool call;
+- use `^git status` in a `native_shell` tool call or a user-facing Nushell example.
+
+Execution tools do not translate between shell dialects. Failed commands remain visible to the agent so it can correct the command and retry when safe.

--- a/packages/monopi__extension-shell-format/index.ts
+++ b/packages/monopi__extension-shell-format/index.ts
@@ -1,199 +1,221 @@
-/**
- * Shell-Format Extension
- *
- * Detects the user's login shell and instructs the LLM to format all shell
- * commands for that shell rather than defaulting to Bash syntax. This means
- * nushell users get nushell commands, fish users get fish commands, etc.
- *
- * For supported shells (nu, fish, zsh), a companion skill is available at
- * ~/.pi/agent/skills/<shell>/SKILL.md that the LLM can load for detailed
- * syntax reference.
- *
- * Usage:
- * 1. Copy this file to ~/.pi/agent/extensions/ (already there!)
- * 2. Restart pi or run /reload
- */
-
 import type { ExtensionAPI } from "@earendil-works/pi-coding-agent";
 
-// ---- Shell detection ----
+import { createBashTool } from "@earendil-works/pi-coding-agent";
+import { constants, accessSync } from "node:fs";
+import { Type } from "typebox";
 
-/** Shell profile with optional companion skill reference. */
-interface ShellProfile {
+export const NATIVE_SHELL_TOOL = "native_shell";
+
+const SHELL_INSTRUCTION_MARKER = "## Shell Syntax";
+const SHELL_PATH_SEPARATOR_REGEX = /[\\/]/;
+const SHELL_VERSION_SUFFIX_REGEX = /[-.]\d.*$/;
+const WINDOWS_EXECUTABLE_SUFFIX_REGEX = /\.exe$/;
+const SUPPORTED_SHELL_KEYS = new Set(["fish", "nu", "pwsh", "zsh"]);
+
+const NATIVE_SHELL_PARAMETERS = Type.Object({
+	command: Type.String({ description: "Command to execute using the user's login shell syntax" }),
+	timeout: Type.Optional(Type.Number({ description: "Optional timeout in seconds" })),
+});
+
+export interface ShellProfile {
 	name: string;
-	/** Skill name (e.g., "nushell") if a companion SKILL.md exists */
-	skill?: string;
 	note: string;
 }
 
-/**
- * Map of shell binary names to profiles.
- * Shells with `skill` set have a companion skill file the LLM can load.
- */
 const SHELL_PROFILES: Record<string, ShellProfile> = {
 	nu: {
 		name: "Nushell",
-		skill: "nushell",
 		note:
-			"Commands run through a bash execution backend but you MUST write them in Nushell syntax.\n" +
-			"The `nushell` skill is available — use the `read` tool to load\n" +
-			"`~/.pi/agent/skills/nushell/SKILL.md` when you need detailed Nushell syntax reference\n" +
-			"(variables, tables, pipelines, strings, custom commands, control flow, etc.).\n" +
+			"For user-facing commands and `native_shell` calls, use Nushell syntax.\n" +
 			"Key differences from Bash:\n" +
 			"- Variables: `$var` not `${var}`; use `$env.VAR` for environment variables\n" +
 			"- Lists: `[a b c]` not quoted space-separated strings\n" +
-			"- Pipes: `|` works but structured data flows through records/tables\n" +
-			"- Commands: `ls`, `open`, `each`, `where`, `select`, `str replace`, `def`\n" +
+			"- Pipes pass structured records and tables\n" +
 			"- No `&&` chaining; use `;` or `and`/`or` keywords\n" +
 			'- String interpolation: `$"Hello ($name)"`\n' +
-			"- Use `^` prefix to run external commands directly (e.g., `^git status`)\n" +
-			"- Shell variables set with `let`, mutable with `mut`",
+			"- Use `^` to explicitly run external commands, for example `^git status`\n" +
+			"- Shell variables use `let`, or `mut` when reassignment is required",
 	},
 	fish: {
 		name: "Fish",
-		skill: "fish",
 		note:
-			"Commands run through a bash execution backend but you MUST write them in Fish syntax.\n" +
-			"The `fish` skill is available — use `read` to load\n" +
-			"`~/.pi/agent/skills/fish/SKILL.md` for detailed Fish syntax reference.\n" +
+			"For user-facing commands and `native_shell` calls, use Fish syntax.\n" +
 			"Key differences from Bash:\n" +
-			"- Variables: `set var value`, use `$var`\n" +
-			"- No `$()` command substitution; use `(command)` directly\n" +
-			"- `and`/`or` instead of `&&`/`||`\n" +
-			"- `end` instead of `fi`/`done`/`esac`\n" +
-			"- String manipulation: `string replace`, `string split`, etc.\n" +
-			"- Functions: `function name ... end`",
+			"- Variables: `set var value`, then use `$var`\n" +
+			"- Use `(command)` instead of `$()` for command substitution\n" +
+			"- Use `and`/`or` instead of `&&`/`||`\n" +
+			"- Use `end` instead of `fi`/`done`/`esac`\n" +
+			"- Functions use `function name ... end`",
 	},
 	bash: {
 		name: "Bash",
-		note: "Use standard Bash/POSIX shell syntax.",
+		note: "Use standard Bash syntax.",
 	},
 	sh: {
 		name: "POSIX shell",
-		note: "Use POSIX-compatible shell syntax (dash, ash, BusyBox sh).",
+		note: "Use POSIX-compatible shell syntax.",
 	},
 	zsh: {
 		name: "Zsh",
-		note:
-			"Commands run through a bash execution backend. Zsh and Bash have very similar syntax.\n" +
-			"You may use Zsh-specific features like glob qualifiers, `=(cmd)`, `{a,b}` expansions,\n" +
-			"but be aware the backend is bash — test advanced Zsh features first.",
+		note: "For user-facing commands and `native_shell` calls, Zsh-specific syntax is supported.",
 	},
 	pwsh: {
 		name: "PowerShell",
-		skill: "pwsh",
 		note:
-			"Commands run through a bash execution backend but you MUST write them in PowerShell syntax.\n" +
-			"The `pwsh` skill is available — use `read` to load\n" +
-			"`~/.pi/agent/skills/pwsh/SKILL.md` for detailed PowerShell syntax reference.\n" +
-			"Key differences:\n" +
-			"- Variables: `$var`, environment: `$env:VAR`\n" +
-			"- Commands: Verb-Noun pattern (Get-Content, Set-Location, etc.)\n" +
-			"- Pipes pass objects, not text\n" +
-			"- No `grep`/`sed`/`awk`; use `Select-String`, `-replace`, `Where-Object`",
+			"For user-facing commands and `native_shell` calls, use PowerShell syntax.\n" +
+			"Key differences from Bash:\n" +
+			"- Variables: `$var`; environment variables: `$env:VAR`\n" +
+			"- Commands commonly use the Verb-Noun pattern\n" +
+			"- Pipes pass objects rather than text\n" +
+			"- Prefer `Select-String`, `-replace`, and `Where-Object` to grep/sed/awk",
 	},
 };
 
-/** Detect the user's shell from environment variables. */
-function detectShell(): { key: string; info: ShellProfile } {
-	// 1. NU_VERSION → Nushell
-	if (process.env.NU_VERSION) {
+function normalizeShellBinary(shellPath: string): string {
+	const shellBinary = shellPath.split(SHELL_PATH_SEPARATOR_REGEX).pop()?.toLowerCase() ?? "";
+	return shellBinary.replace(WINDOWS_EXECUTABLE_SUFFIX_REGEX, "").replace(SHELL_VERSION_SUFFIX_REGEX, "");
+}
+
+export function detectShell(env: NodeJS.ProcessEnv = process.env): { key: string; info: ShellProfile } {
+	if (env.NU_VERSION) {
 		return { key: "nu", info: SHELL_PROFILES.nu };
 	}
 
-	// 2. FISH_VERSION → Fish
-	if (process.env.FISH_VERSION) {
+	if (env.FISH_VERSION) {
 		return { key: "fish", info: SHELL_PROFILES.fish };
 	}
 
-	// 3. ZSH_VERSION → Zsh
-	if (process.env.ZSH_VERSION) {
+	if (env.ZSH_VERSION) {
 		return { key: "zsh", info: SHELL_PROFILES.zsh };
 	}
 
-	// 4. BASH_VERSION → Bash
-	if (process.env.BASH_VERSION) {
+	if (env.BASH_VERSION) {
 		return { key: "bash", info: SHELL_PROFILES.bash };
 	}
 
-	// 5. Parse $SHELL path
-	const shellPath = process.env.SHELL ?? "";
-	const shellBin = shellPath.split("/").pop()?.toLowerCase() ?? "";
-	const baseName = shellBin.replace(/[-.]\d.*$/, "");
-
-	if (baseName in SHELL_PROFILES) {
-		return { key: baseName, info: SHELL_PROFILES[baseName] };
+	if (env.PSModulePath && !env.SHELL) {
+		return { key: "pwsh", info: SHELL_PROFILES.pwsh };
 	}
 
-	// Fallback: unknown shell
+	const shellPath = env.SHELL ?? "";
+	const shellKey = normalizeShellBinary(shellPath);
+	const info = SHELL_PROFILES[shellKey];
+
+	if (info) {
+		return { key: shellKey, info };
+	}
+
 	return {
-		key: baseName || "unknown",
+		key: shellKey || "unknown",
 		info: {
-			name: baseName || "unknown shell",
+			name: shellKey || "unknown shell",
 			note: `Could not determine shell type from $SHELL="${shellPath}". Use standard POSIX syntax.`,
 		},
 	};
 }
 
-// ---- System prompt injection ----
+function isExecutableFile(filePath: string): boolean {
+	try {
+		accessSync(filePath, constants.X_OK);
+		return true;
+	} catch {
+		return false;
+	}
+}
 
-const { key: shellKey, info } = detectShell();
+export function resolveNativeShellPath(
+	shellKey: string,
+	env: NodeJS.ProcessEnv = process.env,
+	isExecutable: (filePath: string) => boolean = isExecutableFile,
+): string | undefined {
+	const shellPath = env.SHELL?.trim();
 
-const SHELL_INSTRUCTION = `
-## Shell Syntax
+	if (
+		!SUPPORTED_SHELL_KEYS.has(shellKey) ||
+		!shellPath ||
+		normalizeShellBinary(shellPath) !== shellKey ||
+		!isExecutable(shellPath)
+	) {
+		return undefined;
+	}
 
-**IMPORTANT:** The user's login shell is **${info.name}**, NOT Bash. When providing
-shell commands (including commands passed to the \`bash\` tool), you MUST format
-them using ${info.name} syntax.
-`;
+	return shellPath;
+}
 
-const SKILL_REFERENCE = info.skill
-	? `A comprehensive \`${info.skill}\` skill is available. Use the \`read\` tool to load
-\`~/.pi/agent/skills/${info.skill}/SKILL.md\` for complete ${info.name} syntax
-reference (command equivalents, pipelines, data types, common patterns, and gotchas).
+export function buildShellInstruction(info: ShellProfile, nativeShellAvailable: boolean): string {
+	const nativeShellGuidance = nativeShellAvailable
+		? `- The \`${NATIVE_SHELL_TOOL}\` tool executes ${info.name} syntax directly. Use it when native-shell execution is required.\n`
+		: `- No native ${info.name} execution tool is available. Use Bash syntax for \`bash\` tool calls.\n`;
+	return `
+${SHELL_INSTRUCTION_MARKER}
 
-`
-	: "";
+The user's login shell is **${info.name}**. Format commands intended for the user to copy and run in
+${info.name} syntax.
 
-const SINK = `
+Execution tools do not translate between shell dialects. Tool calls MUST use the syntax declared by the tool:
+- The \`bash\` tool executes Bash syntax. Never send ${info.name}-specific syntax to \`bash\`.
+${nativeShellGuidance}- Other command tools must receive the dialect stated in their descriptions.
+
+A failed command is recoverable. Read the tool result, correct the command or dialect, and retry when safe.
+
 ${info.note}
 
-Always provide commands in ${info.name} syntax. The bash tool will execute them;
-the execution backend handles compatibility. Your job is to give the user commands
-they can understand, reuse, and learn from — in their native shell dialect.
+Keep user-facing examples in ${info.name} syntax while keeping execution-tool calls in each tool's declared dialect.
 `;
+}
 
-const FULL_INSTRUCTION = SHELL_INSTRUCTION + SKILL_REFERENCE + SINK;
+function isPromptInjectionSupported(shellKey: string): boolean {
+	return SUPPORTED_SHELL_KEYS.has(shellKey);
+}
 
-/** Slug for display in status bar. */
-const STATUS_LABEL = `${info.name} shell-format`;
+export interface ShellFormatOptions {
+	env?: NodeJS.ProcessEnv;
+	isExecutable?: (filePath: string) => boolean;
+	createShellTool?: typeof createBashTool;
+}
 
-/** Whether we need to inject shell instructions (skip for bash/sh/unknown). */
-const isSupported = shellKey !== "bash" && shellKey !== "sh" && shellKey !== "unknown";
+export default function shellFormatExtension(pi: ExtensionAPI, options: ShellFormatOptions = {}): void {
+	const env = options.env ?? process.env;
+	const { key: shellKey, info } = detectShell(env);
+	const nativeShellPath = resolveNativeShellPath(shellKey, env, options.isExecutable);
+	const createShellTool = options.createShellTool ?? createBashTool;
+	const isSupported = isPromptInjectionSupported(shellKey);
+	const fullInstruction = buildShellInstruction(info, Boolean(nativeShellPath));
+	const statusLabel = `${info.name} user syntax`;
 
-// ---- Extension entry point ----
+	if (isSupported && nativeShellPath) {
+		pi.registerTool({
+			name: NATIVE_SHELL_TOOL,
+			label: `${info.name} shell`,
+			description: `Execute commands directly with the user's ${info.name} login shell. Accepts ${info.name} syntax.`,
+			parameters: NATIVE_SHELL_PARAMETERS,
+			async execute(toolCallId, params, signal, onUpdate, ctx) {
+				const nativeShell = createShellTool(ctx.cwd, { shellPath: nativeShellPath });
+				return nativeShell.execute(toolCallId, params, signal, onUpdate);
+			},
+		});
+	}
 
-export default function (pi: ExtensionAPI) {
 	pi.on("session_start", (_event, ctx) => {
-		if (isSupported) {
-			ctx.ui.setStatus("shell-format", STATUS_LABEL);
-			ctx.ui.notify(
-				`Shell format: commands will use ${info.name} syntax` + (info.skill ? ` (${info.skill} skill available)` : ""),
-				"info",
-			);
+		if (!isSupported) {
+			return;
 		}
+
+		ctx.ui.setStatus("shell-format", statusLabel);
+		ctx.ui.notify(
+			`Shell format: user-facing commands use ${info.name}; tool calls use each tool's declared dialect` +
+				(nativeShellPath ? ` (${NATIVE_SHELL_TOOL} available)` : ""),
+			"info",
+		);
 	});
 
 	pi.on("before_agent_start", (event) => {
-		if (!isSupported) return;
-
-		const { systemPrompt } = event;
-
-		// Avoid double-injection
-		if (systemPrompt.includes("The user's login shell is")) return;
+		if (!isSupported || event.systemPrompt.includes(SHELL_INSTRUCTION_MARKER)) {
+			return;
+		}
 
 		return {
-			systemPrompt: systemPrompt + FULL_INSTRUCTION,
+			systemPrompt: event.systemPrompt + fullInstruction,
 		};
 	});
 
@@ -201,3 +223,12 @@ export default function (pi: ExtensionAPI) {
 		ctx.ui.setStatus("shell-format", undefined);
 	});
 }
+
+export const shellFormatInternals = {
+	SHELL_PROFILES,
+	buildShellInstruction,
+	detectShell,
+	isPromptInjectionSupported,
+	normalizeShellBinary,
+	resolveNativeShellPath,
+};

--- a/packages/monopi__extension-shell-format/tests/shell-format.test.ts
+++ b/packages/monopi__extension-shell-format/tests/shell-format.test.ts
@@ -1,0 +1,161 @@
+import { chmodSync, mkdtempSync, rmSync, writeFileSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { describe, expect, it, vi } from "vitest";
+
+import { createExtensionHarness } from "../../../test-utils/extension-runtime-harness.js";
+import shellFormatExtension, {
+	NATIVE_SHELL_TOOL,
+	buildShellInstruction,
+	detectShell,
+	resolveNativeShellPath,
+	shellFormatInternals,
+} from "../index.js";
+
+describe("shell detection", () => {
+	it("detects common shells without conflating login and execution dialects", () => {
+		expect(detectShell({ NU_VERSION: "0.105.1", SHELL: "/opt/homebrew/bin/nu" })).toMatchObject({
+			key: "nu",
+			info: { name: "Nushell" },
+		});
+		expect(detectShell({ SHELL: "/bin/zsh-5.9" })).toMatchObject({ key: "zsh" });
+		expect(detectShell({ SHELL: "C:\\Program Files\\PowerShell\\pwsh.exe" })).toMatchObject({ key: "pwsh" });
+		expect(detectShell({ PSModulePath: "C:\\Program Files\\PowerShell\\Modules" })).toMatchObject({
+			key: "pwsh",
+		});
+	});
+
+	it("only resolves a native executable when it matches the detected shell", () => {
+		const executable = () => true;
+		expect(resolveNativeShellPath("nu", { SHELL: "/opt/homebrew/bin/nu" }, executable)).toBe("/opt/homebrew/bin/nu");
+		expect(resolveNativeShellPath("nu", { SHELL: "/bin/bash" }, executable)).toBeUndefined();
+		expect(resolveNativeShellPath("custom", { SHELL: "/tmp/custom" }, executable)).toBeUndefined();
+		expect(resolveNativeShellPath("nu", {}, executable)).toBeUndefined();
+		expect(resolveNativeShellPath("nu", { SHELL: "/missing/nu" }, () => false)).toBeUndefined();
+	});
+
+	it("checks executable access when no override is provided", () => {
+		const directory = mkdtempSync(join(tmpdir(), "shell-format-"));
+		const executablePath = join(directory, "nu");
+		writeFileSync(executablePath, "#!/usr/bin/env nu\n");
+		chmodSync(executablePath, 0o755);
+
+		try {
+			expect(resolveNativeShellPath("nu", { SHELL: executablePath })).toBe(executablePath);
+			expect(resolveNativeShellPath("nu", { SHELL: join(directory, "missing", "nu") })).toBeUndefined();
+		} finally {
+			rmSync(directory, { recursive: true });
+		}
+	});
+});
+
+describe("shell instructions", () => {
+	it("separates user-facing Nushell syntax from Bash tool syntax", () => {
+		const instruction = buildShellInstruction(shellFormatInternals.SHELL_PROFILES.nu, true);
+
+		expect(instruction).toContain("commands intended for the user");
+		expect(instruction).toContain("The `bash` tool executes Bash syntax");
+		expect(instruction).toContain("Never send Nushell-specific syntax to `bash`");
+		expect(instruction).toContain("The `native_shell` tool executes Nushell syntax directly");
+		expect(instruction).toContain("`^git status`");
+		expect(instruction).not.toContain("execution backend handles compatibility");
+		expect(instruction).not.toContain("commands passed to the `bash` tool");
+	});
+
+	it("does not claim native execution when the login-shell executable is unavailable", () => {
+		const instruction = buildShellInstruction(shellFormatInternals.SHELL_PROFILES.fish, false);
+
+		expect(instruction).toContain("No native Fish execution tool is available");
+		expect(instruction).toContain("Use Bash syntax for `bash` tool calls");
+	});
+});
+
+describe("extension registration", () => {
+	it("registers a native shell tool and injects unambiguous guidance", async () => {
+		const harness = createExtensionHarness();
+		const executeShell = vi.fn(async (..._args: unknown[]) => ({ content: [{ type: "text", text: "ok" }] }));
+		const createShellTool = vi.fn(() => ({ execute: executeShell }));
+		shellFormatExtension(harness.pi as never, {
+			env: { NU_VERSION: "0.105.1", SHELL: "/usr/local/bin/nu" },
+			isExecutable: () => true,
+			createShellTool: createShellTool as never,
+		});
+
+		await harness.emitAsync("session_start", {}, harness.ctx);
+		expect(harness.statusMap.get("shell-format")).toBe("Nushell user syntax");
+		expect(harness.notifications[0]?.msg).toContain("native_shell available");
+
+		const nativeShell = harness.tools.get(NATIVE_SHELL_TOOL);
+		expect(nativeShell).toMatchObject({
+			label: "Nushell shell",
+			description: expect.stringContaining("Accepts Nushell syntax"),
+			parameters: {
+				properties: {
+					command: { description: expect.stringContaining("login shell syntax") },
+				},
+			},
+		});
+
+		const commands = [
+			"^git status",
+			"^gh api repos/owner/repo --jq '.[] | .name'",
+			"ls | where type == file",
+			"^git status; ^git branch --show-current",
+			`^tool '{"nested":{"value":"quoted"}}'`,
+		];
+		const signal = new AbortController().signal;
+		const onUpdate = () => {};
+		for (const command of commands) {
+			await nativeShell.execute("call-1", { command }, signal, onUpdate, harness.ctx);
+		}
+
+		expect(createShellTool).toHaveBeenCalledTimes(commands.length);
+		for (let index = 0; index < commands.length; index++) {
+			expect(createShellTool).toHaveBeenNthCalledWith(index + 1, harness.ctx.cwd, {
+				shellPath: "/usr/local/bin/nu",
+			});
+			expect(executeShell.mock.calls[index]?.[1]).toEqual({ command: commands[index] });
+		}
+
+		const results = await harness.emitAsync("before_agent_start", { systemPrompt: "Base prompt" }, harness.ctx);
+		const injected = results.find((result) => result !== undefined) as { systemPrompt: string };
+
+		expect(injected.systemPrompt).toContain("Base prompt");
+		expect(injected.systemPrompt).toContain("The `bash` tool executes Bash syntax");
+		expect(injected.systemPrompt).toContain("native_shell");
+
+		const duplicateResults = await harness.emitAsync(
+			"before_agent_start",
+			{ systemPrompt: injected.systemPrompt },
+			harness.ctx,
+		);
+		expect(duplicateResults.every((result) => result === undefined)).toBe(true);
+	});
+
+	it("does not trust an unknown shell executable", async () => {
+		const harness = createExtensionHarness();
+		shellFormatExtension(harness.pi as never, {
+			env: { SHELL: "/tmp/custom-shell" },
+			isExecutable: () => true,
+		});
+
+		expect(harness.tools.has(NATIVE_SHELL_TOOL)).toBe(false);
+		const results = await harness.emitAsync("before_agent_start", { systemPrompt: "Base prompt" }, harness.ctx);
+		expect(results.every((result) => result === undefined)).toBe(true);
+	});
+
+	it("does not inject guidance or register a native tool for Bash", async () => {
+		const harness = createExtensionHarness();
+		shellFormatExtension(harness.pi as never, {
+			env: { BASH_VERSION: "5.2", SHELL: "/bin/bash" },
+			isExecutable: () => true,
+		});
+
+		expect(harness.tools.has(NATIVE_SHELL_TOOL)).toBe(false);
+		await harness.emitAsync("session_start", {}, harness.ctx);
+		expect(harness.statusMap.has("shell-format")).toBe(false);
+		expect(harness.notifications).toEqual([]);
+		const results = await harness.emitAsync("before_agent_start", { systemPrompt: "Base prompt" }, harness.ctx);
+		expect(results.every((result) => result === undefined)).toBe(true);
+	});
+});

--- a/packages/monopi__subagents/tests/utils-extra.test.ts
+++ b/packages/monopi__subagents/tests/utils-extra.test.ts
@@ -189,6 +189,20 @@ describe("subagent utils", () => {
 			details: "Command failed with exit code 23",
 		});
 
+		const nativeShellExit = detectSubagentError([
+			{
+				role: "toolResult",
+				toolName: "native_shell",
+				content: [{ type: "text", text: "Command failed with exit code 127" }],
+				isError: false,
+			},
+		] as never);
+		expect(nativeShellExit).toMatchObject({
+			hasError: true,
+			exitCode: 127,
+			errorType: "native_shell",
+		});
+
 		const bashFatal = detectSubagentError([
 			{
 				role: "toolResult",

--- a/packages/monopi__subagents/utils.ts
+++ b/packages/monopi__subagents/utils.ts
@@ -16,6 +16,18 @@ import type { AsyncStatus, DisplayItem, ErrorInfo } from "./types.js";
 
 // Cache for status file reads - avoid re-reading unchanged files
 const statusCache = new Map<string, { mtime: number; status: AsyncStatus }>();
+const COMMAND_TOOL_NAMES = new Set(["bash", "native_shell"]);
+const COMMAND_EXIT_CODE_REGEX = /exit(?:ed)?\s*(?:with\s*)?(?:code|status)?\s*[:\s]?\s*(\d+)/i;
+const FATAL_COMMAND_OUTPUT_PATTERNS = [
+	/command not found/i,
+	/permission denied/i,
+	/no such file or directory/i,
+	/segmentation fault/i,
+	/killed|terminated/i,
+	/out of memory/i,
+	/connection refused/i,
+	/timeout/i,
+];
 
 /**
  * Read async job status from disk (with mtime-based caching)
@@ -249,7 +261,7 @@ export function detectSubagentError(messages: Message[]): ErrorInfo {
 		if ((msg as unknown as { isError: boolean }).isError) {
 			const text = msg.content.find((c) => c.type === "text");
 			const details = text && "text" in text ? text.text : undefined;
-			const exitMatch = details?.match(/exit(?:ed)?\s*(?:with\s*)?(?:code|status)?\s*[:\s]?\s*(\d+)/i);
+			const exitMatch = details?.match(COMMAND_EXIT_CODE_REGEX);
 			return {
 				details: details?.slice(0, 200),
 				errorType: (msg as unknown as { toolName: string }).toolName || "tool",
@@ -259,7 +271,7 @@ export function detectSubagentError(messages: Message[]): ErrorInfo {
 		}
 
 		const { toolName } = msg as unknown as { toolName: string };
-		if (toolName !== "bash") {
+		if (!COMMAND_TOOL_NAMES.has(toolName)) {
 			continue;
 		}
 
@@ -269,13 +281,13 @@ export function detectSubagentError(messages: Message[]): ErrorInfo {
 		}
 		const output = text.text;
 
-		const exitMatch = output.match(/exit(?:ed)?\s*(?:with\s*)?(?:code|status)?\s*[:\s]?\s*(\d+)/i);
+		const exitMatch = output.match(COMMAND_EXIT_CODE_REGEX);
 		if (exitMatch) {
 			const code = Number.parseInt(exitMatch[1], 10);
 			if (code !== 0) {
 				return {
 					details: output.slice(0, 200),
-					errorType: "bash",
+					errorType: toolName,
 					exitCode: code,
 					hasError: true,
 				};
@@ -285,21 +297,11 @@ export function detectSubagentError(messages: Message[]): ErrorInfo {
 		// NOTE: These patterns can match legitimate output (grep results, logs,
 		// Testing). With the assistant-message check above, most false positives
 		// Are mitigated since the agent will have responded after routine errors.
-		const fatalPatterns = [
-			/command not found/i,
-			/permission denied/i,
-			/no such file or directory/i,
-			/segmentation fault/i,
-			/killed|terminated/i,
-			/out of memory/i,
-			/connection refused/i,
-			/timeout/i,
-		];
-		for (const pattern of fatalPatterns) {
+		for (const pattern of FATAL_COMMAND_OUTPUT_PATTERNS) {
 			if (pattern.test(output)) {
 				return {
 					details: output.slice(0, 200),
-					errorType: "bash",
+					errorType: toolName,
 					exitCode: 1,
 					hasError: true,
 				};


### PR DESCRIPTION
## Summary

- separate user-facing login-shell syntax from execution-tool dialects
- add guarded native-shell execution for supported executable shells
- apply Git mutation safeguards and subagent error detection to `native_shell`
- document and test shell detection, quoting, prompt injection, and guard behavior

## Changeset

- `.changeset/fix-shell-dialect-execution.md` (`monopi: patch`)

## Verification

- `pnpm format:check`
- `pnpm lint`
- `pnpm typecheck`
- `pnpm test`
- `pnpm build`
- `pnpm security:check`
- `pnpm mc check`
- `pnpm mdt check`
- patch coverage: **100.00% (60/60)**
