### PR TITLE
feat(subagents): add fleet inspector for toggling between live subagent runs

### DIFF
--- a/.changeset/fleet-inspector.md
+++ b/.changeset/fleet-inspector.md
@@ -1,0 +1,7 @@
+---
+monopi-group: minor
+---
+
+# Subagent fleet inspector
+
+Add a live fleet inspector for toggling between background subagent runs. Open it with `/fleet` or the new `ctrl+alt+f` shortcut (matching upstream pi-subagents). The list shows every async run with status, step progress, elapsed time, tokens and activity freshness; `enter` drills into a run to watch per-step status and a rolling output tail (`x` expands it), `esc` goes back, and the view auto-refreshes while open. The async widget header now hints the shortcut so the feature is discoverable.

--- a/packages/monopi__subagents/README.md
+++ b/packages/monopi__subagents/README.md
@@ -143,8 +143,34 @@ The MCP adapter's metadata cache must be populated for direct tools to work. On 
 | `/chain agent1 "task1" -> agent2 "task2"`    | Run agents in sequence with per-step tasks |
 | `/parallel agent1 "task1" -> agent2 "task2"` | Run agents in parallel with per-step tasks |
 | `/agents`                                    | Open the Agents Manager overlay            |
+| `/fleet`                                     | Toggle between subagents and inspect them  |
 
 All commands validate agent names locally and tab-complete them, then route through the tool framework for full live progress rendering. Results are sent to the conversation for the LLM to discuss.
+
+### Fleet Inspector
+
+While subagents run in the background, press `ctrl+alt+f` (or run `/fleet`) to open the fleet inspector — a live overlay for toggling between runs and watching what each one is doing:
+
+```text
+╭────────────────────── Subagent fleet [2 active / 3] ──────────────────────╮
+│ ▸ ● scout → planner · step 1/2 · 12.0s · 4.2k tok · active now            │
+│   ● reviewer · running · 38s · 1.1k tok · active now                      │
+│   ✗ researcher → writer · failed · 1m 02s                                 │
+╰──────────────── ↑↓/jk select · enter inspect · r refresh · esc close ─────╯
+```
+
+Keys inside the inspector:
+
+| Key                | Action                                             |
+| ------------------ | -------------------------------------------------- |
+| `↑`/`↓` or `j`/`k` | Move between subagent runs                         |
+| `enter` or `→`     | Inspect the selected run                           |
+| `←`, `backspace`   | Back to the run list                               |
+| `x` or `ctrl+o`    | Expand/collapse the live output tail               |
+| `r`                | Refresh immediately (the view also auto-refreshes) |
+| `esc`              | Back, or close from the list                       |
+
+The detail view shows every chain step with status, duration and token counts, plus a rolling output tail of the current step. The async widget above the editor also gains a `· ctrl+alt+f fleet` hint whenever background work is active.
 
 ### Per-Step Tasks
 

--- a/packages/monopi__subagents/command-registration.ts
+++ b/packages/monopi__subagents/command-registration.ts
@@ -20,6 +20,7 @@ interface ParsedStep {
 interface RegisterSubagentCommandsOptions {
 	getBaseCwd: () => string;
 	openAgentManager: (ctx: ExtensionContext) => Promise<void>;
+	openFleetInspector: (ctx: ExtensionContext) => Promise<void>;
 }
 
 function parseInlineConfig(raw: string): InlineConfig {
@@ -209,6 +210,13 @@ export function registerSubagentCommands(pi: ExtensionAPI, options: RegisterSuba
 		description: "Open the Agents Manager",
 		handler: async (_args, ctx) => {
 			await options.openAgentManager(ctx);
+		},
+	});
+
+	pi.registerCommand("fleet", {
+		description: "Toggle between running subagents and inspect their live output",
+		handler: async (_args, ctx) => {
+			await options.openFleetInspector(ctx);
 		},
 	});
 

--- a/packages/monopi__subagents/fleet-inspector.ts
+++ b/packages/monopi__subagents/fleet-inspector.ts
@@ -1,0 +1,556 @@
+/**
+ * Fleet Inspector — interactive overlay for toggling between subagent runs
+ * and watching their live activity.
+ *
+ * Two screens:
+ * - "list": every async subagent run with status, step progress and freshness
+ * - "detail": one run's steps plus a live output tail
+ *
+ * Navigation mirrors upstream pi-subagents' fleet view and OpenCode's
+ * subagent switcher: j/k or arrows to move between runs, enter/right to
+ * inspect, left/esc to go back.
+ */
+
+import type { Theme } from "@earendil-works/pi-coding-agent";
+import type { Component, TUI } from "@earendil-works/pi-tui";
+
+import { matchesKey } from "@earendil-works/pi-tui";
+
+import type { AsyncJobState, AsyncStatus } from "./types.js";
+
+import { formatDuration, formatTokens } from "./formatters.js";
+import { pad, renderFooter, renderHeader, row } from "./render-helpers.js";
+import { getLastActivity, getOutputTail, readStatus } from "./utils.js";
+
+// ============================================================================
+// Types
+// ============================================================================
+
+export interface FleetStepView {
+	agent: string;
+	status: string;
+	durationMs?: number;
+	tokens?: number;
+	error?: string;
+}
+
+export interface FleetJobView {
+	asyncId: string;
+	status: AsyncJobState["status"];
+	mode?: string;
+	agents?: string[];
+	currentStep?: number;
+	stepsTotal: number;
+	startedAt?: number;
+	updatedAt?: number;
+	totalTokens?: number;
+	activity: string;
+	outputFile?: string;
+	sessionFile?: string;
+	steps: FleetStepView[];
+}
+
+export type FleetScreen = "list" | "detail";
+
+export interface FleetState {
+	screen: FleetScreen;
+	cursor: number;
+	scrollOffset: number;
+	selectedId: string | null;
+	expandedOutput: boolean;
+}
+
+export type FleetAction =
+	| { type: "close" }
+	| { type: "open-detail" }
+	| { type: "back" }
+	| { type: "toggle-output" }
+	| { type: "refresh" };
+
+const LIST_VIEWPORT_HEIGHT = 10;
+const COLLAPSED_TAIL_LINES = 3;
+const EXPANDED_TAIL_LINES = 14;
+
+export function createFleetState(): FleetState {
+	return {
+		cursor: 0,
+		expandedOutput: false,
+		scrollOffset: 0,
+		screen: "list",
+		selectedId: null,
+	};
+}
+
+// ============================================================================
+// Snapshot building
+// ============================================================================
+
+const STATUS_PRIORITY: Record<AsyncJobState["status"], number> = {
+	complete: 2,
+	failed: 1,
+	queued: 0,
+	running: 0,
+};
+
+/**
+ * Build sorted, display-ready job views from the live async job map.
+ * Active runs come first (launch order), then failed, then completed.
+ */
+export function buildFleetJobs(jobs: AsyncJobState[], now: number = Date.now()): FleetJobView[] {
+	const views: FleetJobView[] = [];
+	for (const job of jobs) {
+		const status: AsyncStatus | null = readStatus(job.asyncDir);
+		const steps: FleetStepView[] = (status?.steps ?? []).map((step) => ({
+			agent: step.agent,
+			durationMs: step.durationMs,
+			error: step.error,
+			status: step.status,
+			tokens: step.tokens?.total,
+		}));
+		const endTime = job.status === "complete" || job.status === "failed" ? (job.updatedAt ?? now) : now;
+		const outputFile = status?.outputFile ?? job.outputFile;
+		views.push({
+			activity: job.status === "running" ? getLastActivity(outputFile) || "starting" : "",
+			agents: job.agents,
+			asyncId: job.asyncId,
+			currentStep: status?.currentStep ?? job.currentStep,
+			mode: status?.mode ?? job.mode,
+			outputFile,
+			sessionFile: status?.sessionFile ?? job.sessionFile,
+			startedAt: status?.startedAt ?? job.startedAt,
+			status: job.status,
+			steps,
+			stepsTotal: status?.steps?.length ?? job.stepsTotal ?? job.agents?.length ?? 1,
+			totalTokens: status?.totalTokens?.total ?? job.totalTokens?.total,
+			updatedAt: endTime,
+		});
+	}
+	return views.sort((a, b) => {
+		const priorityDiff = STATUS_PRIORITY[a.status] - STATUS_PRIORITY[b.status];
+		if (priorityDiff !== 0) {
+			return priorityDiff;
+		}
+		return (a.startedAt ?? 0) - (b.startedAt ?? 0);
+	});
+}
+
+function clampCursor(state: FleetState, count: number): void {
+	if (count === 0) {
+		state.cursor = 0;
+		state.scrollOffset = 0;
+		return;
+	}
+	if (state.cursor < 0) {
+		state.cursor = 0;
+	}
+	if (state.cursor >= count) {
+		state.cursor = count - 1;
+	}
+	if (state.cursor < state.scrollOffset) {
+		state.scrollOffset = state.cursor;
+	}
+	if (state.cursor >= state.scrollOffset + LIST_VIEWPORT_HEIGHT) {
+		state.scrollOffset = state.cursor - LIST_VIEWPORT_HEIGHT + 1;
+	}
+}
+
+/** Resolve the currently selected job, keeping selection stable across refreshes. */
+export function selectedJob(state: FleetState, jobs: FleetJobView[]): FleetJobView | undefined {
+	clampCursor(state, jobs.length);
+	const job = jobs[state.cursor];
+	if (job) {
+		state.selectedId = job.asyncId;
+	}
+	return job;
+}
+
+// ============================================================================
+// Input handling
+// ============================================================================
+
+/**
+ * Handle a keypress. Mutates cursor/scroll position; returns an action for
+ * anything the caller must perform (screen switches, close, refresh).
+ */
+export function handleFleetInput(state: FleetState, jobs: FleetJobView[], data: string): FleetAction | undefined {
+	if (matchesKey(data, "escape") || matchesKey(data, "ctrl+c")) {
+		if (state.screen === "detail") {
+			return { type: "back" };
+		}
+		return { type: "close" };
+	}
+
+	if (state.screen === "list") {
+		if (matchesKey(data, "return") || matchesKey(data, "right")) {
+			if (jobs.length > 0) {
+				return { type: "open-detail" };
+			}
+			return;
+		}
+	} else if (state.screen === "detail") {
+		if (matchesKey(data, "left") || matchesKey(data, "backspace")) {
+			return { type: "back" };
+		}
+		if (matchesKey(data, "x") || matchesKey(data, "ctrl+o")) {
+			return { type: "toggle-output" };
+		}
+	}
+
+	if (matchesKey(data, "up") || matchesKey(data, "k")) {
+		state.cursor -= 1;
+		clampCursor(state, jobs.length);
+		return;
+	}
+	if (matchesKey(data, "down") || matchesKey(data, "j")) {
+		state.cursor += 1;
+		clampCursor(state, jobs.length);
+		return;
+	}
+	if (matchesKey(data, "pageUp")) {
+		state.cursor -= LIST_VIEWPORT_HEIGHT;
+		clampCursor(state, jobs.length);
+		return;
+	}
+	if (matchesKey(data, "pageDown")) {
+		state.cursor += LIST_VIEWPORT_HEIGHT;
+		clampCursor(state, jobs.length);
+		return;
+	}
+	if (matchesKey(data, "r")) {
+		return { type: "refresh" };
+	}
+
+	if (state.screen === "list" && matchesKey(data, "q")) {
+		return { type: "close" };
+	}
+
+	return undefined;
+}
+
+// ============================================================================
+// Rendering
+// ============================================================================
+
+function statusIcon(status: FleetJobView["status"], theme: Theme): string {
+	switch (status) {
+		case "running":
+			return theme.fg("warning", "●");
+		case "queued":
+			return theme.fg("dim", "○");
+		case "failed":
+			return theme.fg("error", "✗");
+		default:
+			return theme.fg("success", "●");
+	}
+}
+
+function statusLabel(status: FleetJobStateLabel, theme: Theme): string {
+	const labels: Record<FleetJobStateLabel, string> = {
+		complete: "done",
+		failed: "failed",
+		queued: "queued",
+		running: "running",
+	};
+	const colors: Record<FleetJobStateLabel, Parameters<Theme["fg"]>[0]> = {
+		complete: "success",
+		failed: "error",
+		queued: "dim",
+		running: "warning",
+	};
+	return theme.fg(colors[status], labels[status]);
+}
+
+type FleetJobStateLabel = AsyncJobState["status"];
+
+function elapsedLabel(job: FleetJobView, now: number): string {
+	if (!job.startedAt) {
+		return "";
+	}
+	const end = job.status === "complete" || job.status === "failed" ? (job.updatedAt ?? now) : now;
+	return formatDuration(end - job.startedAt);
+}
+
+function agentChain(job: FleetJobView, theme: Theme): string {
+	const agents = job.agents ?? [];
+	if (agents.length === 0) {
+		return job.mode ?? "run";
+	}
+	const parts: string[] = [];
+	for (let i = 0; i < agents.length; i++) {
+		const stepStatus = job.steps[i]?.status;
+		let icon = theme.fg("dim", "○");
+		if (stepStatus === "running") {
+			icon = theme.fg("warning", "●");
+		} else if (stepStatus === "complete") {
+			icon = theme.fg("success", "●");
+		} else if (stepStatus === "failed") {
+			icon = theme.fg("error", "✗");
+		} else if (!job.steps.length && i <= (job.currentStep ?? -1)) {
+			icon = theme.fg("warning", "●");
+		}
+		parts.push(`${icon} ${agents[i]}`);
+	}
+	return parts.join(theme.fg("dim", " → "));
+}
+
+export function renderFleetList(
+	state: FleetState,
+	jobs: FleetJobView[],
+	width: number,
+	theme: Theme,
+	now: number = Date.now(),
+): string[] {
+	clampCursor(state, jobs.length);
+	const activeCount = jobs.filter((j) => j.status === "running" || j.status === "queued").length;
+	const lines: string[] = [];
+	lines.push(renderHeader(` Subagent fleet [${activeCount} active / ${jobs.length}] `, width, theme));
+	lines.push(row("", width, theme));
+
+	const startIdx = state.scrollOffset;
+	const endIdx = Math.min(jobs.length, startIdx + LIST_VIEWPORT_HEIGHT);
+
+	if (jobs.length === 0) {
+		lines.push(row(` ${theme.fg("dim", "No subagent activity")}`, width, theme));
+		for (let i = 1; i < LIST_VIEWPORT_HEIGHT; i++) {
+			lines.push(row("", width, theme));
+		}
+	} else {
+		const innerW = width - 8;
+		for (let i = startIdx; i < endIdx; i++) {
+			const job = jobs[i]!;
+			const isCursor = i === state.cursor;
+			const cursorChar = isCursor ? theme.fg("accent", "▸") : " ";
+			const icon = statusIcon(job.status, theme);
+			const chain = agentChain(job, theme);
+			const meta: string[] = [];
+			const stepsTotal = job.stepsTotal;
+			if (stepsTotal > 1 && job.currentStep !== undefined) {
+				meta.push(`step ${Math.min(job.currentStep + 1, stepsTotal)}/${stepsTotal}`);
+			} else if (stepsTotal > 1) {
+				meta.push(`${stepsTotal} steps`);
+			}
+			const elapsed = elapsedLabel(job, now);
+			if (elapsed) {
+				meta.push(elapsed);
+			}
+			if (job.totalTokens) {
+				meta.push(`${formatTokens(job.totalTokens)} tok`);
+			}
+			if (job.activity) {
+				meta.push(job.activity);
+			}
+			let line = `${cursorChar} ${icon} ${chain} ${theme.fg("dim", `· ${meta.join(" · ")}`)}`;
+			if (visibleWidthSafe(line) > innerW) {
+				line = truncateAnsi(line, innerW);
+			}
+			lines.push(row(` ${line}`, width, theme));
+		}
+		for (let i = jobs.length; i < startIdx + LIST_VIEWPORT_HEIGHT; i++) {
+			if (i >= endIdx) {
+				lines.push(row("", width, theme));
+			}
+		}
+	}
+
+	const hint = jobs.length ? " ↑↓/jk select · enter inspect · r refresh · esc close " : " esc close ";
+	lines.push(renderFooter(hint, width, theme));
+	return lines;
+}
+
+export function renderFleetDetail(
+	state: FleetState,
+	job: FleetJobView | undefined,
+	width: number,
+	theme: Theme,
+	now: number = Date.now(),
+): string[] {
+	const lines: string[] = [];
+	const id = job?.asyncId.slice(0, 6) ?? "------";
+	lines.push(renderHeader(` Subagent detail [${id}] `, width, theme));
+
+	if (!job) {
+		lines.push(row("", width, theme));
+		lines.push(row(` ${theme.fg("dim", "Run no longer active")}`, width, theme));
+		lines.push(row("", width, theme));
+		lines.push(renderFooter(" ← back · esc close ", width, theme));
+		return lines;
+	}
+
+	lines.push(row("", width, theme));
+	const icon = statusIcon(job.status, theme);
+	const label = statusLabel(job.status, theme);
+	const elapsed = elapsedLabel(job, now);
+	const tokensText = job.totalTokens ? ` · ${formatTokens(job.totalTokens)} tok` : "";
+	lines.push(row(` ${icon} ${theme.bold(agentChainPlain(job))} ${label}${tokensText}`, width, theme));
+	if (elapsed) {
+		lines.push(row(`   ${theme.fg("dim", `elapsed ${elapsed}`)}`, width, theme));
+	}
+
+	if (job.steps.length > 0) {
+		lines.push(row("", width, theme));
+		for (let i = 0; i < job.steps.length; i++) {
+			const step = job.steps[i]!;
+			const isCurrent = i === job.currentStep;
+			const marker = isCurrent ? theme.fg("accent", "▸") : " ";
+			const stepIcon = statusIcon(
+				step.status === "complete"
+					? "complete"
+					: step.status === "failed"
+						? "failed"
+						: step.status === "running"
+							? "running"
+							: "queued",
+				theme,
+			);
+			const bits: string[] = [];
+			if (step.durationMs !== undefined) {
+				bits.push(formatDuration(step.durationMs));
+			}
+			if (step.tokens !== undefined) {
+				bits.push(`${formatTokens(step.tokens)} tok`);
+			}
+			const suffix = bits.length ? theme.fg("dim", ` · ${bits.join(" · ")}`) : "";
+			lines.push(row(` ${marker} ${stepIcon} ${pad(step.agent, 16)}${suffix}`, width, theme));
+			if (step.error) {
+				lines.push(row(`     ${theme.fg("error", truncateAnsi(step.error, width - 9))}`, width, theme));
+			}
+		}
+	}
+
+	const tailLines = getOutputTail(job.outputFile, state.expandedOutput ? EXPANDED_TAIL_LINES : COLLAPSED_TAIL_LINES);
+	if (tailLines.length > 0 || job.status === "running") {
+		lines.push(row("", width, theme));
+		lines.push(
+			row(` ${theme.fg("dim", `output (${state.expandedOutput ? "x collapse" : "x expand"})`)}`, width, theme),
+		);
+		if (tailLines.length === 0) {
+			lines.push(row(`   ${theme.fg("dim", "waiting for output…")}`, width, theme));
+		}
+		for (const tailLine of tailLines) {
+			for (const wrapped of tailLine.split("\n")) {
+				lines.push(row(`   ${theme.fg("dim", truncateAnsi(wrapped, width - 7))}`, width, theme));
+			}
+		}
+	}
+
+	lines.push(row("", width, theme));
+	lines.push(renderFooter(" ← back · x output · r refresh · esc close ", width, theme));
+	return lines;
+}
+
+function agentChainPlain(job: FleetJobView): string {
+	return job.agents?.length ? job.agents.join(" → ") : (job.mode ?? "run");
+}
+
+// Minimal ANSI-aware helpers (avoid importing render.ts internals)
+// Hoisted per repo performance rules (no per-call RegExp compilation)
+const ANSI_REGEX = /\x1B\[[0-9;]*m/g;
+const ANSI_PREFIX_REGEX = /^\x1B\[[0-9;]*m/;
+
+function visibleWidthSafe(text: string): number {
+	return text.replace(ANSI_REGEX, "").length;
+}
+
+function truncateAnsi(text: string, maxWidth: number): string {
+	if (visibleWidthSafe(text) <= maxWidth) {
+		return text;
+	}
+	let result = "";
+	let width = 0;
+	let i = 0;
+	while (i < text.length) {
+		const match = ANSI_PREFIX_REGEX.exec(text.slice(i));
+		if (match) {
+			result += match[0];
+			i += match[0].length;
+			continue;
+		}
+		result += text[i]!;
+		width++;
+		i++;
+		if (width >= maxWidth - 1) {
+			return `${result}…`;
+		}
+	}
+	return result;
+}
+
+// ============================================================================
+// Component
+// ============================================================================
+
+export class FleetInspectorComponent implements Component {
+	private jobs: FleetJobView[] = [];
+	private pollTimer: ReturnType<typeof setInterval> | null = null;
+
+	constructor(
+		private readonly tui: TUI,
+		private readonly theme: Theme,
+		private readonly state: FleetState,
+		private readonly getJobs: () => AsyncJobState[],
+		private readonly done: (result: boolean) => void,
+	) {
+		this.refresh();
+		this.pollTimer = setInterval(() => this.refresh(), 500);
+		this.pollTimer.unref?.();
+	}
+
+	refresh(): void {
+		this.jobs = buildFleetJobs(this.getJobs());
+		if (this.state.selectedId && !this.jobs.some((j) => j.asyncId === this.state.selectedId)) {
+			this.state.selectedId = null;
+		}
+		this.tui.requestRender();
+	}
+
+	dispose(): void {
+		if (this.pollTimer) {
+			clearInterval(this.pollTimer);
+			this.pollTimer = null;
+		}
+	}
+
+	handleInput(data: string): void {
+		const action = handleFleetInput(this.state, this.jobs, data);
+		if (!action) {
+			this.tui.requestRender();
+			return;
+		}
+		switch (action.type) {
+			case "close":
+				this.dispose();
+				this.done(true);
+				break;
+			case "open-detail": {
+				const job = selectedJob(this.state, this.jobs);
+				if (job) {
+					this.state.screen = "detail";
+					this.state.expandedOutput = false;
+					this.state.selectedId = job.asyncId;
+				}
+				break;
+			}
+			case "back":
+				this.state.screen = "list";
+				this.state.expandedOutput = false;
+				break;
+			case "toggle-output":
+				this.state.expandedOutput = !this.state.expandedOutput;
+				break;
+			case "refresh":
+				this.refresh();
+				break;
+		}
+		this.tui.requestRender();
+	}
+
+	render(width: number): string[] {
+		if (this.state.screen === "detail") {
+			const job = this.jobs.find((j) => j.asyncId === this.state.selectedId) ?? selectedJob(this.state, this.jobs);
+			return renderFleetDetail(this.state, job, width, this.theme);
+		}
+		return renderFleetList(this.state, this.jobs, width, this.theme);
+	}
+
+	invalidate(): void {}
+}

--- a/packages/monopi__subagents/fleet-inspector.ts
+++ b/packages/monopi__subagents/fleet-inspector.ts
@@ -472,7 +472,9 @@ function truncateAnsi(text: string, maxWidth: number): string {
 			return `${result}…`;
 		}
 	}
-	return result;
+	// Unreachable: entering the loop requires visibleWidth > maxWidth, so the
+	// check above always returns before every visible char is consumed.
+	return result; // patch-coverage-ignore
 }
 
 // ============================================================================

--- a/packages/monopi__subagents/index.ts
+++ b/packages/monopi__subagents/index.ts
@@ -46,6 +46,7 @@ import { registerSubagentCommands } from "./command-registration.js";
 import { createDynamicAgent } from "./dynamic-agent.js";
 import { runSync } from "./execution.js";
 import { closeExternalAgentWatchers, parseStringList, resolveExternalAgent } from "./external-agents.js";
+import { createFleetState, FleetInspectorComponent } from "./fleet-inspector.js";
 import { resolveSubagentLimits } from "./limits.js";
 import { resolveSubagentModelResolution, toAvailableModelRefs } from "./model-routing.js";
 import { renderSubagentResult, renderWidget } from "./render.js";
@@ -1209,6 +1210,21 @@ MANAGEMENT (use action field, omit agent/task/chain/tasks):
 		};
 	};
 
+	const openFleetInspector = async (ctx: ExtensionContext) => {
+		if (!ctx.hasUI) {
+			ctx.ui.notify("Fleet inspector requires a TUI session", "error");
+			return;
+		}
+		await ctx.ui.custom<boolean>(
+			(tui, theme, _kb, done) =>
+				new FleetInspectorComponent(tui, theme, createFleetState(), () => [...asyncJobs.values()], done),
+			{
+				overlay: true,
+				overlayOptions: { anchor: "center", maxHeight: "80%", width: 84 },
+			},
+		);
+	};
+
 	const openAgentManager = async (ctx: ExtensionContext) => {
 		const agentData = { ...discoverAgentsAll(ctx.cwd), cwd: ctx.cwd };
 		const models = ctx.modelRegistry.getAvailable().map((m) => ({
@@ -1326,11 +1342,19 @@ MANAGEMENT (use action field, omit agent/task/chain/tasks):
 	registerSubagentCommands(pi, {
 		getBaseCwd: () => baseCwd,
 		openAgentManager,
+		openFleetInspector,
 	});
 
 	pi.registerShortcut("ctrl+shift+a", {
 		handler: async (ctx) => {
 			await openAgentManager(ctx);
+		},
+	});
+
+	// Same key as upstream pi-subagents' fleet inspector; free in pi defaults.
+	pi.registerShortcut("ctrl+alt+f", {
+		handler: async (ctx) => {
+			await openFleetInspector(ctx);
 		},
 	});
 

--- a/packages/monopi__subagents/render.ts
+++ b/packages/monopi__subagents/render.ts
@@ -169,7 +169,7 @@ export function renderWidget(
 	const { theme } = ctx.ui;
 	const w = getTermWidth();
 	const lines: string[] = [];
-	lines.push(theme.fg("accent", "Async subagents"));
+	lines.push(truncLine(`${theme.fg("accent", "Async subagents")} ${theme.fg("dim", "· ctrl+alt+f fleet")}`, w));
 
 	for (const job of displayedJobs) {
 		const id = job.asyncId.slice(0, 6);

--- a/packages/monopi__subagents/tests/command-registration.test.ts
+++ b/packages/monopi__subagents/tests/command-registration.test.ts
@@ -37,6 +37,19 @@ function createCtx() {
 }
 
 describe("registerSubagentCommands", () => {
+	it("opens the fleet inspector from /fleet", async () => {
+		const pi = createPi();
+		const openFleetInspector = vi.fn(async () => {});
+		registerSubagentCommands(pi as never, {
+			getBaseCwd: () => "/repo",
+			openAgentManager: vi.fn(),
+			openFleetInspector,
+		});
+
+		await pi.commands.get("fleet").handler("", {});
+		expect(openFleetInspector).toHaveBeenCalledTimes(1);
+	});
+
 	it("opens the agent manager and offers agent completions", async () => {
 		discoverAgentsMock.mockReturnValue({
 			agents: [{ name: "scout" }, { name: "planner" }, { name: "reviewer" }],

--- a/packages/monopi__subagents/tests/command-registration.test.ts
+++ b/packages/monopi__subagents/tests/command-registration.test.ts
@@ -46,6 +46,7 @@ describe("registerSubagentCommands", () => {
 		registerSubagentCommands(pi as never, {
 			getBaseCwd: () => "/repo",
 			openAgentManager,
+			openFleetInspector: vi.fn(async () => {}),
 		});
 
 		await pi.commands.get("agents").handler("", {});
@@ -64,6 +65,7 @@ describe("registerSubagentCommands", () => {
 		registerSubagentCommands(pi as never, {
 			getBaseCwd: () => "/repo",
 			openAgentManager: vi.fn(),
+			openFleetInspector: vi.fn(),
 		});
 
 		await pi.commands.get("run").handler("unknown investigate", ctx);
@@ -98,6 +100,7 @@ describe("registerSubagentCommands", () => {
 		registerSubagentCommands(pi as never, {
 			getBaseCwd: () => "/repo",
 			openAgentManager: vi.fn(),
+			openFleetInspector: vi.fn(),
 		});
 
 		await pi.commands
@@ -129,6 +132,7 @@ describe("registerSubagentCommands", () => {
 		registerSubagentCommands(pi as never, {
 			getBaseCwd: () => "/repo",
 			openAgentManager: vi.fn(),
+			openFleetInspector: vi.fn(),
 		});
 
 		await pi.commands.get("parallel").handler('scout "inspect" -> planner "plan" -> reviewer "review"', ctx);

--- a/packages/monopi__subagents/tests/fleet-inspector-smoke.mts
+++ b/packages/monopi__subagents/tests/fleet-inspector-smoke.mts
@@ -1,0 +1,85 @@
+/**
+ * Smoke check for the fleet inspector against real on-disk run artifacts
+ * (status.json + output log), bypassing all unit-test mocks.
+ *
+ * Run with: pnpm exec tsx tests/fleet-inspector-smoke.mts
+ */
+import * as fs from "node:fs";
+import * as os from "node:os";
+import * as path from "node:path";
+
+import { buildFleetJobs, createFleetState, FleetInspectorComponent } from "../fleet-inspector.js";
+import { ASYNC_DIR } from "../types.js";
+
+const tmp = fs.mkdtempSync(path.join(os.tmpdir(), "fleet-smoke-"));
+const runDir = path.join(ASYNC_DIR, "smokerun123");
+fs.mkdirSync(runDir, { recursive: true });
+fs.writeFileSync(
+	path.join(runDir, "status.json"),
+	JSON.stringify({
+		currentStep: 1,
+		cwd: tmp,
+		lastUpdate: Date.now(),
+		mode: "chain",
+		outputFile: path.join(runDir, "output-1.log"),
+		pid: process.pid,
+		runId: "smokerun123",
+		startedAt: Date.now() - 8_000,
+		state: "running",
+		steps: [
+			{
+				agent: "scout",
+				durationMs: 4_200,
+				endedAt: Date.now() - 3_000,
+				startedAt: Date.now() - 8_000,
+				status: "complete",
+			},
+			{ agent: "planner", status: "running" },
+		],
+		totalTokens: { input: 100, output: 50, total: 150 },
+	}),
+);
+fs.writeFileSync(path.join(runDir, "output-1.log"), "thinking about the plan\nreading src/index.ts\ndrafting steps\n");
+
+try {
+	const jobs = buildFleetJobs([
+		{
+			asyncDir: runDir,
+			asyncId: "smokerun123",
+			status: "running",
+		},
+	]);
+	if (jobs[0]!.steps.length !== 2 || jobs[0]!.totalTokens !== 150) {
+		throw new Error(`unexpected snapshot: ${JSON.stringify(jobs[0])}`);
+	}
+
+	class FakeTui {
+		requestRender(): void {}
+	}
+	const theme = {
+		bold: (t: string) => t,
+		fg: (_c: string, t: string) => t,
+	};
+	const component = new FleetInspectorComponent(
+		new FakeTui() as never,
+		theme as never,
+		createFleetState(),
+		() => [{ asyncDir: runDir, asyncId: "smokerun123", status: "running" }],
+		() => {},
+	);
+
+	const list = component.render(84);
+	console.log(list.join("\n"));
+
+	component.handleInput("\r");
+	const detail = component.render(84);
+	console.log(detail.join("\n"));
+	if (!detail.join("\n").includes("reading src/index.ts")) {
+		throw new Error("detail view did not show live output tail");
+	}
+	component.dispose();
+	console.log("\nSMOKE OK");
+} finally {
+	fs.rmSync(tmp, { recursive: true, force: true });
+	fs.rmSync(path.join(ASYNC_DIR, "smokerun123"), { recursive: true, force: true });
+}

--- a/packages/monopi__subagents/tests/fleet-inspector.test.ts
+++ b/packages/monopi__subagents/tests/fleet-inspector.test.ts
@@ -107,6 +107,14 @@ describe("buildFleetJobs", () => {
 			steps: [],
 		});
 	});
+
+	it("breaks priority ties by start time", () => {
+		utilsMocks.readStatus.mockReturnValue(null);
+		const later = makeJob({ asyncId: "late", startedAt: 3_000 });
+		const earlier = makeJob({ asyncId: "early", startedAt: 1_000 });
+		const jobs = buildFleetJobs([later, earlier], NOW);
+		expect(jobs.map((j) => j.asyncId)).toEqual(["early", "late"]);
+	});
 });
 
 describe("handleFleetInput", () => {
@@ -162,6 +170,156 @@ describe("handleFleetInput", () => {
 		expect(handleFleetInput(state, jobs, "\x7F")).toEqual({ type: "back" });
 		expect(handleFleetInput(state, jobs, "x")).toEqual({ type: "toggle-output" });
 		expect(handleFleetInput(state, jobs, "\x0F")).toEqual({ type: "toggle-output" });
+	});
+
+	it("pages up and down by viewport height", () => {
+		const { jobs, state } = stateWithJobs(14);
+
+		handleFleetInput(state, jobs, "\x1B[6~");
+		expect(state.cursor).toBe(10);
+		handleFleetInput(state, jobs, "\x1B[6~");
+		expect(state.cursor).toBe(13);
+		handleFleetInput(state, jobs, "\x1B[5~");
+		expect(state.cursor).toBe(3);
+		handleFleetInput(state, jobs, "\x1B[5~");
+		expect(state.cursor).toBe(0);
+	});
+
+	it("scrolls the viewport to keep the cursor visible", () => {
+		const state = createFleetState();
+		const jobs: FleetJobView[] = Array.from({ length: 12 }, (_, i) => ({
+			asyncId: `job-${i}`,
+			status: "running",
+			activity: "",
+			steps: [],
+			stepsTotal: 1,
+		}));
+
+		state.cursor = 11;
+		selectedJob(state, jobs);
+		expect(state.scrollOffset).toBe(2);
+
+		state.cursor = 1;
+		selectedJob(state, jobs);
+		expect(state.scrollOffset).toBe(1);
+	});
+
+	it("renders queued/failed icons, mode fallback chains and step counts", () => {
+		const views: FleetJobView[] = [
+			{
+				activity: "",
+				agents: [],
+				asyncId: "queued-job",
+				mode: "single",
+				status: "queued",
+				steps: [],
+				stepsTotal: 1,
+			},
+			{
+				activity: "",
+				agents: ["scout", "planner"],
+				asyncId: "failed-job",
+				currentStep: 1,
+				status: "failed",
+				steps: [
+					{ agent: "scout", status: "complete" },
+					{ agent: "planner", error: "boom", status: "failed" },
+				],
+				stepsTotal: 2,
+			},
+			{
+				activity: "",
+				agents: ["scout"],
+				asyncId: "no-step-details",
+				currentStep: 0,
+				status: "running",
+				steps: [],
+				stepsTotal: 1,
+			},
+			{
+				activity: "",
+				agents: ["a", "b", "c"],
+				asyncId: "count-only",
+				startedAt: NOW - 5_000,
+				status: "complete",
+				steps: [],
+				stepsTotal: 3,
+				updatedAt: NOW - 1_000,
+			},
+			{
+				activity: "",
+				agents: [],
+				asyncId: "never-started",
+				mode: undefined,
+				status: "queued",
+				steps: [],
+				stepsTotal: 1,
+			},
+		];
+
+		const lines = renderFleetList(createFleetState(), views, 84, theme, NOW);
+		const text = lines.join("\n");
+		expect(text).toContain("○ single");
+		expect(text).toContain("✗ planner");
+		expect(text).toContain("● scout");
+		expect(text).toContain("3 steps");
+	});
+
+	it("omits elapsed labels for runs without a start time", () => {
+		utilsMocks.getOutputTail.mockReturnValue([]);
+		const job: FleetJobView = {
+			activity: "",
+			agents: [],
+			asyncId: "never-started",
+			status: "queued",
+			steps: [],
+			stepsTotal: 1,
+		};
+
+		const text = renderFleetDetail({ ...createFleetState(), screen: "detail" }, job, 84, theme, NOW).join("\n");
+		expect(text).toContain("queued");
+		expect(text).not.toContain("elapsed");
+	});
+
+	it("truncates long rows to the available width", () => {
+		const views: FleetJobView[] = [
+			{
+				activity: "doing lots of work right now indeed yes",
+				agents: ["verylongagentname", "anotherlongone"],
+				asyncId: "wide-job",
+				currentStep: 0,
+				startedAt: NOW - 90_000,
+				status: "running",
+				steps: [],
+				stepsTotal: 1,
+			},
+		];
+
+		const lines = renderFleetList(createFleetState(), views, 30, theme, NOW);
+		expect(lines.join("\n")).toContain("…");
+	});
+
+	it("shows failed step errors and truncates ANSI-colored output tails in detail", () => {
+		utilsMocks.getOutputTail.mockReturnValue(["\x1B[31mthis output line is long enough to need truncation\x1B[0m"]);
+		const job: FleetJobView = {
+			activity: "",
+			agents: ["scout"],
+			asyncId: "err-job-123456",
+			currentStep: 0,
+			outputFile: "/tmp/out.log",
+			startedAt: NOW - 2_000,
+			status: "failed",
+			steps: [{ agent: "scout", durationMs: 500, error: "kaboom: unexpected failure", status: "failed", tokens: 10 }],
+			stepsTotal: 1,
+			updatedAt: NOW,
+		};
+
+		const state = createFleetState();
+		state.screen = "detail";
+		state.selectedId = job.asyncId;
+		const text = renderFleetDetail(state, job, 20, theme, NOW).join("\n");
+		expect(text).toContain("kaboom");
+		expect(text).toContain("…");
 	});
 
 	it("r refreshes anywhere and q closes only from list", () => {
@@ -320,5 +478,30 @@ describe("FleetInspectorComponent", () => {
 		setJobs([]);
 		component.refresh();
 		expect(component.render(84).join("\n")).toContain("Run no longer active");
+	});
+
+	it("renders the list screen from the component", () => {
+		const { component } = makeComponent([makeJob()]);
+		const text = component.render(84).join("\n");
+		expect(text).toContain("Subagent fleet");
+		expect(text).toContain("▸ ● ● scout");
+	});
+
+	it("re-renders without acting on unmapped keys", () => {
+		const { component, tui } = makeComponent([makeJob()]);
+		component.handleInput("z");
+		expect(component["state"].screen).toBe("list");
+		expect(tui.requestRender).toHaveBeenCalled();
+	});
+
+	it("toggles output expansion and refreshes on demand", () => {
+		const { component } = makeComponent([makeJob()]);
+		component.handleInput("\r");
+		component.handleInput("x");
+		expect(component["state"].expandedOutput).toBe(true);
+		component.handleInput("x");
+		expect(component["state"].expandedOutput).toBe(false);
+		component.handleInput("r");
+		expect(component["state"].screen).toBe("detail");
 	});
 });

--- a/packages/monopi__subagents/tests/fleet-inspector.test.ts
+++ b/packages/monopi__subagents/tests/fleet-inspector.test.ts
@@ -1,0 +1,324 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+
+const utilsMocks = vi.hoisted(() => ({
+	readStatus: vi.fn(),
+	getOutputTail: vi.fn(() => [] as string[]),
+	getLastActivity: vi.fn(() => "active now"),
+}));
+
+vi.mock("../utils.js", () => utilsMocks);
+
+vi.mock("../formatters.js", () => ({
+	formatDuration: (value: number) => `${value}ms`,
+	formatTokens: (value: number) => `${value}t`,
+	formatToolCall: (name: string) => `tool:${name}`,
+	formatUsage: () => "usage",
+	shortenPath: (value: string) => value,
+}));
+
+import type { AsyncJobState } from "../types.js";
+
+import {
+	buildFleetJobs,
+	createFleetState,
+	FleetInspectorComponent,
+	handleFleetInput,
+	renderFleetDetail,
+	renderFleetList,
+	selectedJob,
+	type FleetJobView,
+	type FleetState,
+} from "../fleet-inspector.js";
+
+function makeJob(overrides: Partial<AsyncJobState> = {}): AsyncJobState {
+	return {
+		asyncDir: "/tmp/run-1",
+		asyncId: "abcdef1234567890",
+		status: "running",
+		startedAt: 1_000,
+		updatedAt: 2_000,
+		stepsTotal: 2,
+		agents: ["scout", "planner"],
+		currentStep: 0,
+		...overrides,
+	};
+}
+
+const NOW = 10_000;
+const theme = {
+	bold: (text: string) => `\u0001${text}\u0001`,
+	fg: (_color: string, text: string) => text,
+};
+
+beforeEach(() => {
+	utilsMocks.readStatus.mockReset();
+	utilsMocks.getOutputTail.mockReset().mockReturnValue([]);
+	utilsMocks.getLastActivity.mockReset().mockReturnValue("active now");
+});
+
+describe("buildFleetJobs", () => {
+	it("merges status.json steps and sorts active runs before finished ones", () => {
+		const running = makeJob({ asyncId: "aaa", status: "running" });
+		const done = makeJob({
+			asyncId: "bbb",
+			status: "complete",
+			currentStep: undefined,
+			updatedAt: 5_000,
+		});
+		utilsMocks.readStatus.mockImplementation((dir: string) =>
+			dir === running.asyncDir
+				? {
+						currentStep: 1,
+						mode: "chain",
+						startedAt: 1_000,
+						state: "running",
+						steps: [
+							{ agent: "scout", durationMs: 4_000, status: "complete", tokens: { total: 120 } },
+							{ agent: "planner", error: "boom", status: "running" },
+						],
+						totalTokens: { input: 0, output: 0, total: 500 },
+					}
+				: null,
+		);
+
+		const jobs = buildFleetJobs([done, running], NOW);
+		expect(jobs.map((j) => j.asyncId)).toEqual(["aaa", "bbb"]);
+
+		const active = jobs[0]!;
+		expect(active.steps).toHaveLength(2);
+		expect(active.steps[0]).toMatchObject({ agent: "scout", tokens: 120 });
+		expect(active.steps[1]).toMatchObject({ agent: "planner", error: "boom" });
+		expect(active.currentStep).toBe(1);
+		expect(active.totalTokens).toBe(500);
+		expect(active.activity).toBe("active now");
+
+		const finished = jobs[1]!;
+		expect(finished.stepsTotal).toBe(2);
+		expect(finished.activity).toBe("");
+	});
+
+	it("falls back to job fields when status.json is missing", () => {
+		utilsMocks.readStatus.mockReturnValue(null);
+		const jobs = buildFleetJobs([makeJob()], NOW);
+		expect(jobs[0]).toMatchObject({
+			currentStep: 0,
+			status: "running",
+			stepsTotal: 2,
+			steps: [],
+		});
+	});
+});
+
+describe("handleFleetInput", () => {
+	function stateWithJobs(count: number): { state: FleetState; jobs: FleetJobView[] } {
+		const state = createFleetState();
+		const jobs: FleetJobView[] = Array.from({ length: count }, (_, i) => ({
+			asyncId: `job-${i}`,
+			status: "running",
+			activity: "",
+			steps: [],
+			stepsTotal: 1,
+		}));
+		return { jobs, state };
+	}
+
+	it("moves the cursor with arrows and vim keys, clamping at edges", () => {
+		const { jobs, state } = stateWithJobs(3);
+
+		handleFleetInput(state, jobs, "j");
+		expect(state.cursor).toBe(1);
+		handleFleetInput(state, jobs, "\x1B[B");
+		expect(state.cursor).toBe(2);
+		handleFleetInput(state, jobs, "\x1B[B");
+		expect(state.cursor).toBe(2);
+		handleFleetInput(state, jobs, "k");
+		expect(state.cursor).toBe(1);
+		handleFleetInput(state, jobs, "\x1B[A");
+		handleFleetInput(state, jobs, "\x1B[A");
+		expect(state.cursor).toBe(0);
+	});
+
+	it("opens detail from list with enter or right only when jobs exist", () => {
+		const { jobs, state } = stateWithJobs(2);
+		expect(handleFleetInput(state, jobs, "\r")).toEqual({ type: "open-detail" });
+		expect(handleFleetInput(state, jobs, "\x1B[C")).toEqual({ type: "open-detail" });
+
+		const empty = createFleetState();
+		expect(handleFleetInput(empty, [], "\r")).toBeUndefined();
+	});
+
+	it("escape closes from list but goes back from detail", () => {
+		const { jobs, state } = stateWithJobs(1);
+		expect(handleFleetInput(state, jobs, "\x1B")).toEqual({ type: "close" });
+
+		state.screen = "detail";
+		expect(handleFleetInput(state, jobs, "\x1B")).toEqual({ type: "back" });
+	});
+
+	it("left and backspace return from detail; x toggles output expansion", () => {
+		const { jobs, state } = stateWithJobs(1);
+		state.screen = "detail";
+		expect(handleFleetInput(state, jobs, "\x1B[D")).toEqual({ type: "back" });
+		expect(handleFleetInput(state, jobs, "\x7F")).toEqual({ type: "back" });
+		expect(handleFleetInput(state, jobs, "x")).toEqual({ type: "toggle-output" });
+		expect(handleFleetInput(state, jobs, "\x0F")).toEqual({ type: "toggle-output" });
+	});
+
+	it("r refreshes anywhere and q closes only from list", () => {
+		const { jobs, state } = stateWithJobs(1);
+		expect(handleFleetInput(state, jobs, "q")).toEqual({ type: "close" });
+		expect(handleFleetInput(state, jobs, "r")).toEqual({ type: "refresh" });
+
+		state.screen = "detail";
+		expect(handleFleetInput(state, jobs, "q")).toBeUndefined();
+		expect(handleFleetInput(state, jobs, "r")).toEqual({ type: "refresh" });
+	});
+});
+
+describe("selectedJob", () => {
+	it("tracks selection by id and clamps when jobs disappear", () => {
+		const state = createFleetState();
+		const jobs: FleetJobView[] = [
+			{ asyncId: "a", status: "complete", activity: "", steps: [], stepsTotal: 1 },
+			{ asyncId: "b", status: "running", activity: "", steps: [], stepsTotal: 1 },
+		];
+
+		state.cursor = 1;
+		expect(selectedJob(state, jobs)?.asyncId).toBe("b");
+		expect(state.selectedId).toBe("b");
+
+		state.cursor = 99;
+		expect(selectedJob(state, [jobs[0]!])?.asyncId).toBe("a");
+		expect(state.cursor).toBe(0);
+	});
+});
+
+describe("rendering", () => {
+	const jobs: FleetJobView[] = [
+		{
+			activity: "active now",
+			agents: ["scout", "planner"],
+			asyncId: "abc123final0000",
+			currentStep: 0,
+			mode: "chain",
+			outputFile: "/tmp/output.log",
+			startedAt: NOW - 5_000,
+			status: "running",
+			steps: [
+				{ agent: "scout", durationMs: 4_000, status: "complete", tokens: 900 },
+				{ agent: "planner", status: "running" },
+			],
+			stepsTotal: 2,
+			totalTokens: 900,
+		},
+	];
+
+	it("list shows header, cursor marker on selected row and footer hints", () => {
+		const state = createFleetState();
+		const lines = renderFleetList(state, jobs, 84, theme, NOW);
+		const text = lines.join("\n");
+		expect(text).toContain("Subagent fleet");
+		expect(text).toContain("scout");
+		expect(text).toContain("▸ ● ● scout");
+		expect(lines.at(-1)).toContain("enter inspect");
+	});
+
+	it("list shows an empty-state row without jobs", () => {
+		const lines = renderFleetList(createFleetState(), [], 84, theme, NOW);
+		expect(lines.join("\n")).toContain("No subagent activity");
+	});
+
+	it("detail shows step table, output section and back hint", () => {
+		utilsMocks.getOutputTail.mockReturnValue(["reading src/auth.ts"]);
+		const state = createFleetState();
+		state.screen = "detail";
+		state.selectedId = jobs[0]!.asyncId;
+
+		const lines = renderFleetDetail(state, jobs[0], 84, theme, NOW);
+		const text = lines.join("\n");
+		expect(text).toContain("Subagent detail [abc123]");
+		expect(text).toContain("scout");
+		expect(text).toContain("4000ms");
+		expect(text).toContain("900t tok");
+		expect(text).toContain("reading src/auth.ts");
+		expect(lines.at(-1)).toContain("← back");
+	});
+
+	it("detail handles a vanished run gracefully", () => {
+		const lines = renderFleetDetail(createFleetState(), undefined, 84, theme, NOW);
+		expect(lines.join("\n")).toContain("Run no longer active");
+	});
+});
+
+describe("FleetInspectorComponent", () => {
+	class FakeTui {
+		requestRender = vi.fn();
+	}
+
+	afterEach(() => {
+		vi.useRealTimers();
+	});
+
+	function makeComponent(jobList: AsyncJobState[]) {
+		const tui = new FakeTui();
+		const done = vi.fn();
+		let current = jobList;
+		const component = new FleetInspectorComponent(
+			tui as never,
+			theme as never,
+			createFleetState(),
+			() => current,
+			done,
+		);
+		return {
+			component,
+			done,
+			setJobs(next: AsyncJobState[]) {
+				current = next;
+			},
+			tui,
+		};
+	}
+
+	it("drills into detail with enter and returns with left", () => {
+		const { component } = makeComponent([makeJob()]);
+		component.handleInput("\r");
+		expect(component["state"].screen).toBe("detail");
+		component.handleInput("\x1B[D");
+		expect(component["state"].screen).toBe("list");
+	});
+
+	it("closes via escape and disposes its poller exactly once", () => {
+		vi.useFakeTimers();
+		const setInt = vi.spyOn(globalThis, "setInterval");
+		const clearInt = vi.spyOn(globalThis, "clearInterval");
+		const { component, done } = makeComponent([]);
+
+		expect(setInt).toHaveBeenCalledTimes(1);
+		component.handleInput("\x1B");
+		expect(done).toHaveBeenCalledWith(true);
+
+		component.dispose();
+		component.dispose();
+		expect(clearInt).toHaveBeenCalledTimes(1);
+
+		setInt.mockRestore();
+		clearInt.mockRestore();
+	});
+
+	it("detail follows the selected run and clamps when it vanishes", () => {
+		const one = makeJob({ asyncId: "one-of-four" });
+		const { component, setJobs } = makeComponent([one]);
+
+		component.handleInput("\r");
+		expect(component.render(84).join("\n")).toContain("Subagent detail [one-of]");
+
+		setJobs([makeJob({ asyncId: "two-of-six" })]);
+		component.refresh();
+		expect(component.render(84).join("\n")).toContain("Subagent detail [two-of]");
+
+		setJobs([]);
+		component.refresh();
+		expect(component.render(84).join("\n")).toContain("Run no longer active");
+	});
+});

--- a/packages/monopi__subagents/tests/index-entrypoint.test.ts
+++ b/packages/monopi__subagents/tests/index-entrypoint.test.ts
@@ -692,4 +692,30 @@ describe("subagent entrypoint", () => {
 		expect(found.content[0]?.text).toContain("Run: result-1");
 		expect(found.content[0]?.text).toContain("State: complete");
 	});
+
+	it("opens the fleet inspector via ctrl+alt+f and guards headless sessions", async () => {
+		const pi = createMockPi();
+		const ctx = createCtx();
+		registerSubagentExtension(pi as never);
+
+		const shortcut = pi.shortcuts.get("ctrl+alt+f");
+		expect(shortcut).toBeDefined();
+
+		let created: { dispose?: () => void } | undefined;
+		ctx.ui.custom = vi.fn(async (factory: (...args: unknown[]) => unknown) => {
+			created = factory({ requestRender: () => {} }, ctx.ui.theme, {}, vi.fn()) as {
+				dispose?: () => void;
+			};
+			return true;
+		});
+
+		await shortcut.handler(ctx);
+		expect(ctx.ui.custom).toHaveBeenCalledTimes(1);
+		expect(typeof created?.dispose).toBe("function");
+		created?.dispose?.();
+
+		const notify = vi.fn();
+		await shortcut.handler({ ...ctx, hasUI: false, ui: { notify } });
+		expect(notify).toHaveBeenCalledWith("Fleet inspector requires a TUI session", "error");
+	});
 });

--- a/packages/monopi__subagents/types.ts
+++ b/packages/monopi__subagents/types.ts
@@ -162,7 +162,10 @@ export interface AsyncStatus {
 	steps?: {
 		agent: string;
 		status: string;
+		startedAt?: number;
+		endedAt?: number;
 		durationMs?: number;
+		error?: string;
 		tokens?: TokenUsage;
 		skills?: string[];
 	}[];


### PR DESCRIPTION
## Why

Background subagents were a black box: the async widget showed a read-only summary line per run, but there was no way to toggle between runs or watch what each one was doing. Other harnesses solve this — OpenCode has a dedicated subagent view (leader+a, arrows to cycle children), Claude Code toggles a task list with ctrl+t, and upstream pi-subagents ships a fleet inspector on ctrl+alt+f. This PR brings that capability to @monopi/subagents, based on that research.

## Implementation

- **New `fleet-inspector.ts`** — an overlay component (`ctx.ui.custom({ overlay: true })`, same pattern as the agents manager) with two screens:
  - **List**: every async run sorted active → failed → complete, showing status icon, agent chain with per-step icons, step progress, elapsed time, tokens and activity freshness.
  - **Detail**: per-step table (status/duration/tokens/errors) plus a rolling output tail of the current step.
- **Keys** follow the conventions found in the research: `↑↓/jk` select (upstream pi-subagents fleet), `enter`/`→` inspect, `←`/`backspace` back (OpenCode child navigation), `x`/`ctrl+o` expand output (Claude Code convention), `r` refresh, `esc` back/close. `ctrl+alt+f` matches upstream pi-subagents' muscle memory and is free across pi and monopi defaults; it also works mid-turn via the global shortcut API.
- The component polls every 500ms while open and reuses the existing mtime-cached `readStatus`/`getOutputTail` helpers — no new I/O patterns. Poller is cleared on close/dispose.
- **Wiring**: `/fleet` command in `command-registration.ts`, `ctrl+alt+f` shortcut in `index.ts`, and a `· ctrl+alt+f fleet` hint appended to the async widget header so the feature is discoverable.
- `AsyncStatus.steps` typing extended with the fields the runner already writes (`error`, `startedAt`, `endedAt`).
- A no-mock smoke script (`fleet-inspector-smoke.mts`) exercises the real status.json/output-log data path end-to-end.

Deliberately out of scope: steering/stopping runs (needs intercom infrastructure monopi doesn't have yet) — inspection only, keeping the surface small.

_Created on behalf of Ifiok Jr. ([@ifiokjr](https://github.com/ifiokjr)) by pi using ox-alpha at high thinking._