### PR TITLE
fix(subagents): preserve failure output

### DIFF
--- a/.changeset/preserve-subagent-failure-output.md
+++ b/.changeset/preserve-subagent-failure-output.md
@@ -1,0 +1,7 @@
+---
+monopi: patch
+---
+
+# Preserve subagent failure output
+
+Preserve partial assistant output and real transcript paths when synchronous subagent runs fail.

--- a/packages/monopi__subagents/execution.ts
+++ b/packages/monopi__subagents/execution.ts
@@ -559,7 +559,7 @@ export async function runSync(
 		}
 	}
 
-	if (shareEnabled && options.sessionDir) {
+	if (options.sessionDir) {
 		const sessionFile = findLatestSessionFile(options.sessionDir);
 		if (sessionFile) {
 			result.sessionFile = sessionFile;

--- a/packages/monopi__subagents/index.ts
+++ b/packages/monopi__subagents/index.ts
@@ -53,7 +53,12 @@ import { recordRun } from "./run-history.js";
 import { createSubagentRuntimeMonitor } from "./runtime-monitor.js";
 import { StatusParams, SubagentParams } from "./schemas.js";
 import { cleanupOldChainDirs, isParallelStep, resolveStepBehavior } from "./settings.js";
-import { finalizeSingleOutput, injectSingleOutputInstruction, resolveSingleOutputPath } from "./single-output.js";
+import {
+	finalizeSingleOutput,
+	formatSingleFailure,
+	injectSingleOutputInstruction,
+	resolveSingleOutputPath,
+} from "./single-output.js";
 import { discoverAvailableSkills, normalizeSkillInput } from "./skills.js";
 import {
 	ASYNC_DIR,
@@ -1003,8 +1008,17 @@ MANAGEMENT (use action field — omit agent/task/chain/tasks):
 				});
 
 				if (r.exitCode !== 0) {
+					const partialOutput = r.truncation?.text || fullOutput;
+					const transcriptPath =
+						r.sessionFile || (artifactConfig.includeJsonl ? r.artifactPaths?.jsonlPath : undefined);
+					const failureOutput = formatSingleFailure({
+						error: r.error,
+						partialOutput,
+						transcriptPath,
+					});
+
 					return {
-						content: [{ type: "text", text: r.error || "Failed" }],
+						content: [{ type: "text", text: failureOutput }],
 						details: {
 							mode: "single",
 							results: [r],

--- a/packages/monopi__subagents/single-output.ts
+++ b/packages/monopi__subagents/single-output.ts
@@ -43,6 +43,25 @@ export function persistSingleOutput(
 	}
 }
 
+export function formatSingleFailure(params: {
+	error?: string;
+	partialOutput?: string;
+	transcriptPath?: string;
+}): string {
+	const sections = [`Agent failed: ${params.error?.trim() || "Unknown subagent failure"}`];
+	const partialOutput = params.partialOutput?.trim();
+
+	if (partialOutput) {
+		sections.push(`Partial output:\n${partialOutput}`);
+	}
+
+	if (params.transcriptPath) {
+		sections.push(`Transcript: ${params.transcriptPath}`);
+	}
+
+	return sections.join("\n\n");
+}
+
 export function finalizeSingleOutput(params: {
 	fullOutput: string;
 	truncatedOutput?: string;

--- a/packages/monopi__subagents/tests/execution.test.ts
+++ b/packages/monopi__subagents/tests/execution.test.ts
@@ -253,6 +253,25 @@ describe("runSync", () => {
 		expect(executionMocks.resolveSkillsAsync).toHaveBeenCalledWith(["ecsc-reviewer"], "/legal/project");
 	});
 
+	it("returns a session transcript when persistence is enabled without sharing", async () => {
+		const runPromise = runSync(
+			"/repo",
+			[{ name: "reviewer", model: "anthropic/claude-sonnet-4" }],
+			"reviewer",
+			"Inspect",
+			{ sessionDir: "/tmp/session", share: false },
+		);
+
+		await vi.waitFor(() => expect(executionMocks.procs).toHaveLength(1));
+		executionMocks.procs[0].emit("close", 0);
+
+		await expect(runPromise).resolves.toMatchObject({
+			exitCode: 0,
+			sessionFile: "/tmp/session/run.jsonl",
+		});
+		expect(executionMocks.findLatestSessionFile).toHaveBeenCalledWith("/tmp/session");
+	});
+
 	it("streams successful runs, writes artifacts, and records truncation + shared sessions", async () => {
 		const onUpdate = vi.fn();
 		const longTask = "A".repeat(9000);

--- a/packages/monopi__subagents/tests/index-entrypoint.test.ts
+++ b/packages/monopi__subagents/tests/index-entrypoint.test.ts
@@ -46,6 +46,11 @@ const mocks = vi.hoisted(() => ({
 	finalizeSingleOutput: vi.fn(({ truncatedOutput, fullOutput }: any) => ({
 		displayOutput: truncatedOutput || fullOutput || "(no output)",
 	})),
+	formatSingleFailure: vi.fn(({ error, partialOutput, transcriptPath }: any) => {
+		const sections = [`Agent failed: ${error}`, `Partial output:\n${partialOutput}`];
+		if (transcriptPath) sections.push(`Transcript: ${transcriptPath}`);
+		return sections.join("\n\n");
+	}),
 	injectSingleOutputInstruction: vi.fn((task: string) => task),
 	resolveSingleOutputPath: vi.fn((output: string | undefined) => (output ? `/tmp/${output}` : undefined)),
 	recordRun: vi.fn(),
@@ -151,6 +156,7 @@ vi.mock("../skills.js", () => ({
 }));
 vi.mock("../single-output.js", () => ({
 	finalizeSingleOutput: mocks.finalizeSingleOutput,
+	formatSingleFailure: mocks.formatSingleFailure,
 	injectSingleOutputInstruction: mocks.injectSingleOutputInstruction,
 	resolveSingleOutputPath: mocks.resolveSingleOutputPath,
 }));
@@ -632,11 +638,41 @@ describe("subagent entrypoint", () => {
 			messages: [],
 			truncation: { text: "truncated" },
 			error: "boom",
+			sessionFile: "/tmp/session/run.jsonl",
 			progressSummary: { durationMs: 5 },
 		});
 		const failure = await tool.execute("s4", { agent: "scout", task: "inspect" }, undefined, undefined, ctx);
 		expect(failure.isError).toBe(true);
-		expect(failure.content[0]?.text).toBe("boom");
+		expect(failure.content[0]?.text).toContain("Agent failed: boom");
+		expect(failure.content[0]?.text).toContain("Partial output:\ntruncated");
+		expect(failure.content[0]?.text).toContain("Transcript: /tmp/session/run.jsonl");
+		expect(mocks.formatSingleFailure).toHaveBeenCalledWith({
+			error: "boom",
+			partialOutput: "truncated",
+			transcriptPath: "/tmp/session/run.jsonl",
+		});
+
+		mocks.runSync.mockResolvedValueOnce({
+			agent: "scout",
+			exitCode: 1,
+			messages: [],
+			artifactPaths: { jsonlPath: "/tmp/artifacts/not-created.jsonl" },
+			error: "no transcript",
+			progressSummary: { durationMs: 5 },
+		});
+		const failureWithoutTranscript = await tool.execute(
+			"s5",
+			{ agent: "scout", task: "inspect" },
+			undefined,
+			undefined,
+			ctx,
+		);
+		expect(failureWithoutTranscript.content[0]?.text).not.toContain("Transcript:");
+		expect(mocks.formatSingleFailure).toHaveBeenLastCalledWith({
+			error: "no transcript",
+			partialOutput: "final output",
+			transcriptPath: undefined,
+		});
 	});
 
 	it("reports async run status from result files and not-found cases", async () => {

--- a/packages/monopi__subagents/tests/single-output.test.ts
+++ b/packages/monopi__subagents/tests/single-output.test.ts
@@ -3,7 +3,12 @@ import * as os from "node:os";
 import * as path from "node:path";
 import { afterEach, describe, expect, it } from "vitest";
 
-import { finalizeSingleOutput, injectSingleOutputInstruction, resolveSingleOutputPath } from "../single-output.js";
+import {
+	finalizeSingleOutput,
+	formatSingleFailure,
+	injectSingleOutputInstruction,
+	resolveSingleOutputPath,
+} from "../single-output.js";
 
 const tempDirs: string[] = [];
 
@@ -46,6 +51,24 @@ describe("injectSingleOutputInstruction", () => {
 	it("appends an output instruction with the resolved path", () => {
 		const output = injectSingleOutputInstruction("Analyze this", "/tmp/report.md");
 		expect(output).toMatch(/Write your findings to: \/tmp\/report\.md/);
+	});
+});
+
+describe("formatSingleFailure", () => {
+	it("preserves partial output and a transcript path", () => {
+		const output = formatSingleFailure({
+			error: "bash failed (exit 127): ^git: command not found",
+			partialOutput: "Inspected the package before the command failed.",
+			transcriptPath: "/tmp/artifacts/run.jsonl",
+		});
+
+		expect(output).toContain("Agent failed: bash failed (exit 127)");
+		expect(output).toContain("Partial output:\nInspected the package");
+		expect(output).toContain("Transcript: /tmp/artifacts/run.jsonl");
+	});
+
+	it("provides a useful fallback when no details were captured", () => {
+		expect(formatSingleFailure({})).toBe("Agent failed: Unknown subagent failure");
 	});
 });
 


### PR DESCRIPTION
## Summary

- preserve partial assistant output when synchronous subagent runs fail
- include only real persisted transcript paths in failure output
- return session transcript paths when persistence is enabled without sharing
- add regression coverage for failure formatting and session persistence

## Changeset

- `.changeset/preserve-subagent-failure-output.md` (`monopi: patch`)

## Verification

- `pnpm format:check`
- `pnpm lint`
- `pnpm typecheck`
- `pnpm test`
- `pnpm build`
- `pnpm security:check`
- `pnpm mc check`
- `pnpm mdt check`
- patch coverage: **100.00% (11/11)**
